### PR TITLE
Gcode macro parameter default values

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -974,8 +974,13 @@
 #   evaluated using Python "string format syntax" with the command
 #   parameters as named arguments. For example, if one were to define
 #   a macro MY_DELAY with gcode "G4 P{DELAY}" then the command
-#   "MY_DELAY DELAY=100" would evaluate to "G4 P100". This parameter
-#   must be provided.
+#   "MY_DELAY DELAY=100" would evaluate to "G4 P100". It's also
+#   possible to set default value to missing parameters.
+#   For example [gcode_macro MY_DELAY DELAY=50] with gcode "G4 P{DELAY}"
+#   allows to call macro MY_DELAY without parameter. Gcode will be evaluated
+#   by using missing parameter default value. Multiple default parameters
+#   can used by separating them with comma.
+#   This parameter must be provided.
 
 
 # Replicape support - see the generic-replicape.cfg file for further

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -968,18 +968,20 @@
 # G-Code macros (one may define any number of sections with a
 # "gcode_macro" prefix).
 #[gcode_macro my_cmd]
+#default_parameter_<parameter>:
+#   The command parameter can be made optional by defining its default value.
+#   All command parameter default values must have prefix "default_parameter_"
+#   Gcode will be evaluated by using missing parameter default value.
+#   For example, config option "default_parameter_DELAY:50" will define a default
+#   value for command parameter DELAY.
+#   The default is no default values for parameters.
 #gcode:
 #   A list of G-Code commands (one per line; subsequent lines
 #   indented) to execute in place of "my_cmd". This parameter is
 #   evaluated using Python "string format syntax" with the command
 #   parameters as named arguments. For example, if one were to define
 #   a macro MY_DELAY with gcode "G4 P{DELAY}" then the command
-#   "MY_DELAY DELAY=100" would evaluate to "G4 P100". It's also
-#   possible to set default value to missing parameters.
-#   For example [gcode_macro MY_DELAY DELAY=50] with gcode "G4 P{DELAY}"
-#   allows to call macro MY_DELAY without parameter. Gcode will be evaluated
-#   by using missing parameter default value. Multiple default parameters
-#   can used by separating them with comma "DELAY=50, S=0".
+#   "MY_DELAY DELAY=100" would evaluate to "G4 P100".
 #   This parameter must be provided.
 
 

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -979,7 +979,7 @@
 #   For example [gcode_macro MY_DELAY DELAY=50] with gcode "G4 P{DELAY}"
 #   allows to call macro MY_DELAY without parameter. Gcode will be evaluated
 #   by using missing parameter default value. Multiple default parameters
-#   can used by separating them with comma.
+#   can used by separating them with comma "DELAY=50, S=0".
 #   This parameter must be provided.
 
 

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -74,6 +74,9 @@ class ConfigWrapper:
     def get_prefix_sections(self, prefix):
         return [self.getsection(s) for s in self.fileconfig.sections()
                 if s.startswith(prefix)]
+    def get_prefix_options(self, prefix):
+        return [o for o in self.fileconfig.options(self.section)
+                if o.startswith(prefix)]
 
 AUTOSAVE_HEADER = """
 #*# <---------------------- SAVE_CONFIG ---------------------->

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -5,10 +5,12 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 
+DEFAULT_PREFIX = 'default_parameter_'
+
+
 class GCodeMacro:
     def __init__(self, config):
         self.alias = config.get_name().split()[1].upper()
-        self.dp = " ".join(config.get_name().split()[2:])
         self.script = config.get('gcode')
         printer = config.get_printer()
         self.gcode = printer.lookup_object('gcode')
@@ -20,8 +22,10 @@ class GCodeMacro:
         self.in_script = False
         self.kwparams = {}
         try:
-            self.kwparams = {str(k).upper(): v for k, o, v in (map(
-                str.strip, x.partition('=')) for x in self.dp.split(',')) if k}
+            kvpairs = [map(str.strip, (
+                o[len(DEFAULT_PREFIX):], config.get(o, '')
+            )) for o in config.get_prefix_options(DEFAULT_PREFIX)]
+            self.kwparams = {str(k).upper(): v for (k, v) in kvpairs if k}
         except Exception:
             raise config.error("Unable to parse default parameter values")
     cmd_desc = "G-Code macro"


### PR DESCRIPTION
Addition to gcode_macro parameters.
It allows defining default values to these parameters.
```ini
[gcode_macro MY_DELAY DELAY=50]
gcode:
    G4 P{DELAY}
```
It makes possible to call macro without specifying the parameter.

EDIT:
Default values can be defined as a config option with a prefix `default_parameter_`
```ini
[gcode_macro MY_DELAY]
default_parameter_DELAY: 50
gcode:
    G4 P{DELAY}
```
