### PR TITLE
Add display buttons pins for anycubic kossel pulley 2016

### DIFF
--- a/config/printer-anycubic-kossel-2016.cfg
+++ b/config/printer-anycubic-kossel-2016.cfg
@@ -97,4 +97,4 @@ d5_pin: ar25
 d6_pin: ar27
 d7_pin: ar29
 encoder_pins: ^ar31, ^ar33
-click_pin: ^ar35
+click_pin: ^!ar35

--- a/config/printer-anycubic-kossel-2016.cfg
+++ b/config/printer-anycubic-kossel-2016.cfg
@@ -96,3 +96,5 @@ d4_pin: ar23
 d5_pin: ar25
 d6_pin: ar27
 d7_pin: ar29
+encoder_pins: ^ar31, ^ar33
+click_pin: ^ar35

--- a/config/printer-anycubic-kossel-2016.cfg
+++ b/config/printer-anycubic-kossel-2016.cfg
@@ -98,3 +98,4 @@ d6_pin: ar27
 d7_pin: ar29
 encoder_pins: ^ar31, ^ar33
 click_pin: ^!ar35
+kill_pin: ^!ar41


### PR DESCRIPTION
I added click pin, encoder pins and kill pin in order to be able to be able to use the menu in the printer and to stop the printer in case of emergency

Signed-off-by: Alejandro alemorbel@alemorbel.es