### PR TITLE
extruder: Add SET_PRESSURE_ADVANCE command.

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -71,6 +71,9 @@ The following standard commands are supported:
   cycles. If the WRITE_FILE parameter is enabled, then the file
   /tmp/heattest.txt will be created with a log of all temperature
   samples taken during the test.
+- `SET_PRESSURE_ADVANCE [ADVANCE=<pressure_advance>]
+  [ADVANCE_LOOKAHEAD_TIME=<pressure_advance_lookahead_time>]`:
+  Set pressure advance parameters.
 - `RESTART`: This will cause the host software to reload its config
   and perform an internal reset. This command will not clear error
   state from the micro-controller (see FIRMWARE_RESTART) nor will it

--- a/klippy/extruder.py
+++ b/klippy/extruder.py
@@ -10,6 +10,7 @@ EXTRUDE_DIFF_IGNORE = 1.02
 
 class PrinterExtruder:
     def __init__(self, printer, config):
+        self.printer = printer
         shared_heater = config.get('shared_heater', None)
         if shared_heater is None:
             self.heater = heater.PrinterHeater(printer, config)
@@ -39,12 +40,13 @@ class PrinterExtruder:
         self.deactivate_gcode = config.get('deactivate_gcode', '')
         self.pressure_advance = config.getfloat(
             'pressure_advance', 0., minval=0.)
-        self.pressure_advance_lookahead_time = 0.
-        if self.pressure_advance:
-            self.pressure_advance_lookahead_time = config.getfloat(
-                'pressure_advance_lookahead_time', 0.010, minval=0.)
+        self.pressure_advance_lookahead_time = config.getfloat(
+            'pressure_advance_lookahead_time', 0.010, minval=0.)
         self.need_motor_enable = True
         self.extrude_pos = 0.
+        self.printer.lookup_object('gcode').register_command(
+            "SET_PRESSURE_ADVANCE", self.cmd_SET_PRESSURE_ADVANCE,
+            desc=self.cmd_SET_PRESSURE_ADVANCE_help)
     def get_heater(self):
         return self.heater
     def set_active(self, print_time, is_active):
@@ -104,7 +106,7 @@ class PrinterExtruder:
         return move.max_cruise_v2
     def lookahead(self, moves, flush_count, lazy):
         lookahead_t = self.pressure_advance_lookahead_time
-        if not lookahead_t:
+        if not self.pressure_advance or not lookahead_t:
             return flush_count
         # Calculate max_corner_v - the speed the head will accelerate
         # to after cornering.
@@ -220,6 +222,21 @@ class PrinterExtruder:
             step_const(move_time, start_pos, -retract_d, retract_v, accel)
             start_pos -= retract_d
         self.extrude_pos = start_pos
+    cmd_SET_PRESSURE_ADVANCE_help = "Set pressure advance parameters"
+    def cmd_SET_PRESSURE_ADVANCE(self, params):
+        self.printer.lookup_object('toolhead').get_last_move_time()
+        gcode = self.printer.lookup_object('gcode')
+        if 'ADVANCE' in params:
+            v = gcode.get_float('ADVANCE', params)
+            self.pressure_advance = v if v > 0. else 0.
+        if 'ADVANCE_LOOKAHEAD_TIME' in params:
+            v = gcode.get_float('ADVANCE_LOOKAHEAD_TIME', params)
+            self.pressure_advance_lookahead_time = v if v > 0. else 0.
+        gcode.respond_info(
+            "pressure_advance: %.6f\n"
+            "pressure_advance_lookahead_time: %.6f\n" % (
+                self.pressure_advance,
+                self.pressure_advance_lookahead_time))
 
 # Dummy extruder class used when a printer has no extruder at all
 class DummyExtruder:


### PR DESCRIPTION
Allows setting `pressure_advance` and `pressure_advance_lookahead_time` from g-code. Not sure whether it's a good idea to respond with the new values, but I added that anyway. Let me know if I should change anything.

Fixes issue #247.

Signed-off-by: Michael Barbour <barbour.michael.0@gmail.com>