### PR TITLE
Cycle time configuration for print cooling fan

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -254,6 +254,9 @@ pin: ar9
 #kick_start_time: 0.100
 #   Time (in seconds) to run the fan at full speed when first enabling
 #   it (helps get the fan spinning). The default is 0.100 seconds.
+#cycle_time: 0.010
+#   The amount of time (in seconds) per PWM cycle when using software
+#   based PWM. The default is 0.010 seconds.
 
 # Micro-controller information.
 [mcu]

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -14,10 +14,11 @@ class PrinterFan:
         self.last_fan_time = 0.
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
         self.kick_start_time = config.getfloat('kick_start_time', 0.1, minval=0.)
+        self.cycle_time = config.getfloat('cycle_time', PWM_CYCLE_TIME, above=0.)
         printer = config.get_printer()
         self.mcu_fan = pins.setup_pin(printer, 'pwm', config.get('pin'))
         self.mcu_fan.setup_max_duration(0.)
-        self.mcu_fan.setup_cycle_time(PWM_CYCLE_TIME)
+        self.mcu_fan.setup_cycle_time(self.cycle_time)
         self.mcu_fan.setup_hard_pwm(config.getint('hard_pwm', 0))
     def set_speed(self, print_time, value):
         value = max(0., min(self.max_power, value))


### PR DESCRIPTION
My fan sound is better with another cycle time value. It may be useful for others.
It's looks like [pwm_output my_pin] in extras.