### PR TITLE
serialhdl: Close serial port on _bg_thread terminate

### DIFF
--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -51,6 +51,7 @@ class SerialReader:
                 hdl(params)
             except:
                 logging.exception("Exception in serial callback")
+        self.ser.close()
     def connect(self):
         # Initial connection
         logging.info("Starting serial connect")


### PR DESCRIPTION
Close serial port when serialhdl background thread terminates.
This resolves an issue where a lost serial connection results in
the file descriptor not being immediately closed. This issue results
in the serial hardware being assigned a new name on reconnection
(i.e. /dev/ttyUSB1) and thus requires klippy to be restarted after
every disconnect if the new name does not match the config file.

Signed-off-by: Nick Brennan <nick.brennan01@gmail.com>