### PR TITLE
gcode: modify get_status method to output more info

### DIFF
--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -96,7 +96,21 @@ class GCodeParser:
         return False, "gcodein=%d" % (self.bytes_read,)
     def get_status(self, eventtime):
         busy = self.is_processing_data
-        return {'speed_factor': self.speed_factor * 60., 'busy': busy}
+        return {
+            'speed_factor': self.speed_factor * 60.,
+            'busy': busy,
+            'last_xpos': self.last_position[0],
+            'last_ypos': self.last_position[1],
+            'last_zpos': self.last_position[2],
+            'last_epos': self.last_position[3],
+            'base_xpos': self.base_position[0],
+            'base_ypos': self.base_position[1],
+            'base_zpos': self.base_position[2],
+            'base_epos': self.base_position[3],
+            'homing_xpos': self.homing_position[0],
+            'homing_ypos': self.homing_position[1],
+            'homing_zpos': self.homing_position[2]
+        }
     def printer_state(self, state):
         if state == 'shutdown':
             if not self.is_printer_ready:


### PR DESCRIPTION
Now `gcode.py` module method `get_status` will also output last, base and homing positions.
It makes possible to use real-time SET_GCODE_OFFSET absolute adjustments in the menu.

Signed-off-by: Janar Sööt <janar.soot@gmail.com>