### PR TITLE
Adding support for startup value for servos

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -427,6 +427,15 @@
 #   The maximum pulse width time (in seconds). This should correspond
 #   with an angle of maximum_servo_angle. The default is 0.002
 #   seconds.
+#initial_angle: 70
+#   Initial angle to set the servo to when the mcu resets.  Must be between
+#   0 and maximum_servo_angle  This parameter is optional.  If both 
+#   initial_angle and initial_pulse_width are set initial_angle will be used.
+#initial_pulse_width: 0.0015
+#   Initial pulse width time (in seconds) to set the servo to when 
+#   the mcu resets.  Must be between minimum_pulse_width and maximum_pulse_width. 
+#   This parameter is optional.  If both initial_angle and initial_pulse_width 
+#   are set initial_angle will be used
 
 
 # Statically configured digital output pins (one may define any number

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -429,12 +429,12 @@
 #   seconds.
 #initial_angle: 70
 #   Initial angle to set the servo to when the mcu resets.  Must be between
-#   0 and maximum_servo_angle  This parameter is optional.  If both 
+#   0 and maximum_servo_angle  This parameter is optional.  If both
 #   initial_angle and initial_pulse_width are set initial_angle will be used.
 #initial_pulse_width: 0.0015
-#   Initial pulse width time (in seconds) to set the servo to when 
-#   the mcu resets.  Must be between minimum_pulse_width and maximum_pulse_width. 
-#   This parameter is optional.  If both initial_angle and initial_pulse_width 
+#   Initial pulse width time (in seconds) to set the servo to when
+#   the mcu resets.  Must be between minimum_pulse_width and maximum_pulse_width.
+#   This parameter is optional.  If both initial_angle and initial_pulse_width
 #   are set initial_angle will be used
 
 

--- a/klippy/extras/servo.py
+++ b/klippy/extras/servo.py
@@ -28,28 +28,46 @@ class PrinterServo:
         self.gcode.register_mux_command("SET_SERVO", "SERVO", servo_name,
                                         self.cmd_SET_SERVO,
                                         desc=self.cmd_SET_SERVO_help)
-    def set_pwm(self, print_time, value):
+
+        initial_pwm_value = -1
+        #Check to see if an initial angle or pulse width is configured and set it as required
+        initial_angle = config.getfloat('initial_angle', -1)
+        if initial_angle != -1:
+            initial_pwm_value = round(self._get_pwm_from_angle(initial_angle),3)
+        else:
+            initial_pulse_width = config.getfloat('initial_pulse_width', -1)
+            if initial_pulse_width != -1:
+                initial_pwm_value = round(self._get_pwm_from_pulse_width(initial_pulse_width),3)
+
+        if initial_pwm_value > 0:
+            #if we have an initial value for our servo schedule it to happen right away
+            self.mcu_servo.setup_start_value(initial_pwm_value, initial_pwm_value, False)
+            
+    def _set_pwm(self, print_time, value):
         if value == self.last_value:
             return
         print_time = max(print_time, self.last_value_time + PIN_MIN_TIME)
         self.mcu_servo.set_pwm(print_time, value)
         self.last_value = value
         self.last_value_time = print_time
-    def set_angle(self, print_time, angle):
+
+    def _get_pwm_from_angle(self, angle):
         angle = max(0., min(self.max_angle, angle))
         width = self.min_width + angle * self.angle_to_width
-        self.set_pwm(print_time, width * self.width_to_value)
-    def set_pulse_width(self, print_time, width):
+        return width * self.width_to_value
+
+    def _get_pwm_from_pulse_width(self, width):
         width = max(self.min_width, min(self.max_width, width))
-        self.set_pwm(print_time, width * self.width_to_value)
+        return width * self.width_to_value
+
+
     cmd_SET_SERVO_help = "Set servo angle"
     def cmd_SET_SERVO(self, params):
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         if 'WIDTH' in params:
-            self.set_pulse_width(print_time,
-                                 self.gcode.get_float('WIDTH', params))
+            self._set_pwm(print_time, self._get_pwm_from_pulse_width(self.gcode.get_float('WIDTH', params)))
         else:
-            self.set_angle(print_time, self.gcode.get_float('ANGLE', params))
+            self._set_pwm(print_time, self._get_pwm_from_angle(self.gcode.get_float('ANGLE', params)))
 
 def load_config_prefix(config):
     return PrinterServo(config)

--- a/klippy/extras/servo.py
+++ b/klippy/extras/servo.py
@@ -29,7 +29,7 @@ class PrinterServo:
                                         self.cmd_SET_SERVO,
                                         desc=self.cmd_SET_SERVO_help)
 
-        self.initial_pwm_value = -1
+        self.initial_pwm_value = None
         #Check to see if an initial angle or pulse width is configured and
         # set it as required
         initial_angle = config.getfloat('initial_angle', -1)
@@ -43,8 +43,9 @@ class PrinterServo:
 
     def printer_state(self, state):
         if state == 'ready':
-            print_time = self.printer.lookup_object('toolhead').get_last_move_time()
-            self._set_pwm(print_time, self.initial_pwm_value)
+            if self.initial_pwm_value != None:
+                print_time = self.printer.lookup_object('toolhead').get_last_move_time()
+                self._set_pwm(print_time, self.initial_pwm_value)
 
     def _set_pwm(self, print_time, value):
         if value == self.last_value:
@@ -62,7 +63,6 @@ class PrinterServo:
     def _get_pwm_from_pulse_width(self, width):
         width = max(self.min_width, min(self.max_width, width))
         return width * self.width_to_value
-
 
     cmd_SET_SERVO_help = "Set servo angle"
     def cmd_SET_SERVO(self, params):

--- a/klippy/extras/servo.py
+++ b/klippy/extras/servo.py
@@ -42,7 +42,7 @@ class PrinterServo:
         if initial_pwm_value > 0:
             #if we have an initial value for our servo schedule it to happen right away
             self.mcu_servo.setup_start_value(initial_pwm_value, initial_pwm_value, False)
-            
+
     def _set_pwm(self, print_time, value):
         if value == self.last_value:
             return

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -331,10 +331,6 @@ class MCU_pwm:
             self._set_cmd = self._mcu.lookup_command(
                 "schedule_pwm_out oid=%c clock=%u value=%hu", cq=cmd_queue)
         else:
-            if (self._start_value not in [0., 1.]
-                or self._shutdown_value not in [0., 1.]):
-                raise pins.error(
-                    "start and shutdown values must be 0.0 or 1.0 on soft pwm")
             self._pwm_max = self._mcu.get_constant_float("SOFT_PWM_MAX")
             if self._is_static:
                 self._mcu.add_config_cmd("set_digital_out pin=%s value=%d" % (
@@ -349,6 +345,12 @@ class MCU_pwm:
                     self._mcu.seconds_to_clock(self._max_duration)))
             self._set_cmd = self._mcu.lookup_command(
                 "schedule_soft_pwm_out oid=%c clock=%u value=%hu", cq=cmd_queue)
+
+            if (self._start_value not in [0., 1.] ):
+                #since we have a start value that isn't straight on or off we need to spin up PWM right away
+                value = int(max(0., min(1., self._start_value)) * self._pwm_max + 0.5)
+                self._mcu.add_config_cmd("schedule_soft_pwm_out oid=%d clock=%u value=%hu" % (self._oid, self._mcu.print_time_to_clock(self._mcu._printer.lookup_object('toolhead').get_last_move_time()), value))
+
     def set_pwm(self, print_time, value):
         clock = self._mcu.print_time_to_clock(print_time)
         if self._invert:


### PR DESCRIPTION
This allows for a startup angle or pulse-width to be defined in the config file.  Keeps servos from moving around randomly when power is re-applied to them.

Presently only supports softpwm as the servo stuff is hard coded to use that.

Signed-off-by: Chris Whiteford <github@chrisandtennille.com>