### PR TITLE
Added config option for PWM cycle time for bed heaters

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -227,6 +227,19 @@ control: watermark
 #   re-enabling the heater. The default is 2 degrees Celsius.
 min_temp: 0
 max_temp: 110
+#pwm_cycle_time: 0.100
+#   Time in seconds for each PWM cycle when control is "pid". Defaults
+#   to 0.100, or 10hz. Making this value shorter may result in less 
+#   power rail droop as the bed cycles on and off. If you notice
+#   flickering in onboard LEDs or noise in temperature measurements when
+#   bed heater PID is enabled, you may benefit from shorter cycle times.
+#   When changing this setting, recognize that shorter cycle times raise
+#   the MCU workload. Also check to ensure that the MOSFET controlling
+#   your bed heater doesn't become hot, as some printer controllers use 
+#   MOSFETs with high internal "Ron" resistance that are susceptible to
+#   overheating at high switching rates. If in doubt, stay safe.
+#   This option may also be used in extruder sections, but is generally
+#   not required.
 
 # Print cooling fan (omit section if fan not present).
 [fan]

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -95,7 +95,6 @@ Sensors = {
 SAMPLE_TIME = 0.001
 SAMPLE_COUNT = 8
 REPORT_TIME = 0.300
-PWM_CYCLE_TIME = 0.100
 MAX_HEAT_TIME = 5.0
 AMBIENT_TEMP = 25.
 PID_PARAM_BASE = 255.
@@ -125,7 +124,8 @@ class PrinterHeater:
             self.mcu_pwm = pins.setup_pin(printer, 'digital_out', heater_pin)
         else:
             self.mcu_pwm = pins.setup_pin(printer, 'pwm', heater_pin)
-            self.mcu_pwm.setup_cycle_time(PWM_CYCLE_TIME)
+            pwm_cycle_time = config.getfloat('pwm_cycle_time', 0.100, above=0.007, maxval=1.) 
+            self.mcu_pwm.setup_cycle_time(pwm_cycle_time)
         self.mcu_pwm.setup_max_duration(MAX_HEAT_TIME)
         self.mcu_adc = pins.setup_pin(printer, 'adc', config.get('sensor_pin'))
         adc_range = [self.sensor.calc_adc(self.min_temp),


### PR DESCRIPTION
Added the pwm_cycle_time option for heater config sections.  Defaults
to previous value of 0.100 seconds, but may be reduced to shorter times
at the expense of MCU workload and possible MOSFET heating, depending on
controller design.  Some printers that need bed PID to be enabled,
notably the Felixprinters series, are known to benefit from shorter
cycle times, as the default 10hz rate results in excessive voltage
supply droop.

While this option can be used on extruder heaters as well, there
is not expected to be any particular benefit from doing so unless
the extruder heater presents a particularly large load.

Signed-off-by: Andy Silverman <andrewsi@outlook.com>