### PR TITLE
Add Safe Homing for cartesian printer.

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -309,3 +309,8 @@ max_z_accel: 30
 #   centripetal velocity cornering algorithm. A larger number will
 #   permit higher "cornering speeds" at the junction of two moves. The
 #   default is 0.02mm.
+#safe_homing: no
+#   For cartesian printer using a Distance Sensor or Touch Sensor.
+#   Move Z axis after X and Y axes was homed and center the head on the
+#   bed. This option up a litlle (homing_retract_dist) the Z axis before
+#   homing axes to prevent bed hitting the head.


### PR DESCRIPTION
Hi,
Thanks for your work.
This is a homing option for cartesian printers where the Z end stop sensor is a distance sensor or a touch sensor mounted on the printing head. These kind of printer require to made safe the printing head before homing each axes.

Any advices and test are welcome.