### PR TITLE
heaters: sensors moved to own module

### DIFF
--- a/config/avrsim.cfg
+++ b/config/avrsim.cfg
@@ -36,6 +36,18 @@ position_min: 0.1
 position_endstop: 0.5
 position_max: 200
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog7
+min_temp: 0
+max_temp: 210
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog0
+min_temp: 0
+max_temp: 110
+
 [extruder]
 # Pins: PC3, PC2
 step_pin: ar19
@@ -44,24 +56,18 @@ enable_pin: ar25
 step_distance: .004242
 nozzle_diameter: 0.500
 filament_diameter: 3.500
+sensor: hotend
 heater_pin: ar4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog7
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
 min_extrude_temp: 0
-max_temp: 210
 
 [heater_bed]
+sensor: bed
 heater_pin: ar3
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog0
 control: watermark
-min_temp: 0
-max_temp: 110
 
 [fan]
 pin: ar14

--- a/config/example-corexy.cfg
+++ b/config/example-corexy.cfg
@@ -40,6 +40,18 @@ endstop_pin: ^ar18
 position_endstop: 0.5
 position_max: 200
 
+[sensor hotend]
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: analog13
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: ar26
 dir_pin: ar28
@@ -47,23 +59,17 @@ enable_pin: !ar24
 step_distance: .0022
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: ar10
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: ar8
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: ar9

--- a/config/example-delta.cfg
+++ b/config/example-delta.cfg
@@ -51,6 +51,18 @@ enable_pin: !ar62
 step_distance: .01
 endstop_pin: ^ar19
 
+[sensor hotend]
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: analog13
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: ar26
 dir_pin: ar28
@@ -58,23 +70,17 @@ enable_pin: !ar24
 step_distance: .0022
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: ar10
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: ar8
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
 control: watermark
-min_temp: 0
-max_temp: 130
 
 # Print cooling fan (omit section if fan not present).
 #[fan]

--- a/config/example-multi-mcu.cfg
+++ b/config/example-multi-mcu.cfg
@@ -51,6 +51,18 @@ endstop_pin: ^zboard:ar18
 position_endstop: 0.5
 position_max: 200
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: auxboard:analog13
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: auxboard:analog14
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: auxboard:ar26
 dir_pin: auxboard:ar28
@@ -58,23 +70,17 @@ enable_pin: !auxboard:ar24
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: auxboard:ar10
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: auxboard:analog13
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: auxboard:ar8
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: auxboard:analog14
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: auxboard:ar9

--- a/config/example.cfg
+++ b/config/example.cfg
@@ -82,6 +82,39 @@ endstop_pin: ^ar18
 position_endstop: 0.5
 position_max: 200
 
+# The sensor section is used to describe sensor parameters for heaters
+# This section name is then referenced in extruders section.
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+#   Type of sensor - this may be "EPCOS 100K B57560G104F", "ATC
+#   Semitec 104GT-2", "NTC 100K beta 3950", or "AD595". This parameter
+#   must be provided.
+sensor_pin: analog13
+#   Analog input pin connected to the sensor. This parameter must be
+#   provided.
+#pullup_resistor: 4700
+#   The resistance (in ohms) of the pullup attached to the
+#   thermistor. This parameter is only valid when the sensor is a
+#   thermistor. The default is 4700 ohms.
+#adc_voltage: 5.0
+#   The ADC comparison voltage. This parameter is only valid when the
+#   sensor is an AD595. The default is 5 volts.
+min_temp: 0
+#   Minimum temperature in Celsius (mcu will shutdown if not
+#   met). This parameter must be provided.
+max_temp: 210
+#   Maximum temperature (mcu will shutdown if temperature is above
+#   this value). This parameter must be provided.
+
+# This section is similar to above but is used for bed heater
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+min_temp: 0
+max_temp: 110
+
+
+
 # The extruder section is used to describe both the stepper
 # controlling the printer extruder and the heater parameters for the
 # nozzle. The stepper configuration has the same settings as the
@@ -134,6 +167,9 @@ filament_diameter: 3.500
 #   non-zero. The default is 0.010 (10 milliseconds).
 #
 # The remaining variables describe the extruder heater.
+sensor: hotend
+#   This parameter is reference to sensor section. Heater temperature
+#   is read by using referenced sensor.
 heater_pin: ar10
 #   PWM output pin controlling the heater. This parameter must be
 #   provided.
@@ -144,20 +180,6 @@ heater_pin: ar10
 #   allow the pin to be enabled for no more than half the time. This
 #   setting may be used to limit the total power output (over extended
 #   periods) to the heater. The default is 1.0.
-sensor_type: EPCOS 100K B57560G104F
-#   Type of sensor - this may be "EPCOS 100K B57560G104F", "ATC
-#   Semitec 104GT-2", "NTC 100K beta 3950", or "AD595". This parameter
-#   must be provided.
-sensor_pin: analog13
-#   Analog input pin connected to the sensor. This parameter must be
-#   provided.
-#pullup_resistor: 4700
-#   The resistance (in ohms) of the pullup attached to the
-#   thermistor. This parameter is only valid when the sensor is a
-#   thermistor. The default is 4700 ohms.
-#adc_voltage: 5.0
-#   The ADC comparison voltage. This parameter is only valid when the
-#   sensor is an AD595. The default is 5 volts.
 control: pid
 #   Control algorithm (either pid or watermark). This parameter must
 #   be provided.
@@ -185,27 +207,18 @@ pid_Kd: 114
 #min_extrude_temp: 170
 #   The minimum temperature (in Celsius) at which extruder move
 #   commands may be issued. The default is 170 Celsius.
-min_temp: 0
-#   Minimum temperature in Celsius (mcu will shutdown if not
-#   met). This parameter must be provided.
-max_temp: 210
-#   Maximum temperature (mcu will shutdown if temperature is above
-#   this value). This parameter must be provided.
 
 # The heater_bed section describes a heated bed (if present - omit
 # section if not present).
 [heater_bed]
+sensor: bed
 heater_pin: ar8
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
 control: watermark
 #max_delta: 2.0
 #   On 'watermark' controlled heaters this is the number of degrees in
 #   Celsius above the target temperature before disabling the heater
 #   as well as the number of degrees below the target before
 #   re-enabling the heater. The default is 2 degrees Celsius.
-min_temp: 0
-max_temp: 110
 
 # Print cooling fan (omit section if fan not present).
 [fan]

--- a/config/generic-cramps.cfg
+++ b/config/generic-cramps.cfg
@@ -39,6 +39,18 @@ endstop_pin: ^P9_13
 position_endstop: 0
 position_max: 200
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P9_36
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P9_33
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: P9_16
 dir_pin: P9_12
@@ -46,23 +58,17 @@ enable_pin: !P9_14
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: P9_15
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: P9_36
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: P8_11
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: P9_33
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: P9_41

--- a/config/generic-melzi.cfg
+++ b/config/generic-melzi.cfg
@@ -40,6 +40,18 @@ endstop_pin: ^!PC4
 position_endstop: 0.5
 position_max: 200
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA7
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA6
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: PB1
 dir_pin: PB0
@@ -47,23 +59,17 @@ enable_pin: !PD6
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: PD5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: PD2
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA6
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: PB4

--- a/config/generic-mini-rambo.cfg
+++ b/config/generic-mini-rambo.cfg
@@ -33,6 +33,19 @@ endstop_pin: ^PB4
 position_endstop: 0.5
 position_max: 200
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF0
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF2
+min_temp: 0
+max_temp: 130
+
+
 [extruder]
 step_pin: PC3
 dir_pin: PL6
@@ -40,23 +53,17 @@ enable_pin: !PA4
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: PE5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF0
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: PG5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF2
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: PH5

--- a/config/generic-printrboard.cfg
+++ b/config/generic-printrboard.cfg
@@ -37,6 +37,18 @@ endstop_pin: ^PE4
 position_endstop: 0.5
 position_max: 200
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF1
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF0
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: PA6
 dir_pin: PA7
@@ -44,23 +56,17 @@ enable_pin: !PC3
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: PC5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF1
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: PC4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF0
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: PC6

--- a/config/generic-rambo.cfg
+++ b/config/generic-rambo.cfg
@@ -35,6 +35,24 @@ endstop_pin: ^PB4
 position_endstop: 0.5
 position_max: 200
 
+[sensor hotend1]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF0
+min_temp: 0
+max_temp: 250
+
+#[sensor hotend2]
+#sensor_type: EPCOS 100K B57560G104F
+#sensor_pin: PF1
+#min_temp: 0
+#max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF2
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: PC3
 dir_pin: PL6
@@ -42,31 +60,25 @@ enable_pin: !PA4
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend1
 heater_pin: PH6
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF0
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 #[extruder1]
 #step_pin: PC4
 #dir_pin: PL7
 #enable_pin: !PA3
 #heater_pin: PH4
-#sensor_pin: PF1
+#sensor: hotend2
 #...
 
 [heater_bed]
+sensor: bed
 heater_pin: PE5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF2
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: PH5

--- a/config/generic-ramps.cfg
+++ b/config/generic-ramps.cfg
@@ -36,6 +36,24 @@ endstop_pin: ^ar18
 position_endstop: 0.5
 position_max: 200
 
+[sensor hotend1]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+min_temp: 0
+max_temp: 250
+
+#[sensor hotend2]
+#sensor_type: EPCOS 100K B57560G104F
+#sensor_pin: analog15
+#min_temp: 0
+#max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: ar26
 dir_pin: ar28
@@ -43,31 +61,25 @@ enable_pin: !ar24
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend1
 heater_pin: ar10
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 #[extruder1]
 #step_pin: ar36
 #dir_pin: ar34
 #enable_pin: !ar30
 #heater_pin: ar9
-#sensor_pin: analog15
+#sensor: hotend2
 #...
 
 [heater_bed]
+sensor: bed
 heater_pin: ar8
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: ar9

--- a/config/generic-replicape.cfg
+++ b/config/generic-replicape.cfg
@@ -99,6 +99,18 @@ max_accel: 3000
 max_z_velocity: 25
 max_z_accel: 30
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: host:analog4
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: host:analog6
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: P9_12
 dir_pin: P8_15
@@ -106,23 +118,17 @@ enable_pin: replicape:stepper_e_enable
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: replicape:power_e
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: host:analog4
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: replicape:power_hotbed
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: host:analog6
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: replicape:power_fan0

--- a/config/printer-anet-a8-2017.cfg
+++ b/config/printer-anet-a8-2017.cfg
@@ -40,6 +40,18 @@ position_endstop: 0.5
 position_max: 240
 homing_speed: 20
 
+[sensor hotend]
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PA7
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PA6
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: PB1
 dir_pin: PB0
@@ -47,23 +59,17 @@ enable_pin: !PD6
 step_distance: .0105
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: PD5
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA7
 control: pid
 pid_Kp: 2.151492
 pid_Ki: 0.633897
 pid_Kd: 230.042965
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: PD4
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA6
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: PB4

--- a/config/printer-anycubic-i3-mega-2017.cfg
+++ b/config/printer-anycubic-i3-mega-2017.cfg
@@ -44,6 +44,18 @@ enable_pin: !ar30
 step_distance: .0025
 endstop_pin: ^!ar43
 
+[sensor hotend]
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: analog13
+min_temp: 0
+max_temp: 245
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+min_temp: 0
+max_temp: 110
+
 [extruder]
 step_pin: ar26
 dir_pin: ar28
@@ -51,29 +63,23 @@ enable_pin: !ar24
 step_distance: .010799
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: ar10
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
 control: pid
 pid_Kp: 15.717
 pid_Ki: 0.569
 pid_Kd: 108.451
-min_temp: 0
-max_temp: 245
 
 [heater_fan extruder_fan]
 pin: ar44
 
 [heater_bed]
+sensor: bed
 heater_pin: ar8
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
 control: pid
 pid_Kp: 74.883
 pid_Ki: 1.809
 pid_Kd: 775.038
-min_temp: 0
-max_temp: 110
 
 [fan]
 pin: ar9

--- a/config/printer-creality-cr10-2017.cfg
+++ b/config/printer-creality-cr10-2017.cfg
@@ -40,6 +40,18 @@ endstop_pin: ^PC4
 position_endstop: 0.0
 position_max: 400
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA7
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA6
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: PB1
 dir_pin: !PB0
@@ -47,26 +59,20 @@ enable_pin: !PD6
 step_distance: 0.010526
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: PD5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
 control: pid
 pid_Kp: 22.57
 pid_Ki: 1.72
 pid_Kd: 73.96
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: PD4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA6
 control: pid
 pid_Kp: 426.68
 pid_Ki: 78.92
 pid_Kd: 576.71
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: PB4

--- a/config/printer-creality-cr10s-2017.cfg
+++ b/config/printer-creality-cr10s-2017.cfg
@@ -32,6 +32,18 @@ endstop_pin: ^ar18
 position_endstop: 0.5
 position_max: 200
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+min_temp: 0
+max_temp: 250
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: ar26
 dir_pin: ar28
@@ -39,26 +51,20 @@ enable_pin: !ar24
 step_distance: .010526
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: ar10
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 250
 
 [heater_bed]
+sensor: bed
 heater_pin: ar8
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
 control: pid
 pid_Kp: 690.34
 pid_Ki: 111.47
 pid_Kd: 1068.83
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: ar9

--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -37,6 +37,24 @@ position_min: -1.5
 position_max: 270
 homing_speed: 1
 
+[sensor hotend1]
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PF0
+min_temp: 0
+max_temp: 300
+
+#[sensor hotend2]
+#sensor_type: ATC Semitec 104GT-2
+#sensor_pin: PF1
+#min_temp: 0
+#max_temp: 300
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF2
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: PC3
 dir_pin: !PL6
@@ -44,32 +62,26 @@ enable_pin: !PA4
 step_distance: 0.001182
 nozzle_diameter: 0.400
 filament_diameter: 2.920
+sensor: hotend1
 heater_pin: PH6
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PF0
 control: pid
 pid_Kp: 28.79
 pid_Ki: 1.91
 pid_Kd: 108.51
-min_temp: 0
-max_temp: 300
 min_extrude_temp: 140
 
 #[extruder1]
 #step_pin: PC4
 #dir_pin: PL7
 #enable_pin: !PA3
+#sensor: hotend2
 #heater_pin: PH4
-#sensor_pin: PF1
 #...
 
 [heater_bed]
+sensor: bed
 heater_pin: PE5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF2
 control: watermark
-min_temp: 0
-max_temp: 130
 
 [fan]
 pin: PH5

--- a/config/printer-makergear-m2-2012.cfg
+++ b/config/printer-makergear-m2-2012.cfg
@@ -40,6 +40,18 @@ homing_retract_dist: 2.0
 homing_stepper_phases: 32
 homing_endstop_accuracy: .070
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF0
+min_temp: 0
+max_temp: 210
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF2
+min_temp: 0
+max_temp: 100
+
 [extruder]
 step_pin: PC3
 dir_pin: PL6
@@ -48,23 +60,17 @@ step_distance: .004242
 nozzle_diameter: 0.350
 filament_diameter: 1.750
 pressure_advance: 0.07
+sensor: hotend
 heater_pin: PH6
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF0
 control: pid
 pid_Kp: 7.0
 pid_Ki: 0.1
 pid_Kd: 12
-min_temp: 0
-max_temp: 210
 
 [heater_bed]
+sensor: bed
 heater_pin: PE5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF2
 control: watermark
-min_temp: 0
-max_temp: 100
 
 [fan]
 pin: PH5

--- a/config/printer-seemecnc-rostock-max-v2-2015.cfg
+++ b/config/printer-seemecnc-rostock-max-v2-2015.cfg
@@ -28,6 +28,18 @@ enable_pin: !PA5
 step_distance: .0125
 endstop_pin: ^PC7
 
+[sensor hotend]
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PF0
+min_temp: 0
+max_temp: 300
+
+[sensor bed]
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PF2
+min_temp: 0
+max_temp: 130
+
 [extruder]
 step_pin: PC3
 dir_pin: !PL6
@@ -35,26 +47,20 @@ enable_pin: !PA4
 step_distance: .010793
 nozzle_diameter: 0.500
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: PH6
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PF0
 control: pid
 pid_Kp: 20.9700
 pid_Ki: 1.3400
 pid_Kd: 80.5600
-min_temp: 0
-max_temp: 300
 
 [heater_bed]
+sensor: bed
 heater_pin: PE5
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PF2
 control: pid
 pid_Kp: 46.510
 pid_Ki: 1.040
 pid_Kd: 500.000
-min_temp: 0
-max_temp: 300
 
 [fan]
 pin: PH5

--- a/config/printer-tronxy-x5s-2017.cfg
+++ b/config/printer-tronxy-x5s-2017.cfg
@@ -40,6 +40,18 @@ endstop_pin: ^!PC4
 position_endstop: 0.5
 position_max: 400
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA7
+min_temp: 0
+max_temp: 275
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA6
+min_temp: 0
+max_temp: 150
+
 [extruder]
 step_pin: PB1
 dir_pin: PB0
@@ -47,23 +59,17 @@ enable_pin: !PD6
 step_distance: .0111
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: PD5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
 pid_Kd: 114
-min_temp: 0
-max_temp: 275
 
 [heater_bed]
+sensor: bed
 heater_pin: PD4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA6
 control: watermark
-min_temp: 0
-max_temp: 150
 
 [fan]
 pin: PB4

--- a/config/printer-wanhao-duplicator-i3-plus-2017.cfg
+++ b/config/printer-wanhao-duplicator-i3-plus-2017.cfg
@@ -36,6 +36,18 @@ endstop_pin: ^!PA1
 position_endstop: 0.5
 position_max: 180
 
+[sensor hotend]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF1
+min_temp: 0
+max_temp: 260
+
+[sensor bed]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+min_temp: 0
+max_temp: 110
+
 [extruder]
 step_pin: PF4
 dir_pin: PF5
@@ -43,26 +55,20 @@ enable_pin: !PF3
 step_distance: 0.010417
 nozzle_diameter: 0.400
 filament_diameter: 1.750
+sensor: hotend
 heater_pin: PG5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF1
 control: pid
 pid_Kp: 30.850721
 pid_Ki: .208175
 pid_Kd: 192.298728
-min_temp: 0
-max_temp: 260
 
 [heater_bed]
+sensor: bed
 heater_pin: PE5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
 control: pid
 pid_Kp: 64.095903
 pid_Ki: 1.649830
 pid_Kd: 622.531455
-min_temp: 0
-max_temp: 110
 
 [fan]
 pin: PE3

--- a/klippy/extras/sensors/__init__.py
+++ b/klippy/extras/sensors/__init__.py
@@ -1,0 +1,23 @@
+# Printer heater support
+#
+# Copyright (C) 2016,2017  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import os, sys
+from thermistor import Thermistor, ThermistorBeta, Linear
+
+Sensors = {
+    "EPCOS 100K B57560G104F": {
+        'class': Thermistor, 't1': 25., 'r1': 100000.,
+        't2': 150., 'r2': 1641.9, 't3': 250., 'r3': 226.15 },
+    "ATC Semitec 104GT-2": {
+        'class': Thermistor, 't1': 20., 'r1': 126800.,
+        't2': 150., 'r2': 1360., 't3': 300., 'r3': 80.65 },
+    "NTC 100K beta 3950": {
+        'class': ThermistorBeta, 't1': 25., 'r1': 100000., 'beta': 3950. },
+    "AD595": { 'class': Linear, 't1': 25., 'v1': .25, 't2': 300., 'v2': 3.022 },
+}
+
+def load_sensor(config):
+    sensor_params = config.getchoice('sensor_type', Sensors)
+    return sensor_params['class'](config, sensor_params)

--- a/klippy/extras/sensors/sensorbase.py
+++ b/klippy/extras/sensors/sensorbase.py
@@ -1,0 +1,34 @@
+# Printer heater support
+#
+# Copyright (C) 2016,2017  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import pins
+
+SAMPLE_TIME_DEFAULT    = 0.001
+SAMPLE_COUNT_DEFAULT   = 8
+
+class SensorBase(object):
+    sample_time  = SAMPLE_TIME_DEFAULT
+    sample_count = SAMPLE_COUNT_DEFAULT
+    def __init__(self,
+                 config,
+                 sample_time  = SAMPLE_TIME_DEFAULT,
+                 sample_count = SAMPLE_COUNT_DEFAULT):
+        self.printer = config.get_printer()
+        self.sample_time = sample_time
+        self.sample_count = sample_count
+        self.min_temp = config.getfloat('min_temp', minval=0., default=0.)
+        self.max_temp = config.getfloat('max_temp', above=self.min_temp)
+        sensor_pin = config.get('sensor_pin')
+        adc_range = [self.calc_adc(self.min_temp),
+                     self.calc_adc(self.max_temp)]
+        self.mcu = pins.setup_pin(
+            self.printer, 'adc', sensor_pin)
+        self.mcu.setup_minmax(
+            sample_time, sample_count,
+            minval=min(adc_range), maxval=max(adc_range))
+    def get_mcu(self):
+        return self.mcu
+    def get_min_max_temp(self):
+        return self.min_temp, self.max_temp

--- a/klippy/extras/sensors/thermistor.py
+++ b/klippy/extras/sensors/thermistor.py
@@ -1,0 +1,79 @@
+# Printer heater support
+#
+# Copyright (C) 2016,2017  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import math
+from sensorbase import SensorBase
+
+KELVIN_TO_CELCIUS = -273.15
+
+# Thermistor calibrated with three temp measurements
+class Thermistor(SensorBase):
+    def __init__(self, config, params):
+        self.pullup = config.getfloat('pullup_resistor', 4700., above=0.)
+        # Calculate Steinhart-Hart coefficents from temp measurements
+        inv_t1 = 1. / (params['t1'] - KELVIN_TO_CELCIUS)
+        inv_t2 = 1. / (params['t2'] - KELVIN_TO_CELCIUS)
+        inv_t3 = 1. / (params['t3'] - KELVIN_TO_CELCIUS)
+        ln_r1 = math.log(params['r1'])
+        ln_r2 = math.log(params['r2'])
+        ln_r3 = math.log(params['r3'])
+        ln3_r1, ln3_r2, ln3_r3 = ln_r1**3, ln_r2**3, ln_r3**3
+
+        inv_t12, inv_t13 = inv_t1 - inv_t2, inv_t1 - inv_t3
+        ln_r12, ln_r13 = ln_r1 - ln_r2, ln_r1 - ln_r3
+        ln3_r12, ln3_r13 = ln3_r1 - ln3_r2, ln3_r1 - ln3_r3
+
+        self.c3 = ((inv_t12 - inv_t13 * ln_r12 / ln_r13)
+                   / (ln3_r12 - ln3_r13 * ln_r12 / ln_r13))
+        self.c2 = (inv_t12 - self.c3 * ln3_r12) / ln_r12
+        self.c1 = inv_t1 - self.c2 * ln_r1 - self.c3 * ln3_r1
+        SensorBase.__init__(self, config)
+    def calc_temp(self, adc):
+        adc = max(.00001, min(.99999, adc))
+        r = self.pullup * adc / (1.0 - adc)
+        ln_r = math.log(r)
+        inv_t = self.c1 + self.c2 * ln_r + self.c3 * ln_r**3
+        return 1.0/inv_t + KELVIN_TO_CELCIUS
+    def calc_adc(self, temp):
+        inv_t = 1. / (temp - KELVIN_TO_CELCIUS)
+        if self.c3:
+            y = (self.c1 - inv_t) / (2. * self.c3)
+            x = math.sqrt((self.c2 / (3. * self.c3))**3 + y**2)
+            ln_r = math.pow(x - y, 1./3.) - math.pow(x + y, 1./3.)
+        else:
+            ln_r = (inv_t - self.c1) / self.c2
+        r = math.exp(ln_r)
+        return r / (self.pullup + r)
+    def check_faults(self, fault):
+        pass
+
+# Thermistor calibrated from one temp measurement and its beta
+class ThermistorBeta(Thermistor):
+    def __init__(self, config, params):
+        self.pullup = config.getfloat('pullup_resistor', 4700., above=0.)
+        # Calculate Steinhart-Hart coefficents from beta
+        inv_t1 = 1. / (params['t1'] - KELVIN_TO_CELCIUS)
+        ln_r1 = math.log(params['r1'])
+        self.c3 = 0.
+        self.c2 = 1. / params['beta']
+        self.c1 = inv_t1 - self.c2 * ln_r1
+        SensorBase.__init__(self, config)
+    def check_faults(self, fault):
+        pass
+
+# Linear style conversion chips calibrated with two temp measurements
+class Linear(SensorBase):
+    def __init__(self, config, params):
+        adc_voltage = config.getfloat('adc_voltage', 5., above=0.)
+        slope = (params['t2'] - params['t1']) / (params['v2'] - params['v1'])
+        self.gain = adc_voltage * slope
+        self.offset = params['t1'] - params['v1'] * slope
+        SensorBase.__init__(self, config)
+    def calc_temp(self, adc):
+        return adc * self.gain + self.offset
+    def calc_adc(self, temp):
+        return (temp - self.offset) / self.gain
+    def check_faults(self, fault):
+        pass

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -5,87 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging, threading
 import pins
-
-
-######################################################################
-# Sensors
-######################################################################
-
-KELVIN_TO_CELCIUS = -273.15
-
-# Thermistor calibrated with three temp measurements
-class Thermistor:
-    def __init__(self, config, params):
-        self.pullup = config.getfloat('pullup_resistor', 4700., above=0.)
-        # Calculate Steinhart-Hart coefficents from temp measurements
-        inv_t1 = 1. / (params['t1'] - KELVIN_TO_CELCIUS)
-        inv_t2 = 1. / (params['t2'] - KELVIN_TO_CELCIUS)
-        inv_t3 = 1. / (params['t3'] - KELVIN_TO_CELCIUS)
-        ln_r1 = math.log(params['r1'])
-        ln_r2 = math.log(params['r2'])
-        ln_r3 = math.log(params['r3'])
-        ln3_r1, ln3_r2, ln3_r3 = ln_r1**3, ln_r2**3, ln_r3**3
-
-        inv_t12, inv_t13 = inv_t1 - inv_t2, inv_t1 - inv_t3
-        ln_r12, ln_r13 = ln_r1 - ln_r2, ln_r1 - ln_r3
-        ln3_r12, ln3_r13 = ln3_r1 - ln3_r2, ln3_r1 - ln3_r3
-
-        self.c3 = ((inv_t12 - inv_t13 * ln_r12 / ln_r13)
-                   / (ln3_r12 - ln3_r13 * ln_r12 / ln_r13))
-        self.c2 = (inv_t12 - self.c3 * ln3_r12) / ln_r12
-        self.c1 = inv_t1 - self.c2 * ln_r1 - self.c3 * ln3_r1
-    def calc_temp(self, adc):
-        adc = max(.00001, min(.99999, adc))
-        r = self.pullup * adc / (1.0 - adc)
-        ln_r = math.log(r)
-        inv_t = self.c1 + self.c2 * ln_r + self.c3 * ln_r**3
-        return 1.0/inv_t + KELVIN_TO_CELCIUS
-    def calc_adc(self, temp):
-        inv_t = 1. / (temp - KELVIN_TO_CELCIUS)
-        if self.c3:
-            y = (self.c1 - inv_t) / (2. * self.c3)
-            x = math.sqrt((self.c2 / (3. * self.c3))**3 + y**2)
-            ln_r = math.pow(x - y, 1./3.) - math.pow(x + y, 1./3.)
-        else:
-            ln_r = (inv_t - self.c1) / self.c2
-        r = math.exp(ln_r)
-        return r / (self.pullup + r)
-
-# Thermistor calibrated from one temp measurement and its beta
-class ThermistorBeta(Thermistor):
-    def __init__(self, config, params):
-        self.pullup = config.getfloat('pullup_resistor', 4700., above=0.)
-        # Calculate Steinhart-Hart coefficents from beta
-        inv_t1 = 1. / (params['t1'] - KELVIN_TO_CELCIUS)
-        ln_r1 = math.log(params['r1'])
-        self.c3 = 0.
-        self.c2 = 1. / params['beta']
-        self.c1 = inv_t1 - self.c2 * ln_r1
-
-# Linear style conversion chips calibrated with two temp measurements
-class Linear:
-    def __init__(self, config, params):
-        adc_voltage = config.getfloat('adc_voltage', 5., above=0.)
-        slope = (params['t2'] - params['t1']) / (params['v2'] - params['v1'])
-        self.gain = adc_voltage * slope
-        self.offset = params['t1'] - params['v1'] * slope
-    def calc_temp(self, adc):
-        return adc * self.gain + self.offset
-    def calc_adc(self, temp):
-        return (temp - self.offset) / self.gain
-
-# Available sensors
-Sensors = {
-    "EPCOS 100K B57560G104F": {
-        'class': Thermistor, 't1': 25., 'r1': 100000.,
-        't2': 150., 'r2': 1641.9, 't3': 250., 'r3': 226.15 },
-    "ATC Semitec 104GT-2": {
-        'class': Thermistor, 't1': 20., 'r1': 126800.,
-        't2': 150., 'r2': 1360., 't3': 300., 'r3': 80.65 },
-    "NTC 100K beta 3950": {
-        'class': ThermistorBeta, 't1': 25., 'r1': 100000., 'beta': 3950. },
-    "AD595": { 'class': Linear, 't1': 25., 'v1': .25, 't2': 300., 'v2': 3.022 },
-}
+import extras.sensors as sensors
 
 
 ######################################################################
@@ -107,10 +27,12 @@ class PrinterHeater:
     def __init__(self, printer, config):
         self.printer = printer
         self.name = config.get_name()
-        sensor_params = config.getchoice('sensor_type', Sensors)
-        self.sensor = sensor_params['class'](config, sensor_params)
-        self.min_temp = config.getfloat('min_temp', minval=0.)
-        self.max_temp = config.getfloat('max_temp', above=self.min_temp)
+        sensor_name = config.get('sensor')
+        logging.debug("Add heater: {}, sensor: {}".
+                          format(self.name, sensor_name))
+        self.sensor = sensors.load_sensor(
+            config.getsection('sensor %s'%sensor_name))
+        self.min_temp, self.max_temp = self.sensor.get_min_max_temp()
         self.min_extrude_temp = config.getfloat(
             'min_extrude_temp', 170., minval=self.min_temp, maxval=self.max_temp)
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
@@ -129,13 +51,9 @@ class PrinterHeater:
                 'pwm_cycle_time', 0.100, above=0., maxval=REPORT_TIME)
             self.mcu_pwm.setup_cycle_time(pwm_cycle_time)
         self.mcu_pwm.setup_max_duration(MAX_HEAT_TIME)
-        self.mcu_adc = pins.setup_pin(printer, 'adc', config.get('sensor_pin'))
-        adc_range = [self.sensor.calc_adc(self.min_temp),
-                     self.sensor.calc_adc(self.max_temp)]
-        self.mcu_adc.setup_minmax(SAMPLE_TIME, SAMPLE_COUNT,
-                                  minval=min(adc_range), maxval=max(adc_range))
-        self.mcu_adc.setup_adc_callback(REPORT_TIME, self.adc_callback)
-        is_fileoutput = self.mcu_adc.get_mcu().is_fileoutput()
+        self.mcu_sensor = self.sensor.get_mcu()
+        self.mcu_sensor.setup_adc_callback(REPORT_TIME, self.adc_callback)
+        is_fileoutput = self.mcu_sensor.get_mcu().is_fileoutput()
         self.can_extrude = self.min_extrude_temp <= 0. or is_fileoutput
         self.control = algo(self, config)
         # pwm caching
@@ -148,14 +66,16 @@ class PrinterHeater:
             and abs(value - self.last_pwm_value) < 0.05):
             # No significant change in value - can suppress update
             return
-        pwm_time = read_time + REPORT_TIME + SAMPLE_TIME*SAMPLE_COUNT
+        pwm_time = read_time + REPORT_TIME + self.sensor.sample_time*self.sensor.sample_count
         self.next_pwm_time = pwm_time + 0.75 * MAX_HEAT_TIME
         self.last_pwm_value = value
         logging.debug("%s: pwm=%.3f@%.3f (from %.3f@%.3f [%.3f])",
                       self.name, value, pwm_time,
                       self.last_temp, self.last_temp_time, self.target_temp)
         self.mcu_pwm.set_pwm(pwm_time, value)
-    def adc_callback(self, read_time, read_value):
+    def adc_callback(self, read_time, read_value, fault = 0):
+        if (fault):
+            self.sensor.check_faults(fault)
         temp = self.sensor.calc_temp(read_value)
         with self.lock:
             self.last_temp = temp
@@ -171,7 +91,7 @@ class PrinterHeater:
         with self.lock:
             self.target_temp = degrees
     def get_temp(self, eventtime):
-        print_time = self.mcu_adc.get_mcu().estimated_print_time(eventtime) - 5.
+        print_time = self.mcu_sensor.get_mcu().estimated_print_time(eventtime) - 5.
         with self.lock:
             if self.last_temp_time < print_time:
                 return 0., self.target_temp


### PR DESCRIPTION
         Now thermistors are defined as a module with own section to
         make configuration simple. Sensor section is referenced
         in extruder or heater_bed section to get temperature read from
         correct sensor.
         This is also preparation for coming thermocouple/RTD support.

Signed-off-by: cruwaller <cruwaller@gmail.com>