### PR TITLE
probe:  ProbePointsHelper enhancements

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -552,6 +552,82 @@ type: command
 name: Dump parameters
 gcode: MENU DO=dump
 
+## Probe Points Helper Menu ###
+[menu __probe_helper]
+type: deck
+name: Probe Helper
+longpress_menu: __probe_helper_menu
+items:
+    ._main
+
+[menu __probe_helper _main]
+type: card
+name: Probe Helper Card
+content:
+    "Cal Wizard:"
+    "{0}"
+    "{1}"
+items:
+    ._move_status
+    ._move_pos
+
+[menu __probe_helper _main _move_status]
+type: item
+name: "Moving..."
+
+[menu __probe_helper _main _move_pos]
+type: item
+name: "X:{0[0]:0.2f} Y:{0[1]:0.2f}"
+parameter: ProbePointsHelper.next_pos
+
+[menu __probe_helper_menu]
+type: list
+name: Probe Menu
+enable: ProbePointsHelper.write_enabled
+show_back: False
+items:
+    ._move_z_01mm
+    ._next
+
+[menu __probe_helper_menu _next]
+type: command
+name: Move Next
+enable: ProbePointsHelper.write_enabled
+gcode: NEXT
+
+[menu __probe_helper_menu _move_z_1mm]
+type: input
+name: "Move Z:{0:04.1f}"
+enable: ProbePointsHelper.write_enabled
+parameter: toolhead.zpos
+realtime: True
+input_min: -5
+input_max: 50.0
+input_step: 1.
+gcode: G1 Z{0:.1f}
+
+[menu __probe_helper_menu _move_z_01mm]
+type: input
+name: "Move Z:{0:04.1f}"
+enable: ProbePointsHelper.write_enabled
+parameter: toolhead.zpos
+realtime: True
+input_min: -5
+input_max: 50.0
+input_step: 0.1
+gcode: G1 Z{0:.1f}
+
+[menu __probe_helper_menu _move_z_001mm]
+type: input
+name: "Move Z:{0:04.2f}"
+enable: ProbePointsHelper.write_enabled
+parameter: toolhead.zpos
+realtime: True
+input_min: -5
+input_max: 50.0
+input_step: 0.01
+gcode: G1 Z{0:.2f}
+
 ### info screens ###
 [menu __screen2004_static]
 type: deck


### PR DESCRIPTION
- Extract Lift-Z code into its own function, and lift z prior to moving to the first point.
- Add point multi-sampling to ProbePointsHelper.  Initially I was going to add this directly to bed_mesh by duplicating points during generation and averaging the returned values.  There are two advantages of adding this to ProbePointsHelper: it is functional for all calibration classes and it allows the user to specify a different retraction distance between samples.
- Basic support for a menu based wizard during manual calibration.  I noticed you mention this in the IRC channel and I thought I would take a shot at it.  I had to extend menu.py to get this to work, and while  I'm confident I didn't break anything, @mcmatrix may want to review my changes to be sure.  

Currently the wizard allows the user to move Z in .1 steps with realtime mode enabled.  I looked at ways to allow the user to select step resolution (1mm, .1mm, and .01mm), but the only way I could come up with was to add menu items for each resolution.   I felt like this looked over-burdensome on the wizard, so I removed 1mm and .01mm, however it wouldn't be any problem to add them back if you think it is necessary as I left them in menu.cfg.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>