### PR TITLE
Adding support for a homing_speed_slow parameter

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -49,6 +49,11 @@ position_max: 200
 #homing_speed: 5.0
 #   Maximum velocity (in mm/s) of the stepper when homing. The default
 #   is 5mm/s.
+#second_homing_speed: 5.0
+#   Maximum velocity (in mm/s) of the stepper when performing the second
+#   stage of homing (the move off the endstop and then back towards for the
+#   second trigger).  This parameter is optional, and defaults to
+#   homing_speed/2.0
 #homing_retract_dist: 5.0
 #   Distance to backoff (in mm) before homing a second time during
 #   homing. The default is 5mm.

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -68,7 +68,7 @@ class CartKinematics:
             r2pos = rpos + hi.retract_dist
         # Initial homing
         homing_speed = hi.speed
-        homing_speed_slow = hi.slow_speed
+        homing_speed_slow = hi.speed_slow
         if axis == 2:
             homing_speed = min(homing_speed, self.max_z_velocity)
         homepos = [None, None, None, None]

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -68,6 +68,7 @@ class CartKinematics:
             r2pos = rpos + hi.retract_dist
         # Initial homing
         homing_speed = hi.speed
+        homing_speed_slow = hi.slow_speed
         if axis == 2:
             homing_speed = min(homing_speed, self.max_z_velocity)
         homepos = [None, None, None, None]
@@ -77,11 +78,11 @@ class CartKinematics:
         homing_state.home(coord, homepos, rail.get_endstops(), homing_speed)
         # Retract
         coord[axis] = rpos
-        homing_state.retract(coord, homing_speed)
+        homing_state.retract(coord, homing_speed_slow)
         # Home again
         coord[axis] = r2pos
         homing_state.home(coord, homepos, rail.get_endstops(),
-                          homing_speed/2.0, second_home=True)
+                          homing_speed_slow, second_home=True)
         # Set final homed position
         coord[axis] = hi.position_endstop + rail.get_homed_offset()
         homing_state.set_homed_position(coord)

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -68,7 +68,7 @@ class CartKinematics:
             r2pos = rpos + hi.retract_dist
         # Initial homing
         homing_speed = hi.speed
-        homing_speed_slow = hi.speed_slow
+        second_homing_speed = hi.second_homing_speed
         if axis == 2:
             homing_speed = min(homing_speed, self.max_z_velocity)
         homepos = [None, None, None, None]
@@ -78,11 +78,11 @@ class CartKinematics:
         homing_state.home(coord, homepos, rail.get_endstops(), homing_speed)
         # Retract
         coord[axis] = rpos
-        homing_state.retract(coord, homing_speed_slow)
+        homing_state.retract(coord, second_homing_speed)
         # Home again
         coord[axis] = r2pos
         homing_state.home(coord, homepos, rail.get_endstops(),
-                          homing_speed_slow, second_home=True)
+                          second_homing_speed, second_home=True)
         # Set final homed position
         coord[axis] = hi.position_endstop + rail.get_homed_offset()
         homing_state.set_homed_position(coord)

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -63,7 +63,7 @@ class CoreXYKinematics:
                 r2pos = rpos + hi.retract_dist
             # Initial homing
             homing_speed = hi.speed
-            homing_speed_slow = hi.speed_slow
+            second_homing_speed = hi.second_homing_speed
             if axis == 2:
                 homing_speed = min(homing_speed, self.max_z_velocity)
             homepos = [None, None, None, None]
@@ -73,11 +73,11 @@ class CoreXYKinematics:
             homing_state.home(coord, homepos, rail.get_endstops(), homing_speed)
             # Retract
             coord[axis] = rpos
-            homing_state.retract(coord, homing_speed_slow)
+            homing_state.retract(coord, second_homing_speed)
             # Home again
             coord[axis] = r2pos
             homing_state.home(coord, homepos, rail.get_endstops(),
-                              homing_speed_slow, second_home=True)
+                              second_homing_speed, second_home=True)
             if axis == 2:
                 # Support endstop phase detection on Z axis
                 coord[axis] = hi.position_endstop + rail.get_homed_offset()

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -63,6 +63,7 @@ class CoreXYKinematics:
                 r2pos = rpos + hi.retract_dist
             # Initial homing
             homing_speed = hi.speed
+            homing_speed_slow = hi.speed_slow
             if axis == 2:
                 homing_speed = min(homing_speed, self.max_z_velocity)
             homepos = [None, None, None, None]
@@ -72,11 +73,11 @@ class CoreXYKinematics:
             homing_state.home(coord, homepos, rail.get_endstops(), homing_speed)
             # Retract
             coord[axis] = rpos
-            homing_state.retract(coord, homing_speed)
+            homing_state.retract(coord, homing_speed_slow)
             # Home again
             coord[axis] = r2pos
             homing_state.home(coord, homepos, rail.get_endstops(),
-                              homing_speed/2.0, second_home=True)
+                              homing_speed_slow, second_home=True)
             if axis == 2:
                 # Support endstop phase detection on Z axis
                 coord[axis] = hi.position_endstop + rail.get_homed_offset()

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -102,17 +102,18 @@ class DeltaKinematics:
         # Initial homing - assume homing speed same for all steppers
         hi = self.rails[0].get_homing_info()
         homing_speed = min(hi.speed, self.max_z_velocity)
+        homing_speed_slow = min(hi.speed_slow, self.max_z_velocity)
         homepos = [0., 0., self.max_z, None]
         coord = list(homepos)
         coord[2] = -1.5 * math.sqrt(max(self.arm2)-self.max_xy2)
         homing_state.home(coord, homepos, endstops, homing_speed)
         # Retract
         coord[2] = homepos[2] - hi.retract_dist
-        homing_state.retract(coord, homing_speed)
+        homing_state.retract(coord, homing_speed_slow)
         # Home again
         coord[2] -= hi.retract_dist
         homing_state.home(coord, homepos, endstops,
-                          homing_speed/2.0, second_home=True)
+                          homing_speed_slow, second_home=True)
         # Set final homed position
         spos = [ep + rail.get_homed_offset()
                 for ep, rail in zip(self.endstops, self.rails)]

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -102,18 +102,18 @@ class DeltaKinematics:
         # Initial homing - assume homing speed same for all steppers
         hi = self.rails[0].get_homing_info()
         homing_speed = min(hi.speed, self.max_z_velocity)
-        homing_speed_slow = min(hi.speed_slow, self.max_z_velocity)
+        second_homing_speed = min(hi.second_homing_speed, self.max_z_velocity)
         homepos = [0., 0., self.max_z, None]
         coord = list(homepos)
         coord[2] = -1.5 * math.sqrt(max(self.arm2)-self.max_xy2)
         homing_state.home(coord, homepos, endstops, homing_speed)
         # Retract
         coord[2] = homepos[2] - hi.retract_dist
-        homing_state.retract(coord, homing_speed_slow)
+        homing_state.retract(coord, second_homing_speed)
         # Home again
         coord[2] -= hi.retract_dist
         homing_state.home(coord, homepos, endstops,
-                          homing_speed_slow, second_home=True)
+                          second_homing_speed, second_home=True)
         # Set final homed position
         spos = [ep + rail.get_homed_offset()
                 for ep, rail in zip(self.endstops, self.rails)]

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -143,6 +143,7 @@ class PrinterRail:
                 " position_min and position_max" % config.get_name())
         # Homing mechanics
         self.homing_speed = config.getfloat('homing_speed', 5.0, above=0.)
+        self.homing_speed_slow = config.getfloat('homing_speed_slow', self.homing_speed/2., above=0.)
         self.homing_retract_dist = config.getfloat(
             'homing_retract_dist', 5., minval=0.)
         self.homing_positive_dir = config.getboolean(
@@ -218,9 +219,9 @@ class PrinterRail:
         return self.position_min, self.position_max
     def get_homing_info(self):
         homing_info = collections.namedtuple('homing_info', [
-            'speed', 'position_endstop', 'retract_dist', 'positive_dir'])(
+            'speed', 'position_endstop', 'retract_dist', 'positive_dir', 'speed_slow'])(
                 self.homing_speed, self.position_endstop,
-                self.homing_retract_dist, self.homing_positive_dir)
+                self.homing_retract_dist, self.homing_positive_dir, self.homing_speed_slow)
         return homing_info
     def get_steppers(self):
         return list(self.steppers)

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -143,7 +143,7 @@ class PrinterRail:
                 " position_min and position_max" % config.get_name())
         # Homing mechanics
         self.homing_speed = config.getfloat('homing_speed', 5.0, above=0.)
-        self.homing_speed_slow = config.getfloat('homing_speed_slow', self.homing_speed/2., above=0.)
+        self.second_homing_speed = config.getfloat('second_homing_speed', self.homing_speed/2., above=0.)
         self.homing_retract_dist = config.getfloat(
             'homing_retract_dist', 5., minval=0.)
         self.homing_positive_dir = config.getboolean(
@@ -219,9 +219,9 @@ class PrinterRail:
         return self.position_min, self.position_max
     def get_homing_info(self):
         homing_info = collections.namedtuple('homing_info', [
-            'speed', 'position_endstop', 'retract_dist', 'positive_dir', 'speed_slow'])(
+            'speed', 'position_endstop', 'retract_dist', 'positive_dir', 'second_homing_speed'])(
                 self.homing_speed, self.position_endstop,
-                self.homing_retract_dist, self.homing_positive_dir, self.homing_speed_slow)
+                self.homing_retract_dist, self.homing_positive_dir, self.second_homing_speed)
         return homing_info
     def get_steppers(self):
         return list(self.steppers)


### PR DESCRIPTION
Allows a second homing_speed_slow parameter to be defined in the config file so that the approach after initial endstop trigger can be slowed down more then the old default of homing_speed/2.0.

Code maintains the existing default if this new parameter is not configured in the config file.

Signed-off-by: Chris Whiteford <chris@chrisandtennille.com>