### PR TITLE
Added live Z adjust to menu.cfg

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -49,7 +49,7 @@ type: command
 name: ".05 "
 gcode:
     SET_GCODE_OFFSET Z_ADJUST=0.05
-    G1	
+    G1
 
 [menu __adjustz __up10]
 type: command

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -8,6 +8,7 @@
 type: list
 name: Main Menu
 items:
+	__adjustz
     __octoprint
     __sdcard
     __control
@@ -15,6 +16,72 @@ items:
     __filament
     __prepare
     __test
+
+
+### menu zadjust ###
+[menu __adjustz]
+type: list
+name: Live Z Adjust
+enable: toolhead.is_printing
+items:
+    .__zpos
+    .__up, .__up01, .__up05, .__up10
+    .__down, .__down01, .__down05, .__down10
+
+[menu __adjustz __zpos]
+type: item
+name: "Current Z:{0:02.2f}"
+parameter: toolhead.zpos
+
+[menu __adjustz __up]
+type: item
+name: "UP "
+
+[menu __adjustz __up01]
+type: command
+name: ".01 "
+gcode: 
+	SET_GCODE_OFFSET Z_ADJUST=0.01
+	G1
+
+[menu __adjustz __up05]
+type: command
+name: ".05 "
+gcode: 
+	SET_GCODE_OFFSET Z_ADJUST=0.05
+	G1	
+
+[menu __adjustz __up10]
+type: command
+name: ".10"
+gcode: 
+	SET_GCODE_OFFSET Z_ADJUST=0.1
+	G1
+
+[menu __adjustz __down]
+type: item
+name: "DN "
+
+[menu __adjustz __down01]
+type: command
+name: ".01 "
+gcode: 
+	SET_GCODE_OFFSET Z_ADJUST=-0.01
+	G1
+
+[menu __adjustz __down05]
+type: command
+name: ".05 "
+gcode: 
+	SET_GCODE_OFFSET Z_ADJUST=-0.05
+	G1
+
+[menu __adjustz __down10]
+type: command
+name: ".10"
+gcode: 
+	SET_GCODE_OFFSET Z_ADJUST=-0.1
+	G1
 
 ### menu octoprint ###
 [menu __octoprint]

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -8,7 +8,7 @@
 type: list
 name: Main Menu
 items:
-	__adjustz
+    __adjustz
     __octoprint
     __sdcard
     __control
@@ -18,7 +18,7 @@ items:
     __test
 
 
-### menu zadjust ###
+### menu adjustz ###
 [menu __adjustz]
 type: list
 name: Live Z Adjust
@@ -40,23 +40,23 @@ name: "UP "
 [menu __adjustz __up01]
 type: command
 name: ".01 "
-gcode: 
-	SET_GCODE_OFFSET Z_ADJUST=0.01
-	G1
+gcode:
+    SET_GCODE_OFFSET Z_ADJUST=0.01
+    G1
 
 [menu __adjustz __up05]
 type: command
 name: ".05 "
-gcode: 
-	SET_GCODE_OFFSET Z_ADJUST=0.05
-	G1	
+gcode:
+    SET_GCODE_OFFSET Z_ADJUST=0.05
+    G1	
 
 [menu __adjustz __up10]
 type: command
 name: ".10"
-gcode: 
-	SET_GCODE_OFFSET Z_ADJUST=0.1
-	G1
+gcode:
+    SET_GCODE_OFFSET Z_ADJUST=0.1
+    G1
 
 [menu __adjustz __down]
 type: item
@@ -65,23 +65,23 @@ name: "DN "
 [menu __adjustz __down01]
 type: command
 name: ".01 "
-gcode: 
-	SET_GCODE_OFFSET Z_ADJUST=-0.01
-	G1
+gcode:
+    SET_GCODE_OFFSET Z_ADJUST=-0.01
+    G1
 
 [menu __adjustz __down05]
 type: command
 name: ".05 "
-gcode: 
-	SET_GCODE_OFFSET Z_ADJUST=-0.05
-	G1
+gcode:
+    SET_GCODE_OFFSET Z_ADJUST=-0.05
+    G1
 
 [menu __adjustz __down10]
 type: command
 name: ".10"
-gcode: 
-	SET_GCODE_OFFSET Z_ADJUST=-0.1
-	G1
+gcode:
+    SET_GCODE_OFFSET Z_ADJUST=-0.1
+    G1
 
 ### menu octoprint ###
 [menu __octoprint]


### PR DESCRIPTION
module: MENU.CFG WITH LIVE Z ADJUSTMENT

Added menu options to allow adjusting of Z height during printing.
Using the "SET_GCODE_OFFSET Z_ADJUST" function. The menu will only 
display during prints and should appear at the top of the list. 

To make it work you need to allow Z height to go negative with 
position_min -1 for the Z stepper in printer.cfg else it is likely 
to throw errors.

I have had to add a G1 command after the adjustment as I was seeing an 
error about min extrusion without it.

Signed-off-by: Gav Lewis - <gvnlws@gmail.com>