### PR TITLE
Add Generic Configuration File for Re-Arm (LPC1768) / Modify Display delay to work with Re-Arm

### DIFF
--- a/config/generic-re-arm.cfg
+++ b/config/generic-re-arm.cfg
@@ -7,9 +7,9 @@
 
 [stepper_x]
 step_pin: P2.1
-dir_pin: P0.11aa
+dir_pin: P0.11
 enable_pin: !P0.10
-step_distance: .00313
+step_distance: .0125
 endstop_pin: ^P1.24
 #endstop_pin: ^P1.25
 position_endstop: 0.5
@@ -23,7 +23,7 @@ homing_speed: 50
 step_pin: P2.2
 dir_pin: P0.20
 enable_pin: !P0.19
-step_distance: .00313
+step_distance: .0125
 endstop_pin: ^P1.26
 #endstop_pin: ^P1.27
 position_endstop: 0
@@ -36,7 +36,7 @@ dir_pin: P0.22
 enable_pin: !P0.21
 step_distance: .0025
 endstop_pin: ^P1.29
-endstop_pin: ^P1.28
+#endstop_pin: ^P1.28
 position_endstop: 0.5
 position_min: 0
 position_max: 200
@@ -51,7 +51,6 @@ filament_diameter: 1.750
 heater_pin: P2.5
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: P0.23
-control: pid
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -71,10 +70,7 @@ max_temp: 250
 heater_pin: P2.7
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: P0.24
-control: pid
-pid_Kp: 87.017
-pid_Ki: 3.586
-pid_Kd: 226.644
+control: watermark
 min_temp: 0
 max_temp: 130
 
@@ -82,7 +78,7 @@ max_temp: 130
 pin: P2.4
 
 [mcu]
-serial: /dev/ttyACM0
+serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00
 
 [printer]
 kinematics: cartesian

--- a/config/generic-re-arm.cfg
+++ b/config/generic-re-arm.cfg
@@ -95,7 +95,7 @@ max_z_accel: 100
 #[display]
 #lcd_type: st7920
 #cs_pin: P0.16
-#sclk_pin: P0.18
-#sid_pin: P0.15
+#sclk_pin: P0.15
+#sid_pin: P0.18
 
 

--- a/config/generic-re-arm.cfg
+++ b/config/generic-re-arm.cfg
@@ -1,8 +1,6 @@
 # This file contains common pin mappings for Re-Arm. To use this
 # config, the firmware should be compiled for the LPC176x.
 
-# THIS FILE HAS NOT BEEN TESTED - PROCEED WITH CAUTION!
-
 # See the example.cfg file for a description of available parameters.
 
 [stepper_x]
@@ -90,12 +88,13 @@ max_z_accel: 100
 
 # "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
 # Re-Arm will only work with this type of display
-# Currently not working as of commit 711a69396f9201a939dbd0be24c3c5d4e3898d33
-# Reported in issue #405
 #[display]
 #lcd_type: st7920
 #cs_pin: P0.16
 #sclk_pin: P0.15
 #sid_pin: P0.18
+#chip_delay needs to be set to the below for the LCD to initialise correctly.
+#chip_delay: .000040
+
 
 

--- a/config/generic-re-arm.cfg
+++ b/config/generic-re-arm.cfg
@@ -1,0 +1,105 @@
+# This file contains common pin mappings for Re-Arm. To use this
+# config, the firmware should be compiled for the LPC176x.
+
+# THIS FILE HAS NOT BEEN TESTED - PROCEED WITH CAUTION!
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: P2.1
+dir_pin: P0.11aa
+enable_pin: !P0.10
+step_distance: .00313
+endstop_pin: ^P1.24
+#endstop_pin: ^P1.25
+position_endstop: 0.5
+position_min: 0
+position_max: 200
+homing_speed: 50
+
+# The stepper_y section is used to describe the Y axis as well as the
+# stepper controlling the X-Y movement.
+[stepper_y]
+step_pin: P2.2
+dir_pin: P0.20
+enable_pin: !P0.19
+step_distance: .00313
+endstop_pin: ^P1.26
+#endstop_pin: ^P1.27
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: P2.3
+dir_pin: P0.22
+enable_pin: !P0.21
+step_distance: .0025
+endstop_pin: ^P1.29
+endstop_pin: ^P1.28
+position_endstop: 0.5
+position_min: 0
+position_max: 200
+
+[extruder]
+step_pin: P2.0
+dir_pin: P0.5
+enable_pin: !P0.4
+step_distance: .0011365 
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: P2.5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P0.23
+control: pid
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+#[extruder1]
+#step_pin: P2.8
+#dir_pin: P2.13
+#enable_pin: !P4.29
+#heater_pin: P2.4
+#sensor_pin: P0.25
+#...
+
+[heater_bed]
+heater_pin: P2.7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P0.24
+control: pid
+pid_Kp: 87.017
+pid_Ki: 3.586
+pid_Kd: 226.644
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: P2.4
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+
+# "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
+# Re-Arm will only work with this type of display
+# Currently not working as of commit 711a69396f9201a939dbd0be24c3c5d4e3898d33
+# Reported in issue #405
+#[display]
+#lcd_type: st7920
+#cs_pin: P0.16
+#sclk_pin: P0.18
+#sid_pin: P0.15
+
+

--- a/klippy/extras/display.py
+++ b/klippy/extras/display.py
@@ -161,7 +161,7 @@ HD44780_chars = [
 # ST7920 (128x64 graphics) lcd chip
 ######################################################################
 
-ST7920_DELAY = .000020 # Spec says 72us, but faster is possible in practice
+ST7920_DELAY = .000040 # Spec says 72us, but faster is possible in practice
 
 class ST7920:
     char_right_arrow = '\x1a'

--- a/klippy/extras/display.py
+++ b/klippy/extras/display.py
@@ -161,7 +161,7 @@ HD44780_chars = [
 # ST7920 (128x64 graphics) lcd chip
 ######################################################################
 
-ST7920_DELAY = .000040 # Spec says 72us, but faster is possible in practice
+ST7920_DELAY = .000020 # Spec says 72us, but faster is possible in practice
 
 class ST7920:
     char_right_arrow = '\x1a'


### PR DESCRIPTION
Re-Arm is a Smoothie LPC1768 replacement for the Arduino Mega. Due to this the pinout is slightly different to the smoothieboard. [Board]( https://bit.ly/2lcv3ts) & [Pinout](https://bit.ly/2JKaseW)

Pinout tested in personal config file - see log file in issue #405. LCD does not work currently, but pinout is there for when and if it is resolved. 

Note: Smoothie based LPC176* boards do not work with the 2004 style display only the st7920 Full Graphic Controller

Signed-off-by: Ax Smith-Laffin (ax@darknetweb.co.uk)