### PR TITLE
gcode_macro: macro improvement with parameters

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -12,14 +12,16 @@ class GCodeMacro:
         printer = config.get_printer()
         self.gcode = printer.lookup_object('gcode')
         try:
-            self.gcode.register_command(self.alias, self.cmd, desc=self.cmd_desc)
+            self.gcode.register_command(
+                self.alias, self.cmd, desc=self.cmd_desc)
         except self.gcode.error as e:
             raise config.error(str(e))
         self.in_script = False
     cmd_desc = "G-Code macro"
     def cmd(self, params):
         if self.in_script:
-            raise self.gcode.error("Macro %s called recursively" % (self.alias,))
+            raise self.gcode.error(
+                "Macro %s called recursively" % (self.alias,))
         script = ""
         try:
             script = self.script.format(**params)

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
 
 class GCodeMacro:
     def __init__(self, config):
@@ -19,9 +20,16 @@ class GCodeMacro:
     def cmd(self, params):
         if self.in_script:
             raise self.gcode.error("Macro %s called recursively" % (self.alias,))
+        script = ""
+        try:
+            script = self.script.format(**params)
+        except Exception:
+            msg = "Macro %s script formatting failed" % (self.alias,)
+            logging.exception(msg)
+            raise self.gcode.error(msg)
         self.in_script = True
         try:
-            self.gcode.run_script_from_command(self.script)
+            self.gcode.run_script_from_command(script)
         finally:
             self.in_script = False
 


### PR DESCRIPTION
This dev makes possible to use g-code parameters inside a macro script.
It should be backwards compatible with existing user macros.

All parameter values are passed as they are (strings) and by name. 
It's internally using python advanced string formatting with params as kwargs.

Example macro
```ini
[gcode_macro M355]
gcode:
    SET_PIN PIN=caselight VALUE={S}
```
When calling the macro with parameter `M355 S1`
then available options for formatting are:
```
S → 1
M → 355
```

**NB!** Extended G-Code Command style macros will only accept params in form of `KEY=VAL`
Example call `CASE_LIGHT STATE=1`
```ini
[gcode_macro CASE_LIGHT]
gcode:
    SET_PIN PIN=caselight VALUE={STATE}
```

Signed-off-by: Janar Sööt <janar.soot@gmail.com>