### PR TITLE
add probe X- and Y-offset to bed-leveling settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out
 *.pyc
 .config
 .config.old
+*~

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -36,6 +36,12 @@
 # Bed tilt compensation. One may define a [bed_tilt] config section to
 # enable move transformations that account for a tilted bed.
 #[bed_tilt]
+#x_offset: 0
+#y_offset: 0
+#   Unless you're using something like a Precision Piezo, your probe is
+#   offset from the nozzle by some fixed amount.  Enter that amount here.
+#   Positive values are to the left (X) and forward (Y) of the nozzle;
+#   negative values are to the right (X) and behind (Y) the nozzle.
 #x_adjust: 0
 #   The amount to add to each move's Z height for each mm on the X
 #   axis. The default is 0.

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -136,6 +136,8 @@ class ProbePointsHelper:
         self.printer = config.get_printer()
         self.callback = callback
         self.probe_points = default_points
+        self.x_offset = config.getfloat('x_offset')
+        self.y_offset = config.getfloat('y_offset')
         # Read config settings
         if default_points is None or config.get('points', None) is not None:
             points = config.get('points').split('\n')
@@ -191,8 +193,8 @@ class ProbePointsHelper:
     def move_next(self):
         x, y = self.probe_points[len(self.results)]
         curpos = self.toolhead.get_position()
-        curpos[0] = x
-        curpos[1] = y
+        curpos[0] = x+self.x_offset
+        curpos[1] = y+self.y_offset
         curpos[2] = self.horizontal_move_z
         try:
             self.toolhead.move(curpos, self.speed)


### PR DESCRIPTION
Most bed-leveling probes are offset from the nozzle.  For instance, when I center the nozzle on my printer at (110,110), the probe is at (84,70).  When probing the bed, this offset should be taken into account to get accurate x_adjust and y_adjust values.
