### PR TITLE
bed_mesh: manual probing QoL improvements

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -184,6 +184,9 @@ class ProbePointsHelper:
         # Begin probing
         self.toolhead = self.printer.lookup_object('toolhead')
         self.gcode = self.printer.lookup_object('gcode')
+        # Unregister NEXT command in case we are starting over from an
+        # unfinalized calibration
+        self.gcode.register_command('NEXT', None)
         self.gcode.register_command(
             'NEXT', self.cmd_NEXT, desc=self.cmd_NEXT_help)
         self.results = []


### PR DESCRIPTION
These short commits improve things a little bit when manually probing for a bed mesh.

* Allow restarting a calibration sequence midway, without klipper panicking to death trying to redefine the `NEXT` command.
* Be more consistent in toolhead movements while doing the probing; moving to the first probe point did not respect horizontal_move_z by moving vertically like the other points.
* Allow saving and restoring the mesh with the `MESH_BED_LOAD` command. This makes it possible to reuse a previous calibration on multiple prints without having to re-probe (very useful if you probe manually). The command can be put, eg in the slicer's starting g-code section.

Signed-off-by: Romain “Artefact2” Dal Maso <artefact2@gmail.com>