### PR TITLE
Support for writing calibration data to printer.cfg

### DIFF
--- a/docs/Config_checks.md
+++ b/docs/Config_checks.md
@@ -139,8 +139,8 @@ To calibrate the extruder, navigate to the OctoPrint terminal tab and
 run the PID_CALIBRATE command. For example: `PID_CALIBRATE
 HEATER=extruder TARGET=170`
 
-At the completion of the tuning test, update the printer.cfg file with
-the recommended pid_Kp, pid_Ki, and pid_Kd values.
+At the completion of the tuning test run `SAVE_CONFIG` to update the
+printer.cfg file the new PID settings.
 
 If the printer has a heated bed and it supports being driven by PWM
 (Pulse Width Modulation) then it is recommended to use PID control for

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -114,6 +114,10 @@ The following standard commands are supported:
   [the FAQ](FAQ.md#how-do-i-upgrade-to-the-latest-software)).
 - `FIRMWARE_RESTART`: This is similar to a RESTART command, but it
   also clears any error state from the micro-controller.
+- `SAVE_CONFIG`: This command will overwrite the main printer config
+  file and restart the host software. This command is used in
+  conjunction with other calibration commands to store the results of
+  calibration tests.
 - `STATUS`: Report the Klipper host software status.
 - `HELP`: Report the list of available extended G-Code commands.
 

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -1,0 +1,116 @@
+# Code for reading the Klipper config file
+#
+# Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import ConfigParser
+
+error = ConfigParser.Error
+
+class sentinel:
+    pass
+
+class ConfigWrapper:
+    error = ConfigParser.Error
+    def __init__(self, printer, fileconfig, access_tracking, section):
+        self.printer = printer
+        self.fileconfig = fileconfig
+        self.access_tracking = access_tracking
+        self.section = section
+    def get_printer(self):
+        return self.printer
+    def get_name(self):
+        return self.section
+    def _get_wrapper(self, parser, option, default,
+                     minval=None, maxval=None, above=None, below=None):
+        if (default is not sentinel
+            and not self.fileconfig.has_option(self.section, option)):
+            return default
+        self.access_tracking[(self.section.lower(), option.lower())] = 1
+        try:
+            v = parser(self.section, option)
+        except self.error as e:
+            raise
+        except:
+            raise error("Unable to parse option '%s' in section '%s'" % (
+                option, self.section))
+        if minval is not None and v < minval:
+            raise error(
+                "Option '%s' in section '%s' must have minimum of %s" % (
+                    option, self.section, minval))
+        if maxval is not None and v > maxval:
+            raise error(
+                "Option '%s' in section '%s' must have maximum of %s" % (
+                    option, self.section, maxval))
+        if above is not None and v <= above:
+            raise error("Option '%s' in section '%s' must be above %s" % (
+                option, self.section, above))
+        if below is not None and v >= below:
+            raise self.error("Option '%s' in section '%s' must be below %s" % (
+                option, self.section, below))
+        return v
+    def get(self, option, default=sentinel):
+        return self._get_wrapper(self.fileconfig.get, option, default)
+    def getint(self, option, default=sentinel, minval=None, maxval=None):
+        return self._get_wrapper(
+            self.fileconfig.getint, option, default, minval, maxval)
+    def getfloat(self, option, default=sentinel,
+                 minval=None, maxval=None, above=None, below=None):
+        return self._get_wrapper(self.fileconfig.getfloat, option, default,
+                                 minval, maxval, above, below)
+    def getboolean(self, option, default=sentinel):
+        return self._get_wrapper(self.fileconfig.getboolean, option, default)
+    def getchoice(self, option, choices, default=sentinel):
+        c = self.get(option, default)
+        if c not in choices:
+            raise error("Choice '%s' for option '%s' in section '%s'"
+                        " is not a valid choice" % (c, option, self.section))
+        return choices[c]
+    def getsection(self, section):
+        return ConfigWrapper(self.printer, self.fileconfig,
+                             self.access_tracking, section)
+    def has_section(self, section):
+        return self.fileconfig.has_section(section)
+    def get_prefix_sections(self, prefix):
+        return [self.getsection(s) for s in self.fileconfig.sections()
+                if s.startswith(prefix)]
+
+class ConfigLogger:
+    def __init__(self, fileconfig, printer):
+        self.lines = ["===== Config file ====="]
+        fileconfig.write(self)
+        self.lines.append("=======================")
+        printer.set_rollover_info("config", "\n".join(self.lines))
+    def write(self, data):
+        self.lines.append(data.strip())
+
+class PrinterConfig:
+    def __init__(self, printer):
+        self.printer = printer
+    def read_config(self, filename):
+        fileconfig = ConfigParser.RawConfigParser()
+        res = fileconfig.read(filename)
+        if not res:
+            raise error("Unable to open config file %s" % (filename,))
+        return ConfigWrapper(self.printer, fileconfig, {}, 'printer')
+    def read_main_config(self):
+        filename = self.printer.get_start_args()['config_file']
+        return self.read_config(filename)
+    def check_unused_options(self, config):
+        access_tracking = config.access_tracking
+        fileconfig = config.fileconfig
+        objects = dict(self.printer.lookup_objects())
+        # Validate that there are no undefined parameters in the config file
+        valid_sections = { s: 1 for s, o in access_tracking }
+        for section_name in fileconfig.sections():
+            section = section_name.lower()
+            if section not in valid_sections and section not in objects:
+                raise error("Section '%s' is not a valid config section" % (
+                    section,))
+            for option in fileconfig.options(section_name):
+                option = option.lower()
+                if (section, option) not in access_tracking:
+                    raise error("Option '%s' is not valid in section '%s'" % (
+                        option, section))
+    def log_config(self, config):
+        ConfigLogger(config.fileconfig, self.printer)

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -56,6 +56,17 @@ def get_stable_position(stepper_position, delta_params):
             for sd, ep, sp in zip(
                     dp.stepdists, dp.abs_endstops, stepper_position)]
 
+# Load a stable position from a config entry
+def load_config_stable(config, option):
+    spos = config.get(option)
+    try:
+        sa, sb, sc = map(float, spos.split(','))
+    except:
+        msg = "Unable to parse stable position '%s'" % (spos,)
+        logging.exception(msg)
+        raise config.error(msg)
+    return sa, sb, sc
+
 
 ######################################################################
 # Delta Calibrate class
@@ -76,11 +87,37 @@ class DeltaCalibrate:
             points.append((math.cos(r) * dist, math.sin(r) * dist))
         self.probe_helper = probe.ProbePointsHelper(
             config, self, default_points=points)
+        # Restore probe stable positions
+        self.last_probe_positions = []
+        for i in range(999):
+            height = config.getfloat("height%d" % (i,), None)
+            if height is None:
+                break
+            height_pos = load_config_stable(config, "height%d_pos" % (i,))
+            self.last_probe_positions.append((height, height_pos))
         # Register DELTA_CALIBRATE command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(
             'DELTA_CALIBRATE', self.cmd_DELTA_CALIBRATE,
             desc=self.cmd_DELTA_CALIBRATE_help)
+    def save_state(self, probe_positions, params):
+        # Save main delta parameters
+        configfile = self.printer.lookup_object('configfile')
+        configfile.set('printer', 'delta_radius', "%.6f" % (params['radius']))
+        for axis in 'abc':
+            configfile.set('stepper_'+axis, 'angle',
+                           "%.6f" % (params['angle_'+axis],))
+            configfile.set('stepper_'+axis, 'arm_length',
+                           "%.6f" % (params['arm_'+axis],))
+            configfile.set('stepper_'+axis, 'position_endstop',
+                           "%.6f" % (params['endstop_'+axis],))
+        # Save probe stable positions
+        section = 'delta_calibrate'
+        configfile.remove_section(section)
+        for i, (z_offset, spos) in enumerate(probe_positions):
+            configfile.set(section, "height%d" % (i,), z_offset)
+            configfile.set(section, "height%d_pos" % (i,),
+                           "%d,%d,%d" % tuple(spos))
     cmd_DELTA_CALIBRATE_help = "Delta calibration script"
     def cmd_DELTA_CALIBRATE(self, params):
         self.gcode.run_script_from_command("G28")
@@ -89,43 +126,55 @@ class DeltaCalibrate:
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         return [s.get_commanded_position() for s in kin.get_steppers()]
     def finalize(self, offsets, positions):
+        # Convert positions into (z_offset, stable_position) pairs
         z_offset = offsets[2]
+        kin = self.printer.lookup_object('toolhead').get_kinematics()
+        delta_params = build_delta_params(kin.get_calibrate_params())
+        probe_positions = [(z_offset, get_stable_position(p, delta_params))
+                           for p in positions]
+        # Perform analysis
+        self.calculate_params(probe_positions)
+    def calculate_params(self, probe_positions):
+        # Setup for coordinate descent analysis
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         params = kin.get_calibrate_params()
         orig_delta_params = build_delta_params(params)
-        stable_positions = [get_stable_position(p, orig_delta_params)
-                            for p in positions]
         logging.info("Calculating delta_calibrate with: %s\n"
                      "Initial delta_calibrate parameters: %s",
-                     stable_positions, params)
+                     probe_positions, params)
         adj_params = ('radius', 'angle_a', 'angle_b',
                       'endstop_a', 'endstop_b', 'endstop_c')
+        # Perform coordinate descent
         def delta_errorfunc(params):
             delta_params = build_delta_params(params)
             total_error = 0.
-            for stable_pos in stable_positions:
+            for z_offset, stable_pos in probe_positions:
                 x, y, z = get_position_from_stable(stable_pos, delta_params)
                 total_error += (z - z_offset)**2
             return total_error
         new_params = mathutil.coordinate_descent(
             adj_params, params, delta_errorfunc)
+        # Log and report results
         logging.info("Calculated delta_calibrate parameters: %s", new_params)
         new_delta_params = build_delta_params(new_params)
-        for spos in stable_positions:
-            logging.info("orig: %s new: %s",
-                         get_position_from_stable(spos, orig_delta_params),
-                         get_position_from_stable(spos, new_delta_params))
+        for z_offset, spos in probe_positions:
+            logging.info("height orig: %.6f new: %.6f goal: %.6f",
+                         get_position_from_stable(spos, orig_delta_params)[2],
+                         get_position_from_stable(spos, new_delta_params)[2],
+                         z_offset)
         self.gcode.respond_info(
             "stepper_a: position_endstop: %.6f angle: %.6f\n"
             "stepper_b: position_endstop: %.6f angle: %.6f\n"
             "stepper_c: position_endstop: %.6f angle: %.6f\n"
             "delta_radius: %.6f\n"
-            "To use these parameters, update the printer config file with\n"
-            "the above and then issue a RESTART command" % (
+            "The SAVE_CONFIG command will update the printer config file\n"
+            "with these parameters and restart the printer." % (
                 new_params['endstop_a'], new_params['angle_a'],
                 new_params['endstop_b'], new_params['angle_b'],
                 new_params['endstop_c'], new_params['angle_c'],
                 new_params['radius']))
+        # Store results for SAVE_CONFIG
+        self.save_state(probe_positions, new_params)
 
 def load_config(config):
     return DeltaCalibrate(config)

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -3,8 +3,63 @@
 # Copyright (C) 2017-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import math, logging
+import math, logging, collections
 import probe, mathutil
+
+
+######################################################################
+# Delta "stable position" coordinates
+######################################################################
+
+# A "stable position" is a 3-tuple containing the number of steps
+# taken since hitting the endstop on each delta tower.  Delta
+# calibration uses this coordinate system because it allows a position
+# to be described independent of the software parameters.
+
+# Storage helper for delta parameters
+DeltaParams = collections.namedtuple('DeltaParams', [
+    'radius', 'angles', 'arms', 'endstops', 'stepdists',
+    'towers', 'abs_endstops'])
+
+# Generate delta_params from delta configuration parameters
+def build_delta_params(params):
+    radius = params['radius']
+    angles = [params['angle_'+a] for a in 'abc']
+    arms = [params['arm_'+a] for a in 'abc']
+    endstops = [params['endstop_'+a] for a in 'abc']
+    stepdists = [params['stepdist_'+a] for a in 'abc']
+    # Calculate the XY cartesian coordinates of the delta towers
+    radian_angles = [math.radians(a) for a in angles]
+    towers = [(math.cos(a) * radius, math.sin(a) * radius)
+              for a in radian_angles]
+    # Calculate the absolute Z height of each tower endstop
+    radius2 = radius**2
+    abs_endstops = [e + math.sqrt(a**2 - radius2)
+                    for e, a in zip(endstops, arms)]
+    return DeltaParams(radius, angles, arms, endstops, stepdists,
+                       towers, abs_endstops)
+
+# Return cartesian coordinates for the given stable_positions when the
+# given delta_params are used.
+def get_position_from_stable(stable_position, delta_params):
+    dp = delta_params
+    sphere_coords = [
+        (t[0], t[1], es - sp * sd)
+        for sd, t, es, sp in zip(
+                dp.stepdists, dp.towers, dp.abs_endstops, stable_position) ]
+    return mathutil.trilateration(sphere_coords, [a**2 for a in dp.arms])
+
+# Return a stable position from the nominal delta tower positions
+def get_stable_position(stepper_position, delta_params):
+    dp = delta_params
+    return [int((ep - sp) / sd + .5)
+            for sd, ep, sp in zip(
+                    dp.stepdists, dp.abs_endstops, stepper_position)]
+
+
+######################################################################
+# Delta Calibrate class
+######################################################################
 
 class DeltaCalibrate:
     def __init__(self, config):
@@ -32,27 +87,34 @@ class DeltaCalibrate:
         self.probe_helper.start_probe()
     def get_probed_position(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()
-        return kin.get_stable_position()
+        return [s.get_commanded_position() for s in kin.get_steppers()]
     def finalize(self, offsets, positions):
         z_offset = offsets[2]
         kin = self.printer.lookup_object('toolhead').get_kinematics()
-        logging.info("Calculating delta_calibrate with: %s", positions)
         params = kin.get_calibrate_params()
-        logging.info("Initial delta_calibrate parameters: %s", params)
-        adj_params = ('endstop_a', 'endstop_b', 'endstop_c', 'radius',
-                      'angle_a', 'angle_b')
+        orig_delta_params = build_delta_params(params)
+        stable_positions = [get_stable_position(p, orig_delta_params)
+                            for p in positions]
+        logging.info("Calculating delta_calibrate with: %s\n"
+                     "Initial delta_calibrate parameters: %s",
+                     stable_positions, params)
+        adj_params = ('radius', 'angle_a', 'angle_b',
+                      'endstop_a', 'endstop_b', 'endstop_c')
         def delta_errorfunc(params):
+            delta_params = build_delta_params(params)
             total_error = 0.
-            for x, y, z in kin.get_positions_from_stable(positions, params):
+            for stable_pos in stable_positions:
+                x, y, z = get_position_from_stable(stable_pos, delta_params)
                 total_error += (z - z_offset)**2
             return total_error
         new_params = mathutil.coordinate_descent(
             adj_params, params, delta_errorfunc)
         logging.info("Calculated delta_calibrate parameters: %s", new_params)
-        old_positions = kin.get_positions_from_stable(positions, params)
-        new_positions = kin.get_positions_from_stable(positions, new_params)
-        for oldpos, newpos in zip(old_positions, new_positions):
-            logging.info("orig: %s new: %s", oldpos, newpos)
+        new_delta_params = build_delta_params(new_params)
+        for spos in stable_positions:
+            logging.info("orig: %s new: %s",
+                         get_position_from_stable(spos, orig_delta_params),
+                         get_position_from_stable(spos, new_delta_params))
         self.gcode.respond_info(
             "stepper_a: position_endstop: %.6f angle: %.6f\n"
             "stepper_b: position_endstop: %.6f angle: %.6f\n"

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -5,9 +5,7 @@
 # Copyright (C) 2018  Janar Sööt <janar.soot@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import os, ConfigParser, logging
-import sys, ast, re
-import klippy
+import os, logging, sys, ast, re
 
 
 class error(Exception):
@@ -954,10 +952,9 @@ class MenuManager:
                                         desc=self.cmd_DO_help)
 
         # Parse local config file in same directory as current module
-        fileconfig = ConfigParser.RawConfigParser()
+        pconfig = self.printer.lookup_object('configfile')
         localname = os.path.join(os.path.dirname(__file__), 'menu.cfg')
-        fileconfig.read(localname)
-        localconfig = klippy.ConfigWrapper(self.printer, fileconfig, {}, None)
+        localconfig = pconfig.read_config(localname)
 
         # Load items from local config
         self.load_menuitems(localconfig)

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -35,12 +35,19 @@ class PIDCalibrate:
         heater.set_control(old_control)
         if write_file:
             calibrate.write_file('/tmp/heattest.txt')
+        # Log and report results
         Kp, Ki, Kd = calibrate.calc_final_pid()
         logging.info("Autotune: final: Kp=%f Ki=%f Kd=%f", Kp, Ki, Kd)
         self.gcode.respond_info(
             "PID parameters: pid_Kp=%.3f pid_Ki=%.3f pid_Kd=%.3f\n"
-            "To use these parameters, update the printer config file with\n"
-            "the above and then issue a RESTART command" % (Kp, Ki, Kd))
+            "The SAVE_CONFIG command will update the printer config file\n"
+            "with these parameters and restart the printer." % (Kp, Ki, Kd))
+        # Store results for SAVE_CONFIG
+        configfile = self.printer.lookup_object('configfile')
+        configfile.set(heater_name, 'control', 'pid')
+        configfile.set(heater_name, 'pid_Kp', "%.3f" % (Kp,))
+        configfile.set(heater_name, 'pid_Ki', "%.3f" % (Ki,))
+        configfile.set(heater_name, 'pid_Kd', "%.3f" % (Kd,))
 
 TUNE_PID_DELTA = 5.0
 

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -12,8 +12,7 @@ SLOW_RATIO = 3.
 class DeltaKinematics:
     def __init__(self, toolhead, config):
         # Setup tower rails
-        stepper_configs = [config.getsection('stepper_' + n)
-                           for n in ['a', 'b', 'c']]
+        stepper_configs = [config.getsection('stepper_' + a) for a in 'abc']
         rail_a = stepper.PrinterRail(
             stepper_configs[0], need_position_minmax = False)
         a_endstop = rail_a.get_homing_info().position_endstop
@@ -31,9 +30,9 @@ class DeltaKinematics:
             sconfig.getfloat('arm_length', arm_length_a, above=radius)
             for sconfig in stepper_configs]
         self.arm2 = [arm**2 for arm in arm_lengths]
-        self.endstops = [(rail.get_homing_info().position_endstop
-                          + math.sqrt(arm2 - radius**2))
-                         for rail, arm2 in zip(self.rails, self.arm2)]
+        self.abs_endstops = [(rail.get_homing_info().position_endstop
+                              + math.sqrt(arm2 - radius**2))
+                             for rail, arm2 in zip(self.rails, self.arm2)]
         # Setup boundary checks
         self.need_motor_enable = self.need_home = True
         self.limit_xy2 = -1.
@@ -41,7 +40,7 @@ class DeltaKinematics:
                           for rail in self.rails])
         self.min_z = config.getfloat('minimum_z_position', 0, maxval=self.max_z)
         self.limit_z = min([ep - arm
-                            for ep, arm in zip(self.endstops, arm_lengths)])
+                            for ep, arm in zip(self.abs_endstops, arm_lengths)])
         logging.info(
             "Delta max build height %.2fmm (radius tapered above %.2fmm)" % (
                 self.max_z, self.limit_z))
@@ -115,7 +114,7 @@ class DeltaKinematics:
                           homing_speed/2.0, second_home=True)
         # Set final homed position
         spos = [ep + rail.get_homed_offset()
-                for ep, rail in zip(self.endstops, self.rails)]
+                for ep, rail in zip(self.abs_endstops, self.rails)]
         homing_state.set_homed_position(self._actuator_to_cartesian(spos))
     def motor_off(self, print_time):
         self.limit_xy2 = -1.
@@ -160,38 +159,15 @@ class DeltaKinematics:
             self._check_motor_enable(print_time)
         for rail in self.rails:
             rail.step_itersolve(move.cmove)
-    # Helper functions for DELTA_CALIBRATE script
-    def get_stable_position(self):
-        steppers = [rail.get_steppers()[0] for rail in self.rails]
-        return [int((ep - s.get_commanded_position()) / s.get_step_dist() + .5)
-                for ep, s in zip(self.endstops, steppers)]
+    # Helper function for DELTA_CALIBRATE script
     def get_calibrate_params(self):
         out = { 'radius': self.radius }
         for i, axis in enumerate('abc'):
             rail = self.rails[i]
-            out['endstop_'+axis] = rail.get_homing_info().position_endstop
-            out['stepdist_'+axis] = rail.get_steppers()[0].get_step_dist()
             out['angle_'+axis] = self.angles[i]
             out['arm_'+axis] = self.arm_lengths[i]
-        return out
-    def get_positions_from_stable(self, stable_positions, params):
-        angle_names = ['angle_a', 'angle_b', 'angle_c']
-        angles = [math.radians(params[an]) for an in angle_names]
-        radius = params['radius']
-        radius2 = radius**2
-        towers = [(math.cos(a) * radius, math.sin(a) * radius) for a in angles]
-        arm2 = [params[an]**2 for an in ['arm_a', 'arm_b', 'arm_c']]
-        stepdist_names = ['stepdist_a', 'stepdist_b', 'stepdist_c']
-        stepdists = [params[sn] for sn in stepdist_names]
-        endstop_names = ['endstop_a', 'endstop_b', 'endstop_c']
-        endstops = [params[en] + math.sqrt(a2 - radius2)
-                    for en, a2 in zip(endstop_names, arm2)]
-        out = []
-        for spos in stable_positions:
-            sphere_coords = [
-                (t[0], t[1], es - sp * sd)
-                for t, es, sd, sp in zip(towers, endstops, stepdists, spos) ]
-            out.append(mathutil.trilateration(sphere_coords, arm2))
+            out['endstop_'+axis] = rail.get_homing_info().position_endstop
+            out['stepdist_'+axis] = rail.get_steppers()[0].get_step_dist()
         return out
 
 def load_kinematics(toolhead, config):

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -4,10 +4,9 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import sys, os, optparse, logging, time, threading
-import collections, ConfigParser, importlib
+import sys, os, optparse, logging, time, threading, collections, importlib
 import util, reactor, queuelogger, msgproto
-import gcode, pins, heater, mcu, toolhead
+import gcode, configfile, pins, heater, mcu, toolhead
 
 message_ready = "Printer is ready"
 
@@ -46,89 +45,8 @@ config, and restart the host software.
 Printer is shutdown
 """
 
-class ConfigWrapper:
-    error = ConfigParser.Error
-    class sentinel:
-        pass
-    def __init__(self, printer, fileconfig, access_tracking, section):
-        self.printer = printer
-        self.fileconfig = fileconfig
-        self.access_tracking = access_tracking
-        self.section = section
-    def get_printer(self):
-        return self.printer
-    def get_name(self):
-        return self.section
-    def _get_wrapper(self, parser, option, default,
-                     minval=None, maxval=None, above=None, below=None):
-        if (default is not self.sentinel
-            and not self.fileconfig.has_option(self.section, option)):
-            return default
-        self.access_tracking[(self.section.lower(), option.lower())] = 1
-        try:
-            v = parser(self.section, option)
-        except self.error as e:
-            raise
-        except:
-            raise self.error("Unable to parse option '%s' in section '%s'" % (
-                option, self.section))
-        if minval is not None and v < minval:
-            raise self.error(
-                "Option '%s' in section '%s' must have minimum of %s" % (
-                    option, self.section, minval))
-        if maxval is not None and v > maxval:
-            raise self.error(
-                "Option '%s' in section '%s' must have maximum of %s" % (
-                    option, self.section, maxval))
-        if above is not None and v <= above:
-            raise self.error(
-                "Option '%s' in section '%s' must be above %s" % (
-                    option, self.section, above))
-        if below is not None and v >= below:
-            raise self.error(
-                "Option '%s' in section '%s' must be below %s" % (
-                    option, self.section, below))
-        return v
-    def get(self, option, default=sentinel):
-        return self._get_wrapper(self.fileconfig.get, option, default)
-    def getint(self, option, default=sentinel, minval=None, maxval=None):
-        return self._get_wrapper(
-            self.fileconfig.getint, option, default, minval, maxval)
-    def getfloat(self, option, default=sentinel,
-                 minval=None, maxval=None, above=None, below=None):
-        return self._get_wrapper(self.fileconfig.getfloat, option, default,
-                                 minval, maxval, above, below)
-    def getboolean(self, option, default=sentinel):
-        return self._get_wrapper(self.fileconfig.getboolean, option, default)
-    def getchoice(self, option, choices, default=sentinel):
-        c = self.get(option, default)
-        if c not in choices:
-            raise self.error(
-                "Choice '%s' for option '%s' in section '%s'"
-                " is not a valid choice" % (c, option, self.section))
-        return choices[c]
-    def getsection(self, section):
-        return ConfigWrapper(self.printer, self.fileconfig,
-                             self.access_tracking, section)
-    def has_section(self, section):
-        return self.fileconfig.has_section(section)
-    def get_prefix_sections(self, prefix):
-        return [self.getsection(s) for s in self.fileconfig.sections()
-                if s.startswith(prefix)]
-
-class ConfigLogger():
-    def __init__(self, cfg, bglogger):
-        self.lines = ["===== Config file ====="]
-        cfg.write(self)
-        self.lines.append("=======================")
-        data = "\n".join(self.lines)
-        logging.info(data)
-        bglogger.set_rollover_info("config", data)
-    def write(self, data):
-        self.lines.append(data.strip())
-
 class Printer:
-    config_error = ConfigParser.Error
+    config_error = configfile.error
     def __init__(self, input_fd, bglogger, start_args):
         self.bglogger = bglogger
         self.start_args = start_args
@@ -156,10 +74,10 @@ class Printer:
             raise self.config_error(
                 "Printer object '%s' already created" % (name,))
         self.objects[name] = obj
-    def lookup_object(self, name, default=ConfigWrapper.sentinel):
+    def lookup_object(self, name, default=configfile.sentinel):
         if name in self.objects:
             return self.objects[name]
-        if default is ConfigWrapper.sentinel:
+        if default is configfile.sentinel:
             raise self.config_error("Unknown config object '%s'" % (name,))
         return default
     def lookup_objects(self, module=None):
@@ -196,36 +114,19 @@ class Printer:
             self.objects[section] = init_func(config.getsection(section))
             return self.objects[section]
     def _read_config(self):
-        fileconfig = ConfigParser.RawConfigParser()
-        config_file = self.start_args['config_file']
-        res = fileconfig.read(config_file)
-        if not res:
-            raise self.config_error("Unable to open config file %s" % (
-                config_file,))
+        self.objects['configfile'] = pconfig = configfile.PrinterConfig(self)
+        config = pconfig.read_main_config()
         if self.bglogger is not None:
-            ConfigLogger(fileconfig, self.bglogger)
+            pconfig.log_config(config)
         # Create printer components
-        access_tracking = {}
-        config = ConfigWrapper(self, fileconfig, access_tracking, 'printer')
         for m in [pins, heater, mcu]:
             m.add_printer_objects(config)
-        for section in fileconfig.sections():
-            self.try_load_module(config, section)
+        for section_config in config.get_prefix_sections(''):
+            self.try_load_module(config, section_config.get_name())
         for m in [toolhead]:
             m.add_printer_objects(config)
         # Validate that there are no undefined parameters in the config file
-        valid_sections = { s: 1 for s, o in access_tracking }
-        for section_name in fileconfig.sections():
-            section = section_name.lower()
-            if section not in valid_sections and section not in self.objects:
-                raise self.config_error(
-                    "Section '%s' is not a valid config section" % (section,))
-            for option in fileconfig.options(section_name):
-                option = option.lower()
-                if (section, option) not in access_tracking:
-                    raise self.config_error(
-                        "Option '%s' is not valid in section '%s'" % (
-                            option, section))
+        pconfig.check_unused_options(config)
         # Determine which printer objects have state callbacks
         self.state_cb = [o.printer_state for o in self.objects.values()
                          if hasattr(o, 'printer_state')]


### PR DESCRIPTION
I'm currently planning to add support for a SAVE_CONFIG command that will allow users to automatically write calibration data to their printer.cfg file.  This pull request adds this support for the PID_CALIBRATE, BED_TILT_CALIBRATE, and DELTA_CALIBRATE commands.  With this change, users need only run the calibration command and the new SAVE_CONFIG command to apply the new settings - users wont be asked to copy-and-paste the new config values into their config, nor will then need to manually RESTART.

Admittedly, this support is a bit "goofy" - the new calibration data is stored at the end of the printer.cfg file in a special configuration block.  If the new calibration data supersedes a config parameter that the user had previously specified, then the original config parameter is commented out when printer.cfg is written.  If the user later updates the config to set a value for a particular parameter then that setting will take precedence over any settings in the SAVE_CONFIG block.  The reason the code does it this way is I want to preserve comments the user may have in their config, avoid user confusion on what config settings are being used, and make it simple to backup/restore settings.

The "enhanced delta printer calibration" (issue #615) needs an automated save and restore mechanism to be effective.  Similarly, it's highly desirable for bed mesh leveling.

-Kevin