### PR TITLE
menu: vsdcard - scroll long filenames

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -95,6 +95,7 @@ gcode:
 [menu __sdcard]
 type: vsdcard
 name: SD Card
+scroll_long_filenames: true
 items:
     .__start
     .__resume

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -95,7 +95,6 @@ gcode:
 [menu __sdcard]
 type: vsdcard
 name: SD Card
-scroll_long_filenames: true
 items:
     .__start
     .__resume

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -770,8 +770,6 @@ class MenuList(MenuContainer):
 class MenuVSDCard(MenuList):
     def __init__(self, manager, config, namespace=''):
         super(MenuVSDCard, self).__init__(manager, config, namespace)
-        self._scroll_lfns = self._asbool(
-            config.get('scroll_long_filenames', 'false'))
 
     def _populate_files(self):
         sdcard = self._manager.objs.get('virtual_sdcard')
@@ -785,9 +783,9 @@ class MenuVSDCard(MenuList):
                     'name': '%s' % str(fname),
                     'cursor': '+',
                     'gcode': "\n".join(gcode),
-                    'scroll': self._scroll_lfns,
+                    'scroll': True,
                     # mind the cursor size in width
-                    'width': (self._manager.cols-1) if self._scroll_lfns else 0
+                    'width': (self._manager.cols-1)
                 }))
 
     def populate_items(self):

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -770,6 +770,8 @@ class MenuList(MenuContainer):
 class MenuVSDCard(MenuList):
     def __init__(self, manager, config, namespace=''):
         super(MenuVSDCard, self).__init__(manager, config, namespace)
+        self._scroll_lfns = self._asbool(
+            config.get('scroll_long_filenames', 'false'))
 
     def _populate_files(self):
         sdcard = self._manager.objs.get('virtual_sdcard')
@@ -782,7 +784,10 @@ class MenuVSDCard(MenuList):
                 self.append_item(MenuCommand(self._manager, {
                     'name': '%s' % str(fname),
                     'cursor': '+',
-                    'gcode': "\n".join(gcode)
+                    'gcode': "\n".join(gcode),
+                    'scroll': self._scroll_lfns,
+                    # mind the cursor size in width
+                    'width': (self._manager.cols-1) if self._scroll_lfns else 0
                 }))
 
     def populate_items(self):


### PR DESCRIPTION
Long filename scrolling option for `vsdcard` menu item.
It adds `scroll_long_filenames` boolean attribute to `vsdcard` config.
The default value is false.

I turned it on for klippers default menu.
```ini
...
[menu __sdcard]
type: vsdcard
name: SD Card
scroll_long_filenames: true
items:
...
```
Signed-off-by: Janar Sööt <janar.soot@gmail.com>