### PR TITLE
display: UC1701 support, Add M117, Update M73

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -522,10 +522,11 @@
 # Support for a display attached to the micro-controller.
 #[display]
 #lcd_type:
-#   The type of LCD chip in use. This may be either "hd44780" (which
-#   is used in "RepRapDiscount 2004 Smart Controller" type displays)
-#   or "st7920" (which is used in "RepRapDiscount 12864 Full Graphic
-#   Smart Controller" type displays). This parameter must be provided.
+#   The type of LCD chip in use. This may be "hd44780" (which is
+#   used in "RepRapDiscount 2004 Smart Controller" type displays),
+#   "st7920" (which is used in "RepRapDiscount 12864 Full Graphic
+#   Smart Controller" type displays) or "uc1701" (which is used
+#   in MKS Mini 12864 tyep displays). This parameter must be provided.
 #rs_pin:
 #e_pin:
 #d4_pin:
@@ -537,8 +538,12 @@
 #cs_pin:
 #sclk_pin:
 #sid_pin:
-#   The pins connected to an st7920 type lcd. These parameters must be
-#   provided when using an st7920 display.
+#   The pins connected to an st7920 or uc1701 type lcd. These parameters
+#   must be provided when using an st7920 or uc1701 display.
+#a0_pin:
+#   The additional pin required by an uc1701 type LCD.  This parameter
+#   must be provided when using an uc1701 display.
+
 
 
 # Custom thermistors (one may define any number of sections with a

--- a/config/printer-creality-ender2.cfg
+++ b/config/printer-creality-ender2.cfg
@@ -1,0 +1,93 @@
+# This file contains common pin mappings for the 2017 Creality
+# Ender 2. To use this config, the firmware should be compiled for the
+# AVR atmega1284p.
+
+# Note, a number of Melzi boards are shipped without a bootloader. In
+# that case, an external programmer will be needed to flash a
+# bootloader to the board (for example, see
+# http://www.instructables.com/id/Flashing-a-Bootloader-to-the-CR-10/
+# ). Once that is done, one should be able to use the standard "make
+# flash" command to flash Klipper.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: PD7
+dir_pin: !PC5
+enable_pin: !PD6
+step_distance: .0125
+endstop_pin: ^PC2
+position_endstop: 0
+position_max: 165
+homing_speed: 50
+
+[stepper_y]
+step_pin: PC6
+dir_pin: !PC7
+enable_pin: !PD6
+step_distance: .0125
+endstop_pin: ^PC3
+position_endstop: 0
+position_max: 165
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB3
+dir_pin: PB2
+enable_pin: !PA5
+step_distance: .0025
+endstop_pin: ^PC4
+position_endstop: 0.0
+position_max: 205
+
+[extruder]
+step_pin: PB1
+dir_pin: !PB0
+enable_pin: !PD6
+step_distance: 0.010753
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+max_extrude_only_distance: 500.0
+max_extrude_only_velocity: 200.0
+max_extrude_only_accel: 500.0
+heater_pin: PD5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA7
+control: pid
+pid_Kp: 21.73
+pid_Ki: 1.54
+pid_Kd: 76.55
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PD4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA6
+control: pid
+# PID Tuned for 60C
+pid_Kp: 72.487
+pid_Ki: 2.279
+pid_Kd: 576.275
+min_temp: 0
+max_temp: 100
+
+[fan]
+pin: PB4
+
+[mcu]
+serial: /dev/ttyUSB0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1500
+max_z_velocity: 5
+max_z_accel: 100
+
+[display]
+lcd_type: uc1701
+cs_pin: PA3
+sclk_pin: PB7
+sid_pin: PB5
+a0_pin: PA1

--- a/klippy/extras/display.py
+++ b/klippy/extras/display.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 # Copyright (C) 2018  Aleph Objects, Inc <marcio@alephobjects.com>
+# Copyright (C) 2018  Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
@@ -22,6 +23,8 @@ class HD44780:
     char_speed_factor = '\x02'
     char_clock = '\x03'
     char_degrees = '\x04'
+    char_usb = '\x05'
+    char_sd = '\x06'
     def __init__(self, config):
         self.printer = config.get_printer()
         # pin config
@@ -154,6 +157,24 @@ HD44780_chars = [
     0b00000,
     0b00000,
     0b00000,
+    # USB
+    0b01110,
+	0b01110,
+	0b01110,
+	0b11111,
+	0b11111,
+	0b11111,
+	0b00100,
+	0b00100,
+    # SD
+    0b00000,
+	0b00111,
+	0b01111,
+	0b11111,
+	0b11111,
+	0b11111,
+	0b11111,
+	0b00000,
 ]
 
 
@@ -279,6 +300,439 @@ class ST7920:
         zeros = bytearray(32)
         for new_data, old_data, fb_id in self.graphics_framebuffers:
             new_data[:] = zeros
+
+######################################################################
+# UC1701 Character Set
+# Font - Terminal 8x14, Row Major, MSB
+# 
+######################################################################
+
+CHAR_SET = [
+bytearray('\x00\x00\x00\x7E\xC3\x81\xA5\x81\xBD\x99\xC3\x7E\x00\x00'), # Code 1
+bytearray('\x00\x00\x00\x7E\xFF\xFF\xDB\xFF\xC3\xE7\xFF\x7E\x00\x00'), # Code 2
+bytearray('\x00\x00\x00\x00\x44\xEE\xFE\xFE\xFE\x7C\x38\x10\x00\x00'), # Code 3
+bytearray('\x00\x00\x00\x10\x38\x7C\xFE\xFE\x7C\x38\x10\x00\x00\x00'), # Code 4
+bytearray('\x00\x00\x00\x18\x3C\x3C\xFF\xE7\xE7\x18\x18\x7E\x00\x00'), # Code 5
+bytearray('\x00\x00\x00\x18\x3C\x7E\xFF\xFF\x7E\x18\x18\x7E\x00\x00'), # Code 6
+bytearray('\x00\x00\x00\x00\x00\x00\x3C\x7E\x7E\x3C\x00\x00\x00\x00'), # Code 7
+bytearray('\x00\x00\xFF\xFF\xFF\xFF\xC3\x81\x81\xC3\xFF\xFF\xFF\xFF'), # Code 8
+bytearray('\x00\x00\x00\x00\x3C\x7E\x66\x42\x42\x66\x7E\x3C\x00\x00'), # Code 9
+bytearray('\x00\x00\xFF\xFF\xC3\x81\x99\xBD\xBD\x99\x81\xC3\xFF\xFF'), # Code 10
+bytearray('\x00\x00\x00\x3E\x0E\x3A\x72\xF8\xCC\xCC\xCC\x78\x00\x00'), # Code 11
+bytearray('\x00\x00\x00\x3C\x66\x66\x66\x3C\x18\x7E\x18\x18\x00\x00'), # Code 12
+bytearray('\x00\x00\x00\x1F\x19\x19\x1F\x18\x18\x78\xF8\x70\x00\x00'), # Code 13
+bytearray('\x00\x00\x00\x7F\x63\x7F\x63\x63\x63\x67\xE7\xE6\xC0\x00'), # Code 14
+bytearray('\x00\x00\x00\x00\x18\xDB\x7E\xE7\xE7\x7E\xDB\x18\x00\x00'), # Code 15
+bytearray('\x00\x00\x00\x80\xC0\xE0\xF8\xFE\xF8\xE0\xC0\x80\x00\x00'), # Code 16
+bytearray('\x00\x00\x00\x02\x06\x0E\x3E\xFE\x3E\x0E\x06\x02\x00\x00'), # Code 17
+bytearray('\x00\x00\x00\x18\x3C\x7E\x18\x18\x18\x7E\x3C\x18\x00\x00'), # Code 18
+bytearray('\x00\x00\x00\x66\x66\x66\x66\x66\x00\x00\x66\x66\x00\x00'), # Code 19
+bytearray('\x00\x00\x00\x7F\xDB\xDB\xDB\x7B\x1B\x1B\x1B\x1B\x00\x00'), # Code 20
+bytearray('\x00\x00\x00\x7E\x63\x30\x3C\x66\x66\x3C\x0C\xC6\x7E\x00'), # Code 21
+bytearray('\x00\x00\x00\x00\x00\x00\x00\x00\x00\xFE\xFE\xFE\x00\x00'), # Code 22
+bytearray('\x00\x00\x00\x18\x3C\x7E\x18\x18\x18\x7E\x3C\x18\x7E\x00'), # Code 23
+bytearray('\x00\x00\x00\x18\x3C\x7E\x18\x18\x18\x18\x18\x18\x00\x00'), # Code 24
+bytearray('\x00\x00\x00\x18\x18\x18\x18\x18\x18\x7E\x3C\x18\x00\x00'), # Code 25
+bytearray('\x00\x00\x00\x00\x00\x18\x0C\xFE\x0C\x18\x00\x00\x00\x00'), # Code 26
+bytearray('\x00\x00\x00\x00\x00\x30\x60\xFE\x60\x30\x00\x00\x00\x00'), # Code 27
+bytearray('\x00\x00\x00\x00\x00\x00\xC0\xC0\xC0\xFE\x00\x00\x00\x00'), # Code 28
+bytearray('\x00\x00\x00\x00\x00\x24\x66\xFF\x66\x24\x00\x00\x00\x00'), # Code 29
+bytearray('\x00\x00\x00\x00\x10\x10\x38\x38\x7C\x7C\xFE\xFE\x00\x00'), # Code 30
+bytearray('\x00\x00\x00\x00\xFE\xFE\x7C\x7C\x38\x38\x10\x10\x00\x00'), # Code 31
+bytearray('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'), # Code 32
+bytearray('\x00\x00\x00\x30\x78\x78\x78\x30\x30\x00\x30\x30\x00\x00'), # Code 33
+bytearray('\x00\x00\x00\x66\x66\x66\x24\x00\x00\x00\x00\x00\x00\x00'), # Code 34
+bytearray('\x00\x00\x00\x6C\x6C\xFE\x6C\x6C\x6C\xFE\x6C\x6C\x00\x00'), # Code 35
+bytearray('\x00\x00\x30\x30\x7C\xC0\xC0\x78\x0C\x0C\xF8\x30\x30\x00'), # Code 36
+bytearray('\x00\x00\x00\x00\x00\xC4\xCC\x18\x30\x60\xCC\x8C\x00\x00'), # Code 37
+bytearray('\x00\x00\x00\x70\xD8\xD8\x70\xFA\xDE\xCC\xDC\x76\x00\x00'), # Code 38
+bytearray('\x00\x00\x00\x30\x30\x30\x60\x00\x00\x00\x00\x00\x00\x00'), # Code 39
+bytearray('\x00\x00\x00\x0C\x18\x30\x60\x60\x60\x30\x18\x0C\x00\x00'), # Code 40
+bytearray('\x00\x00\x00\x60\x30\x18\x0C\x0C\x0C\x18\x30\x60\x00\x00'), # Code 41
+bytearray('\x00\x00\x00\x00\x00\x66\x3C\xFF\x3C\x66\x00\x00\x00\x00'), # Code 42
+bytearray('\x00\x00\x00\x00\x00\x18\x18\x7E\x18\x18\x00\x00\x00\x00'), # Code 43
+bytearray('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x38\x38\x60\x00'), # Code 44
+bytearray('\x00\x00\x00\x00\x00\x00\x00\xFE\x00\x00\x00\x00\x00\x00'), # Code 45
+bytearray('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x38\x38\x00\x00'), # Code 46
+bytearray('\x00\x00\x00\x00\x02\x06\x0C\x18\x30\x60\xC0\x80\x00\x00'), # Code 47
+bytearray('\x00\x00\x00\x7C\xC6\xCE\xDE\xD6\xF6\xE6\xC6\x7C\x00\x00'), # Code 48
+bytearray('\x00\x00\x00\x10\x30\xF0\x30\x30\x30\x30\x30\xFC\x00\x00'), # Code 49
+bytearray('\x00\x00\x00\x78\xCC\xCC\x0C\x18\x30\x60\xCC\xFC\x00\x00'), # Code 50
+bytearray('\x00\x00\x00\x78\xCC\x0C\x0C\x38\x0C\x0C\xCC\x78\x00\x00'), # Code 51
+bytearray('\x00\x00\x00\x0C\x1C\x3C\x6C\xCC\xFE\x0C\x0C\x1E\x00\x00'), # Code 52
+bytearray('\x00\x00\x00\xFC\xC0\xC0\xC0\xF8\x0C\x0C\xCC\x78\x00\x00'), # Code 53
+bytearray('\x00\x00\x00\x38\x60\xC0\xC0\xF8\xCC\xCC\xCC\x78\x00\x00'), # Code 54
+bytearray('\x00\x00\x00\xFE\xC6\xC6\x06\x0C\x18\x30\x30\x30\x00\x00'), # Code 55
+bytearray('\x00\x00\x00\x78\xCC\xCC\xEC\x78\xDC\xCC\xCC\x78\x00\x00'), # Code 56
+bytearray('\x00\x00\x00\x78\xCC\xCC\xCC\x7C\x18\x18\x30\x70\x00\x00'), # Code 57
+bytearray('\x00\x00\x00\x00\x00\x38\x38\x00\x00\x38\x38\x00\x00\x00'), # Code 58
+bytearray('\x00\x00\x00\x00\x00\x38\x38\x00\x00\x38\x38\x18\x30\x00'), # Code 59
+bytearray('\x00\x00\x00\x0C\x18\x30\x60\xC0\x60\x30\x18\x0C\x00\x00'), # Code 60
+bytearray('\x00\x00\x00\x00\x00\x00\x7E\x00\x7E\x00\x00\x00\x00\x00'), # Code 61
+bytearray('\x00\x00\x00\x60\x30\x18\x0C\x06\x0C\x18\x30\x60\x00\x00'), # Code 62
+bytearray('\x00\x00\x00\x78\xCC\x0C\x18\x30\x30\x00\x30\x30\x00\x00'), # Code 63
+bytearray('\x00\x00\x00\x7C\xC6\xC6\xDE\xDE\xDE\xC0\xC0\x7C\x00\x00'), # Code 64
+bytearray('\x00\x00\x00\x30\x78\xCC\xCC\xCC\xFC\xCC\xCC\xCC\x00\x00'), # Code 65
+bytearray('\x00\x00\x00\xFC\x66\x66\x66\x7C\x66\x66\x66\xFC\x00\x00'), # Code 66
+bytearray('\x00\x00\x00\x3C\x66\xC6\xC0\xC0\xC0\xC6\x66\x3C\x00\x00'), # Code 67
+bytearray('\x00\x00\x00\xF8\x6C\x66\x66\x66\x66\x66\x6C\xF8\x00\x00'), # Code 68
+bytearray('\x00\x00\x00\xFE\x62\x60\x64\x7C\x64\x60\x62\xFE\x00\x00'), # Code 69
+bytearray('\x00\x00\x00\xFE\x66\x62\x64\x7C\x64\x60\x60\xF0\x00\x00'), # Code 70
+bytearray('\x00\x00\x00\x3C\x66\xC6\xC0\xC0\xCE\xC6\x66\x3E\x00\x00'), # Code 71
+bytearray('\x00\x00\x00\xCC\xCC\xCC\xCC\xFC\xCC\xCC\xCC\xCC\x00\x00'), # Code 72
+bytearray('\x00\x00\x00\x78\x30\x30\x30\x30\x30\x30\x30\x78\x00\x00'), # Code 73
+bytearray('\x00\x00\x00\x1E\x0C\x0C\x0C\x0C\xCC\xCC\xCC\x78\x00\x00'), # Code 74
+bytearray('\x00\x00\x00\xE6\x66\x6C\x6C\x78\x6C\x6C\x66\xE6\x00\x00'), # Code 75
+bytearray('\x00\x00\x00\xF0\x60\x60\x60\x60\x62\x66\x66\xFE\x00\x00'), # Code 76
+bytearray('\x00\x00\x00\xC6\xEE\xFE\xFE\xD6\xC6\xC6\xC6\xC6\x00\x00'), # Code 77
+bytearray('\x00\x00\x00\xC6\xC6\xE6\xF6\xFE\xDE\xCE\xC6\xC6\x00\x00'), # Code 78
+bytearray('\x00\x00\x00\x38\x6C\xC6\xC6\xC6\xC6\xC6\x6C\x38\x00\x00'), # Code 79
+bytearray('\x00\x00\x00\xFC\x66\x66\x66\x7C\x60\x60\x60\xF0\x00\x00'), # Code 80
+bytearray('\x00\x00\x00\x38\x6C\xC6\xC6\xC6\xCE\xDE\x7C\x0C\x1E\x00'), # Code 81
+bytearray('\x00\x00\x00\xFC\x66\x66\x66\x7C\x6C\x66\x66\xE6\x00\x00'), # Code 82
+bytearray('\x00\x00\x00\x78\xCC\xCC\xC0\x70\x18\xCC\xCC\x78\x00\x00'), # Code 83
+bytearray('\x00\x00\x00\xFC\xB4\x30\x30\x30\x30\x30\x30\x78\x00\x00'), # Code 84
+bytearray('\x00\x00\x00\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\x78\x00\x00'), # Code 85
+bytearray('\x00\x00\x00\xCC\xCC\xCC\xCC\xCC\xCC\xCC\x78\x30\x00\x00'), # Code 86
+bytearray('\x00\x00\x00\xC6\xC6\xC6\xC6\xD6\xD6\x6C\x6C\x6C\x00\x00'), # Code 87
+bytearray('\x00\x00\x00\xCC\xCC\xCC\x78\x30\x78\xCC\xCC\xCC\x00\x00'), # Code 88
+bytearray('\x00\x00\x00\xCC\xCC\xCC\xCC\x78\x30\x30\x30\x78\x00\x00'), # Code 89
+bytearray('\x00\x00\x00\xFE\xCE\x98\x18\x30\x60\x62\xC6\xFE\x00\x00'), # Code 90
+bytearray('\x00\x00\x00\x3C\x30\x30\x30\x30\x30\x30\x30\x3C\x00\x00'), # Code 91
+bytearray('\x00\x00\x00\x00\x80\xC0\x60\x30\x18\x0C\x06\x02\x00\x00'), # Code 92
+bytearray('\x00\x00\x00\x3C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x3C\x00\x00'), # Code 93
+bytearray('\x00\x00\x10\x38\x6C\xC6\x00\x00\x00\x00\x00\x00\x00\x00'), # Code 94
+bytearray('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xFF\x00'), # Code 95
+bytearray('\x00\x00\x30\x30\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00'), # Code 96
+bytearray('\x00\x00\x00\x00\x00\x00\x78\x0C\x7C\xCC\xCC\x76\x00\x00'), # Code 97
+bytearray('\x00\x00\x00\xE0\x60\x60\x7C\x66\x66\x66\x66\xDC\x00\x00'), # Code 98
+bytearray('\x00\x00\x00\x00\x00\x00\x78\xCC\xC0\xC0\xCC\x78\x00\x00'), # Code 99
+bytearray('\x00\x00\x00\x1C\x0C\x0C\x7C\xCC\xCC\xCC\xCC\x76\x00\x00'), # Code 100
+bytearray('\x00\x00\x00\x00\x00\x00\x78\xCC\xFC\xC0\xCC\x78\x00\x00'), # Code 101
+bytearray('\x00\x00\x00\x38\x6C\x60\x60\xF8\x60\x60\x60\xF0\x00\x00'), # Code 102
+bytearray('\x00\x00\x00\x00\x00\x00\x76\xCC\xCC\xCC\x7C\x0C\xCC\x78'), # Code 103
+bytearray('\x00\x00\x00\xE0\x60\x60\x6C\x76\x66\x66\x66\xE6\x00\x00'), # Code 104
+bytearray('\x00\x00\x00\x18\x18\x00\x78\x18\x18\x18\x18\x7E\x00\x00'), # Code 105
+bytearray('\x00\x00\x00\x0C\x0C\x00\x3C\x0C\x0C\x0C\x0C\xCC\xCC\x78'), # Code 106
+bytearray('\x00\x00\x00\xE0\x60\x60\x66\x6C\x78\x6C\x66\xE6\x00\x00'), # Code 107
+bytearray('\x00\x00\x00\x78\x18\x18\x18\x18\x18\x18\x18\x7E\x00\x00'), # Code 108
+bytearray('\x00\x00\x00\x00\x00\x00\xFC\xD6\xD6\xD6\xD6\xC6\x00\x00'), # Code 109
+bytearray('\x00\x00\x00\x00\x00\x00\xF8\xCC\xCC\xCC\xCC\xCC\x00\x00'), # Code 110
+bytearray('\x00\x00\x00\x00\x00\x00\x78\xCC\xCC\xCC\xCC\x78\x00\x00'), # Code 111
+bytearray('\x00\x00\x00\x00\x00\x00\xDC\x66\x66\x66\x66\x7C\x60\xF0'), # Code 112
+bytearray('\x00\x00\x00\x00\x00\x00\x76\xCC\xCC\xCC\xCC\x7C\x0C\x1E'), # Code 113
+bytearray('\x00\x00\x00\x00\x00\x00\xEC\x6E\x76\x60\x60\xF0\x00\x00'), # Code 114
+bytearray('\x00\x00\x00\x00\x00\x00\x78\xCC\x60\x18\xCC\x78\x00\x00'), # Code 115
+bytearray('\x00\x00\x00\x00\x20\x60\xFC\x60\x60\x60\x6C\x38\x00\x00'), # Code 116
+bytearray('\x00\x00\x00\x00\x00\x00\xCC\xCC\xCC\xCC\xCC\x76\x00\x00'), # Code 117
+bytearray('\x00\x00\x00\x00\x00\x00\xCC\xCC\xCC\xCC\x78\x30\x00\x00'), # Code 118
+bytearray('\x00\x00\x00\x00\x00\x00\xC6\xC6\xD6\xD6\x6C\x6C\x00\x00'), # Code 119
+bytearray('\x00\x00\x00\x00\x00\x00\xC6\x6C\x38\x38\x6C\xC6\x00\x00'), # Code 120
+bytearray('\x00\x00\x00\x00\x00\x00\x66\x66\x66\x66\x3C\x0C\x18\xF0'), # Code 121
+bytearray('\x00\x00\x00\x00\x00\x00\xFC\x8C\x18\x60\xC4\xFC\x00\x00'), # Code 122
+bytearray('\x00\x00\x00\x1C\x30\x30\x60\xC0\x60\x30\x30\x1C\x00\x00'), # Code 123
+bytearray('\x00\x00\x00\x18\x18\x18\x18\x00\x18\x18\x18\x18\x00\x00'), # Code 124
+bytearray('\x00\x00\x00\xE0\x30\x30\x18\x0C\x18\x30\x30\xE0\x00\x00'), # Code 125
+bytearray('\x00\x00\x00\x73\xDA\xCE\x00\x00\x00\x00\x00\x00\x00\x00'), # Code 126
+bytearray('\x00\x00\x00\x00\x00\x10\x38\x6C\xC6\xC6\xFE\x00\x00\x00'), # Code 127
+bytearray('\x00\x00\x00\x78\xCC\xCC\xC0\xC0\xC0\xCC\xCC\x78\x30\xF0'), # Code 128
+bytearray('\x00\x00\x00\xCC\xCC\x00\xCC\xCC\xCC\xCC\xCC\x76\x00\x00'), # Code 129
+bytearray('\x00\x00\x0C\x18\x30\x00\x78\xCC\xFC\xC0\xCC\x78\x00\x00'), # Code 130
+bytearray('\x00\x00\x30\x78\xCC\x00\x78\x0C\x7C\xCC\xCC\x76\x00\x00'), # Code 131
+bytearray('\x00\x00\x00\xCC\xCC\x00\x78\x0C\x7C\xCC\xCC\x76\x00\x00'), # Code 132
+bytearray('\x00\x00\xC0\x60\x30\x00\x78\x0C\x7C\xCC\xCC\x76\x00\x00'), # Code 133
+bytearray('\x00\x00\x38\x6C\x6C\x38\xF8\x0C\x7C\xCC\xCC\x76\x00\x00'), # Code 134
+bytearray('\x00\x00\x00\x00\x00\x00\x78\xCC\xC0\xC0\xCC\x78\x30\xF0'), # Code 135
+bytearray('\x00\x00\x30\x78\xCC\x00\x78\xCC\xFC\xC0\xC0\x7C\x00\x00'), # Code 136
+bytearray('\x00\x00\x00\xCC\xCC\x00\x78\xCC\xFC\xC0\xC0\x7C\x00\x00'), # Code 137
+bytearray('\x00\x00\xC0\x60\x30\x00\x78\xCC\xFC\xC0\xC0\x7C\x00\x00'), # Code 138
+bytearray('\x00\x00\x00\x6C\x6C\x00\x78\x18\x18\x18\x18\x7E\x00\x00'), # Code 139
+bytearray('\x00\x00\x10\x38\x6C\x00\x78\x18\x18\x18\x18\x7E\x00\x00'), # Code 140
+bytearray('\x00\x00\x60\x30\x18\x00\x78\x18\x18\x18\x18\x7E\x00\x00'), # Code 141
+bytearray('\x00\x00\x00\xCC\x00\x30\x78\xCC\xCC\xFC\xCC\xCC\x00\x00'), # Code 142
+bytearray('\x00\x00\x78\xCC\xCC\x78\x78\xCC\xCC\xFC\xCC\xCC\x00\x00'), # Code 143
+bytearray('\x00\x00\x0C\x18\x30\xFC\xC4\xC0\xF8\xC0\xC4\xFC\x00\x00'), # Code 144
+bytearray('\x00\x00\x00\x00\x00\x00\xFE\x1B\x7F\xD8\xD8\xEF\x00\x00'), # Code 145
+bytearray('\x00\x00\x00\x3E\x78\xD8\xD8\xFE\xD8\xD8\xD8\xDE\x00\x00'), # Code 146
+bytearray('\x00\x00\x30\x78\xCC\x00\x78\xCC\xCC\xCC\xCC\x78\x00\x00'), # Code 147
+bytearray('\x00\x00\x00\xCC\xCC\x00\x78\xCC\xCC\xCC\xCC\x78\x00\x00'), # Code 148
+bytearray('\x00\x00\xC0\x60\x30\x00\x78\xCC\xCC\xCC\xCC\x78\x00\x00'), # Code 149
+bytearray('\x00\x00\x30\x78\xCC\x00\xCC\xCC\xCC\xCC\xCC\x76\x00\x00'), # Code 150
+bytearray('\x00\x00\xC0\x60\x30\x00\xCC\xCC\xCC\xCC\xCC\x76\x00\x00'), # Code 151
+bytearray('\x00\x00\x00\x66\x66\x00\x66\x66\x66\x66\x3C\x0C\x18\xF0'), # Code 152
+bytearray('\x00\x00\xCC\x00\x78\xCC\xCC\xCC\xCC\xCC\xCC\x78\x00\x00'), # Code 153
+bytearray('\x00\x00\xCC\x00\xCC\xCC\xCC\xCC\xCC\xCC\xCC\x78\x00\x00'), # Code 154
+bytearray('\x00\x00\x00\x30\x30\x78\xCC\xC0\xC0\xCC\x78\x30\x30\x00'), # Code 155
+bytearray('\x00\x00\x3C\x66\x60\x60\x60\xFC\x60\x60\xC0\xFE\x00\x00'), # Code 156
+bytearray('\x00\x00\xCC\xCC\xCC\xCC\x78\xFC\x30\xFC\x30\x30\x00\x00'), # Code 157
+bytearray('\x00\x00\xF0\x88\x88\x88\xF0\x88\x9E\x8C\x8D\x86\x00\x00'), # Code 158
+bytearray('\x00\x00\x0E\x1B\x18\x18\x7E\x18\x18\x18\xD8\x70\x00\x00'), # Code 159
+bytearray('\x00\x00\x0C\x18\x30\x00\x78\x0C\x7C\xCC\xCC\x76\x00\x00'), # Code 160
+bytearray('\x00\x00\x0C\x18\x30\x00\x78\x18\x18\x18\x18\x7E\x00\x00'), # Code 161
+bytearray('\x00\x00\x0C\x18\x30\x00\x78\xCC\xCC\xCC\xCC\x78\x00\x00'), # Code 162
+bytearray('\x00\x00\x0C\x18\x30\x00\xCC\xCC\xCC\xCC\xCC\x76\x00\x00'), # Code 163
+bytearray('\x00\x00\x00\x76\xDC\x00\xF8\xCC\xCC\xCC\xCC\xCC\x00\x00'), # Code 164
+bytearray('\x00\x00\x76\xDC\x00\xC6\xE6\xF6\xDE\xCE\xC6\xC6\x00\x00'), # Code 165
+bytearray('\x00\x00\x00\x78\xCC\xCC\x7E\x00\xFE\x00\x00\x00\x00\x00'), # Code 166
+bytearray('\x00\x00\x00\x78\xCC\xCC\x78\x00\xFE\x00\x00\x00\x00\x00'), # Code 167
+bytearray('\x00\x00\x00\x30\x30\x00\x30\x60\xC0\xC0\xCC\x78\x00\x00'), # Code 168
+bytearray('\x00\x00\x00\x00\x00\x00\x00\xFC\xC0\xC0\xC0\x00\x00\x00'), # Code 169
+bytearray('\x00\x00\x00\x00\x00\x00\x00\xFC\x0C\x0C\x0C\x00\x00\x00'), # Code 170
+bytearray('\x00\x00\x00\x42\xC6\xCC\xD8\x30\x6E\xC3\x86\x0C\x1F\x00'), # Code 171
+bytearray('\x00\x00\x00\x63\xE6\x6C\x78\x37\x6F\xDB\xB3\x3F\x03\x00'), # Code 172
+bytearray('\x00\x00\x00\x30\x30\x00\x30\x30\x78\x78\x78\x30\x00\x00'), # Code 173
+bytearray('\x00\x00\x00\x00\x00\x00\x33\x66\xCC\xCC\x66\x33\x00\x00'), # Code 174
+bytearray('\x00\x00\x00\x00\x00\x00\xCC\x66\x33\x33\x66\xCC\x00\x00'), # Code 175
+bytearray('\x00\x00\x24\x92\x49\x24\x92\x49\x24\x92\x49\x24\x92\x49'), # Code 176
+bytearray('\x00\x00\x55\xAA\x55\xAA\x55\xAA\x55\xAA\x55\xAA\x55\xAA'), # Code 177
+bytearray('\x00\x00\x6D\xDB\xB6\x6D\xDB\xB6\x6D\xDB\xB6\x6D\xDB\xB6'), # Code 178
+bytearray('\x00\x00\x18\x18\x18\x18\x18\x18\x18\x18\x18\x18\x18\x18'), # Code 179
+bytearray('\x00\x00\x18\x18\x18\x18\x18\xF8\x18\x18\x18\x18\x18\x18'), # Code 180
+bytearray('\x00\x00\x18\x18\x18\x18\xF8\x18\x18\xF8\x18\x18\x18\x18'), # Code 181
+bytearray('\x00\x00\x66\x66\x66\x66\x66\xE6\x66\x66\x66\x66\x66\x66'), # Code 182
+bytearray('\x00\x00\x00\x00\x00\x00\x00\xFE\x66\x66\x66\x66\x66\x66'), # Code 183
+bytearray('\x00\x00\x00\x00\x00\x00\xF8\x18\x18\xF8\x18\x18\x18\x18'), # Code 184
+bytearray('\x00\x00\x66\x66\x66\x66\xE6\x06\x06\xE6\x66\x66\x66\x66'), # Code 185
+bytearray('\x00\x00\x66\x66\x66\x66\x66\x66\x66\x66\x66\x66\x66\x66'), # Code 186
+bytearray('\x00\x00\x00\x00\x00\x00\xFE\x06\x06\xE6\x66\x66\x66\x66'), # Code 187
+bytearray('\x00\x00\x66\x66\x66\x66\xE6\x06\x06\xFE\x00\x00\x00\x00'), # Code 188
+bytearray('\x00\x00\x66\x66\x66\x66\x66\xFE\x00\x00\x00\x00\x00\x00'), # Code 189
+bytearray('\x00\x00\x18\x18\x18\x18\xF8\x18\x18\xF8\x00\x00\x00\x00'), # Code 190
+bytearray('\x00\x00\x00\x00\x00\x00\x00\xF8\x18\x18\x18\x18\x18\x18'), # Code 191
+bytearray('\x00\x00\x18\x18\x18\x18\x18\x1F\x00\x00\x00\x00\x00\x00'), # Code 192
+bytearray('\x00\x00\x18\x18\x18\x18\x18\xFF\x00\x00\x00\x00\x00\x00'), # Code 193
+bytearray('\x00\x00\x00\x00\x00\x00\x00\xFF\x18\x18\x18\x18\x18\x18'), # Code 194
+bytearray('\x00\x00\x18\x18\x18\x18\x18\x1F\x18\x18\x18\x18\x18\x18'), # Code 195
+bytearray('\x00\x00\x00\x00\x00\x00\x00\xFF\x00\x00\x00\x00\x00\x00'), # Code 196
+bytearray('\x00\x00\x18\x18\x18\x18\x18\xFF\x18\x18\x18\x18\x18\x18'), # Code 197
+bytearray('\x00\x00\x18\x18\x18\x18\x1F\x18\x18\x1F\x18\x18\x18\x18'), # Code 198
+bytearray('\x00\x00\x66\x66\x66\x66\x66\x67\x66\x66\x66\x66\x66\x66'), # Code 199
+bytearray('\x00\x00\x66\x66\x66\x66\x67\x60\x60\x7F\x00\x00\x00\x00'), # Code 200
+bytearray('\x00\x00\x00\x00\x00\x00\x7F\x60\x60\x67\x66\x66\x66\x66'), # Code 201
+bytearray('\x00\x00\x66\x66\x66\x66\xE7\x00\x00\xFF\x00\x00\x00\x00'), # Code 202
+bytearray('\x00\x00\x00\x00\x00\x00\xFF\x00\x00\xE7\x66\x66\x66\x66'), # Code 203
+bytearray('\x00\x00\x66\x66\x66\x66\x67\x60\x60\x67\x66\x66\x66\x66'), # Code 204
+bytearray('\x00\x00\x00\x00\x00\x00\xFF\x00\x00\xFF\x00\x00\x00\x00'), # Code 205
+bytearray('\x00\x00\x66\x66\x66\x66\xE7\x00\x00\xE7\x66\x66\x66\x66'), # Code 206
+bytearray('\x00\x00\x18\x18\x18\x18\xFF\x00\x00\xFF\x00\x00\x00\x00'), # Code 207
+bytearray('\x00\x00\x66\x66\x66\x66\x66\xFF\x00\x00\x00\x00\x00\x00'), # Code 208
+bytearray('\x00\x00\x00\x00\x00\x00\xFF\x00\x00\xFF\x18\x18\x18\x18'), # Code 209
+bytearray('\x00\x00\x00\x00\x00\x00\x00\xFF\x66\x66\x66\x66\x66\x66'), # Code 210
+bytearray('\x00\x00\x66\x66\x66\x66\x66\x7F\x00\x00\x00\x00\x00\x00'), # Code 211
+bytearray('\x00\x00\x18\x18\x18\x18\x1F\x18\x18\x1F\x00\x00\x00\x00'), # Code 212
+bytearray('\x00\x00\x00\x00\x00\x00\x1F\x18\x18\x1F\x18\x18\x18\x18'), # Code 213
+bytearray('\x00\x00\x00\x00\x00\x00\x00\x7F\x66\x66\x66\x66\x66\x66'), # Code 214
+bytearray('\x00\x00\x66\x66\x66\x66\x66\xE7\x66\x66\x66\x66\x66\x66'), # Code 215
+bytearray('\x00\x00\x18\x18\x18\x18\xFF\x00\x00\xFF\x18\x18\x18\x18'), # Code 216
+bytearray('\x00\x00\x18\x18\x18\x18\x18\xF8\x00\x00\x00\x00\x00\x00'), # Code 217
+bytearray('\x00\x00\x00\x00\x00\x00\x00\x1F\x18\x18\x18\x18\x18\x18'), # Code 218
+bytearray('\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'), # Code 219
+bytearray('\x00\x00\x00\x00\x00\x00\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF'), # Code 220
+bytearray('\x00\x00\xF0\xF0\xF0\xF0\xF0\xF0\xF0\xF0\xF0\xF0\xF0\xF0'), # Code 221
+bytearray('\x00\x00\x0F\x0F\x0F\x0F\x0F\x0F\x0F\x0F\x0F\x0F\x0F\x0F'), # Code 222
+bytearray('\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF\x00\x00\x00\x00\x00\x00'), # Code 223
+bytearray('\x00\x00\x00\x00\x00\x00\x76\xDE\xCC\xCC\xDE\x76\x00\x00'), # Code 224
+bytearray('\x00\x00\x00\x78\xCC\xCC\xD8\xCC\xCC\xCC\xF8\xC0\x60\x00'), # Code 225
+bytearray('\x00\x00\x00\xFC\xCC\xCC\xC0\xC0\xC0\xC0\xC0\xC0\x00\x00'), # Code 226
+bytearray('\x00\x00\x00\xFE\x6C\x6C\x6C\x6C\x6C\x6C\x6C\x66\x00\x00'), # Code 227
+bytearray('\x00\x00\x00\xFC\xC4\x64\x60\x30\x60\x64\xC4\xFC\x00\x00'), # Code 228
+bytearray('\x00\x00\x00\x00\x00\x00\x7E\xC8\xCC\xCC\xCC\x78\x00\x00'), # Code 229
+bytearray('\x00\x00\x00\x00\x00\x00\x66\x66\x66\x66\x66\x7B\x60\xC0'), # Code 230
+bytearray('\x00\x00\x00\x00\x00\x76\xDC\x18\x18\x18\x18\x0E\x00\x00'), # Code 231
+bytearray('\x00\x00\x00\xFC\x30\x78\xCC\xCC\xCC\x78\x30\xFC\x00\x00'), # Code 232
+bytearray('\x00\x00\x00\x78\xCC\xCC\xCC\xFC\xCC\xCC\xCC\x78\x00\x00'), # Code 233
+bytearray('\x00\x00\x00\x7C\xC6\xC6\xC6\xC6\x6C\x6C\x6C\xEE\x00\x00'), # Code 234
+bytearray('\x00\x00\x00\x3C\x60\x30\x78\xCC\xCC\xCC\xCC\x78\x00\x00'), # Code 235
+bytearray('\x00\x00\x00\x00\x00\x76\xDB\xDB\xDB\x6E\x00\x00\x00\x00'), # Code 236
+bytearray('\x00\x00\x00\x00\x06\x7C\xDE\xD6\xF6\x7C\xC0\x00\x00\x00'), # Code 237
+bytearray('\x00\x00\x00\x3C\x60\xC0\xC0\xFC\xC0\xC0\x60\x3C\x00\x00'), # Code 238
+bytearray('\x00\x00\x00\x00\x78\xCC\xCC\xCC\xCC\xCC\xCC\xCC\x00\x00'), # Code 239
+bytearray('\x00\x00\x00\x00\xFC\x00\x00\xFC\x00\x00\xFC\x00\x00\x00'), # Code 240
+bytearray('\x00\x00\x00\x00\x30\x30\xFC\x30\x30\x00\xFC\x00\x00\x00'), # Code 241
+bytearray('\x00\x00\x00\x60\x30\x18\x18\x30\x60\x00\xFC\x00\x00\x00'), # Code 242
+bytearray('\x00\x00\x00\x18\x30\x60\x60\x30\x18\x00\xFC\x00\x00\x00'), # Code 243
+bytearray('\x00\x00\x00\x00\x0E\x1B\x1B\x18\x18\x18\x18\x18\x18\x18'), # Code 244
+bytearray('\x00\x00\x18\x18\x18\x18\x18\x18\x18\xD8\xD8\x70\x00\x00'), # Code 245
+bytearray('\x00\x00\x00\x00\x30\x30\x00\xFC\x00\x30\x30\x00\x00\x00'), # Code 246
+bytearray('\x00\x00\x00\x00\x73\xDB\xCE\x00\x73\xDB\xCE\x00\x00\x00'), # Code 247
+bytearray('\x00\x00\x00\x3C\x66\x66\x66\x3C\x00\x00\x00\x00\x00\x00'), # Code 248
+bytearray('\x00\x00\x00\x00\x00\x00\x1C\x1C\x00\x00\x00\x00\x00\x00'), # Code 249
+bytearray('\x00\x00\x00\x00\x00\x00\x00\x18\x00\x00\x00\x00\x00\x00'), # Code 250
+bytearray('\x00\x00\x00\x07\x04\x04\x04\x44\x64\x34\x1C\x0C\x00\x00'), # Code 251
+bytearray('\x00\x00\x00\xD8\x6C\x6C\x6C\x6C\x00\x00\x00\x00\x00\x00'), # Code 252
+bytearray('\x00\x00\x00\x78\x0C\x18\x30\x7C\x00\x00\x00\x00\x00\x00'), # Code 253
+bytearray('\x00\x00\x00\x00\x3C\x3C\x3C\x3C\x3C\x3C\x3C\x3C\x00\x00')  # Code 254
+]
+
+
+######################################################################
+# UC1701 (128x64 graphics) lcd chip
+######################################################################
+
+UC1701_DELAY = .000020 # Seems to work okay, there is no mention in the spec to delay between
+                       # bytes but probably required on faster hardware
+
+class UC1701:
+    char_right_arrow = '\x1a'
+    CURRENT_BUF, OLD_BUF = 0, 1
+    EMPTY_CHAR = (0, 32, 255)
+    def __init__(self, config):
+        printer = config.get_printer()
+        # pin config
+        ppins = printer.lookup_object('pins')
+        pins = [ppins.lookup_pin('digital_out', config.get(name + '_pin'))
+                for name in ['cs', 'sclk', 'sid', 'a0']]
+        mcu = None
+        for pin_params in pins:
+            if mcu is not None and pin_params['chip'] != mcu:
+                raise ppins.error("uc1701 all pins must be on same mcu")
+            mcu = pin_params['chip']
+            if pin_params['invert']:
+                raise ppins.error("uc1701 can not invert pin")
+        self.pins = [pin_params['pin'] for pin_params in pins]
+        self.mcu = mcu
+        self.oid = self.mcu.create_oid()
+        self.mcu.add_config_object(self)
+        self.glyph_buffer = []
+        self.send_data_cmd = self.send_cmds_cmd = self.init_cmd = None
+        self.vram = ([bytearray(128) for i in range(8)], 
+                    [bytearray('~'*128) for i in range(8)])
+    def build_config(self):
+        self.mcu.add_config_cmd(
+            "config_uc1701 oid=%u cs_pin=%s sclk_pin=%s sid_pin=%s"
+            " a0_pin=%s delay_ticks=%d" % (
+                self.oid, self.pins[0], self.pins[1], self.pins[2],
+                self.pins[3], self.mcu.seconds_to_clock(UC1701_DELAY)))
+        cmd_queue = self.mcu.alloc_command_queue()
+        self.send_cmds_cmd = self.mcu.lookup_command(
+            "uc1701_send_cmds oid=%c cmds=%*s", cq=cmd_queue)
+        self.send_data_cmd = self.mcu.lookup_command(
+            "uc1701_send_data oid=%c data=%*s", cq=cmd_queue)
+        self.init_cmd = self.mcu.lookup_command(
+            "uc1701_init oid=%c cmds=%*s", cq=cmd_queue)
+    def send(self, cmds, is_data=False):
+        cmd_type = self.send_cmds_cmd
+        if is_data:
+            cmd_type = self.send_data_cmd
+        cmd_type.send([self.oid, cmds], reqclock=BACKGROUND_PRIORITY_CLOCK)        
+    def init(self):
+        init_cmds = [0xE2, # System reset
+                     0x40, # Set display to start at line 0
+                     0xA0, # Set SEG direction
+                     0xC8, # Set COM Direction
+                     0xA2, # Set Bias = 1/9
+                     0x2C, # Boost ON
+                     0x2E, # Voltage regulator on
+                     0x2F, # Voltage follower on
+                     0xF8, # Set booster ratio
+                     0x00, # Booster ratio value (4x)
+                     0x23, # Set resistor ratio (3)
+                     0x81, # Set Electronic Volume
+                     0x28, # Electronic volume value (40)
+                     0xAC, # Set static indicator off
+                     0x00, # NOP 
+                     0xA6, # Disable Inverse
+                     0xAF] # Set display enable
+        self.init_cmd.send([self.oid, init_cmds], reqclock=BACKGROUND_PRIORITY_CLOCK)
+        self.flush()
+        logging.info("uc1701 initialized")
+    def flush(self):
+        new_data = self.vram[self.CURRENT_BUF]
+        old_data = self.vram[self.OLD_BUF]
+        for page in range(8):
+            if new_data[page] == old_data[page]:
+                continue
+            # Find the position of all changed bytes in this framebuffer
+            diffs = [[i, 1] for i, (nd, od) in enumerate(zip(new_data[page], old_data[page]))
+                     if nd != od]
+            # Batch together changes that are close to each other
+            for i in range(len(diffs)-2, -1, -1):
+                pos, count = diffs[i]
+                nextpos, nextcount = diffs[i+1]
+                if pos + 5 >= nextpos and nextcount < 16:
+                    diffs[i][1] = nextcount + (nextpos - pos)
+                    del diffs[i+1]
+            # Transmit
+            for col_pos, count in diffs:
+                # Set Position registers
+                ra = 0xb0 | (page & 0x0F)
+                ca_msb = 0x10 | ((col_pos >> 4) & 0x0F)
+                ca_lsb = col_pos & 0x0F
+                self.send([ra, ca_msb, ca_lsb])
+                # Send Data
+                self.send(new_data[page][col_pos:col_pos+count], is_data=True)
+            old_data[page][:] = new_data[page]
+    def set_pixel(self, pix_x, pix_y, exclusive=True):
+        page_idx = pix_y // 8
+        page_byte = 0x01 << (pix_y % 8)
+        if exclusive and self.vram[self.CURRENT_BUF][page_idx][pix_x] & page_byte:
+            #invert pixel if it has alread been set
+            self.vram[self.CURRENT_BUF][page_idx][pix_x] &= ~page_byte
+        else:
+            #set the correct pixel in the vram buffer to 1
+            self.vram[self.CURRENT_BUF][page_idx][pix_x] |= page_byte
+    def clear_pixel(self, pix_x, pix_y):
+        page_idx = pix_y // 8
+        page_byte = ~(0x01 << (pix_y % 8))
+        #set the correct pixel in the vram buffer to 0
+        self.vram[self.CURRENT_BUF][page_idx][pix_x] &= page_byte
+    def load_glyph(self, glyph_id, data):
+        if len(data) > 16:
+            data = data[:16]
+        self.glyph_buffer.append((glyph_id, data))
+        self.glyph_buffer.sort(key=lambda x: x[0])
+    def write_glyph(self, x, y, glyph_id):
+        pix_x = x*8   
+        pix_y = y*16
+        data = self.glyph_buffer[glyph_id][1]
+        for bits in data:
+            if bits:
+                bit_x = pix_x
+                for i in range(15, -1, -1):
+                    mask = 0x0001 << i
+                    if bits & mask:
+                        self.set_pixel(bit_x, pix_y)
+                    bit_x += 1
+            pix_y += 1
+    def write_text(self, x, y, data):
+        if x + len(data) > 16:
+            data = data[:16 - min(x, 16)]
+        pix_x = x*8
+        pix_y = y*16
+        for c in data:
+            c_idx = ord(c)
+            if c_idx in self.EMPTY_CHAR:
+                # Blank Character, skip it
+                pix_x += 8
+                continue
+            c_idx -= 1
+            char = CHAR_SET[c_idx]
+            bit_y = pix_y
+            for bits in char:
+                if bits:
+                    bit_x = pix_x
+                    for i in range(7, -1, -1):
+                        mask = 0x01 << i
+                        if bits & mask:
+                            self.set_pixel(bit_x, bit_y)
+                        bit_x += 1
+                bit_y += 1
+            pix_x += 8
+    def write_graphics(self, x, y, row, data):
+        if x + len(data) > 16:
+            data = data[:16 - min(x, 16)]
+        pix_x = x*8
+        pix_y = y*16 + row
+        for bits in data:
+            for i in range(7, -1, -1):
+                mask = 0x01 << i
+                if bits & mask:
+                    self.set_pixel(pix_x, pix_y)
+                pix_x += 1
+    def clear(self):
+        zeros = bytearray(128)
+        for page in self.vram[self.CURRENT_BUF]:
+            page[:] = zeros
 
 
 ######################################################################
@@ -423,7 +877,7 @@ feedrate_icon = [
 # LCD screen updates
 ######################################################################
 
-LCD_chips = { 'st7920': ST7920, 'hd44780': HD44780 }
+LCD_chips = { 'st7920': ST7920, 'hd44780': HD44780, 'uc1701' : UC1701 }
 
 class PrinterLCD:
     def __init__(self, config):
@@ -450,8 +904,12 @@ class PrinterLCD:
             self.extruder0 = self.printer.lookup_object('extruder0', None)
             self.extruder1 = self.printer.lookup_object('extruder1', None)
             self.heater_bed = self.printer.lookup_object('heater_bed', None)
+            self.prg_time = .0
             self.progress = None
+            self.msg_time = None
+            self.message = None
             self.gcode.register_command('M73', self.cmd_M73)
+            self.gcode.register_command('M117', self.cmd_M117, desc=self.cmd_M117_help)
             # Load glyphs
             self.load_glyph(self.BED1_GLYPH, heat1_icon)
             self.load_glyph(self.BED2_GLYPH, heat2_icon)
@@ -459,18 +917,22 @@ class PrinterLCD:
             self.load_glyph(self.FAN2_GLYPH, fan2_icon)
             # Start screen update timer
             self.reactor.update_timer(self.screen_update_timer, self.reactor.NOW)
-    # ST7920 Glyphs
+    # ST7920/UC1701 Glyphs
     def load_glyph(self, glyph_id, data):
-        if self.lcd_type != 'st7920':
-            return
-        glyph = [0x00] * (len(data) * 2)
-        for i, bits in enumerate(data):
-            glyph[i*2] = (bits >> 8) & 0xff
-            glyph[i*2 + 1] = bits & 0xff
-        return self.lcd_chip.load_glyph(glyph_id, glyph)
+        if self.lcd_type == 'uc1701':
+            self.lcd_chip.load_glyph(glyph_id, data)
+        elif self.lcd_type == 'st7920':
+            glyph = [0x00] * (len(data) * 2)
+            for i, bits in enumerate(data):
+                glyph[i*2] = (bits >> 8) & 0xff
+                glyph[i*2 + 1] = bits & 0xff
+            return self.lcd_chip.load_glyph(glyph_id, glyph)
     def animate_glyphs(self, eventtime, x, y, glyph_id, do_animate):
         frame = do_animate and int(eventtime) & 1
-        self.lcd_chip.write_text(x, y, (0, (glyph_id + frame)*2))
+        if self.lcd_type == 'uc1701':
+            self.lcd_chip.write_glyph(x, y, glyph_id + frame)
+        elif self.lcd_type == 'st7920':
+            self.lcd_chip.write_text(x, y, (0, (glyph_id + frame)*2))
     # Graphics drawing
     def draw_icon(self, x, y, data):
         for i, bits in enumerate(data):
@@ -499,7 +961,7 @@ class PrinterLCD:
         if self.lcd_type == 'hd44780':
             self.screen_update_hd44780(eventtime)
         else:
-            self.screen_update_st7920(eventtime)
+            self.screen_update_128x64(eventtime)
         self.lcd_chip.flush()
         return eventtime + .500
     def screen_update_hd44780(self, eventtime):
@@ -526,17 +988,37 @@ class PrinterLCD:
         gcode_info = self.gcode.get_status(eventtime)
         lcd_chip.write_text(0, 2, lcd_chip.char_speed_factor)
         self.draw_percent(1, 2, 4, gcode_info['speed_factor'])
-        # SD card print progress
-        if self.sdcard is not None:
-            info = self.sdcard.get_status(eventtime)
-            lcd_chip.write_text(7, 2, "SD")
-            self.draw_percent(9, 2, 4, info['progress'])
-        # Printing time and status
+        # Print progress
+        progress = None
         toolhead_info = self.toolhead.get_status(eventtime)
+        if self.progress is not None:
+            progress = self.progress / 100.
+            lcd_chip.write_text(8, 2, lcd_chip.char_usb)
+            if toolhead_info['status'] != "Printing":
+                # 5 second timeout when not printing
+                self.prg_time -= .5
+                if self.prg_time <= 0.:
+                    self.progress = None
+        elif self.sdcard is not None:
+            info = self.sdcard.get_status(eventtime)
+            progress = info['progress']
+            lcd_chip.write_text(8, 2, lcd_chip.char_sd)
+        if progress is not None:
+            self.draw_percent(9, 2, 4, progress)
         lcd_chip.write_text(14, 2, lcd_chip.char_clock)
         self.draw_time(15, 2, toolhead_info['printing_time'])
-        self.draw_status(0, 3, gcode_info, toolhead_info)
-    def screen_update_st7920(self, eventtime):
+        # If there is a message set by M117, display it instead of toolhead info
+        if self.message:
+            lcd_chip.write_text(0, 3, self.message)
+            if self.msg_time:
+                # Screen updates every .5 seconds
+                self.msg_time -= .5 
+                if self.msg_time <= 0.:
+                    self.message = None
+                    self.msg_time = None
+        else:
+            self.draw_status(0, 3, gcode_info, toolhead_info)
+    def screen_update_128x64(self, eventtime):
         # Heaters
         if self.extruder0 is not None:
             info = self.extruder0.get_heater().get_status(eventtime)
@@ -560,16 +1042,21 @@ class PrinterLCD:
             info = self.fan.get_status(eventtime)
             self.animate_glyphs(eventtime, 10, 0, self.FAN1_GLYPH,
                                 info['speed'] != 0.)
-            self.draw_percent(12, 0, 4, info['speed'])
-
-        progress = None
+            align = '>'if self.lcd_type == 'uc1701' else '^'
+            self.draw_percent(12, 0, 4, info['speed'], align)
         # SD card print progress
-        if self.sdcard is not None:
+        progress = None
+        toolhead_info = self.toolhead.get_status(eventtime)
+        if self.progress is not None:
+            progress = self.progress / 100.
+            if toolhead_info['status'] != "Printing":
+                # 5 second timeout when not printing
+                self.prg_time -= .5
+                if self.prg_time <= 0.:
+                    self.progress = None
+        elif self.sdcard is not None:
             info = self.sdcard.get_status(eventtime)
             progress = info['progress']
-        elif self.progress is not None:
-            progress = self.progress / 100.
-
         if progress is not None:
             if extruder_count == 1:
                 x, y, width = 0, 2, 10
@@ -577,20 +1064,17 @@ class PrinterLCD:
                 x, y, width = 10, 1, 6
             self.draw_percent(x, y, width, progress)
             self.draw_progress_bar(x, y, width, progress)
-
         # G-Code speed factor
         gcode_info = self.gcode.get_status(eventtime)
         if extruder_count == 1:
             self.draw_icon(10, 1, feedrate_icon)
-            self.draw_percent(12, 1, 4, gcode_info['speed_factor'])
-
+            align = '>'if self.lcd_type == 'uc1701' else '^'
+            self.draw_percent(12, 1, 4, gcode_info['speed_factor'], align)
         # Printing time and status
-        toolhead_info = self.toolhead.get_status(eventtime)
         printing_time = toolhead_info['printing_time']
         remaining_time = None
         if progress is not None and progress > 0:
             remaining_time = int(printing_time / progress) - printing_time
-
         # switch mode every 6s
         if remaining_time is not None and int(eventtime) % 12 < 6:
             self.lcd_chip.write_text(10, 2, "-")
@@ -598,8 +1082,17 @@ class PrinterLCD:
         else:
             offset = 1 if printing_time < 100 * 60 * 60 else 0
             self.draw_time(10 + offset, 2, printing_time)
-
-        self.draw_status(0, 3, gcode_info, toolhead_info)
+        # if there is a message set by M117, display it instead of toolhaed info
+        if self.message:
+            self.lcd_chip.write_text(0, 3, self.message)
+            if self.msg_time:
+                # Screen updates every .5 seconds
+                self.msg_time -= .5 
+                if self.msg_time <= 0.:
+                    self.message = None
+                    self.msg_time = None
+        else:
+            self.draw_status(0, 3, gcode_info, toolhead_info)
     # Screen update helpers
     def draw_heater(self, x, y, info):
         temperature, target = info['temperature'], info['target']
@@ -611,8 +1104,8 @@ class PrinterLCD:
         if self.lcd_type == 'hd44780':
             s += self.lcd_chip.char_degrees
         self.lcd_chip.write_text(x, y, s)
-    def draw_percent(self, x, y, width, value):
-        self.lcd_chip.write_text(x, y, ("%d%%" % (value * 100.,)).center(width))
+    def draw_percent(self, x, y, width, value, align='^'):
+        self.lcd_chip.write_text(x, y, '{:{}{}.0%}'.format(value, align, width))
     def draw_time(self, x, y, seconds):
         seconds = int(seconds)
         self.lcd_chip.write_text(x, y, "%02d:%02d" % (
@@ -623,9 +1116,27 @@ class PrinterLCD:
             pos = self.toolhead.get_position()
             status = "X%-4.0fY%-4.0fZ%-5.2f" % (pos[0], pos[1], pos[2])
         self.lcd_chip.write_text(x, y, status)
+    def set_message(self, msg, msg_time=None):
+        self.message = msg
+        self.msg_time = msg_time
     # print progress: M73 P<percent>
     def cmd_M73(self, params):
         self.progress = self.gcode.get_int('P', params, minval=0, maxval=100)
+        self.prg_time = 5.
+    cmd_M117_help = "Show Message on Display"
+    def cmd_M117(self, params):
+        if '#original' in params:
+            msg = params['#original']
+            if not msg.startswith('M117'):
+                # Parse out additional info if M117 recd during a print
+                start = msg.find('M117')
+                end = msg.rfind('*')
+                msg = msg[start:end]
+            if len(msg) > 5:
+                msg = msg[5:]
+                self.set_message(msg)
+            else:
+                self.set_message(None)
 
 def load_config(config):
     return PrinterLCD(config)

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,4 +5,4 @@ src-$(CONFIG_HAVE_GPIO) += gpiocmds.c stepper.c endstop.c
 src-$(CONFIG_HAVE_GPIO_ADC) += adccmds.c
 src-$(CONFIG_HAVE_GPIO_SPI) += spicmds.c
 src-$(CONFIG_HAVE_GPIO_HARD_PWM) += pwmcmds.c
-src-$(CONFIG_HAVE_USER_INTERFACE) += lcd_st7920.c lcd_hd44780.c
+src-$(CONFIG_HAVE_USER_INTERFACE) += lcd_st7920.c lcd_hd44780.c lcd_uc1701.c

--- a/src/lcd_uc1701.c
+++ b/src/lcd_uc1701.c
@@ -1,0 +1,175 @@
+// Commands for sending messages to an uc1701 lcd driver
+//
+// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+//                     Eric Callahan <arksine.code@gmail.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "basecmd.h" // oid_alloc
+#include "board/gpio.h" // gpio_out_write
+#include "board/irq.h" // irq_poll
+#include "board/misc.h" // timer_from_us
+#include "command.h" // DECL_COMMAND
+#include "sched.h" // DECL_SHUTDOWN
+
+//#define UC1701_DEBUG
+
+struct uc1701 {
+    uint32_t last_cmd_time, cmd_wait_ticks;
+    struct gpio_out sclk, sid, cs, a0;
+#ifdef UC1701_DEBUG
+    uint32_t cmd_bytes_recd, data_bytes_recd, debug_last_sent;
+#endif
+};
+
+static void 
+timer_delay(uint32_t delay_ticks) 
+{
+    uint32_t start = timer_read_time();
+    while(timer_read_time() - start < delay_ticks)
+        irq_poll();
+}
+
+
+/****************************************************************
+ * Transmit functions
+ ****************************************************************/
+
+// Write eight bits to the uc1701 via the serial interface
+static void
+uc1701_xmit_byte(struct uc1701 *u, uint8_t data)
+{
+    struct gpio_out sclk = u->sclk, sid = u->sid;
+    uint8_t i, sid_high=0;
+    for (i=0; i<8; i++) {
+        if (data & 0x80) {
+            gpio_out_toggle(sid);
+            sid_high = ~sid_high;
+            data = ~data;
+        }
+        gpio_out_toggle(sclk);
+        data <<= 1;
+        gpio_out_toggle(sclk);
+    }
+
+    if (sid_high)
+        gpio_out_toggle(sid);
+}
+
+// Transmit a series of bytes to the chip
+static void
+uc1701_xmit(struct uc1701 *u, uint8_t count, uint8_t *bytes)
+{
+    uint32_t last_cmd_time=u->last_cmd_time, cmd_wait_ticks=u->cmd_wait_ticks;
+    while (count--) {
+        uint8_t b = *bytes++;
+        while (timer_read_time() - last_cmd_time < cmd_wait_ticks)
+            irq_poll();
+        uc1701_xmit_byte(u, b);
+        last_cmd_time = timer_read_time();
+    }
+    u->last_cmd_time = last_cmd_time;
+}
+
+/****************************************************************
+ * Interface
+ ****************************************************************/
+
+void
+command_config_uc1701(uint32_t *args)
+{
+    struct uc1701 *u = oid_alloc(args[0], command_config_uc1701, sizeof(*u));
+    u->cs = gpio_out_setup(args[1], 1);
+    u->sclk = gpio_out_setup(args[2], 0);  
+    u->sid = gpio_out_setup(args[3], 0);  
+    u->a0 = gpio_out_setup(args[4], 0);
+
+    irq_disable();
+    uint32_t start = timer_read_time();
+    uc1701_xmit_byte(u, 0xE3);  // NOP
+    uint32_t end = timer_read_time();
+    irq_enable();
+    u->last_cmd_time = end;
+    uint32_t diff = end - start, delay_ticks = args[5];
+    if (delay_ticks > diff)
+        u->cmd_wait_ticks = delay_ticks - diff;
+#ifdef UC1701_DEBUG
+    output("uc1701 configured, command_wait_ticks: %u", u->cmd_wait_ticks);
+    u->cmd_bytes_recd = 0;
+    u->data_bytes_recd = 0;
+    u->debug_last_sent = 0;
+#endif
+}
+DECL_COMMAND(command_config_uc1701,
+             "config_uc1701 oid=%c cs_pin=%u sclk_pin=%u sid_pin=%u"
+             " a0_pin=%u delay_ticks=%u");
+
+void
+command_uc1701_init(uint32_t *args)
+{
+    struct uc1701 *u = oid_lookup(args[0], command_config_uc1701);
+#ifdef UC1701_DEBUG
+    output("uc1701 initializing, oid: %u init array length: %u", args[0], args[1]);
+#endif
+    gpio_out_write(u->cs, 0);   // Enable Chip
+    gpio_out_write(u->a0, 0);   // Enter Command mode
+    uint8_t len = args[1], *data = (void*)(size_t)args[2];
+    uint8_t display_all = 0xA5, normal_disp = 0xA4;
+    uc1701_xmit(u, len, data);
+    timer_delay(timer_from_us(100000));
+    uc1701_xmit_byte(u, display_all);
+    timer_delay(timer_from_us(200000));
+    uc1701_xmit_byte(u, normal_disp);
+    gpio_out_write(u->cs, 1);  // Disable Chip
+
+}
+DECL_COMMAND(command_uc1701_init, "uc1701_init oid=%c cmds=%*s");
+
+void
+command_uc1701_send_cmds(uint32_t *args)
+{
+    struct uc1701 *u = oid_lookup(args[0], command_config_uc1701);
+    uint8_t len = args[1], *data = (void*)(size_t)args[2];
+    gpio_out_write(u->cs, 0);
+    gpio_out_write(u->a0, 0); 
+    uc1701_xmit(u, len, data);
+    gpio_out_write(u->cs, 1);
+#ifdef UC1701_DEBUG
+    u->cmd_bytes_recd += len;
+#endif
+}
+DECL_COMMAND(command_uc1701_send_cmds, "uc1701_send_cmds oid=%c cmds=%*s");
+
+void
+command_uc1701_send_data(uint32_t *args)
+{
+    struct uc1701 *u = oid_lookup(args[0], command_config_uc1701);
+    uint8_t len = args[1], *data = (void*)(size_t)args[2];
+    gpio_out_write(u->cs, 0);
+    gpio_out_write(u->a0, 1);   // Enter Data Mode
+    uc1701_xmit(u, len, data);
+    gpio_out_write(u->cs, 1);
+#ifdef UC1701_DEBUG
+    u->data_bytes_recd += len;
+    if (timer_read_time() - u->debug_last_sent > 1000000) {
+        output("Command Bytes Recd: %u, Data Bytes Recd: %u", u->cmd_bytes_recd, 
+            u->data_bytes_recd);
+        u->debug_last_sent = timer_read_time();
+    }
+#endif 
+}
+DECL_COMMAND(command_uc1701_send_data, "uc1701_send_data oid=%c data=%*s");
+
+void
+uc1701_shutdown(void)
+{
+    uint8_t i;
+    struct uc1701 *u;
+    foreach_oid(i, u, command_config_uc1701) {
+        gpio_out_write(u->sclk, 0);
+        gpio_out_write(u->sid, 0);
+        gpio_out_write(u->cs, 0);  
+        gpio_out_write(u->a0, 0);
+    }
+}
+DECL_SHUTDOWN(uc1701_shutdown);


### PR DESCRIPTION
Adds support for displays equipped with a UC1701 graphics controller, such as the MKS Mini 12864.  Also included in this request:

- Support for M117 "send message" gcode.  If  M117 contains an empty string the display will return to Klipper's default.
- Add M73 support for HD44780.  SD card and USB glyphs are added to differentiate between the two.
- Fix Bug in M73 that prevented the display from updating if virtual sd is enabled
- Add 5 second timeout for M73 when not printing. 
- Add configuration for Creality Ender 2
- Update example-extras.cfg for UC1701 usage

Signed-off-by: Eric Callahan <arksine.code@gmail.com>