### PR TITLE
Add Lulzbot TAZ6 printer configuration

### DIFF
--- a/config/lulzbot-taz6.cfg
+++ b/config/lulzbot-taz6.cfg
@@ -1,0 +1,111 @@
+# This file contains pin mappings for the Lulzbot TAZ 6. To use this
+# config, the firmware should be compiled for the AVR atmega2560.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: PC0
+dir_pin: PL1
+enable_pin: !PA7
+step_distance: .010000
+endstop_pin: ^PB6
+position_endstop: -20
+position_min: -20
+position_max: 300
+homing_speed: 50
+
+[stepper_y]
+step_pin: PC1
+dir_pin: !PL0
+enable_pin: !PA6
+step_distance: .010000
+endstop_pin: ^PA1
+position_endstop: 306
+position_min: -20
+position_max: 306
+homing_speed: 50
+
+[stepper_z]
+step_pin: PC2
+dir_pin: PL2
+enable_pin: !PA5
+step_distance: 0.000625
+endstop_pin: ^!PB4
+position_endstop: -0.7
+position_min: -1.5
+position_max: 270
+homing_speed: 1
+
+[extruder]
+step_pin: PC3
+dir_pin: !PL6
+enable_pin: !PA4
+step_distance: 0.001182
+nozzle_diameter: 0.400
+filament_diameter: 2.920
+heater_pin: PH6
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF0
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 300
+min_extrude_temp: 140
+
+#[extruder1]
+#step_pin: PC4
+#dir_pin: PL7
+#enable_pin: !PA3
+#heater_pin: PH4
+#sensor_pin: PF1
+#...
+
+[heater_bed]
+heater_pin: PE5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF2
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PH5
+
+[heater_fan nozzle_cooling_fan]
+pin: PH3
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 2
+max_z_accel: 10
+
+[ad5206 stepper_digipot]
+enable_pin: PD7
+# Scale the config so that the channel value can be specified in amps.
+# (For Rambo v1.0d boards, use 1.56 instead.)
+scale: 2.08
+# Channel 1 is E0, 2 is E1, 3 is unused, 4 is Z, 5 is X, 6 is Y
+channel_1: 1.34
+channel_2: 1.0
+channel_4: 1.1
+channel_5: 1.1
+channel_6: 1.1
+
+# Enable 16 micro-steps on steppers X, Y, Z, E0, E1
+[static_digital_output stepper_config]
+pins:
+    PG1, PG0,
+    PK7, PG2,
+    PK6, PK5,
+    PK3, PK4,
+    PK1, PK2
+
+[static_digital_output yellow_led]
+pins: !PB7


### PR DESCRIPTION
Homing doesn't work with standard `G28`; you have to `G28 X`, `G28 Y`, and then `G1 X-19 Y252` in order to hit the Z endstop pushbutton, and there's no support for using the washers on the print bed corners to probe yet.