### PR TITLE
Config: Changes to homing override and adding specialised example

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -482,14 +482,23 @@
 # Homing override. One may use this mechanism to run a series of
 # g-code commands in place of a G28 found in the normal g-code input.
 # This may be useful on printers that require a specific procedure to
-# home the machine.
+# home the machine or for using a probe to home the z axis against the
+# surface of the printbed.
 #[homing_override]
+#axes: xyz
+#   The axes for which homing uses the override section.
+#   The default is xyz which uses the override definition for all
+#   G28 operations. If the override is used for homing z with a
+#   probe at a safe position one can define "axes: z". This only
+#   uses the override when the homing request inlucdes the z axis.
+#   This way one can still home x and y axis without changing the z
+#   position of the printhead.
 #gcode:
 #   A list of G-Code commands (one per line) to execute in place of
 #   all G28 commands found in the normal g-code input. If a G28 is
 #   contained in this list of commands then it will invoke the normal
 #   homing procedure for the printer. The commands listed here must
-#   home all axes. This parameter must be provided.
+#   home the axes defined above. This parameter must be provided.
 #set_position_x:
 #set_position_y:
 #set_position_z:


### PR DESCRIPTION
Added a config parameter to define the homing override axis. This way one can still home x and y axis without the z-probe cycle coming in the way.

I also added my full BLTouch configuration as I use it with my Creality3D Ender 3 printer. This contains hints on how to get it working and may serve as a more detailed example for using the BLTouch with an actual printer.

Signed-off-by: Hans Raaf <hr-klipper@oderwat.de>