### PR TITLE
config: Include encoder and click pin

### DIFF
--- a/config/printer-creality-cr10mini-2017.cfg
+++ b/config/printer-creality-cr10mini-2017.cfg
@@ -86,3 +86,5 @@ lcd_type: st7920
 cs_pin: PA3
 sclk_pin: PA1
 sid_pin: PC1
+encoder_pins: ^PD2, ^PD3
+click_pin: ^!PC0


### PR DESCRIPTION
The config for the CR-10 mini does not include encoder and click pins set. It uses the same pins as the CR-10 regular.