### PR TITLE
delta: add delta actuator position fine tuning after homing.

### DIFF
--- a/config/example-delta.cfg
+++ b/config/example-delta.cfg
@@ -32,6 +32,13 @@ arm_length: 333.0
 #   This option specifies the angle (in degrees) that the tower is
 #   at. The default is 210 for stepper_a, 330 for stepper_b, and 90
 #   for stepper_c.
+#endstop_correction:
+#   This option allow finetuning the delta actuator positions after
+#   endstop is triggered (homing done) in mm. The default is None.
+#endstop_correction_steps:
+#   This option is same as endstop_correction but can be defined
+#   in steps instead of mm. endstop_correction is handled prio to
+#   this value. The default is 0 steps.
 
 # The stepper_b section describes the stepper controlling the front
 # right tower (at 330 degrees).

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -27,8 +27,8 @@ class Homing:
             if coord[i] is not None:
                 thcoord[i] = coord[i]
         return thcoord
-    def retract(self, newpos, speed):
-        self.toolhead.move(self._fill_coord(newpos), speed)
+    def retract(self, newpos, speed, check=True):
+        self.toolhead.move(self._fill_coord(newpos), speed, check=check)
     def set_homed_position(self, pos):
         self.toolhead.set_position(self._fill_coord(pos))
     def _get_homing_speed(self, speed, endstops):

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -84,6 +84,12 @@ class PrinterHomingStepper(PrinterStepper):
         else:
             self.position_endstop = config.getfloat(
                 'position_endstop', default_position)
+        # Homing finetune after enstop hit (mainly for deltas)
+        self.tune_after_homing = \
+            config.getfloat('endstop_correction', None) # in mm
+        if (self.tune_after_homing is None):
+            self.tune_after_homing = (config.getfloat('endstop_correction_steps', 0.) *
+                                      self.step_dist)
         # Axis range
         self.position_min = config.getfloat('position_min', 0.)
         self.position_max = config.getfloat(
@@ -91,7 +97,7 @@ class PrinterHomingStepper(PrinterStepper):
         # Homing mechanics
         self.homing_speed = config.getfloat('homing_speed', 5.0, above=0.)
         self.homing_retract_dist = config.getfloat(
-            'homing_retract_dist', 5., above=0.)
+            'homing_retract_dist', 5., minval=0.)
         self.homing_positive_dir = config.getboolean('homing_positive_dir', None)
         if self.homing_positive_dir is None:
             axis_len = self.position_max - self.position_min

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -97,7 +97,7 @@ class PrinterHomingStepper(PrinterStepper):
         # Homing mechanics
         self.homing_speed = config.getfloat('homing_speed', 5.0, above=0.)
         self.homing_retract_dist = config.getfloat(
-            'homing_retract_dist', 5., minval=0.)
+            'homing_retract_dist', 5., above=0.)
         self.homing_positive_dir = config.getboolean('homing_positive_dir', None)
         if self.homing_positive_dir is None:
             axis_len = self.position_max - self.position_min

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -316,12 +316,12 @@ class ToolHead:
         self._flush_lookahead()
         self.commanded_pos[:] = newpos
         self.kin.set_position(newpos, homing_axes)
-    def move(self, newpos, speed):
+    def move(self, newpos, speed, check=True):
         speed = min(speed, self.max_velocity)
         move = Move(self, self.commanded_pos, newpos, speed)
         if not move.move_d:
             return
-        if move.is_kinematic_move:
+        if move.is_kinematic_move and check:
             self.kin.check_move(move)
         if move.axes_d[3]:
             self.extruder.check_move(move)


### PR DESCRIPTION
       This feature allow offset in mm or steps. Actuator is moved
       defined amount after homing to make sure the towers are even.
       Can be used to calibra table or compesate endstop positions.

Signed-off-by: cruwaller <cruwaller@gmail.com>