### PR TITLE
Extras: Probing does reply with the z position where the probe triggers.

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -76,6 +76,10 @@ class PrinterProbe:
             if "Timeout during endstop homing" in reason:
                 reason += HINT_TIMEOUT
             raise self.gcode.error(reason)
+        kin = toolhead.get_kinematics()
+        pos = kin.get_position()
+        self.gcode.respond_info(
+            "probe z: %.3f" % (pos[2]))
         self.gcode.reset_last_position()
     cmd_QUERY_PROBE_help = "Return the status of the z-probe"
     def cmd_QUERY_PROBE(self, params):


### PR DESCRIPTION
This change will make the "PROBE" command actually reply with the
z-position where the probe triggers. As this command is called
internally for the BED_TILT_CALIBRATE and Z_TILT_ADJUST those commands
will also give a response while probing, which I see as advantage over
the silent operation.

This change also lets one define some gcode for a repeatable probing
test to meassure the quality of the sensor and overall probing accuracy.

Signed-off-by: Hans Raaf <hr-klipper@oderwat.de>