### PR TITLE
config: Add LCD configuration to printer-trony-x5s-2017.cfg

### DIFF
--- a/config/printer-tronxy-x5s-2017.cfg
+++ b/config/printer-tronxy-x5s-2017.cfg
@@ -77,3 +77,13 @@ max_velocity: 300
 max_accel: 1000
 max_z_velocity: 20
 max_z_accel: 100
+
+[display]
+lcd_type: st7920
+cs_pin: PA1
+sclk_pin: PC0
+sid_pin: PA3
+
+# buttons are:
+# PD2, PD3: encoder
+# PA5: click


### PR DESCRIPTION
I've added the LCD configuration for the Tronxy X5S printer and its
Melzi board and 128x64 LCD. This is tested and works.

I've also added the pins for the encoder, but that is untested.

Signed-off-by: christian mock <cm@tahina.priv.at>