### PR TITLE
bed_mesh: minor updates

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -17,6 +17,12 @@
 #[probe]
 #pin: ar15
 #   Probe detection pin. This parameter must be provided.
+#x_offset: 0.0
+#   The distance (in mm) between the probe and the nozzle along the
+#   x-axis. The default is 0.
+#y_offset: 0.0
+#   The distance (in mm) between the probe and the nozzle along the
+#   y-axis. The default is 0.
 #z_offset:
 #   The distance (in mm) between the bed and the nozzle when the probe
 #   triggers. This parameter must be provided.
@@ -65,9 +71,9 @@
 #   and true otherwise.
 
 
-# Mesh Bed Leveling.  One may define a [bed_mesh] config section
+# Mesh Bed Leveling. One may define a [bed_mesh] config section
 # to enable move transformations that offset the z axis based
-# on a mesh generated from probed points.  Note that bed_mesh
+# on a mesh generated from probed points. Note that bed_mesh
 # and bed_tilt are incompatible, both cannot be defined.
 #[bed_mesh]
 #speed: 50
@@ -76,34 +82,31 @@
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-#probe_offset:
-#   An X,Y point defining the probe's offset relative to the nozzle.
-#   This parameter must be provided.
 #min_point:
 #   An X,Y point defining the minimum coordinate to probe on
-#   the bed.  Note that this refers to the nozzle position,
+#   the bed. Note that this refers to the nozzle position,
 #   and take care that you do not define a point that will move
-#   the probe off of the bed.  This parameter must be provided.
+#   the probe off of the bed. This parameter must be provided.
 #max_point:
 #   An X,Y point defining the maximum coordinate to probe on
-#   the bed.  Follow the same precautions as listed in min_point.
+#   the bed. Follow the same precautions as listed in min_point.
 #   Also note that this does not necessarily define the last point
-#   probed, only the maximum coordinate.  This parameter must be provided.
+#   probed, only the maximum coordinate. This parameter must be provided.
 #probe_count: 3,3
 #   A comma separated pair of integer values (X,Y) defining the number
 #   of points to probe along each axis. A single value is also valid,
-#   in which case that value will be for both axes.  Default is 3,3
+#   in which case that value will be for both axes. Default is 3,3
 #   which probes a 3x3 grid.
 #fade_start: 1.0
 #   The z-axis position in which to start phasing z-adjustment out.
 #   Default is 1.0.
 #fade_end: 10.0
-#   The z-axis position in which phase out is complete.  If this
+#   The z-axis position in which phase out is complete. If this
 #   value is less than or equal to fade_start then phasing out
 #   is disabled. Default is 10.0.
 #split_delta_z: .025
 #   The amount of Z difference (in mm) along a move that will
-#   trigger a split.  Default is .025.
+#   trigger a split. Default is .025.
 #move_check_distance: 5.0
 #   The distance (in mm) along a move to check for split_delta_z.
 #   This is also the minimum length that a move can be split. Default
@@ -112,17 +115,20 @@
 #   A comma separated pair of integers (X,Y) defining the number of
 #   points per segment to interpolate in the mesh along each axis. A
 #   "segment" can be defined as the space between each probed
-#   point.  The user may enter a single value which will be applied
+#   point. The user may enter a single value which will be applied
 #   to both axes.  Default is 2,2.
 #algorithm: lagrange
-#   The interpolation algorthm to use.  May be either "langrange"
-#   or "bicubic".  This option will not affect 3x3 grids, which
+#   The interpolation algorthm to use. May be either "langrange"
+#   or "bicubic". This option will not affect 3x3 grids, which
 #   are forced to use lagrange sampling.  Default is lagrange.
 #bicubic_tension: .2
 #   When using the bicubic algoritm the tension parameter above
 #   may be applied to change the amount of slope interpolated.
 #   Larger numbers will increase the amount of slope, which
 #   results in more curvature in the mesh. Default is .2.
+#manual_probe:
+#   See the manual_probe option of [bed_tilt] for details. The default
+#   is false if a [probe] config section is present and true otherwise.
 
 
 # Multiple Z stepper tilt adjustment. This feature enables independent

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -51,7 +51,8 @@ class BedTiltCalibrate:
     def get_probed_position(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         return kin.calc_position()
-    def finalize(self, z_offset, positions):
+    def finalize(self, offsets, positions):
+        z_offset = offsets[2]
         logging.info("Calculating bed_tilt with: %s", positions)
         params = { 'x_adjust': self.bedtilt.x_adjust,
                    'y_adjust': self.bedtilt.y_adjust,

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -33,7 +33,8 @@ class DeltaCalibrate:
     def get_probed_position(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         return kin.get_stable_position()
-    def finalize(self, z_offset, positions):
+    def finalize(self, offsets, positions):
+        z_offset = offsets[2]
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         logging.info("Calculating delta_calibrate with: %s", positions)
         params = kin.get_calibrate_params()

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -171,6 +171,11 @@ class ProbePointsHelper:
         self.gcode = self.toolhead = None
     def get_lift_speed(self):
         return self.lift_speed
+    def get_last_xy_home_positon(self):
+        if self.probe is not None:
+            return self.probe.last_home_position()
+        else:
+            return None
     def start_probe(self):
         # Begin probing
         self.toolhead = self.printer.lookup_object('toolhead')

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -43,7 +43,8 @@ class ZTilt:
     def get_probed_position(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         return kin.calc_position()
-    def finalize(self, z_offset, positions):
+    def finalize(self, offsets, positions):
+        z_offset = offsets[2]
         logging.info("Calculating bed tilt with: %s", positions)
         params = { 'x_adjust': 0., 'y_adjust': 0., 'z_adjust': z_offset }
         def adjusted_height(pos, params):


### PR DESCRIPTION
* Only warn user about a difference in probe z_offset vs the z position_endstop if stepper_z is using the probe as a virtual endstop
* Move x_offset and y_offset parameters to [probe]
* Update configuration to reflect these changes.  Also made some minor formatting changes to make bed_mesh consistent with the rest of confg_extras, and briefly documented manual_probe which should also work for bed_mesh.

I currently fetch the x and y probe offsets directly from the config in bed_mesh, however I considered sending all of the offsets back in finalize() in place of the z_offset.  I think that is the cleanest way to do it, but considering it would require changes to bed_tilt and delta_calibrate I thought it best to get your input first.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>