### PR TITLE
bed_mesh: support saving state to profiles

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -189,6 +189,14 @@ section is enabled:
   will be cleared as the process rehomes the printer.
 - `BED_MESH_CLEAR`: This command clears the mesh and removes all
   z adjustment.  It is recommended to put this in your end-gcode.
+  `BED_MESH_PROFILE LOAD=<name> SAVE=<name> REMOVE=<name>`: This
+  command provides profile management for mesh state.  LOAD will
+  restore the mesh state from the profile matching the supplied name.
+  SAVE will save the current mesh state to a profile matching the
+  supplied name.  Remove will delete the profile matching the
+  supplied name from persistent memory.  Note that after SAVE or
+  REMOVE operations have been run the SAVE_CONFIG gcode must be run
+  to make the changes to peristent memory permanent.
 
 ## Z Tilt
 

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -246,8 +246,14 @@ class BedMeshCalibrate:
             self.probed_z_table[y_position][x_position] = \
                 positions[i][2] - z_offset
         if self.build_map:
-            outdict = {'z_probe_offsets:': self.probed_z_table}
-            self.gcode.respond(json.dumps(outdict))
+            params = self.probe_params
+            outdict = {
+                'min_point': (params['min_x'], params['min_y']),
+                'max_point': (params['max_x'], params['max_y']),
+                'xy_offset': offsets[:2],
+                'z_positions': self.probed_z_table}
+            self.gcode.respond(
+                "mesh_map_output " + json.dumps(outdict))
         else:
             mesh = ZMesh(self.probe_params)
             try:


### PR DESCRIPTION
This request adds the ability to save bed_mesh state to individual profiles using Klipper's persistent storage functionality.  This functionality is accessed through a new gcode:

```BED_MESH_PROFILE LOAD=<name> SAVE=<name> REMOVE=<name>```

After the bed has been calibrated, a user may save the current state using BED_MESH_PROFILE SAVE=profile_name.  Saved profiles will appear in printer.cfg as new section labled [bed_mesh <name>].  As with all persistent functionality, calls to BED_MESH_PROFILE SAVE or REMOVE will need the be followed up by a SAVE_CONFIG gcode to make the change permanent. 

Also included in this PR is a small change to BED_MESH_MAP, adding some additional information as requested by the  Mesh Map octoprint plugin developers.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>