### PR TITLE
Download and install newer versions of bossac during installation

### DIFF
--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -16,8 +16,10 @@ install_packages()
     # AVR chip installation and building
     PKGLIST="${PKGLIST} avrdude gcc-avr binutils-avr avr-libc"
     # ARM chip installation and building
-    PKGLIST="${PKGLIST} bossa-cli stm32flash libnewlib-arm-none-eabi"
+    PKGLIST="${PKGLIST} stm32flash libnewlib-arm-none-eabi"
     PKGLIST="${PKGLIST} gcc-arm-none-eabi binutils-arm-none-eabi"
+    # latest bossac
+    PKGLIST="${PKGLIST} git usbutils"
 
     # Update system package info
     report_status "Running apt-get update..."
@@ -67,7 +69,16 @@ KLIPPY_ARGS="${SRCDIR}/klippy/klippy.py ${HOME}/printer.cfg -l /tmp/klippy.log"
 EOF
 }
 
-# Step 5: Start host software
+# Step 5: Install newer version of bossac
+install_bossac()
+{
+    report_status "Installing bossac 1.8"
+    git clone --branch 1.8 https://github.com/shumatech/BOSSA.git /tmp/bossa
+    make -C /tmp/bossa bin/bossac
+    sudo cp /tmp/bossa/bin/bossac /usr/bin/bossac
+}
+
+# Step 6: Start host software
 start_software()
 {
     report_status "Launching Klipper host software..."
@@ -100,4 +111,5 @@ install_packages
 create_virtualenv
 install_script
 install_config
+install_bossac
 start_software

--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -72,10 +72,19 @@ EOF
 # Step 5: Install newer version of bossac
 install_bossac()
 {
-    report_status "Installing bossac 1.8"
-    git clone --branch 1.8 https://github.com/shumatech/BOSSA.git /tmp/bossa
-    make -C /tmp/bossa bin/bossac
-    sudo cp /tmp/bossa/bin/bossac /usr/bin/bossac
+    if [ ! -d "${SRCDIR}/tools/bossa" ]; then
+        report_status "Installing bossac 1.8"
+        rm -rf /tmp/bossa
+        git clone --branch 1.8 https://github.com/shumatech/BOSSA.git /tmp/bossa
+        make -C /tmp/bossa bin/bossac
+        mkdir -p "${SRCDIR}/tools/bossa"
+        sudo cp /tmp/bossa/bin/bossac "${SRCDIR}/tools/bossa/bossac1.8"
+        report_status "Installing bossac 1.7-arduino"
+        git -C /tmp/bossa checkout arduino
+        make -C /tmp/bossa clean && make -C /tmp/bossa bin/bossac
+        sudo cp /tmp/bossa/bin/bossac "${SRCDIR}/tools/bossa/bossac1.7-arduino"
+    fi
+
 }
 
 # Step 6: Start host software


### PR DESCRIPTION
The `bossac` version included in the debian and ubuntu repositories is very old. One can't, for example, use it with the sam4e8e MCU. This change pulls a more recent version (1.8) from the git repository, compiles only the CLI executable and installs it in `/usr/bin`. I avoided the most recent version (1.9) for now because there are reports of that version bricking some devices by overwriting the bootloader unless the user passes a specific offset to the utility.

Let me know if you want me to change anything. I can also provide the installation as a separate script.
