### PR TITLE
config: Updated Wanhao Duplicator i3 Plus cfg

### DIFF
--- a/config/wanhao-duplicator-i3-plus-2017.cfg
+++ b/config/wanhao-duplicator-i3-plus-2017.cfg
@@ -15,6 +15,7 @@ step_distance: .0125
 endstop_pin: ^!PF0
 position_endstop: 0
 position_max: 200
+homing_speed: 30.0
 
 [stepper_y]
 step_pin: PK2
@@ -24,6 +25,7 @@ step_distance: .0125
 endstop_pin: ^!PA2
 position_endstop: 0
 position_max: 200
+homing_speed: 30.0
 
 [stepper_z]
 step_pin: PK5
@@ -33,21 +35,23 @@ step_distance: 0.0025
 endstop_pin: ^!PA1
 position_endstop: 0.5
 position_max: 180
+homing_speed: 30
 
 [extruder]
 step_pin: PF4
 dir_pin: PF5
 enable_pin: !PF3
-step_distance: 0.010417
+step_distance: .0085
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+max_extrude_only_distance: 200.0
 heater_pin: PG5
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PF1
 control: pid
-pid_Kp: 22.2
-pid_Ki: 1.08
-pid_Kd: 114
+pid_Kp: 30.850721
+pid_Ki: .208175
+pid_Kd: 192.298728
 min_temp: 0
 max_temp: 260
 
@@ -55,15 +59,19 @@ max_temp: 260
 heater_pin: PE5
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PK6
-control: watermark
+control: pid
+pid_Kp: 64.095903
+pid_Ki: 1.649830
+pid_Kd: 622.531455
 min_temp: 0
-max_temp: 130
+max_temp: 110
 
 [fan]
 pin: PE3
 
 [mcu]
 serial: /dev/ttyUSB0
+baud:115200
 
 [printer]
 kinematics: cartesian


### PR DESCRIPTION
updated hotend PID values
set bed to PID control and added PID values
updated bed max_temp
set max_extrude_only_length to 200.  This allows for proper e-steps calibration
updated e-steps value
set all axis homing speed to 30
set MCU baud rate

Signed-off-by: max holden <malxholden@gmail.com>