### PR TITLE
pins: add arduino style analog pin mapping support.

### DIFF
--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -108,6 +108,7 @@ def update_map_arduino(pins, mcu):
         pins['ar' + str(i)] = pins[dpins[i]]
     for i in range(len(apins)):
         pins['analog%d' % (i,)] = pins[apins[i]]
+        pins['A%d' % (i,)] = pins[apins[i]]
 
 
 ######################################################################


### PR DESCRIPTION
      User can define analog pins in Arduino stype; a.g. A1.
      Current Analog1 style is not fully compatible with
      Arduino pinout naming.

Signed-off-by: cruwaller <cruwaller@gmail.com>