### PR TITLE
gcode: fix for GET_POSITION

### DIFF
--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -609,7 +609,10 @@ class GCodeParser:
             self.cmd_default(params)
             return
         kin = self.toolhead.get_kinematics()
-        steppers = kin.get_steppers()
+        steppers = []
+        rails = kin.get_rails()
+        for rail in rails:
+            steppers += rail.get_steppers()
         mcu_pos = " ".join(["%s:%d" % (s.get_name(), s.get_mcu_position())
                             for s in steppers])
         stepper_pos = " ".join(


### PR DESCRIPTION
I ran into this when testing mesh leveling against Klipper's latest code.  This fix simply fetches the rails from Kinematics, then concatenates the stepper lists.  

Signed-off-by: Eric Callahan <arksine.code@gmail.com>