### PR TITLE
Add support for volumetric extrusion

### DIFF
--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -481,6 +481,8 @@ class GCodeParser:
                         self.last_position[pos] = v + self.base_position[pos]
             if 'E' in params:
                 v = float(params['E']) * self.extrude_factor
+                if self.extruder.volumetric:
+                    v *= self.extruder.volumetric_multiplier
                 if not self.absolutecoord or not self.absoluteextrude:
                     # value relative to position of last move
                     self.last_position[3] += v


### PR DESCRIPTION
This pull request adds support for volumetric extrusion.

There are some new commands to work with this:
- SET_FILAMENT_DIAMETER which now lets you adjust the filament diameter on the fly
- SET_VOLUMETRIC_EXTRUSION lets your turn on and off volumetric extrusion at run time
- GET_FILAMENT_DIAMETER gets the current filament diameter
- GET_VOLUMETRIC_EXTRUSION gets the active state of volumetric extrusion

There are both default versions of these commands (which work on the active tool/extruder) and specific versions that can operate on any extruder.

A new parameter has also been added to the config file.  By adding 
`volumetric: true`
to an extruder section will turn it on for that extruder on startup.

I have done some initial testing using this code, but more would always be appreciated.

Signed-off-by: Chris Whiteford <github@chrisandtennille.com>