### PR TITLE
New Tune submenu

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -35,7 +35,7 @@ transform:
     map(0,2,0,200)
 input_min: 0
 input_max: 2
-input_step: 0.005
+input_step: 0.01
 realtime: true
 gcode: M220 S{1:d}
 
@@ -47,7 +47,7 @@ transform:
     map(0,2,0,200)
 input_min: 0
 input_max: 2
-input_step: 0.005
+input_step: 0.01
 realtime: true
 gcode: M221 S{1:d}
 

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -25,7 +25,7 @@ name: Tune
 items:
     .__speed
     .__flow
-    .__adjz
+    .__offsetz
 
 [menu __tune __speed]
 type: input
@@ -51,10 +51,12 @@ input_step: 0.005
 realtime: true
 gcode: M221 S{1:d}
 
-[menu __tune __adjz]
+[menu __tune __offsetz]
 type: input
 name: "Offset Z:{0:05.3f} "
 parameter: gcode.homing_zpos
+input_min: -5
+input_max: 5
 input_step: 0.005
 realtime: true
 gcode: SET_GCODE_OFFSET Z={0:.3f}

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -8,6 +8,7 @@
 type: list
 name: Main Menu
 items:
+    __tune
     __octoprint
     __sdcard
     __control
@@ -15,6 +16,48 @@ items:
     __filament
     __prepare
     __test
+
+### menu tune ###
+[menu __tune]
+type: list
+enable: toolhead.is_printing
+name: Tune
+items:
+    .__speed
+    .__flow
+    .__adjz
+
+[menu __tune __speed]
+type: input
+name: "Speed: {1:3d}%"
+parameter: gcode.speed_factor
+transform:
+    map(0,2,0,200)
+input_min: 0
+input_max: 2
+input_step: 0.005
+realtime: true
+gcode: M220 S{1:d}
+
+[menu __tune __flow]
+type: input
+name: "Flow: {1:3d}%"
+parameter: gcode.extrude_factor
+transform:
+    map(0,2,0,200)
+input_min: 0
+input_max: 2
+input_step: 0.005
+realtime: true
+gcode: M221 S{1:d}
+
+[menu __tune __adjz]
+type: input
+name: "Offset Z:{0:05.3f} "
+parameter: gcode.homing_zpos
+input_step: 0.005
+realtime: true
+gcode: SET_GCODE_OFFSET Z={0:.3f}
 
 ### menu octoprint ###
 [menu __octoprint]


### PR DESCRIPTION
Added a new submenu `Tune` to the default menu.
It's visible during the print time and has 3 real-time inputs
`Speed` - Set speed factor override
`Flow` - Set extrude factor override
`Offset Z` - Set a positional offset to the Z axis