### PR TITLE
add M220 speed factor and M221 flow factor

### DIFF
--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -12,22 +12,23 @@ import mcu, homing, cartesian, corexy, delta, extruder
 
 # Class to track each move request
 class Move:
-    def __init__(self, toolhead, start_pos, end_pos, speed, speed_factor, flow_factor):
-        self.toolhead = toolhead
-        self.start_pos = tuple(start_pos)
-        self.end_pos = tuple(end_pos)
-        self.accel = toolhead.max_accel
-        self.is_kinematic_move = True
+    def __init__(self, toolhead, start_pos, end_pos, speed, flow_factor):
         axes_d = [end_pos[i] - start_pos[i] for i in (0, 1, 2, 3)]
         move_d = math.sqrt(sum([d*d for d in axes_d[:3]]))
         axes_d[3] *= flow_factor
-        speed *= speed_factor
+        end_pos[3] = start_pos[3] + axes_d[3]
         if not move_d:
             # Extrude only move
             move_d = abs(axes_d[3])
             self.is_kinematic_move = False
+        else:
+            self.is_kinematic_move = True
+        self.toolhead = toolhead
+        self.accel = toolhead.max_accel
         self.axes_d = axes_d
         self.move_d = move_d
+        self.start_pos = tuple(start_pos)
+        self.end_pos = tuple(end_pos)
         self.min_move_t = move_d / speed
         # Junction speeds are tracked in velocity squared.  The
         # delta_v2 is the maximum amount of this squared-velocity that
@@ -319,8 +320,9 @@ class ToolHead:
         self.commanded_pos[:] = newpos
         self.kin.set_position(newpos)
     def move(self, newpos, speed, speed_factor = 1.0, flow_factor = 1.0):
+        speed *= speed_factor
         speed = min(speed, self.max_velocity)
-        move = Move(self, self.commanded_pos, newpos, speed, speed_factor, flow_factor)
+        move = Move(self, self.commanded_pos, newpos, speed, flow_factor)
         if not move.move_d:
             return
         if move.is_kinematic_move:


### PR DESCRIPTION
implements #50 

* for consistency both factors are handled similar in the gcode module.
* they are stored and used in each G0/G1 as parameter for toolhead.move() which creates a Move object with it
* Move.__init__ handles both factors.
* speed_factor is trivial
* flow_factor is the reason why the handling is done in Move, because here the end position of a move is converted into a distance. Handling the end position and current position with a scaling factor in upper levels, is way too complex and error prone.
