### PR TITLE
Added config for my Anycubic Kossel Plus Delta Printer.

### DIFF
--- a/config/printer-anycubic-kossel-plus-2017.cfg
+++ b/config/printer-anycubic-kossel-plus-2017.cfg
@@ -1,0 +1,107 @@
+# This file contains a configuration for the "Anycubic Kossel Linear
+# Plus Large Printing Size", "Anycubic Kossel Pulley Plus Large
+# Printing Size" and similar delta printer from 2017. The printer uses
+# the TriGorilla board which is an AVR ATmega2560 Arduino + RAMPS
+# compatible board. To use this config, the firmware should be
+# compiled for the AVR atmega2560.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_a]
+arm_length: 271.50
+step_pin: ar54
+dir_pin: !ar55
+enable_pin: !ar38
+step_distance: .0125
+endstop_pin: ^ar2
+homing_speed: 60
+# The next parameter needs to be adjusted for
+# your printer. You may want to start with 280
+# and meassure the distance from nozzle to bed.
+# This value then needs to be added.
+position_endstop: 295.6
+angle: 90
+
+[stepper_b]
+step_pin: ar60
+dir_pin: !ar61
+enable_pin: !ar56
+step_distance: .0125
+endstop_pin: ^ar15
+angle: 210
+
+[stepper_c]
+step_pin: ar46
+dir_pin: !ar48
+enable_pin: !ar62
+step_distance: .0125
+endstop_pin: ^ar19
+angle: 330
+
+[extruder]
+step_pin: ar26
+dir_pin: !ar28
+enable_pin: !ar24
+step_distance: 0.010989
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+control: pid
+pid_Kp: 25.349
+pid_Ki: 1.216
+pid_Kd: 132.130
+min_extrude_temp: 150
+min_temp: 0
+max_temp: 275
+
+#[heater_bed]
+#heater_pin: ar8
+#sensor_type: EPCOS 100K B57560G104F
+#sensor_pin: analog14
+#control: watermark
+#min_temp: 0
+#max_temp: 130
+
+[fan]
+pin: ar9
+kick_start_time: 0.200
+
+[heater_fan extruder_cooler_fan]
+pin: ar44
+
+[mcu]
+serial: /dev/ttyUSB0
+pin_map: arduino
+
+[printer]
+kinematics: delta
+max_velocity: 200
+max_accel: 3000
+max_z_velocity: 200
+motor_off_time: 360
+delta_radius: 115
+# if you want to DELTA_CALIBRATE you may need that
+#minimum_z_position: -5
+
+#[delta_calibrate]
+#radius: 115
+#manual_probe:
+#   If true, then DELTA_CALIBRATE will perform manual probing. If
+#   false, then a PROBE command will be run at each probe
+#   point. Manual probing is accomplished by manually jogging the Z
+#   position of the print head at each probe point and then issuing a
+#   NEXT extended g-code command to record the position at that
+#   point. The default is false if a [probe] config section is present
+#   and true otherwise.
+
+# "RepRapDiscount 2004 Smart Controller" type displays
+[display]
+lcd_type: hd44780
+rs_pin: ar16
+e_pin: ar17
+d4_pin: ar23
+d5_pin: ar25
+d6_pin: ar27
+d7_pin: ar29


### PR DESCRIPTION
Pretty much the same as the non plus config. But it is adjusted and tested with my actual printer. The angles are defined in a way the the coordinates make sense when watching the printer from the side where the display panel is located. I did DELTA_CALIBRATE starting with these settings and the result came really close again.

Signed-off-by: Hans Raaf <hr-klipper@oderwat.de>