### PR TITLE
Accept R<temp> parameters for heating

### DIFF
--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -252,6 +252,7 @@ class GCodeParser:
             eventtime = self.reactor.pause(eventtime + 1.)
     def set_temp(self, params, is_bed=False, wait=False):
         temp = self.get_float('S', params, 0.)
+        temp = self.get_float('R', params, temp)
         heater = None
         if is_bed:
             heater = self.heaters[-1]


### PR DESCRIPTION
I tested this on my TAZ 6 and it worked as I expected. If for some reason a heating control command specifies both S\<temp\> and R\<temp\> parameters, R\<temp\> takes priority.