### PR TITLE
homing: allow to disable homing retract.

### DIFF
--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -77,6 +77,8 @@ class Homing:
         if error is not None:
             raise EndstopError(error)
     def home(self, forcepos, movepos, endstops, speed, second_home=False):
+        if second_home and forcepos == movepos:
+            return
         # Alter kinematics class to think printer is at forcepos
         homing_axes = [axis for axis in range(3) if forcepos[axis] is not None]
         self.toolhead.set_position(

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -91,7 +91,7 @@ class PrinterHomingStepper(PrinterStepper):
         # Homing mechanics
         self.homing_speed = config.getfloat('homing_speed', 5.0, above=0.)
         self.homing_retract_dist = config.getfloat(
-            'homing_retract_dist', 5., above=0.)
+            'homing_retract_dist', 5., minval=0.)
         self.homing_positive_dir = config.getboolean('homing_positive_dir', None)
         if self.homing_positive_dir is None:
             axis_len = self.position_max - self.position_min


### PR DESCRIPTION
        Homing retract can be disabled by setting homing_retract_dist to 0.

Signed-off-by: cruwaller <cruwaller@gmail.com>