### PR TITLE
Spelling error corrected in bed mesh comment

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -131,7 +131,7 @@
 #   point. The user may enter a single value which will be applied
 #   to both axes.  Default is 2,2.
 #algorithm: lagrange
-#   The interpolation algorithm to use. May be either "langrange"
+#   The interpolation algorithm to use. May be either "lagrange"
 #   or "bicubic". This option will not affect 3x3 grids, which
 #   are forced to use lagrange sampling.  Default is lagrange.
 #bicubic_tension: .2


### PR DESCRIPTION
The comment for the algorithm setting had a spelling error, it said:
`May be either "langrange"`
Removed the n.

Signed-off-by: Victor Lazaro <lazarofilm@gmail.com>