### PR TITLE
add setting [printer].mainsync to select mcu for main sync

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1012,3 +1012,11 @@
 # Replicape support - see the generic-replicape.cfg file for further
 # details.
 #[replicape]
+
+
+# Synchronisation master selection
+# the master is usually the anonymous [mcu]
+# if no [mcu] section exists, you have to select the master mcu instead
+#[printer]
+#mainsync = mcu ramps
+#   select mcu used as synchronisation master (section name)

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1014,9 +1014,20 @@
 #[replicape]
 
 
-# Synchronisation master selection
-# the master is usually the anonymous [mcu]
-# if no [mcu] section exists, you have to select the master mcu instead
+# Main mcu.
+# The time of each mcu is synchronized to the time of the main mcu.
+# The main mcu is usually implicitly defined by the [mcu] section.
+# The "mainsync" setting allows to explicitly select a main mcu
+# section instead.
+# This also allows to ommit the anonymous [mcu], which can ease the
+# handling of pin configurations, because the configuration is more
+# constistent and every pin has a prefix.
+# Preferably mainsync should be assigned to the mcu that handles
+# X and Y axes, because these need strict synchronization.
+# However, some tests indicate that synchronization works well for
+# steppers distributed across several mcus.
 #[printer]
-#mainsync = mcu ramps
-#   select mcu used as synchronisation master (section name)
+#mainsync: mcu ramps2
+#   select mcu used as synchronisation master (exact section name)
+#[mcu ramps1]
+#[mcu ramps2]

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -408,7 +408,9 @@ software:
   *curtime*.
 * Print time. The print time is synchronized to the main
   micro-controller clock (the micro-controller defined in the "[mcu]"
-  config section). It is a floating point number stored as seconds and
+  config section or explicitly selected by the "mainsync" setting
+  in the "[printer]" section).
+  The time is a floating point number stored as seconds and
   is relative to when the main mcu was last restarted. It is possible
   to convert from a "print time" to the main micro-controller's
   hardware clock by multiplying the print time by the mcu's statically

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -806,12 +806,12 @@ def add_printer_objects(config):
         raise error("mainsync section [%s] does not exist" % (mainsync_section))
     s = config.getsection(mainsync_section)
     logging.info("mainsync: [%s]", mainsync_section)
-    printer.add_object(s.section, MCU(printer, s, mainsync))
+    printer.add_object(s.section, MCU(s, mainsync))
     for s in config.get_prefix_sections('mcu'):
         if s.section == 'mcu' or s.section.startswith('mcu '):
             if s.section != mainsync_section:
                 sync = clocksync.SecondarySync(reactor, mainsync)
-                printer.add_object(s.section, MCU(printer, s, sync))
+                printer.add_object(s.section, MCU(s, sync))
 
 def get_printer_mcu(printer, name):
     if name == 'mcu':

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -804,14 +804,14 @@ def add_printer_objects(config):
     mainsync_section = s.get("mainsync", "mcu")
     if not config.has_section(mainsync_section):
         raise error("mainsync section [%s] does not exist" % (mainsync_section))
+    s = config.getsection(mainsync_section)
     logging.info("mainsync: [%s]", mainsync_section)
+    printer.add_object(s.section, MCU(printer, s, mainsync))
     for s in config.get_prefix_sections('mcu'):
         if s.section == 'mcu' or s.section.startswith('mcu '):
-            if s.section == mainsync_section:
-                sync = mainsync
-            else:
+            if s.section != mainsync_section:
                 sync = clocksync.SecondarySync(reactor, mainsync)
-            printer.add_object(s.section, MCU(printer, s, sync))
+                printer.add_object(s.section, MCU(printer, s, sync))
 
 def get_printer_mcu(printer, name):
     if name == 'mcu':


### PR DESCRIPTION
This allows to select the mcu section that provides the clock synchronization master.

I also tried code to automatically default to the mcu handling stepper_x by extracting the mcu name from step_pin, but I think this solution is much shorter, simpler, more clear and has less dependencies.

This also removes the need for an anonymous mcu section.

Usage:
```
[printer]
mainsync = mcu ramps
```

Default is "mcu".

Signed-off-by: Harald Gutsche <hg42@gmx.net>