### PR TITLE
config: Add configuration file for the Anycubic Kossel delta printer

### DIFF
--- a/config/printer-anycubic-kossel.cfg
+++ b/config/printer-anycubic-kossel.cfg
@@ -1,0 +1,101 @@
+# This file contains the configuration for the Anycubic Kossel delta
+# printer from 2016. The printer uses the TriGorilla board which is an
+# AVR ATmega2560 Arduino + RAMPS compatible board. To use this config,
+# the firmware should be compiled for the AVR atmega2560.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_a]
+step_pin: ar54
+dir_pin: !ar55
+enable_pin: !ar38
+step_distance: .0125
+endstop_pin: ^ar2
+homing_speed: 60
+position_endstop: 273.0
+arm_length: 229.4
+
+[stepper_b]
+step_pin: ar60
+dir_pin: !ar61
+enable_pin: !ar56
+step_distance: .0125
+endstop_pin: ^ar15
+
+[stepper_c]
+step_pin: ar46
+dir_pin: !ar48
+enable_pin: !ar62
+step_distance: .0125
+endstop_pin: ^ar19
+
+[extruder]
+step_pin: ar26
+dir_pin: !ar28
+enable_pin: !ar24
+step_distance: 0.010989010989
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+control: pid
+pid_Kp=25.349
+pid_Ki=1.216
+pid_Kd=132.130
+min_extrude_temp: 150
+min_temp: 0
+max_temp: 275
+#pressure_advance: 0.0
+#pressure_advance_lookahead_time: 0.010
+
+#[heater_bed]
+#heater_pin: ar8
+#sensor_type: EPCOS 100K B57560G104F
+#sensor_pin: analog14
+#control: watermark
+#min_temp: 0
+#max_temp: 130
+
+[fan]
+pin: ar9
+kick_start_time: 0.200
+
+[heater_fan extruder_cooler_fan]
+pin: ar44
+max_power: 1
+heater: extruder
+heater_temp: 50.0
+
+[mcu]
+serial: /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0
+pin_map: arduino
+
+[printer]
+kinematics: delta
+max_velocity: 500
+max_accel: 3000
+#max_z_velocity: 150
+motor_off_time: 360
+delta_radius: 99.8
+
+#[delta_calibrate]
+#radius: 50
+#manual_probe:
+#   If true, then DELTA_CALIBRATE will perform manual probing. If
+#   false, then a PROBE command will be run at each probe
+#   point. Manual probing is accomplished by manually jogging the Z
+#   position of the print head at each probe point and then issuing a
+#   NEXT extended g-code command to record the position at that
+#   point. The default is false if a [probe] config section is present
+#   and true otherwise.
+
+# "RepRapDiscount 2004 Smart Controller" type displays
+[display]
+lcd_type: hd44780
+rs_pin: ar16
+e_pin: ar17
+d4_pin: ar23
+d5_pin: ar25
+d6_pin: ar27
+d7_pin: ar29


### PR DESCRIPTION
The printer uses the TriGorilla board which is an
AVR ATmega2560 Arduino + RAMPS compatible board.
The diplay is a RepRapDiscount Smart Controller 2004 compatible one.

Signed-off-by: Peter Ruevski <dpr@ruevs.com>