### PR TITLE
Add  pid temp controlled fan

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -233,14 +233,35 @@
 #   will go into a shutdown state. Set this range just wide enough so
 #   that reasonable temperatures do not result in an error. These
 #   parameters must be provided.
-#temp: 40.0
-#   A temperature (in Celsius) that the sensor must exceed before the
-#   fan is enabled. The default is 40 Celsius.
-#fan_speed: 1.0
+#target_temp: 40.0
+#   A temperature (in Celsius) that will be the target temperature
+#max_speed: 1.0
 #   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
 #   will be set to when the sensor temperature exceeds the set value.
 #   The default is 1.0.
-
+#min_speed: 1.0
+#   The minumin fan speed (expressed as a value from 0.0 to 1.0) that the fan
+#   will be set to when the sensor temperature is the set value.
+#   The default is 0.3.
+#control: watermark
+#   Control algorithm (either watermark or pid). This parameter must
+#   be provided.
+#pid_Kp: 40
+#   Kp is the "proportional" constant for the pid. This parameter must
+#   be provided for PID heaters.
+pid_Ki: 0.2
+#   Ki is the "integral" constant for the pid. This parameter must be
+#   provided for PID heaters.
+pid_Kd: 0.1
+#   Kd is the "derivative" constant for the pid. This parameter must
+#   be provided for PID heaters.
+#pid_deriv_time: 2.0
+#   A time value (in seconds) over which the derivative in the pid
+#   will be smoothed to reduce the impact of measurement noise. The
+#   default is 2 seconds.
+#pid_integral_max:
+#   The maximum "windup" the integral term may accumulate. The default
+#   is to use the same value as max_power.
 
 # Additional micro-controllers (one may define any number of sections
 # with an "mcu" prefix). Additional micro-controllers introduce


### PR DESCRIPTION
Perhaps we could unify the temperature controlled fans and add more `control`s to support other scenarios?

This acts like a heater but in reverse adding more fan when cooling is needed.  Two modes are available `BangBang` and `Pid`. 

`min_speed` refers to the minimum speed the fan can spin when on as many fans will not spin unless sufficient power is applied.

Thought? Suggestions to improve?


Signed-off-by Douglas Hammond  <wizhippo@gmail.com>