### PR TITLE
Probe improvements

### DIFF
--- a/config/example-delta.cfg
+++ b/config/example-delta.cfg
@@ -121,14 +121,6 @@ radius: 50
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-#manual_probe:
-#   If true, then DELTA_CALIBRATE will perform manual probing. If
-#   false, then a PROBE command will be run at each probe
-#   point. Manual probing is accomplished by manually jogging the Z
-#   position of the print head at each probe point and then issuing a
-#   NEXT extended g-code command to record the position at that
-#   point. The default is false if a [probe] config section is present
-#   and true otherwise.
 #samples: 1
 #   The number of times to probe each point.  The probed z-values
 #   will be averaged.  The default is to probe 1 time.

--- a/config/example-delta.cfg
+++ b/config/example-delta.cfg
@@ -113,17 +113,19 @@ delta_radius: 174.75
 # angles.
 [delta_calibrate]
 radius: 50
-#   Radius (in mm) of the area that may be probed. This is typically
-#   the size of the printer bed. This parameter must be provided.
+#   Radius (in mm) of the area that may be probed. This is the radius
+#   of nozzle coordinates to be probed; if using an automatic probe
+#   with an XY offset then choose a radius small enough so that the
+#   probe always fits over the bed. This parameter must be provided.
 #speed: 50
-#   The speed (in mm/s) of non-probing moves during the
-#   calibration. The default is 50.
+#   The speed (in mm/s) of non-probing moves during the calibration.
+#   The default is 50.
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
 #samples: 1
-#   The number of times to probe each point.  The probed z-values
-#   will be averaged.  The default is to probe 1 time.
+#   The number of times to probe each point.  The probed z-values will
+#   be averaged. The default is to probe 1 time.
 #sample_retract_dist: 2.0
-#   The distance (in mm) to retract between each sample if
-#   sampling more than once.  Default is 2mm.
+#   The distance (in mm) to retract between each sample if sampling
+#   more than once. The default is 2mm.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -33,12 +33,14 @@
 #activate_gcode:
 #   A list of G-Code commands (one per line; subsequent lines
 #   indented) to execute prior to each probe attempt. This may be
-#   useful if the probe needs to be activated in some way. The default
-#   is to not run any special G-Code commands on activation.
+#   useful if the probe needs to be activated in some way. Do not
+#   issue any commands here that move the toolhead (eg, G1). The
+#   default is to not run any special G-Code commands on activation.
 #deactivate_gcode:
 #   A list of G-Code commands (one per line; subsequent lines
-#   indented) to execute after each probe attempt completes. The
-#   default is to not run any special G-Code commands on deactivation.
+#   indented) to execute after each probe attempt completes. Do not
+#   issue any commands here that move the toolhead. The default is to
+#   not run any special G-Code commands on deactivation.
 
 
 # Bed tilt compensation. One may define a [bed_tilt] config section to

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -48,6 +48,9 @@
 #y_adjust: 0
 #   The amount to add to each move's Z height for each mm on the Y
 #   axis. The default is 0.
+#z_adjust: 0
+#   The amount to add to the Z height when the nozzle is nominally at
+#   0,0. The default is 0.
 # The remaining parameters control a BED_TILT_CALIBRATE extended
 # g-code command that may be used to calibrate appropriate x and y
 # adjustment parameters.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -13,7 +13,9 @@
 # QUERY_PROBE extended g-code commands become available. The probe
 # section also creates a virtual "probe:z_virtual_endstop" pin. One
 # may set the stepper_z endstop_pin to this virtual pin on cartesian
-# style printers that use the probe in place of a z endstop.
+# style printers that use the probe in place of a z endstop. If using
+# "probe:z_virtual_endstop" then do not define a position_endstop in
+# the stepper_z config section.
 #[probe]
 #pin: ar15
 #   Probe detection pin. This parameter must be provided.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -63,14 +63,6 @@
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-#manual_probe:
-#   If true, then BED_TILT_CALIBRATE will perform manual probing. If
-#   false, then a PROBE command will be run at each probe
-#   point. Manual probing is accomplished by manually jogging the Z
-#   position of the print head at each probe point and then issuing a
-#   NEXT extended g-code command to record the position at that
-#   point. The default is false if a [probe] config section is present
-#   and true otherwise.
 #samples: 1
 #   The number of times to probe each point.  The probed z-values
 #   will be averaged.  The default is to probe 1 time.
@@ -140,9 +132,6 @@
 #   may be applied to change the amount of slope interpolated.
 #   Larger numbers will increase the amount of slope, which
 #   results in more curvature in the mesh. Default is .2.
-#manual_probe:
-#   See the manual_probe option of [bed_tilt] for details. The default
-#   is false if a [probe] config section is present and true otherwise.
 
 
 # Multiple Z stepper tilt adjustment. This feature enables independent

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -59,11 +59,11 @@
 # g-code command that may be used to calibrate appropriate x and y
 # adjustment parameters.
 #points:
-#    A list of X,Y coordinates (one per line; subsequent lines
-#    indented) that should be probed during a BED_TILT_CALIBRATE
-#    command. Specify coordinates of the nozzle and be sure the probe
-#    is above the bed at the given nozzle coordinates. The default is
-#    to not enable the command.
+#   A list of X,Y coordinates (one per line; subsequent lines
+#   indented) that should be probed during a BED_TILT_CALIBRATE
+#   command. Specify coordinates of the nozzle and be sure the probe
+#   is above the bed at the given nozzle coordinates. The default is
+#   to not enable the command.
 #speed: 50
 #   The speed (in mm/s) of non-probing moves during the
 #   calibration. The default is 50.
@@ -147,16 +147,16 @@
 # extended G-Code command becomes available.
 #[z_tilt]
 #z_positions:
-#    A list of X,Y coordinates (one per line; subsequent lines
-#    indented) describing the location of each Z stepper. The first
-#    entry corresponds to stepper_z, the second to stepper_z1, the
-#    third to stepper_z2, etc. This parameter must be provided.
+#   A list of X,Y coordinates (one per line; subsequent lines
+#   indented) describing the location of each Z stepper. The first
+#   entry corresponds to stepper_z, the second to stepper_z1, the
+#   third to stepper_z2, etc. This parameter must be provided.
 #points:
-#    A list of X,Y coordinates (one per line; subsequent lines
-#    indented) that should be probed during a Z_TILT_ADJUST
-#    command. Specify coordinates of the nozzle and be sure the probe
-#    is above the bed at the given nozzle coordinates. This parameter
-#    must be provided.
+#   A list of X,Y coordinates (one per line; subsequent lines
+#   indented) that should be probed during a Z_TILT_ADJUST command.
+#   Specify coordinates of the nozzle and be sure the probe is above
+#   the bed at the given nozzle coordinates. This parameter must be
+#   provided.
 #speed: 50
 #   The speed (in mm/s) of non-probing moves during the calibration.
 #   The default is 50.

--- a/config/sample-bltouch.cfg
+++ b/config/sample-bltouch.cfg
@@ -30,8 +30,6 @@ deactivate_gcode:
 
 # Example bed_tilt config section
 [bed_tilt]
-#x_adjust:
-#y_adjust:
 points:
     100,100
     10,10
@@ -45,8 +43,8 @@ points:
 
 # If the BLTouch is used to home the Z axis, then define a
 # homing_override section, use probe:z_virtual_endstop as the
-# endstop_pin in the stepper_z section, and set the position_endstop
-# in the stepper_z section to match the probe's z_offset.
+# endstop_pin in the stepper_z section, and do not set
+# position_endstop in the stepper_z section.
 #[homing_override]
 #set_position_z: 5
 #axes: z

--- a/docs/Delta_Calibrate.md
+++ b/docs/Delta_Calibrate.md
@@ -46,7 +46,7 @@ eliminates error introduced by the probe.
 To perform the basic probe, make sure the config has a
 [delta_calibrate] section defined and run:
 ```
-DELTA_CALIBRATE
+DELTA_CALIBRATE METHOD=manual
 ```
 After probing the seven points new delta parameters will be
 calculated.  Save and apply these parameters by running:

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -147,8 +147,9 @@ enabled:
 
 The following commands are available when the "delta_calibrate" config
 section is enabled:
-- `DELTA_CALIBRATE`: This command will probe seven points on the bed
-  and recommend updated endstop positions, tower angles, and radius.
+- `DELTA_CALIBRATE [METHOD=manual]`: This command will probe seven
+  points on the bed and recommend updated endstop positions, tower
+  angles, and radius.
   - `NEXT`: If manual bed probing is enabled, then one can use this
     command to move to the next probing point during a DELTA_CALIBRATE
     operation.
@@ -159,8 +160,9 @@ section is enabled:
 
 The following commands are available when the "bed_tilt" config
 section is enabled:
-- `BED_TILT_CALIBRATE`: This command will probe the points specified
-  in the config and then recommend updated x and y tilt adjustments.
+- `BED_TILT_CALIBRATE [METHOD=manual]`: This command will probe the
+  points specified in the config and then recommend updated x and y
+  tilt adjustments.
   - `NEXT`: If manual bed probing is enabled, then one can use this
     command to move to the next probing point during a
     BED_TILT_CALIBRATE operation.
@@ -169,9 +171,13 @@ section is enabled:
 
 The following commands are available when the "bed_mesh" config
 section is enabled:
-- `BED_MESH_CALIBRATE`: This command probes the bed using generated
-  points specified by the parameters in the config. After probing,
-  a mesh is generated and z-movement is adjusted according to the mesh.
+- `BED_MESH_CALIBRATE [METHOD=manual]`: This command probes the bed
+  using generated points specified by the parameters in the
+  config. After probing, a mesh is generated and z-movement is
+  adjusted according to the mesh.
+  - `NEXT`: If manual bed probing is enabled, then one can use this
+    command to move to the next probing point during a
+    BED_MESH_CALIBRATE operation.
 - `BED_MESH_OUTPUT`: This command outputs the current probed z values
   and current mesh values to the terminal.
 - `BED_MESH_MAP`: This command probes the bed in a similar fashion

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -246,11 +246,10 @@ class BedMeshCalibrate:
             [0. for i in range(x_cnt)] for j in range(y_cnt)]
         # Check for multi-sampled points
         z_table_len = x_cnt * y_cnt
-        if len(positions) % z_table_len:
+        if len(positions) != z_table_len:
             raise self.gcode.error(
                 ("bed_mesh: Invalid probe table length:\n"
                  "Sampled table length: %d") % len(positions))
-        samples = len(positions) / z_table_len
         # Populate the organized probed table
         for i in range(z_table_len):
             y_position = i / x_cnt
@@ -261,11 +260,8 @@ class BedMeshCalibrate:
             else:
                 # Odd y count, x probed in the negative directon
                 x_position = (x_cnt - 1) - (i % x_cnt)
-            idx = i * samples
-            end = idx + samples
-            avg_z = sum(p[2] for p in positions[idx:end]) / samples
             self.probed_z_table[y_position][x_position] = \
-                avg_z - z_offset
+                positions[i][2] - z_offset
         if self.build_map:
             outdict = {'z_probe_offsets:': self.probed_z_table}
             self.gcode.respond(json.dumps(outdict))

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -138,11 +138,6 @@ class BedMeshCalibrate:
         self._init_probe_params(config, points)
         self.probe_helper = probe.ProbePointsHelper(
             config, self.probe_finalize, points)
-        self.z_endstop_pos = None
-        if config.has_section('stepper_z'):
-            zconfig = config.getsection('stepper_z')
-            self.z_endstop_pos = zconfig.getfloat(
-                'position_endstop', None)
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(
             'BED_MESH_CALIBRATE', self.cmd_BED_MESH_CALIBRATE,
@@ -227,18 +222,6 @@ class BedMeshCalibrate:
         self.probe_params['x_offset'] = offsets[0]
         self.probe_params['y_offset'] = offsets[1]
         z_offset = offsets[2]
-        if self.probe_helper.get_last_xy_home_positon() is not None \
-                and self.z_endstop_pos is not None:
-            # Using probe as a virtual endstop, warn user if the
-            # stepper_z position_endstop is different
-            if self.z_endstop_pos != z_offset:
-                z_msg = "bed_mesh: WARN - probe z_offset is not" \
-                        " equal to Z position_endstop\n"
-                z_msg += "[probe] z_offset: %.4f\n" % z_offset
-                z_msg += "[stepper_z] position_endstop: %.4f" \
-                    % self.z_endstop_pos
-                logging.info(z_msg)
-                self.gcode.respond_info(z_msg)
         x_cnt = self.probe_params['x_count']
         y_cnt = self.probe_params['y_count']
         # create a 2-D array representing the probed z-positions.

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -136,7 +136,8 @@ class BedMeshCalibrate:
         self.probe_params = {}
         points = self._generate_points(config)
         self._init_probe_params(config, points)
-        self.probe_helper = probe.ProbePointsHelper(config, self, points)
+        self.probe_helper = probe.ProbePointsHelper(
+            config, self.probe_finalize, points)
         self.z_endstop_pos = None
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')
@@ -212,9 +213,6 @@ class BedMeshCalibrate:
         self.bedmesh.set_mesh(None)
         self.gcode.run_script_from_command("G28")
         self.probe_helper.start_probe()
-    def get_probed_position(self):
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        return kin.calc_position()
     def print_probed_positions(self, print_func):
         if self.probed_z_table is not None:
             msg = "Mesh Leveling Probed Z positions:\n"
@@ -225,7 +223,7 @@ class BedMeshCalibrate:
             print_func(msg)
         else:
             print_func("bed_mesh: bed has not been probed")
-    def finalize(self, offsets, positions):
+    def probe_finalize(self, offsets, positions):
         self.probe_params['x_offset'] = offsets[0]
         self.probe_params['y_offset'] = offsets[1]
         z_offset = offsets[2]

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -204,15 +204,15 @@ class BedMeshCalibrate:
     cmd_BED_MESH_MAP_help = "Probe the bed and serialize output"
     def cmd_BED_MESH_MAP(self, params):
         self.build_map = True
-        self.start_calibration()
+        self.start_calibration(params)
     cmd_BED_MESH_CALIBRATE_help = "Perform Mesh Bed Leveling"
     def cmd_BED_MESH_CALIBRATE(self, params):
         self.build_map = False
-        self.start_calibration()
-    def start_calibration(self):
+        self.start_calibration(params)
+    def start_calibration(self, params):
         self.bedmesh.set_mesh(None)
         self.gcode.run_script_from_command("G28")
-        self.probe_helper.start_probe()
+        self.probe_helper.start_probe(params)
     def print_probed_positions(self, print_func):
         if self.probed_z_table is not None:
             msg = "Mesh Leveling Probed Z positions:\n"

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -73,10 +73,11 @@ class BedTiltCalibrate:
         new_params = mathutil.coordinate_descent(
             params.keys(), params, errorfunc)
         # Update current bed_tilt calculations
-        z_diff = new_params['z_adjust'] - z_offset
-        bed_tilt = self.printer.lookup_object('bed_tilt')
-        bed_tilt.update_adjust(new_params['x_adjust'], new_params['y_adjust'],
-                               z_diff)
+        x_adjust = new_params['x_adjust']
+        y_adjust = new_params['y_adjust']
+        z_adjust = (new_params['z_adjust'] - z_offset
+                    - x_adjust * offsets[0] - y_adjust * offsets[1])
+        self.bedtilt.update_adjust(x_adjust, y_adjust, z_adjust)
         self.gcode.reset_last_position()
         # Log and report results
         logging.info("Calculated bed_tilt parameters: %s", new_params)
@@ -84,7 +85,7 @@ class BedTiltCalibrate:
             logging.info("orig: %s new: %s", adjusted_height(pos, params),
                          adjusted_height(pos, new_params))
         msg = "x_adjust: %.6f y_adjust: %.6f z_adjust: %.6f" % (
-            new_params['x_adjust'], new_params['y_adjust'], z_diff)
+            x_adjust, y_adjust, z_adjust)
         self.printer.set_rollover_info("bed_tilt", "bed_tilt: %s" % (msg,))
         self.gcode.respond_info(
             "%s\nThe above parameters have been applied to the current\n"

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -56,7 +56,7 @@ class BedTiltCalibrate:
     cmd_BED_TILT_CALIBRATE_help = "Bed tilt calibration script"
     def cmd_BED_TILT_CALIBRATE(self, params):
         self.gcode.run_script_from_command("G28")
-        self.probe_helper.start_probe()
+        self.probe_helper.start_probe(params)
     def probe_finalize(self, offsets, positions):
         z_offset = offsets[2]
         logging.info("Calculating bed_tilt with: %s", positions)

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -42,7 +42,7 @@ class BedTiltCalibrate:
     def __init__(self, config, bedtilt):
         self.printer = config.get_printer()
         self.bedtilt = bedtilt
-        self.probe_helper = probe.ProbePointsHelper(config, self)
+        self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
         # Automatic probe:z_virtual_endstop XY detection
         self.z_position_endstop = None
         if config.has_section('stepper_z'):
@@ -57,10 +57,7 @@ class BedTiltCalibrate:
     def cmd_BED_TILT_CALIBRATE(self, params):
         self.gcode.run_script_from_command("G28")
         self.probe_helper.start_probe()
-    def get_probed_position(self):
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        return kin.calc_position()
-    def finalize(self, offsets, positions):
+    def probe_finalize(self, offsets, positions):
         z_offset = offsets[2]
         logging.info("Calculating bed_tilt with: %s", positions)
         params = { 'x_adjust': self.bedtilt.x_adjust,

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -49,13 +49,6 @@ def get_position_from_stable(stable_position, delta_params):
                 dp.stepdists, dp.towers, dp.abs_endstops, stable_position) ]
     return mathutil.trilateration(sphere_coords, [a**2 for a in dp.arms])
 
-# Return a stable position from the nominal delta tower positions
-def get_stable_position(stepper_position, delta_params):
-    dp = delta_params
-    return [int((ep - sp) / sd + .5)
-            for sd, ep, sp in zip(
-                    dp.stepdists, dp.abs_endstops, stepper_position)]
-
 # Return a stable position from a cartesian coordinate
 def calc_stable_position(coord, delta_params):
     dp = delta_params
@@ -201,13 +194,13 @@ class DeltaCalibrate:
                            "%.3f,%.3f,%.3f" % tuple(spos2))
     def get_probed_position(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()
-        return [s.get_commanded_position() for s in kin.get_steppers()]
+        return kin.calc_position()
     def finalize(self, offsets, positions):
         # Convert positions into (z_offset, stable_position) pairs
         z_offset = offsets[2]
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         delta_params = build_delta_params(kin.get_calibrate_params())
-        probe_positions = [(z_offset, get_stable_position(p, delta_params))
+        probe_positions = [(z_offset, calc_stable_position(p, delta_params))
                            for p in positions]
         # Perform analysis
         self.calculate_params(probe_positions, self.last_distances)

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -142,7 +142,7 @@ class DeltaCalibrate:
             dist = radius * scatter[i]
             points.append((math.cos(r) * dist, math.sin(r) * dist))
         self.probe_helper = probe.ProbePointsHelper(
-            config, self, default_points=points)
+            config, self.probe_finalize, default_points=points)
         # Restore probe stable positions
         self.last_probe_positions = []
         for i in range(999):
@@ -192,10 +192,7 @@ class DeltaCalibrate:
                            "%.3f,%.3f,%.3f" % tuple(spos1))
             configfile.set(section, "distance%d_pos2" % (i,),
                            "%.3f,%.3f,%.3f" % tuple(spos2))
-    def get_probed_position(self):
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        return kin.calc_position()
-    def finalize(self, offsets, positions):
+    def probe_finalize(self, offsets, positions):
         # Convert positions into (z_offset, stable_position) pairs
         z_offset = offsets[2]
         kin = self.printer.lookup_object('toolhead').get_kinematics()

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -184,7 +184,7 @@ class DeltaCalibrate:
         for i, (z_offset, spos) in enumerate(probe_positions):
             configfile.set(section, "height%d" % (i,), z_offset)
             configfile.set(section, "height%d_pos" % (i,),
-                           "%d,%d,%d" % tuple(spos))
+                           "%.3f,%.3f,%.3f" % tuple(spos))
         # Save distance measurements
         for i, (dist, spos1, spos2) in enumerate(distances):
             configfile.set(section, "distance%d" % (i,), dist)

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -275,7 +275,7 @@ class DeltaCalibrate:
     cmd_DELTA_CALIBRATE_help = "Delta calibration script"
     def cmd_DELTA_CALIBRATE(self, params):
         self.gcode.run_script_from_command("G28")
-        self.probe_helper.start_probe()
+        self.probe_helper.start_probe(params)
     def do_extended_calibration(self):
         # Extract distance positions
         if len(self.delta_analyze_entry) <= 1:

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -199,6 +199,18 @@ class ProbePointsHelper:
         except homing.EndstopError as e:
             self.finalize(False)
             raise self.gcode.error(str(e))
+    def move_next(self):
+        x, y = self.probe_points[len(self.results)/self.samples]
+        curpos = self.toolhead.get_position()
+        curpos[0] = x
+        curpos[1] = y
+        curpos[2] = self.horizontal_move_z
+        try:
+            self.toolhead.move(curpos, self.speed)
+        except homing.EndstopError as e:
+            self.finalize(False)
+            raise self.gcode.error(str(e))
+        self.gcode.reset_last_position()
     def probe_point(self):
         for i in range(self.samples):
             self.gcode.run_script_from_command("PROBE")
@@ -228,18 +240,6 @@ class ProbePointsHelper:
             except:
                 self.finalize(False)
                 raise
-    def move_next(self):
-        x, y = self.probe_points[len(self.results)/self.samples]
-        curpos = self.toolhead.get_position()
-        curpos[0] = x
-        curpos[1] = y
-        curpos[2] = self.horizontal_move_z
-        try:
-            self.toolhead.move(curpos, self.speed)
-        except homing.EndstopError as e:
-            self.finalize(False)
-            raise self.gcode.error(str(e))
-        self.gcode.reset_last_position()
     cmd_NEXT_help = "Move to the next XY position to probe"
     def cmd_NEXT(self, params):
         if self.probe is None:

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -70,8 +70,7 @@ class PrinterProbe:
         pos = toolhead.get_position()
         pos[2] = self.z_position
         try:
-            homing_state.homing_move(
-                pos, [(self.mcu_probe, "probe")], self.speed, probe_pos=True)
+            homing_state.probing_move(pos, self.mcu_probe, self.speed)
         except homing.EndstopError as e:
             reason = str(e)
             if "Timeout during endstop homing" in reason:

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -38,7 +38,7 @@ class QuadGantryLevel:
         self.z_steppers = z_steppers
     cmd_QUAD_GANTRY_LEVEL_help = "Conform a moving, twistable gantry to the shape of a stationary bed"
     def cmd_QUAD_GANTRY_LEVEL(self, params):
-        self.probe_helper.start_probe()
+        self.probe_helper.start_probe(params)
     def probe_finalize(self, offsets, positions):
         logging.info("quad_gantry_level Calculating gantry geometry with: %s", positions)
         p1 = [positions[0][0] + offsets[0],positions[0][2]]

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -39,22 +39,7 @@ class QuadGantryLevel:
     cmd_QUAD_GANTRY_LEVEL_help = "Conform a moving, twistable gantry to the shape of a stationary bed"
     def cmd_QUAD_GANTRY_LEVEL(self, params):
         self.probe_helper.start_probe()
-    def squash_positions(self,positions):
-        # Group multi-probe data and average out the Z readings
-        # Assumes samples come in sequentially
-        grouped_pos = []
-        for position in positions:
-            if len(grouped_pos) > 0 and round(grouped_pos[-1][0],3) == round(position[0],3) and round(grouped_pos[-1][1],3) == round(position[1],3):
-                grouped_pos[-1][2].append(position[2])
-            else:
-                grouped_pos.append(position)
-                grouped_pos[-1][2] = [grouped_pos[-1][2]]
-        for id,pos in enumerate(grouped_pos):
-            grouped_pos[id][2] = sum(grouped_pos[id][2]) / len(grouped_pos[id][2])
-        return grouped_pos
     def probe_finalize(self, offsets, positions):
-        if len(positions) > 4:
-            positions = self.squash_positions(positions)
         logging.info("quad_gantry_level Calculating gantry geometry with: %s", positions)
         p1 = [positions[0][0] + offsets[0],positions[0][2]]
         p2 = [positions[1][0] + offsets[0],positions[1][2]]

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -9,7 +9,7 @@ import probe
 class QuadGantryLevel:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.probe_helper = probe.ProbePointsHelper(config, self)
+        self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
         gantry_corners = config.get('gantry_corners').split('\n')
         try:
             gantry_corners = [line.split(',', 1)
@@ -39,9 +39,6 @@ class QuadGantryLevel:
     cmd_QUAD_GANTRY_LEVEL_help = "Conform a moving, twistable gantry to the shape of a stationary bed"
     def cmd_QUAD_GANTRY_LEVEL(self, params):
         self.probe_helper.start_probe()
-    def get_probed_position(self):
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        return kin.calc_position()
     def squash_positions(self,positions):
         # Group multi-probe data and average out the Z readings
         # Assumes samples come in sequentially
@@ -55,7 +52,7 @@ class QuadGantryLevel:
         for id,pos in enumerate(grouped_pos):
             grouped_pos[id][2] = sum(grouped_pos[id][2]) / len(grouped_pos[id][2])
         return grouped_pos
-    def finalize(self, offsets, positions):
+    def probe_finalize(self, offsets, positions):
         if len(positions) > 4:
             positions = self.squash_positions(positions)
         logging.info("quad_gantry_level Calculating gantry geometry with: %s", positions)

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -20,7 +20,7 @@ class ZTilt:
                 config.get_name()))
         if len(z_positions) < 2:
             raise config.error("z_tilt requires at least two z_positions")
-        self.probe_helper = probe.ProbePointsHelper(config, self)
+        self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
         self.z_steppers = []
         # Register Z_TILT_ADJUST command
         self.gcode = self.printer.lookup_object('gcode')
@@ -40,10 +40,7 @@ class ZTilt:
     cmd_Z_TILT_ADJUST_help = "Adjust the Z tilt"
     def cmd_Z_TILT_ADJUST(self, params):
         self.probe_helper.start_probe()
-    def get_probed_position(self):
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        return kin.calc_position()
-    def finalize(self, offsets, positions):
+    def probe_finalize(self, offsets, positions):
         z_offset = offsets[2]
         logging.info("Calculating bed tilt with: %s", positions)
         params = { 'x_adjust': 0., 'y_adjust': 0., 'z_adjust': z_offset }

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -39,7 +39,7 @@ class ZTilt:
         self.z_steppers = z_steppers
     cmd_Z_TILT_ADJUST_help = "Adjust the Z tilt"
     def cmd_Z_TILT_ADJUST(self, params):
-        self.probe_helper.start_probe()
+        self.probe_helper.start_probe(params)
     def probe_finalize(self, offsets, positions):
         z_offset = offsets[2]
         logging.info("Calculating bed tilt with: %s", positions)

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -35,7 +35,8 @@ class ZTilt:
         z_steppers = kin.get_steppers('Z')
         if len(z_steppers) != len(self.z_positions):
             raise self.printer.config_error(
-                "z_tilt z_positions needs exactly %d items" % (len(z_steppers),))
+                "z_tilt z_positions needs exactly %d items" % (
+                    len(z_steppers),))
         self.z_steppers = z_steppers
     cmd_Z_TILT_ADJUST_help = "Adjust the Z tilt"
     def cmd_Z_TILT_ADJUST(self, params):

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -121,7 +121,9 @@ class PrinterRail:
         mcu_endstop = ppins.setup_pin('endstop', config.get('endstop_pin'))
         self.endstops = [(mcu_endstop, self.name)]
         stepper.add_to_endstop(mcu_endstop)
-        if default_position_endstop is None:
+        if hasattr(mcu_endstop, "get_position_endstop"):
+            self.position_endstop = mcu_endstop.get_position_endstop()
+        elif default_position_endstop is None:
             self.position_endstop = config.getfloat('position_endstop')
         else:
             self.position_endstop = config.getfloat(

--- a/test/klippy/z_virtual_endstop.cfg
+++ b/test/klippy/z_virtual_endstop.cfg
@@ -1,0 +1,72 @@
+# Test config for probe:z_virtual_endstop
+[stepper_x]
+step_pin: ar54
+dir_pin: ar55
+enable_pin: !ar38
+step_distance: .0125
+endstop_pin: ^ar3
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: ar60
+dir_pin: !ar61
+enable_pin: !ar56
+step_distance: .0125
+endstop_pin: ^ar14
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: ar46
+dir_pin: ar48
+enable_pin: !ar62
+step_distance: .0025
+endstop_pin: probe:z_virtual_endstop
+position_max: 200
+
+[extruder]
+step_pin: ar26
+dir_pin: ar28
+enable_pin: !ar24
+step_distance: .002
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: ar8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[probe]
+pin: ar9
+z_offset: 1.15
+
+[bed_mesh]
+min_point: 10,10
+max_point: 180,180
+
+[mcu]
+serial: /dev/ttyACM0
+pin_map: arduino
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/z_virtual_endstop.test
+++ b/test/klippy/z_virtual_endstop.test
@@ -1,0 +1,25 @@
+# Test case for probe:z_virtual_endstop support
+CONFIG z_virtual_endstop.cfg
+DICTIONARY atmega2560-16mhz.dict
+
+# Start by homing the printer.
+G28
+G1 F6000
+
+# Z / X / Y moves
+G1 Z1
+G1 X1
+G1 Y1
+
+# Run bed_mesh_calibrate
+BED_MESH_CALIBRATE
+
+# Move again
+G1 Z5 X0 Y0
+
+# Do regular probe
+PROBE
+QUERY_PROBE
+
+# Move again
+G1 Z9


### PR DESCRIPTION
This is a notice that I plan to make some non-backwards compatible changes to the config file:
* Configs that use probe:z_virtual_endstop will no longer specify a position_endstop in the stepper_z config section.  The position_endstop will now automatically be set from the probe's z_offset parameter.
* The manual_probe config option has been removed from the delta_calibrate, bed_tilt, and bed_mesh config sections.  Instead, the DELTA_CALIBRATE, BED_TILT_CALIBRATE, and BED_MESH_CALIBRATE commands have been extended to support a "METHOD=manual" parameter.

In addition to the above changes, this series adds a number of cleanups to the probing code that will hopefully make the probing code more robust.

cd ~/klipper ; git fetch ; git checkout origin/work-probe-20180926 ; sudo service klipper restart

I don't have all the different variations of the hardware, so additional testers would be helpful.

@Arksine , @mzbotreprap - can you verify this series looks correct on your hardware?

-Kevin