### PR TITLE
Updated Voron 2 config for V2.1

### DIFF
--- a/config/kit-voron2-2018.cfg
+++ b/config/kit-voron2-2018.cfg
@@ -15,8 +15,8 @@
 # are on the seconds MCU/RAMPS labeled z . Please change settings for your
 # specific build or ensure you place your items in the same spots on the same
 # MCU as I have.  I've added as many options as I can think of for different
-# displays as well as listed the available commands you can use via the 
-# terminal at the bottom of this configuration file.  Also note that I've 
+# displays as well as listed the available commands you can use via the
+# terminal at the bottom of this configuration file.  Also note that I've
 # created a G32 macro for bed leveling as well at print start and stop
 # macro's for your slicer.  I have crude filament load and unload macro's
 # that are for ABS only.
@@ -207,7 +207,7 @@ gcode:
     G1 X200 E20 F1000
     G92 E0
 
-#    Use print_end for you slicer ending script    
+#    Use print_end for you slicer ending script
 [gcode_macro print_end]
 gcode:
     M104 S0

--- a/config/kit-voron2-2018.cfg
+++ b/config/kit-voron2-2018.cfg
@@ -5,10 +5,10 @@
 # common config parameters.  See "example-extras.cfg, example-multi-mcu.cfg"
 # for setup options.  Also read the following docs to understand how to setup
 # for the frist time. "Installation.md, FAQ.md, Config_checks.md"
- 
+
 # DO NOT COPY THIS FILE WITHOUT CAREFULLY READING AND UPDATING IT
 # FIRST. Incorrectly configured parameters may cause damage.
- 
+
 # This file has been created by "Maglin" for the Voron 2 CoreXY
 # printer.  X/Y/E steppers/endstops/thermisters/heaters
 # are on one MCU/RAMPs board while Z steppers/mechanical switch/endstop_pin
@@ -20,7 +20,7 @@
 # created a G32 macro for bed leveling as well at print start and stop
 # macro's for your slicer.  I have crude filament load and unload macro's
 # that are for ABS only.
- 
+
 [mcu]
 #    mcu for X/Y/E steppers main MCU
 serial: /dev/serial/by-id/usb-Arduino__www.arduino.cc__0042_75636313137351801102-if00
@@ -32,7 +32,7 @@ restart_method: arduino
 serial: /dev/serial/by-id/usb-Arduino__www.arduino.cc__0042_856323332363515111B2-if00
 pin_map: arduino
 restart_method: arduino
-    
+
 [stepper_x]
 #    use preceding ! to invert logic and ^ to activate internal 5V pullup
 #    this is for all pin definitions.  Not all pins have interal pullups
@@ -46,7 +46,7 @@ position_endstop: 257
 position_max: 258
 homing_speed: 100
 homing_positive_dir: true
- 
+
 [stepper_y]
 step_pin: ar60
 dir_pin: ar61
@@ -58,7 +58,7 @@ position_endstop: 245
 position_max: 245
 homing_speed: 100
 homing_positive_dir: true
- 
+
 [stepper_z]
 # X stepper pins on MCU Z
 step_pin: z:ar54
@@ -73,21 +73,21 @@ position_max: 250
 position_min: -25
 homing_speed: 12
 homing_positive_dir: false
- 
+
 [stepper_z1]
 # Y stepper pins on MCU Z
 step_pin: z:ar60
 dir_pin: z:ar61
 enable_pin: !z:ar56
 step_distance: 0.00250
- 
+
 [stepper_z2]
 # Z stepper pins on MCU Z
 step_pin: z:ar46
 dir_pin: !z:ar48
 enable_pin: !z:ar62
 step_distance: 0.00250
- 
+
 [stepper_z3]
 # E0 stepper pins on MCU Z
 step_pin: z:ar26
@@ -118,7 +118,7 @@ gcode:
     G0 X250.2 Y235.5 F6000
     G28 Z
     G0 Z5 F3000
- 
+
 #    macro to level the gantry.  use G32 in the terminal to call
 [gcode_macro g32]
 gcode:
@@ -171,7 +171,7 @@ algorithm: lagrange
 #   may be applied to change the amount of slope interpolated.
 #   Larger numbers will increase the amount of slope, which
 #   results in more curvature in the mesh. Default is .2.
- 
+
 #    extended G-Code command Z_TILT_ADJUST can be used to level gantry
 #    use this for a moving bed with 3+ steppers to get the bed into
 #    plane with the x/y.  Makes a perfect plane adjustment.
@@ -219,7 +219,7 @@ gcode:
     G90
     G0 X125 Y245 F3000
     M84
-    
+
 #    Use unload_filament to unload ABS
 [gcode_macro unload_filament]
 gcode:
@@ -238,7 +238,7 @@ gcode:
     G1 E30 F300
     G1 E-10 F1800
     M82
-    
+
 #    use nozzle_clean to clean nozzle
 #    must change to work for your brush loc
 [gcode_macro nozzle_clean]
@@ -306,7 +306,6 @@ heater: extruder
 heater_temp: 50.0
 fan_speed: 0.9
 
- 
 [heater_bed]
 # connected to mcu_z heated bed D8
 heater_pin: ar8
@@ -326,7 +325,7 @@ pid_Ki: 3.404
 pid_Kd: 299.213
 min_temp: 0
 max_temp: 130
- 
+
 # print cooling fan
 [fan]
 # On MCU Z on extruder heater pin D10
@@ -345,7 +344,7 @@ kick_start_time: 0.100
 #d7_pin: ar29
 #encoder_pins: ^ar31, ^ar33
 #click_pin: ^!ar35
- 
+
 # "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
 [display]
 lcd_type: st7920

--- a/config/kit-voron2-2018.cfg
+++ b/config/kit-voron2-2018.cfg
@@ -1,137 +1,213 @@
-# This file is an example configuration for the Voron 2 CoreXY printer
-# running on two RAMPS boards. This file was created by "Maglin".
-# X/Y/E steppers/endstops/thermisters/heaters are on one MCU/RAMPS
-# board while Z steppers/mechanical switch/endstop_pin are on the
-# second MCU/RAMPS labeled z.
-
-# This file is only an example - be sure to review and update it
-# according to the specifics of your printer. See the example.cfg and
-# example-extras.cfg files for a description of available parameters.
-
+# This file serves as documentation for config parameters of corexy
+# style printers. One may copy and edit this file to configure a new
+# corexy printer. Only parameters unique to corexy printers are
+# described here - see the "example.cfg" file for description of
+# common config parameters.  See "example-extras.cfg, example-multi-mcu.cfg"
+# for setup options.  Also read the following docs to understand how to setup
+# for the frist time. "Installation.md, FAQ.md, Config_checks.md"
+ 
+# DO NOT COPY THIS FILE WITHOUT CAREFULLY READING AND UPDATING IT
+# FIRST. Incorrectly configured parameters may cause damage.
+ 
+# This file has been created by "Maglin" for the Voron 2 CoreXY
+# printer.  X/Y/E steppers/endstops/thermisters/heaters
+# are on one MCU/RAMPs board while Z steppers/mechanical switch/endstop_pin
+# are on the seconds MCU/RAMPS labeled z . Please change settings for your
+# specific build or ensure you place your items in the same spots on the same
+# MCU as I have.  I've added as many options as I can think of for different
+# displays as well as listed the available commands you can use via the 
+# terminal at the bottom of this configuration file.  Also note that I've 
+# created a G32 macro for bed leveling as well at print start and stop
+# macro's for your slicer.  I have crude filament load and unload macro's
+# that are for ABS only.
+ 
 [mcu]
-# mcu for X/Y/E steppers main MCU
-serial: /dev/serial/by-path/platform-3f980000.usb-usb-0:1.3:1.0-port0
+#    mcu for X/Y/E steppers main MCU
+serial: /dev/serial/by-id/usb-Arduino__www.arduino.cc__0042_75636313137351801102-if00
 pin_map: arduino
+restart_method: arduino
 
 [mcu z]
-# mcu for the Z steppers
-serial: /dev/serial/by-path/platform-3f980000.usb-usb-0:1.2:1.0-port0
+#    mcu for the Z steppers
+serial: /dev/serial/by-id/usb-Arduino__www.arduino.cc__0042_856323332363515111B2-if00
 pin_map: arduino
-
+restart_method: arduino
+    
 [stepper_x]
-# use preceding ! to invert logic and ^ to activate internal 5V pullup
-# this is for all pin definitions.  Not all pins have interal pullups
+#    use preceding ! to invert logic and ^ to activate internal 5V pullup
+#    this is for all pin definitions.  Not all pins have interal pullups
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
 step_distance: 0.0125
 endstop_pin: ^ar2
 position_min: 0
-position_endstop: 248
-position_max: 248
-homing_speed: 50
-
+position_endstop: 257
+position_max: 258
+homing_speed: 100
+homing_positive_dir: true
+ 
 [stepper_y]
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
 step_distance: 0.0125
 endstop_pin: ^ar15
-position_min: -5
+position_min: -10
 position_endstop: 245
 position_max: 245
-homing_speed: 50
-
+homing_speed: 100
+homing_positive_dir: true
+ 
 [stepper_z]
 # X stepper pins on MCU Z
 step_pin: z:ar54
-dir_pin: z:ar55
+dir_pin: !z:ar55
 enable_pin: !z:ar38
-step_distance: 0.00625
-# probe:z_virtual_endstop is a virtual pin definition only available if
-# a probe section is defined
-#endstop_pin: probe:z_virtual_endstop
-# mechanical switch on mcu Z X min endstop pin
-endstop_pin: ^z:ar3
-position_endstop: -0.376
-position_min: -5
-position_max: 245
+step_distance: 0.00250
+# FSR switch on mcu_z X max endstop pin
+endstop_pin: ^!z:ar2
+# position endstop is to set your Z offset
+position_endstop: 1.9
+position_max: 250
+position_min: -25
 homing_speed: 12
-
+homing_positive_dir: false
+ 
 [stepper_z1]
 # Y stepper pins on MCU Z
 step_pin: z:ar60
-dir_pin: !z:ar61
+dir_pin: z:ar61
 enable_pin: !z:ar56
-step_distance: 0.00625
-
+step_distance: 0.00250
+ 
 [stepper_z2]
 # Z stepper pins on MCU Z
 step_pin: z:ar46
-dir_pin: z:ar48
+dir_pin: !z:ar48
 enable_pin: !z:ar62
-step_distance: 0.00625
-
+step_distance: 0.00250
+ 
 [stepper_z3]
 # E0 stepper pins on MCU Z
 step_pin: z:ar26
-dir_pin: !z:ar28
+dir_pin: z:ar28
 enable_pin: !z:ar24
-step_distance: 0.00625
+step_distance: 0.00250
 
-# extended G-Code command Z_TILT_ADJUST can be used to level gantry
-[z_tilt]
-# belt locations from origin 0,0
-z_positions:
-    -56,-17
-    -56,322
-    311,322
-    311,-17
-# probing locations for gantry leveling
-points:
-    50,50
-    50,195
-    195,195
-    195,50
-# travel speed between probe points
-speed: 150
-# Move Z to this position for safe probing
-horizontal_move_z: 15
+#    used to force a single stepper to move.  not used once setup
+#[force_move]
+#enable_force_move: True
 
-# this is required for gantry leveling and replaces your G28 command
-# with the gcode used here.  Used to home X/Y/Z with mechanical switches
+[probe]
+# Z_Min pins on MCU Z (must be on same MCU as steppers)
+pin: ^!z:ar18
+x_offset: 0.0
+y_offset: 25.0
+z_offset: 0.195
+speed: 5
+
+#    this is required for gantry leveling and replaces your G28 command
+#    with the gcode used here.  Used to home X/Y/Z with mechanical switches
 [homing_override]
 set_position_z: 0
 gcode:
     G90
-    G0 Z15 F600
-    G28 X0 Y0
-    G0 X248 Y225 F3000
+    G0 Z15 F2000
+    G28 X Y
+    G0 X250.2 Y235.5 F6000
     G28 Z
-    G0 Z15 F6000
-
-# macro to level the gantry.  use G32 in the terminal to call
+    G0 Z5 F3000
+ 
+#    macro to level the gantry.  use G32 in the terminal to call
 [gcode_macro g32]
 gcode:
-    Z_TILT_ADJUST
-    Z_TILT_ADJUST
-    Z_TILT_ADJUST
+    quad_gantry_level
+    quad_gantry_level
+    quad_gantry_level
     G28
-    G0 X125 Y125 Z125 F3600
+    G0 X125 Y125 Z10 F6000
 
-# Use print_start for you slicer starting script
+#    quad_gantry_level is to put a moving gantry into plan with
+#    a fixed bed.  Must have 4 steppers on the gantry
+#    use QUAD_GANTRY_LEVEL to level a gantry.
+[quad_gantry_level]
+gantry_corners:
+    -59,-20
+    307,305
+
+points:
+    50,25
+    50,175
+    200,175
+    200,25
+
+speed: 200
+horizontal_move_z: 10
+#    Number of time to probe a point
+samples = 3
+#    How far to retract from the probe point for multi-probe samples
+sample_retract_dist = 2.0
+
+#    use BED_MESH_CALIBRATE to run a bed mesh.  Not saved
+#    this is for uneven beds.
+[bed_mesh]
+speed: 100
+horizontal_move_z: 10
+min_point: 20,0
+max_point: 230,205
+probe_count: 4,4
+fade_start: 1.0
+fade_end: 10.0
+split_delta_z: .025
+move_check_distance: 5.0
+mesh_pps: 5,5
+algorithm: lagrange
+#   The interpolation algorthm to use.  May be either "langrange"
+#   or "bicubic".  This option will not affect 3x3 grids, which
+#   are forced to use lagrange sampling.  Default is lagrange.
+#bicubic_tension: .2
+#   When using the bicubic algoritm the tension parameter above
+#   may be applied to change the amount of slope interpolated.
+#   Larger numbers will increase the amount of slope, which
+#   results in more curvature in the mesh. Default is .2.
+ 
+#    extended G-Code command Z_TILT_ADJUST can be used to level gantry
+#    use this for a moving bed with 3+ steppers to get the bed into
+#    plane with the x/y.  Makes a perfect plane adjustment.
+[z_tilt]
+# belt locations from orign 0,0
+z_positions:
+  -59,-20
+  -59,305
+  307,305
+  307,-20
+# probing locations for gantry leveling
+points:
+  20,0
+  20,195
+  225,195
+  225,0
+speed: 100
+# Move Z to this position for safe probing
+horizontal_move_z: 10
+
+#    Use print_start for the slicer starting script
+#    change for your starting scripting needs
 [gcode_macro print_start]
 gcode:
-    G1 X0 Y15 Z0.3 F7000
+    G28
+    G32
+    quad_gantry_level
+    nozzle_clean
+    G28
+    G0 X245 Y10 Z0.3 F9000
     G92 E0
     G1 E14 F600
+    G1 X200 E20 F1000
     G92 E0
-    G1 X60.0 E9.0 F1000.0
-    G1 X100.0 E12.5 F1000.0
-    G1 E12 F1000.0
-    G92 E-0.5
 
-# Use print_end for you slicer ending script
+#    Use print_end for you slicer ending script    
 [gcode_macro print_end]
 gcode:
     M104 S0
@@ -141,56 +217,122 @@ gcode:
     G91
     G1 Z10 E-10 F3000
     G90
-    G0 X125 Y245 F1000
+    G0 X125 Y245 F3000
+    M84
+    
+#    Use unload_filament to unload ABS
+[gcode_macro unload_filament]
+gcode:
+    M109 S235
+    M83
+    G1 E15 F300
+    G1 E-780 F1800
+    M82
+
+#    Use load_filament to load ABS
+[gcode_macro load_filament]
+gcode:
+    M109 S235
+    M83
+    G1 E760 F1800
+    G1 E30 F300
+    G1 E-10 F1800
+    M82
+    
+#    use nozzle_clean to clean nozzle
+#    must change to work for your brush loc
+[gcode_macro nozzle_clean]
+gcode:
+    G0 X253 Y0 Z3 F3000
+    G0 Y45
+    G0 X254 Y0
+    G0 X255 Y45
+    G0 X256 Y0
+    G0 X257 Y45
+    G0 X256 Y0
+    G0 X255 Y45
+    G0 X254 Y0
+    G0 X256 Y55
+    G0 Z10
 
 [extruder]
 # on E0 stepper pins of main MCU
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: 0.003339
+step_distance: 0.00176160264276316
 nozzle_diameter: 0.400
+# PA can be disabled by declaring a 0.0 value
+pressure_advance: 0.05
+# time seconds to look ahead for PA moves default is 0.010 or 10ms
+pressure_advance_lookahead_time: 0.010
 filament_diameter: 1.750
-max_extrude_only_distance: 100.0
+max_extrude_only_distance: 800.0
 heater_pin: ar10
 max_power: 1.0
 sensor_type: ATC Semitec 104GT-2
 sensor_pin: analog13
+# pullup_resistor: 4700
+smooth_time: 3.0
 control: pid
-pid_Kp: 21.759
-pid_Ki: 1.107
-pid_Kd: 106.889
+pid_Kp: 21.783
+pid_Ki: 0.925
+pid_Kd: 128.249
+min_extrude_temp: 0
 min_temp: 0
 max_temp: 300
 
-# thermally controlled hotend fan
+#    thermally controlled hotend fan
 [heater_fan my_nozzle_fan]
-# Located on Z MCU on fan D9
+# Located on MCU Z on fan D9
 pin: z:ar9
+#    Max power for the heater.
+max_power: 1.0
+kick_start_time: 0.100
+heater: extruder
+heater_temp: 50.0
+fan_speed: 1.0
 
-[probe]
-# Z_Min pins on MCU Z (must be on same MCU as steppers)
-pin: ^!z:ar18
-z_offset: 1.15
-speed: 2.0
+#    thermally controlled controller fan
+[heater_fan my_controller_fan]
+# Located on MCU on fan D9
+pin: ar9
+max_power: 1.0
+shutdown_speed: 1.0
+#cycle_time: 0.01
+#hardware_pwm: true
+kick_start_time: 1.100
+heater: extruder
+heater_temp: 50.0
+fan_speed: 0.9
 
+ 
 [heater_bed]
+# connected to mcu_z heated bed D8
 heater_pin: ar8
+#    Max power for the heater.  I'm using 66% max power.
+max_power: 0.66
 # NTC 100K MGB18-104F39050L32 is for Kenovo thermistors
 sensor_type: NTC 100K MGB18-104F39050L32
+#sensor_type: EPCOS 100K B57560G104F
+#sensor_type: NTC 100K beta 3950
 sensor_pin: analog14
-# pid gives you better control over bed heat
+# pullup_resistor: 4700
+# adc_voltage: 5.0
+smooth_time: 3.0
 control: pid
 pid_Kp: 63.832
 pid_Ki: 3.404
 pid_Kd: 299.213
 min_temp: 0
 max_temp: 130
-
+ 
 # print cooling fan
 [fan]
-# On z MCU on extruder heater pin D10
+# On MCU Z on extruder heater pin D10
 pin: z:ar10
+max_power: 1.0
+kick_start_time: 0.100
 
 # "RepRapDiscount 2004 Smart Controller" type displays
 #[display]
@@ -201,22 +343,64 @@ pin: z:ar10
 #d5_pin: ar25
 #d6_pin: ar27
 #d7_pin: ar29
-
+#encoder_pins: ^ar31, ^ar33
+#click_pin: ^!ar35
+ 
 # "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
 [display]
 lcd_type: st7920
 cs_pin: ar16
 sclk_pin: ar23
 sid_pin: ar17
+encoder_pins: ^ar31, ^ar33
+click_pin: ^!ar35
 
 [printer]
 # settings below are the max and can't be commanded over in gcode
 kinematics: corexy
 max_velocity: 500
-max_accel: 3000
-max_z_velocity: 100
-max_z_accel: 50
+max_accel: 5000
+max_z_velocity: 50
+max_z_accel: 400
+square_corner_velocity: 15.0
+#   The maximum velocity (in mm/s) that the toolhead may travel a 90
+#   degree corner at. A non-zero value can reduce changes in extruder
+#   flow rates by enabling instantaneous velocity changes of the
+#   toolhead during cornering. This value configures the internal
+#   centripetal velocity cornering algorithm; corners with angles
+#   larger than 90 degrees will have a higher cornering velocity while
+#   corners with angles less than 90 degrees will have a lower
+#   cornering velocity. If this is set to zero then the toolhead will
+#   decelerate to zero at each corner. The default is 5mm/s.
 
 [idle_timeout]
-# high motor off time so I don't have to relevel gantry often
-timeout: 6000
+# 10 minutes idle time out
+gcode:
+    G0 X245 Y245 F6000
+    M84
+timeout: 600
+
+# BED_MESH_CALIBRATE: Perform Mesh Bed Leveling
+# BED_MESH_CLEAR: Clear the Mesh so no z-adjusment is made
+# BED_MESH_MAP: Probe the bed and serialize output
+# BED_MESH_OUTPUT: Retrieve interpolated grid of probed z-points
+# FIRMWARE_RESTART: Restart firmware, host, and reload config
+# G32       : G-Code macro
+# GANTRY_LEVEL: Conform a moving, twistable gantry to the shape of a stationary bed
+# LOAD_FILAMENT: G-Code macro
+# MENU      : Menu do things
+# NOZZLE_CLEAN: G-Code macro
+# PID_CALIBRATE: Run PID calibration test
+# PRINT_END : G-Code macro
+# PRINT_START: G-Code macro
+# PROBE     : Probe Z-height at current XY position
+# QUERY_ENDSTOPS: Report on the status of each endstop
+# QUERY_PROBE: Return the status of the z-probe
+# RESTART   : Reload config file and restart host software
+# SET_GCODE_OFFSET: Set a virtual offset to g-code positions
+# SET_PRESSURE_ADVANCE: Set pressure advance parameters
+# SET_VELOCITY_LIMIT: Set printer velocity limits
+# STATUS    : Report the printer status
+# STEPPER_BUZZ: Oscillate a given stepper to help id it
+# UNLOAD_FILAMENT: G-Code macro
+# Z_TILT_ADJUST: Adjust the Z tilt


### PR DESCRIPTION
I've added some options to parts of the config for others.  I've worked on the tune and for a 250mm^3 machine.  quad_gantry_level is being used.  Bed mesh is added for those that want to use it.  z_tilt is still in place for those that want to test the difference between it and quad-gantry_level.