### PR TITLE
Add M119 command, an alias to QUERY_ENDSTOPS to docs

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -26,6 +26,7 @@ Klipper supports the following standard G-Code commands:
 - Emergency stop: `M112`
 - Get current position: `M114`
 - Get firmware version: `M115`
+- Probe the axis endstops: `M119`
 
 For further details on the above commands see the
 [RepRap G-Code documentation](http://reprap.org/wiki/G-code).
@@ -61,7 +62,7 @@ the same command.)
 The following standard commands are supported:
 - `QUERY_ENDSTOPS`: Probe the axis endstops and report if they are
   "triggered" or in an "open" state. This command is typically used to
-  verify that an endstop is working correctly.
+  verify that an endstop is working correctly. An alias for `M119`.
 - `GET_POSITION`: Return information on the current location of the
   toolhead.
 - `SET_GCODE_OFFSET [X=<pos>|X_ADJUST=<adjust>]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -26,7 +26,7 @@ Klipper supports the following standard G-Code commands:
 - Emergency stop: `M112`
 - Get current position: `M114`
 - Get firmware version: `M115`
-- Probe the axis endstops: `M119`
+- Probe the axis endstops: `M119`, usage is discouraged in favour of `QUERY_ENDSTOPS`.
 
 For further details on the above commands see the
 [RepRap G-Code documentation](http://reprap.org/wiki/G-code).
@@ -62,7 +62,8 @@ the same command.)
 The following standard commands are supported:
 - `QUERY_ENDSTOPS`: Probe the axis endstops and report if they are
   "triggered" or in an "open" state. This command is typically used to
-  verify that an endstop is working correctly. An alias for `M119`.
+  verify that an endstop is working correctly.
+  Usage of this command is preferred over `M119`.
 - `GET_POSITION`: Return information on the current location of the
   toolhead.
 - `SET_GCODE_OFFSET [X=<pos>|X_ADJUST=<adjust>]


### PR DESCRIPTION
Fixes: #441 

It says QUERY_ENDSTOPS is an alias for M119, while in code it is vice-versa.
Still, for docs it seems to better this way, since people are used to MXXX commands first.

Signed-off-by: Yurii Soldak <ysoldak@gmail.com>