### PR TITLE
Display, new example config for Wanhao i3 Mini, updates to uc1701 display

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -647,9 +647,13 @@
 #   The pins connected to an st7920 type lcd. These parameters must be
 #   provided when using an st7920 display.
 #cs_pin:
-#a0_pin
+#a0_pin:
+#contrast: 
+#invert:
 #   The pins connected to an uc1701 type lcd. These parameters must be
 #   provided when using an uc1701 display.
+#   Invert - pixels invert - default False
+#   Integer value to set brightness default 40 max value 63 (increase required for Wanhao i3 mini)
 #menu_root:
 #   Entry point for menu, root menu container name. If this parameter
 #   is not provided then default menu root is used. When provided

--- a/config/printer-wanhao-duplicator-i3-mini.cfg
+++ b/config/printer-wanhao-duplicator-i3-mini.cfg
@@ -1,0 +1,94 @@
+# This file contains pin mappings for the Wanhao Duplicator i3 mini
+# (circa 2017).  To use this config, the firmware should be compiled
+# for the AVR atmega2560.
+# Pin numbers and other parameters were extracted from the
+# official Marlin source available at:
+# https://github.com/garychen99/i3Mini
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: ar22
+dir_pin: ar23
+enable_pin: !ar57
+step_distance: 0.0125
+endstop_pin: ^!ar19
+position_endstop: 0
+position_max: 120
+homing_speed: 30.0
+
+[stepper_y]
+step_pin: ar25
+dir_pin: ar26
+enable_pin: !ar24
+step_distance: 0.0125
+endstop_pin: ^!ar18
+position_endstop: 0
+position_max: 135
+homing_speed: 30.0
+
+[stepper_z]
+step_pin: ar29
+dir_pin: ar39
+enable_pin: !ar28
+step_distance: 0.0025
+endstop_pin: ^!ar38
+position_endstop: 0.5
+position_max: 100
+
+[extruder]
+step_pin: ar55
+dir_pin: !ar56
+enable_pin: !ar54 
+step_distance: 0.00979198
+nozzle_diameter: 0.100
+filament_diameter: 1.750
+max_extrude_only_distance: 100.0
+heater_pin: ar4 
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13 
+control: pid
+pid_Kp: 26.560 
+pid_Ki: 1.670 
+pid_Kd: 105.575
+min_temp: 0
+max_temp: 260
+pressure_advance: 0.10
+pressure_advance_lookahead_time: 0.0
+
+
+[fan]
+pin: ar12 
+max_power: 0.5
+
+[mcu]
+serial: /dev/ttyUSB0
+baud: 250000
+pin_map: arduino
+restart_method: rpi_usb
+
+[printer]
+kinematics: cartesian
+max_velocity: 600
+max_accel: 3000
+max_z_velocity: 10
+max_z_accel: 100
+
+[display]
+lcd_type: uc1701
+cs_pin: ar41
+a0_pin: ar40
+contrast: 63
+invert: True
+
+#[output_pin lcd_bl]
+#pin: ar65
+#value: 1.0
+
+[virtual_sdcard]
+path: ~/.octoprint/uploads/
+
+# need to pull this high for the screen to work
+[output_pin lcd_rst]
+pin: ar27
+value: 1.0

--- a/config/printer-wanhao-duplicator-i3-mini.cfg
+++ b/config/printer-wanhao-duplicator-i3-mini.cfg
@@ -39,17 +39,17 @@ position_max: 100
 [extruder]
 step_pin: ar55
 dir_pin: !ar56
-enable_pin: !ar54 
+enable_pin: !ar54
 step_distance: 0.00979198
 nozzle_diameter: 0.100
 filament_diameter: 1.750
 max_extrude_only_distance: 100.0
-heater_pin: ar4 
+heater_pin: ar4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13 
+sensor_pin: analog13
 control: pid
-pid_Kp: 26.560 
-pid_Ki: 1.670 
+pid_Kp: 26.560
+pid_Ki: 1.670
 pid_Kd: 105.575
 min_temp: 0
 max_temp: 260


### PR DESCRIPTION
New sample configuration to support Wanhao i3 Mini (aka Cocoon Create Modelmaker).  This is based on the Marlin config files.

To get the display to work changes were needed to the brightness settings of the uc1701 display.  Change made to uc1701.py to allow for optional 'contrast' display parameter.  

No display at all without pulling the reset pin high - this is a bit clunky as from reading the documentation this needs to be pulled high for certain milliseconds and other steps in the protocol.  I had given up until noticing the display was working just very low brightness.  Unfortunately this must be in the config - or at least the pin number does.

Additional new optional display parameter 'invert' to set pixel invert setting from config.

I plan to also include the new menu functionality as it is now in the master.  Still learning klipper and how to do pull requests.

Signed-off-by: Cameron Lamont <cameron@lamont.com.au>