### PR TITLE
Update sam4e8e docs and benchmarks

### DIFF
--- a/docs/Bootloaders.md
+++ b/docs/Bootloaders.md
@@ -144,6 +144,24 @@ stty -F /dev/ttyACM0 1200
 bossac -i -p ttyACM0 -R -e -w -v -b out/klipper.bin
 ```
 
+SAM4 micro-controllers (Duet Wifi)
+====================================
+
+It is not common to use a bootloader with the SAM4 mcu. The chip
+itself has a ROM that allows the flash to be programmed from 3.3V
+serial port or from USB.
+
+To enable the ROM, the "erase" pin is held high during a reset, which
+erases the flash contents, and causes the ROM to run.
+
+The code at https://github.com/shumatech/BOSSA can be used to program
+the SAM4. It is necessary to use version `1.8.0` or higher.
+
+To flash an application use something like:
+```
+bossac --port=/dev/ttyACM0 -b -U -e -w -v -R out/klipper.bin
+```
+
 SAMD21 micro-controllers (Arduino Zero)
 =======================================
 

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -288,6 +288,23 @@ single stepper result is `SET ticks 249`, the best dual stepper result
 is `SET ticks 220`, and the best three stepper result is `SET ticks
 374`.
 
+### Duet Wifi step rate benchmark ###
+
+The following configuration sequence is used on the Duet Wifi:
+```
+allocate_oids count=3
+config_stepper oid=0 step_pin=PD6 dir_pin=PD11 min_stop_interval=0 invert_step=0
+config_stepper oid=1 step_pin=PD7 dir_pin=PD12 min_stop_interval=0 invert_step=0
+config_stepper oid=2 step_pin=PD8 dir_pin=PD13 min_stop_interval=0 invert_step=0
+finalize_config crc=0
+```
+
+The test was last run on commit `e94f3b7` with gcc version
+`arm-none-eabi-gcc (15:5.4.1+svn241155-1) 5.4.1 20160919`. The best
+single stepper result is `SET ticks 325`, the best dual stepper result
+is `SET ticks 283`, and the best three stepper result is `SET ticks
+379`.
+
 ### Beaglebone PRU step rate benchmark ###
 
 The following configuration sequence is used on the PRU:

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -98,7 +98,7 @@ represent total number of steps per second on the micro-controller.
 | Arduino Due (ARM SAM3X8E)   | 382K              | 337K              |
 | Smoothieboard (ARM LPC1768) | 385K              | 385K              |
 | Smoothieboard (ARM LPC1769) | 462K              | 462K              |
-| Duet Wifi/Eth (ARM SAM4E8E) | 545K              | 545K              |
+| Duet Wifi/Eth (ARM SAM4E8E) | 475K              | 475K              |
 | Beaglebone PRU              | 689K              | 689K              |
 
 On AVR platforms, the highest achievable step rate is with just one


### PR DESCRIPTION
For some reason the benchmarks for 3 steppers caved in. The numbers are still good, just not as good. Also added flashing and benchmarking instructions to match the existing documentation.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>