### PR TITLE
display: Updates to M73, Add M117

### DIFF
--- a/config/printer-creality-ender2.cfg
+++ b/config/printer-creality-ender2.cfg
@@ -1,0 +1,87 @@
+# This file contains common pin mappings for the 2017 Creality
+# Ender 2. To use this config, the firmware should be compiled for the
+# AVR atmega1284p.
+
+# Note, a number of Melzi boards are shipped without a bootloader. In
+# that case, an external programmer will be needed to flash a
+# bootloader to the board (for example, see
+# http://www.instructables.com/id/Flashing-a-Bootloader-to-the-CR-10/
+# ). Once that is done, one should be able to use the standard "make
+# flash" command to flash Klipper.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: PD7
+dir_pin: !PC5
+enable_pin: !PD6
+step_distance: .0125
+endstop_pin: ^PC2
+position_endstop: 0
+position_max: 165
+homing_speed: 50
+
+[stepper_y]
+step_pin: PC6
+dir_pin: !PC7
+enable_pin: !PD6
+step_distance: .0125
+endstop_pin: ^PC3
+position_endstop: 0
+position_max: 165
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB3
+dir_pin: PB2
+enable_pin: !PA5
+step_distance: .0025
+endstop_pin: ^PC4
+position_endstop: 0.0
+position_max: 205
+
+[extruder]
+step_pin: PB1
+dir_pin: !PB0
+enable_pin: !PD6
+step_distance: 0.010753
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+max_extrude_only_distance: 500.0
+max_extrude_only_velocity: 200.0
+max_extrude_only_accel: 500.0
+heater_pin: PD5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA7
+control: pid
+pid_Kp: 21.73
+pid_Ki: 1.54
+pid_Kd: 76.55
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PD4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA6
+control: pid
+# PID Tuned for 60C
+pid_Kp: 72.487
+pid_Ki: 2.279
+pid_Kd: 576.275
+min_temp: 0
+max_temp: 100
+
+[fan]
+pin: PB4
+
+[mcu]
+serial: /dev/ttyUSB0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1500
+max_z_velocity: 5
+max_z_accel: 100
+


### PR DESCRIPTION
Adds M73 support for HD44780, including SD card and USB glyphs to differentiate between types of progress.  Also fixes a bug that prevents M73 from updating the screen when virtual_sd is enabled.  Finally a 5 second timeout is included to clear progress when not printing.  

Add M117 set message support.  M117 followed by an empty string will reset the display to Klipper's default.  It is also possible to set a message internally by looking up the display and calling its set_message() function, with an optional timeout.  M117 will set a message indefinitely until it is replaced with another message or cleared by an empty string.

Also included is a basic configuration for the Creality Ender 2.

Signed-off-by: Eric Callahan <arksine.code@gmail.com>