### PR TITLE
config: Added Wanhao Duplicator i3 Plus configuration

### DIFF
--- a/config/wanhao-duplicator-i3-plus.cfg
+++ b/config/wanhao-duplicator-i3-plus.cfg
@@ -1,0 +1,75 @@
+# This file contains pin mappings for the Wanhao Duplicator i3 Plus.
+# To use this config, the firmware should be compiled for the AVR
+# atmega2560.
+# Pin numbers and other parameters were extracted from the
+# official Marlin source available at:
+# https://github.com/garychen99/Duplicator-i3-plus
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: PF7
+dir_pin: !PK0
+enable_pin: !PF6
+step_distance: .0125
+endstop_pin: ^!PF0
+position_endstop: 0
+position_max: 200
+
+[stepper_y]
+step_pin: PK2
+dir_pin: !PK3
+enable_pin: !PK1
+step_distance: .0125
+endstop_pin: ^!PA2
+position_endstop: 0
+position_max: 200
+
+[stepper_z]
+step_pin: PK5
+dir_pin: PK7
+enable_pin: !PK4
+step_distance: 0.0025
+endstop_pin: ^!PA1
+position_endstop: 0.5
+position_max: 180
+
+[extruder]
+step_pin: PF4
+dir_pin: PF5
+enable_pin: !PF3
+step_distance: 0.010417
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+#pressure_advance: 0.1
+#pressure_advance_lookahead_time: 0.01
+heater_pin: PG5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF1
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 260
+
+[heater_bed]
+heater_pin: PE5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PE3
+
+[mcu]
+serial: /dev/ttyUSB0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 800
+max_z_velocity: 5
+max_z_accel: 100


### PR DESCRIPTION
The Wanhao Duplicator i3 Plus (aka Maker Select Plus,
Microcenter Powerspec Plus, and others) uses an
atmega2560 AVR. The config is based on generic-ramps.cfg
with pin numbers updated from the official Wanhao Marlin
sources at https://github.com/garychen99/Duplicator-i3-plus

Signed-off-by: Josh Sutinen <josh@damagedgoodz.net>