### PR TITLE
Fix undefined behavior on SPI transaction start

### DIFF
--- a/src/avr/gpio.c
+++ b/src/avr/gpio.c
@@ -438,6 +438,10 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
     return config;
 }
 
+void spi_prepare(struct spi_config config)
+{
+}
+
 void
 spi_transfer(struct spi_config config, uint8_t receive_data
              , uint8_t len, uint8_t *data)

--- a/src/avr/gpio.h
+++ b/src/avr/gpio.h
@@ -39,6 +39,7 @@ struct spi_config {
     uint8_t spcr, spsr;
 };
 struct spi_config spi_setup(uint32_t bus, uint8_t mode, uint32_t rate);
+void spi_prepare(struct spi_config config);
 void spi_transfer(struct spi_config config, uint8_t receive_data
                   , uint8_t len, uint8_t *data);
 

--- a/src/generic/gpio.h
+++ b/src/generic/gpio.h
@@ -35,6 +35,7 @@ struct spi_config {
     uint32_t cfg;
 };
 struct spi_config spi_setup(uint32_t bus, uint8_t mode, uint32_t rate);
+void spi_prepare(struct spi_config config);
 void spi_transfer(struct spi_config config, uint8_t receive_data
                   , uint8_t len, uint8_t *data);
 

--- a/src/linux/gpio.h
+++ b/src/linux/gpio.h
@@ -23,6 +23,7 @@ struct spi_config {
     int fd;
 };
 struct spi_config spi_setup(uint32_t bus, uint8_t mode, uint32_t rate);
+void spi_prepare(struct spi_config config);
 void spi_transfer(struct spi_config config, uint8_t receive_data
                   , uint8_t len, uint8_t *data);
 

--- a/src/linux/spidev.c
+++ b/src/linux/spidev.c
@@ -57,6 +57,11 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
 }
 
 void
+spi_prepare(struct spi_config config)
+{
+}
+
+void
 spi_transfer(struct spi_config config, uint8_t receive_data
              , uint8_t len, uint8_t *data)
 {

--- a/src/sam3x8e/gpio.h
+++ b/src/sam3x8e/gpio.h
@@ -33,6 +33,7 @@ struct spi_config {
     uint32_t cfg;
 };
 struct spi_config spi_setup(uint32_t bus, uint8_t mode, uint32_t rate);
+void spi_prepare(struct spi_config config);
 void spi_transfer(struct spi_config config, uint8_t receive_data
                   , uint8_t len, uint8_t *data);
 

--- a/src/sam3x8e/spi.c
+++ b/src/sam3x8e/spi.c
@@ -96,6 +96,11 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
 }
 
 void
+spi_prepare(struct spi_config config)
+{
+}
+
+void
 spi_transfer(struct spi_config config, uint8_t receive_data
              , uint8_t len, uint8_t *data)
 {

--- a/src/simulator/gpio.c
+++ b/src/simulator/gpio.c
@@ -44,6 +44,10 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
     return (struct spi_config){ };
 }
 void
+spi_prepare(struct spi_config config)
+{
+}
+void
 spi_transfer(struct spi_config config, uint8_t receive_data
              , uint8_t len, uint8_t *data)
 {

--- a/src/spicmds.c
+++ b/src/spicmds.c
@@ -58,10 +58,12 @@ spidev_transfer(struct spidev_s *spi, uint8_t receive_data
                 , uint8_t data_len, uint8_t *data)
 {
     if (spi->flags & SF_HAVE_PIN) {
+        spi_prepare(spi->spi_config);
         gpio_out_write(spi->pin, 0);
         spi_transfer(spi->spi_config, receive_data, data_len, data);
         gpio_out_write(spi->pin, 1);
     } else {
+        spi_prepare(spi->spi_config);
         spi_transfer(spi->spi_config, receive_data, data_len, data);
     }
 }

--- a/src/stm32f1/gpio.c
+++ b/src/stm32f1/gpio.c
@@ -301,6 +301,11 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
 }
 
 void
+spi_prepare(struct spi_config config)
+{
+}
+
+void
 spi_transfer(struct spi_config config, uint8_t receive_data,
              uint8_t len, uint8_t *data)
 {

--- a/src/stm32f1/gpio.c
+++ b/src/stm32f1/gpio.c
@@ -303,15 +303,14 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
 void
 spi_prepare(struct spi_config config)
 {
+    *SPI2 = config.config;
+    LL_SPI_Enable(SPI2);
 }
 
 void
 spi_transfer(struct spi_config config, uint8_t receive_data,
              uint8_t len, uint8_t *data)
 {
-    *SPI2 = config.config;
-    LL_SPI_Enable(SPI2);
-
     while (len--) {
         LL_SPI_TransmitData8(SPI2, *data);
         while (!LL_SPI_IsActiveFlag_TXE(SPI2));

--- a/src/stm32f1/gpio.h
+++ b/src/stm32f1/gpio.h
@@ -34,6 +34,7 @@ struct spi_config {
     SPI_TypeDef config;
 };
 struct spi_config spi_setup(uint32_t bus, uint8_t mode, uint32_t rate);
+void spi_prepare(struct spi_config config);
 void spi_transfer(struct spi_config config, uint8_t receive_data,
                   uint8_t len, uint8_t *data);
 


### PR DESCRIPTION
This fixes the problem discussed in PR #453. General support for spi_prepare() is added. An implementation for the stm32f1 port is added as well.

This makes the SPI transaction sequence work that failed with PR #453:

![image](https://user-images.githubusercontent.com/1834351/42415146-c64b54d8-8245-11e8-9504-41d97f739a05.png)
