### PR TITLE
probe: ProbePointsHelper enhancements V2

### DIFF
--- a/config/example-menu.cfg
+++ b/config/example-menu.cfg
@@ -12,6 +12,28 @@
 #   deck - special container for custom screens (cards) has entry and exit gcode triggers.
 #   card - special content card for custom screens. Can only be used in 'deck'!
 
+# Available actions:
+#   nop - do nothing
+#   editing <...> [<arg1>] input commands
+#         start - will try to start edit mode
+#                 If arg1 is False then skip start_gcode script, default is True
+#                 Has effect for input elements.
+#         stop - will try to stop edit mode
+#                If arg1 is False then skip stop_gcode script, default is True
+#                Has effect for input elements.
+#         gcode - will trigger gcode script.
+#   deck <...> - deck commands
+#         open-menu - will open master container (deck) longpress menu.
+#   respond <response> - will send '// response' to host.
+#   // <response> - same as previous
+#   !! <response> - will send '!! response' to host.
+#   echo <response> - will send 'echo: response' to host.
+#   emit <name> [<arg1> [<arg2> ...]] - will emit event 'menu:action:<name>' with args to klippers event system
+#   log <info> - will write <info> to log file.
+#   back - will execute menu back command
+#   exit - will execute menu exit command
+
+
 #[menu item1]
 #type: item
 #   Type will determine menu item properties and behaviours:
@@ -81,8 +103,9 @@
 #   When menu element is clicked then gcodes on this attribute will be executed.
 #   Can have multiline gcode script and supports output formatting for parameter and transform values.
 #action:
-#   Special action can be executed. Supports [back, exit] menu commands
-#   and [respond response_info] command. Respond command will send '// response_info' to host.
+#   Special action can be executed.
+#   Multiple actions can be used on separate lines.
+#   The default is empty. This parameter is optional.
 
 #[menu input1]
 #type: input
@@ -94,10 +117,24 @@
 #parameter:
 #   Value from parameter (always index 0) is taken as input value when in edit mode.
 #gcode:
-#   This will be triggered in realtime mode, on exit from edit mode
-#   or in edit mode this will be triggered after click button long press (>0.8sec).
+#   This will be triggered in realtime mode and on stop of edit mode or via action.
+#   In normal usage, this is the preferred gcode script.
+#action:
+#   Will trigger special action on stop of edit mode.
+#   Multiple actions can be used on separate lines
+#   The default is empty. This parameter is optional.
 #longpress_gcode:
 #   In edit mode this will be triggered after click button long press (>0.8sec).
+#   The default is empty. This parameter is optional.
+#longpress_action:
+#   In edit mode special action will be triggered after click button long press (>0.8sec).
+#   Multiple actions can be used on separate lines
+#   The default is empty. This parameter is optional.
+#start_gcode:
+#   Will trigger gcode script on start of edit mode.
+#   The default is empty. This parameter is optional.
+#stop_gcode:
+#   Will trigger gcode script on stop of edit mode.
 #   The default is empty. This parameter is optional.
 #reverse:
 #   This attribute accepts static boolean value.
@@ -111,6 +148,11 @@
 #   This attribute accepts static boolean value.
 #   When enabled it will execute gcode after each value change.
 #   The default is False. This parameter is optional.
+#autostop:
+#   This attribute accepts static boolean value.
+#   When disabled it will not stop edit mode after short press.
+#   It allows to manually control editing via short press and long press action
+#   The default is True. This parameter is optional.
 #input_min:
 #   It accepts integer or float value. Will set minimal bound for edit value.
 #   The default is 2.2250738585072014e-308. This parameter is optional.
@@ -165,6 +207,11 @@
 #enable:
 #enter_gcode
 #leave_gcode
+#constrained:
+#   This attribute accepts static boolean value.
+#   When enabled then on menu startup or timeout the selection is always
+#   initialized with card first or sticky child element otherwise none is selected.
+#   The default is False. This parameter is optional.
 #longpress_menu:
 #   Entry point to menu container. When this attribute is set then
 #   long press > 0.8s will initiate this menu container if not in edit mode.
@@ -203,3 +250,7 @@
 #   When enabled the menu system uses a cursor instead of blinking to visualize item selection
 #   and edit mode for this card. Cursor and placeholder is always added as item name prefix.
 #   The default is False. This parameter is optional.
+#sticky:
+#   This element is selected by default on card. In case of input element then edit mode is started.
+#   It has to be non read-only element (selectable)
+#   The default is disabled. This parameter is optional.

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -74,21 +74,21 @@ items:
 type: command
 enable: toolhead.is_printing
 name: Pause printing
-action: respond action:pause
+action: // action:pause
 gcode:
 
 [menu __octoprint __resume]
 type: command
 enable: !toolhead.is_printing
 name: Resume printing
-action: respond action:resume
+action: // action:resume
 gcode:
 
 [menu __octoprint __abort]
 type: command
 enable: toolhead.is_printing
 name: Abort printing
-action: respond action:cancel
+action: // action:cancel
 gcode:
 
 ### menu virtual sdcard ###

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -6,6 +6,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, logging, sys, ast, re, string
+import probe_menu
 
 
 class error(Exception):
@@ -1160,6 +1161,8 @@ class MenuManager:
             'encoder_fast_rate', .03, above=0.)
         self._last_encoder_cw_eventtime = 0
         self._last_encoder_ccw_eventtime = 0
+        # probe menu
+        self.probe_menu = probe_menu.ProbeHelperMenu(config, self)
         # printer objects
         self.buttons = self.printer.try_load_module(config, "buttons")
         # register itself for printer callbacks

--- a/klippy/extras/display/probe_menu.cfg
+++ b/klippy/extras/display/probe_menu.cfg
@@ -1,0 +1,174 @@
+### Probe Points Helper Menu ###
+[menu __probe_helper_done]
+type: deck
+name: Probe Helper Done
+content:
+    "= Probe helper ="
+    "{.__status}"
+    "Returning to the"
+    "menu ..."
+
+[menu __probe_helper_done __status]
+type: item
+name: Probing {1}!
+parameter: probe_menu.end_status
+transform:
+    0.choose('error','done')
+
+[menu __probe_helper_adjust_1mm]
+type: deck
+name: Probe Helper Adjust 1mm
+constrained: True
+sticky: .__move_z
+longpress_menu: __probe_helper_adjust_menu
+content:
+    "= Probe helper ="
+    "Adjust Z 1.00 mm"
+    "================"
+    " Move Z: {.__move_z}"
+
+[menu __probe_helper_adjust_01mm]
+type: deck
+name: Probe Helper Adjust 0.1mm
+constrained: True
+sticky: .__move_z
+longpress_menu: __probe_helper_adjust_menu
+content:
+    "= Probe helper ="
+    "Adjust Z 0.10 mm"
+    "================"
+    " Move Z: {.__move_z}"
+
+[menu __probe_helper_adjust_001mm]
+type: deck
+name: Probe Helper Adjust 0.01mm
+constrained: True
+sticky: .__move_z
+longpress_menu: __probe_helper_adjust_menu
+content:
+    "= Probe helper ="
+    "Adjust Z 0.01 mm"
+    " Axis Z: {__probe_helper_adjust_realz}"
+    " Move Z: {.__move_z}"
+
+[menu __probe_helper_adjust_001mm __move_z]
+type: input
+name: "{0:04.2f}"
+parameter: toolhead.zpos
+input_min: -5.0
+input_max: 50.0
+input_step: 0.01
+autostop: false
+longpress_action:
+    editing stop 0
+    deck open-menu
+gcode:
+    G1 Z{0:.2f}
+    G91
+    G1 Z2
+    G1 Z-2
+    G90
+
+[menu __probe_helper_adjust_01mm __move_z]
+type: input
+name: "{0:04.2f}"
+parameter: toolhead.zpos
+realtime: true
+input_min: -5
+input_max: 50.0
+input_step: 0.10
+autostop: false
+action:
+    editing stop
+    editing start
+longpress_action:
+    editing stop 0
+    deck open-menu
+gcode: G1 Z{0:.2f}
+stop_gcode:
+    G91
+    G1 Z2
+    G1 Z-2
+    G90
+
+[menu __probe_helper_adjust_1mm __move_z]
+type: input
+name: "{0:04.2f}"
+parameter: toolhead.zpos
+realtime: true
+input_min: -5
+input_max: 50.0
+input_step: 1.0
+action:
+    editing stop
+    editing start
+longpress_action:
+    editing stop 0
+    deck open-menu
+gcode: G1 Z{0:.2f}
+stop_gcode:
+    G91
+    G1 Z2
+    G1 Z-2
+    G90
+
+[menu __probe_helper_adjust_realz]
+type: item
+name: "{0:04.2f}"
+parameter: toolhead.zpos
+
+[menu __probe_helper_moving]
+type: deck
+name: Probe Helper Moving
+content:
+    "= Probe helper ="
+    "Moving to {.__points}"
+    "{.__next_pos}"
+    "Please wait..."
+
+[menu __probe_helper_moving __points]
+type: item
+name: "{0:2d}/{1:2d}"
+parameter: probe_menu.index, probe_menu.length
+
+[menu __probe_helper_moving __next_pos]
+type: item
+name: "X:{0:0.2f} Y:{1:0.2f}"
+parameter: toolhead.xpos, toolhead.ypos
+
+[menu __probe_helper_adjust_menu]
+type: list
+name: Adjust menu
+items:
+    .__probe_next
+    .__probe_1mm
+    .__probe_01mm
+    .__probe_001mm
+
+[menu __probe_helper_adjust_menu __probe_next]
+type: command
+name: Probe {1}
+parameter: probe_menu.remaining
+transform:
+    0.choose('done','next')
+gcode: NEXT
+
+[menu __probe_helper_adjust_menu __probe_1mm]
+type: command
+name: Probe 1.00mm
+action: emit probe_helper card100
+
+[menu __probe_helper_adjust_menu __probe_01mm]
+type: command
+name: Probe 0.10mm
+action: emit probe_helper card010
+
+[menu __probe_helper_adjust_menu __probe_001mm]
+type: command
+name: Probe 0.01mm
+action: emit probe_helper card001
+
+[menu __probe_helper_adjust_menu __probe_abort]
+type: command
+name: Abort probing
+action: emit probe_helper abort

--- a/klippy/extras/display/probe_menu.py
+++ b/klippy/extras/display/probe_menu.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# Menu based probing wizard
+#
+# Copyright (C) 2018  Janar Sööt <janar.soot@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import os
+
+
+class ProbeHelperMenu:
+    def __init__(self, config, menu):
+        self.printer = config.get_printer()
+        self.toolhead = None
+        # Load menu
+        self.menu = menu
+        self.menu.load_config(os.path.dirname(__file__), 'probe_menu.cfg')
+        # menuitem names
+        self.probe_menu_done = "__probe_helper_done"
+        self.probe_menu_adjust_100 = "__probe_helper_adjust_1mm"
+        self.probe_menu_adjust_010 = "__probe_helper_adjust_01mm"
+        self.probe_menu_adjust_001 = "__probe_helper_adjust_001mm"
+        self.probe_menu_moving = "__probe_helper_moving"
+        # check menuitem
+        self.menu.lookup_menuitem(self.probe_menu_done)
+        self.menu.lookup_menuitem(self.probe_menu_adjust_100)
+        self.menu.lookup_menuitem(self.probe_menu_adjust_010)
+        self.menu.lookup_menuitem(self.probe_menu_adjust_001)
+        self.menu.lookup_menuitem(self.probe_menu_moving)
+        # Probing context
+        self._adjust_card = self.probe_menu_adjust_100
+        self._wizard_running = False
+        self._end_status = 0
+        self._points_current = 0
+        self._points_count = 0
+        # register itself for a printer_state callback
+        self.printer.add_object('probe_menu', self)
+        # Register event handlers
+        self.printer.register_event_handler("klippy:ready", self.handle_ready)
+        self.printer.register_event_handler("probe:start_manual_probing",
+                                            self.handle_probing_start)
+        self.printer.register_event_handler("probe:end_manual_probing",
+                                            self.handle_probing_end)
+        self.printer.register_event_handler("probe:finalize",
+                                            self.handle_probe_finalize)
+        self.printer.register_event_handler("menu:action:probe_helper",
+                                            self.handle_menu_commands)
+
+    def handle_ready(self):
+        self.toolhead = self.printer.lookup_object('toolhead')
+
+    def get_status(self, eventtime):
+        return {
+            'index': self._points_current+1,
+            'length': self._points_count,
+            'remaining': max(0, self._points_count-(self._points_current+1)),
+            'end_status': self._end_status
+        }
+
+    def handle_menu_commands(self, cmd):
+        if str(cmd) == 'card100':
+            self._adjust_card = self.probe_menu_adjust_100
+            self.menu.restart_root(self._adjust_card)
+        elif str(cmd) == 'card010':
+            self._adjust_card = self.probe_menu_adjust_010
+            self.menu.restart_root(self._adjust_card)
+        elif str(cmd) == 'card001':
+            self._adjust_card = self.probe_menu_adjust_001
+            self.menu.restart_root(self._adjust_card)
+        elif str(cmd) == 'abort':
+            pass
+
+    def display_done(self, eventtime):
+        self.menu.restart_root(self.probe_menu_done)
+
+    def display_adjust(self, eventtime):
+        self._adjust_card = self.probe_menu_adjust_100
+        self.menu.restart_root(self._adjust_card)
+
+    def display_moving(self, eventtime):
+        self.menu.restart_root(self.probe_menu_moving)
+
+    def close_probe_wizard(self, eventtime):
+        self._adjust_card = self.probe_menu_adjust_100
+        self._wizard_running = False
+        self._end_status = 0
+        self._points_current = 0
+        self._points_count = 0
+        # return to default menu
+        self.menu.restart_root()
+
+    def wait_toolhead_moves(self, eventtime, event_print_time):
+        print_time, est_print_time, lookahead_empty = self.toolhead.check_busy(
+            eventtime)
+        if est_print_time >= event_print_time:
+            self.display_adjust(eventtime)
+        else:
+            self.menu.after(0.5, self.wait_toolhead_moves, event_print_time)
+
+    # probe event methods
+    def handle_probing_start(self, event_print_time, points):
+        self._points_current, self._points_count = points
+        if not self._wizard_running:
+            self._wizard_running = True
+            self.menu.after(0, self.display_moving)
+        self.menu.after(0, self.wait_toolhead_moves, event_print_time)
+
+    def handle_probing_end(self):
+        self.menu.after(0, self.display_moving)
+
+    def handle_probe_finalize(self, success):
+        self._end_status = success
+        self.menu.after(0, self.display_done)
+        self.menu.after(4., self.close_probe_wizard)
+
+
+def load_config(config):
+    return ProbeHelperMenu(config)


### PR DESCRIPTION
@Arksine @KevinOConnor 
Based on #575
To better support this kind of menu usage, I've made a lot of changes to the menu system.

It still not fully tested (WIP)!

Short summary:
- Made separate config for the probe module and method to load such config.
- In menu card, the user can choose between cursor and blinking (to visualize selection and edit mode)
- Menu Deck has now a stack mode, it will in realtime evaluate cards enable status for visibility and always will show only first card. If no cards are enabled then it'll show the first card from the item list.
- Method to force edit mode exit. When the input is in edit mode the card stack will not update itself.

In this stack mode, it's easy to switch between cards by using parameter values.
Always only the first card is shown, so you cannot use the encoder to switch between other cards.
You can control card visibility by enabling and disabling it.

Other changes and ideas are taken from #575.

These config options are not yet documented in `example-menu.cfg`.

If this approach is okay for you then I'll complete and refine it. 
Looking forward to your comments

