### PR TITLE
add pid_settle_* settings

### DIFF
--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -141,8 +141,6 @@ class ControlBangBang:
 # Proportional Integral Derivative (PID) control algo
 ######################################################################
 
-PID_SETTLE_DELTA = 1.
-PID_SETTLE_SLOPE = .1
 
 class ControlPID:
     def __init__(self, heater, config):
@@ -150,6 +148,8 @@ class ControlPID:
         self.Kp = config.getfloat('pid_Kp') / PID_PARAM_BASE
         self.Ki = config.getfloat('pid_Ki') / PID_PARAM_BASE
         self.Kd = config.getfloat('pid_Kd') / PID_PARAM_BASE
+        self.pid_settle_delta = config.getfloat('pid_settle_delta', 1., above=0.)
+        self.pid_settle_slope = config.getfloat('pid_settle_slope', .1, above=0.)
         self.min_deriv_time = config.getfloat('pid_deriv_time', 2., above=0.)
         imax = config.getfloat('pid_integral_max', heater.max_power, minval=0.)
         self.temp_integ_max = imax / self.Ki
@@ -184,8 +184,8 @@ class ControlPID:
             self.prev_temp_integ = temp_integ
     def check_busy(self, eventtime):
         temp_diff = self.heater.target_temp - self.heater.last_temp
-        return (abs(temp_diff) > PID_SETTLE_DELTA
-                or abs(self.prev_temp_deriv) > PID_SETTLE_SLOPE)
+        return (abs(temp_diff) > self.pid_settle_delta
+                or abs(self.prev_temp_deriv) > self.pid_settle_slope)
 
 
 ######################################################################


### PR DESCRIPTION
see #67, which I closed because I switched to cruwallers fork.

The patch makes the fixed constants PID_SETTLE_* in heater.py accessible in the config file.

Motivation:
There are way too different heaters to make them constant or find good defaults.
The constants only work for
* small overshoot < 1° where the printing starts when reaching the maximum overshoot
* for fast cool down (low heat capacity), where a bigger overshoot settles quickly

For example, my heated bed (300mm x 300mm x 9mm aluminum with a 2000W sauna heater) has a very high heat capacity and lots of power. This is very different from a small 40W hotend.
For such a heated bed overshooting isn't handled nice if the accepted overshoot is beyond PID_SETTLE_DELTA (which is only 1°). The heat capacity leads to a very long cool down and stays above PID_SETTLE_SLOPE for a long time (about 30 min).
Actually, my current settings are
```
pid_settle_delta = 1
pid_settle_slope = 9999
```
This effectively disables `pid_settle_slope` and starts printing when the bed first reaches 1° below the target temperature.
The amount of overshoot is already handled by the PID parameters.

Signed-off-by: Harald Gutsche <hg42@gmx.net>