### PR TITLE
Full i2c support and SX1509 I2C-to-GPIO expander

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -605,6 +605,23 @@
 #   to not scale the 'wiper_x' parameters.
 
 
+# Configure an SX1509 I2C to GPIO expander. Due to the delay incurred
+# by I2C communication you should NOT use SX1509 pins as stepper enable,
+# step or dir pins or any other pin that requires fast bit-banging. They
+# are best used as static or gcode controlled digital outputs or hardware-pwm
+# pins for e.g. fans. One may define any number of sections with an "sx1509"
+# prefix. Each expander provides a set of 16 pins (sx1509_my_sx1509:PIN_0 to
+# sx1509_my_sx1509:PIN_15) which can be used in the printer configuration.
+#[sx1509 my_sx1509]
+#address:
+#   I2C address used by this expander. Depending on the hardware jumpers
+#   this is one out of the following addresses: 0x3E 0x3F 0x70 0x71. This
+#   parameter must be provided
+#bus: 0
+#   If the I2C implementation of your microcontroller supports multiple I2C
+#   busses, you may specify the bus number here. The default is 0.
+
+
 # Configure a TMC2130 stepper motor driver via SPI bus. To use this
 # feature, define a config section with a "tmc2130" prefix followed by
 # the name of the corresponding stepper config section (for example,

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -1,0 +1,201 @@
+# SX1509 Extra
+#
+# Copyright (C) 2018  Florian Heilmann <Florian.Heilmann@gmx.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import mcu
+import pins
+
+# Word registers
+REG_RESET = 0x7D
+REG_CLOCK = 0x1E
+REG_MISC = 0x1F
+REG_DIR = 0x0E
+REG_DATA = 0x10
+REG_PULLUP = 0x06
+REG_PULLDOWN = 0x08
+REG_INPUT_DISABLE = 0x00
+REG_ANALOG_DRIVER_ENABLE = 0x20
+
+
+# Byte registers
+REG_I_ON = [0x2A, 0x2D, 0x30, 0x33, 0x36, 0x3B, 0x40, 0x45,
+            0x4A, 0x4D, 0x50, 0x53, 0x56, 0x5B, 0x5F, 0x65]
+class SX1509(object):
+    def __init__(self, config):
+        self._printer = config.get_printer()
+        self._name = config.get_name().split()[1]
+        self._chip_address = int(config.get('address'), 0)
+        self._bus = config.getint('bus', minval=0, default=0)
+        self._ppins = self._printer.lookup_object("pins")
+        self._ppins.register_chip("sx1509_" + self._name, self)
+        self._mcu = mcu.get_printer_mcu(self._printer, config.get('mcu', 'mcu'))
+        self._mcu.register_config_callback(self._build_config)
+        self._oid = self._mcu.create_oid()
+        self._i2c_write_cmd = self._i2c_modify_cmd = None
+        self._last_clock = 0
+        self._freq = 400000 # Fixed frequency for SX1509
+        # Set up registers default values
+        self.reg_dict = {REG_DIR : 0xFFFF, REG_DATA : 0, REG_PULLUP : 0, REG_PULLDOWN : 0,
+                         REG_INPUT_DISABLE : 0, REG_ANALOG_DRIVER_ENABLE : 0}
+        self.reg_i_on_dict = {reg : 0 for reg in REG_I_ON}
+    def _build_config(self):
+        self._mcu.add_config_cmd("config_i2c oid=%d bus=%d rate=%d addr=%d" % (
+            self._oid, self._bus, self._freq, self._chip_address))
+        # Reset the chip
+        self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
+            self._oid, REG_RESET, 0x12))
+        self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
+            self._oid, REG_RESET, 0x34))
+        # Enable Oscillator
+        self._mcu.add_config_cmd("i2c_modify_bits oid=%d reg=%02x clear_set_bits=%02x%02x" % (
+            self._oid, REG_CLOCK, 0, (1 << 6)))
+        # Setup Clock Divider
+        self._mcu.add_config_cmd("i2c_modify_bits oid=%d reg=%02x clear_set_bits=%02x%02x" % (
+            self._oid, REG_MISC, 0, (1 << 4)))
+        # Transfer all regs with their initial cached state
+        for _reg, _data in self.reg_dict.iteritems():
+            self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%04x" % (
+                self._oid, _reg, _data), is_init=True)
+        # Build commands
+        cmd_queue = self._mcu.alloc_command_queue()
+        self._i2c_write_cmd = self._mcu.lookup_command(
+            "i2c_write oid=%c data=%*s", cq=cmd_queue)
+        self._i2c_modify_cmd = self._mcu.lookup_command(
+            "i2c_modify_bits oid=%c reg=%*s clear_set_bits=%*s", cq=cmd_queue)
+    def setup_pin(self, pin_type, pin_params):
+        if pin_type == 'digital_out' and pin_params['pin'][0:4] == "PIN_":
+            return SX1509_digital_out(self, pin_params)
+        elif pin_type == 'pwm' and pin_params['pin'][0:4] == "PIN_":
+            return SX1509_pwm(self, pin_params)
+        raise pins.error("Wrong pin or incompatible type: %s with type %s! " % (
+            pin_params['pin'][0:4], pin_type))
+    def get_mcu(self):
+        return self._mcu
+    def get_oid(self):
+        return self._oid
+    def clear_bits_in_register(self, reg, bitmask):
+        if reg in self.reg_dict:
+            self.reg_dict[reg] &= ~(bitmask)
+        elif reg in self.reg_i_on_dict:
+            self.reg_i_on_dict[reg] &= ~(bitmask)
+    def set_bits_in_register(self, reg, bitmask):
+        if reg in self.reg_dict:
+            self.reg_dict[reg] |= bitmask
+        elif reg in self.reg_i_on_dict:
+            self.reg_i_on_dict[reg] |= bitmask
+    def set_register(self, reg, value):
+        if reg in self.reg_dict:
+            self.reg_dict[reg] = value
+        elif reg in self.reg_i_on_dict:
+            self.reg_i_on_dict[reg] = value
+    def send_register(self, reg, print_time=0):
+        data = [reg & 0xFF]
+        if reg in self.reg_dict:
+            # Word
+            data += [(self.reg_dict[reg] >> 8) & 0xFF, self.reg_dict[reg] & 0xFF]
+        elif reg in self.reg_i_on_dict:
+            # Byte
+            data += [self.reg_i_on_dict[reg] & 0xFF]
+        clock = self._mcu.print_time_to_clock(print_time)
+        self._i2c_write_cmd.send([self._oid, data],
+                                 minclock=self._last_clock, reqclock=clock)
+        self._last_clock = clock
+
+class SX1509_digital_out(object):
+    def __init__(self, sx1509, pin_params):
+        self._sx1509 = sx1509
+        self._mcu = sx1509.get_mcu()
+        self._sxpin = int(pin_params['pin'].split('_')[1])
+        self._bitmask = 1 << self._sxpin
+        self._pin = pin_params['pin']
+        self._invert = pin_params['invert']
+        self._start_value = self._shutdown_value = self._invert
+        self._is_static = False
+        self._set_cmd = self._clear_cmd = None
+        # Set direction to output
+        self._sx1509.clear_bits_in_register(REG_DIR, self._bitmask)
+    def get_mcu(self):
+        return self._mcu
+    def setup_max_duration(self, max_duration):
+        pass
+    def setup_start_value(self, start_value, shutdown_value, is_static=False):
+        if is_static or shutdown_value:
+            raise pins.error("SX1509 Pins should not be declared static or have a shutdown value")
+        self._start_value = (not not start_value) ^ self._invert
+        self._shutdown_value = self._invert
+        self._is_static = False
+        # We need to set the start value here so the register is
+        # updated before the SX1509 class writes it.
+        if self._start_value:
+            self._sx1509.set_bits_in_register(REG_DATA, self._bitmask)
+        else:
+            self._sx1509.clear_bits_in_register(REG_DATA, self._bitmask)
+    def set_digital(self, print_time, value):
+        if int(value) ^ self._invert:
+            self._sx1509.set_bits_in_register(REG_DATA, self._bitmask)
+        else:
+            self._sx1509.clear_bits_in_register(REG_DATA, self._bitmask)
+        self._sx1509.send_register(REG_DATA, print_time)
+    def set_pwm(self, print_time, value):
+        self.set_digital(print_time, value >= 0.5)
+
+class SX1509_pwm(object):
+    def __init__(self, sx1509, pin_params):
+        self._sx1509 = sx1509
+        self._mcu = sx1509.get_mcu()
+        self._sxpin = int(pin_params['pin'].split('_')[1])
+        self._bitmask = 1 << self._sxpin
+        self._i_on_reg = REG_I_ON[self._sxpin]
+        self._pin = pin_params['pin']
+        self._invert = pin_params['invert']
+        self._mcu.register_config_callback(self._build_config)
+        self._start_value = self._shutdown_value = float(self._invert)
+        self._is_static = False
+        self._max_duration = 2.
+        self._hardware_pwm = False
+        self._pwm_max = 0.
+        self._set_cmd = None
+        self._cycle_time = 0.
+        # Set required registers
+        self._sx1509.set_bits_in_register(REG_INPUT_DISABLE, self._bitmask)
+        self._sx1509.clear_bits_in_register(REG_PULLUP, self._bitmask)
+        self._sx1509.clear_bits_in_register(REG_DIR, self._bitmask)
+        self._sx1509.set_bits_in_register(REG_ANALOG_DRIVER_ENABLE, self._bitmask)
+        self._sx1509.clear_bits_in_register(REG_DATA, self._bitmask)
+    def _build_config(self):
+        if not self._hardware_pwm:
+            raise pins.error("SX1509_pwm must have hardware_pwm enabled")
+        # Send initial value
+        self._sx1509.set_register(self._i_on_reg, ~int(255 * self._start_value) & 0xFF)
+        self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
+            self._sx1509.get_oid(),
+            self._i_on_reg,
+            self._sx1509.reg_i_on_dict[self._i_on_reg]
+            ),
+                                 is_init=True)
+    def get_mcu(self):
+        return self._mcu
+    def setup_max_duration(self, max_duration):
+        self._max_duration = max_duration
+    def setup_cycle_time(self, cycle_time, hardware_pwm=False):
+        self._cycle_time = cycle_time
+        self._hardware_pwm = hardware_pwm
+    def setup_start_value(self, start_value, shutdown_value, is_static=False):
+        if is_static or shutdown_value:
+            raise pins.error("SX1509 Pins should not be declared static or have a shutdown value")
+        if self._invert:
+            start_value = 1. - start_value
+            shutdown_value = 1. - shutdown_value
+        self._start_value = max(0., min(1., start_value))
+        self._shutdown_value = max(0., min(1., shutdown_value))
+        self._is_static = False
+    def set_pwm(self, print_time, value):
+        self._sx1509.set_register(self._i_on_reg, ~int(255 * value)
+                                  if not self._invert
+                                  else int(255 * value) & 0xFF)
+        self._sx1509.send_register(self._i_on_reg, print_time)
+
+def load_config_prefix(config):
+    return SX1509(config)

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -47,6 +47,9 @@ config HAVE_GPIO_ADC
 config HAVE_GPIO_SPI
     bool
     default n
+config HAVE_GPIO_I2C
+    bool
+    default n
 config HAVE_GPIO_HARD_PWM
     bool
     default n

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,7 @@ src-y += sched.c command.c basecmd.c debugcmds.c
 src-$(CONFIG_HAVE_GPIO) += gpiocmds.c stepper.c endstop.c
 src-$(CONFIG_HAVE_GPIO_ADC) += adccmds.c
 src-$(CONFIG_HAVE_GPIO_SPI) += spicmds.c thermocouple.c
+src-$(CONFIG_HAVE_GPIO_I2C) += i2ccmds.c
 src-$(CONFIG_HAVE_GPIO_HARD_PWM) += pwmcmds.c
 src-$(CONFIG_HAVE_GPIO_BITBANGING) += lcd_st7920.c lcd_hd44780.c buttons.c \
     tmcuart.c

--- a/src/i2ccmds.c
+++ b/src/i2ccmds.c
@@ -1,0 +1,76 @@
+// Commands for sending messages on an I2C bus
+//
+// Copyright (C) 2018  Florian Heilmann <Florian.Heilmann@gmx.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "basecmd.h" //oid_alloc
+#include "command.h"  //sendf
+#include "sched.h" //DECL_COMMAND
+#include "board/gpio.h" //i2c_write/read/setup
+
+struct i2cdev_s {
+    struct i2c_config i2c_config;
+};
+
+void
+command_config_i2c(uint32_t *args)
+{
+    struct i2cdev_s *i2c = oid_alloc(args[0], command_config_i2c
+                                     , sizeof(*i2c));
+    i2c->i2c_config = i2c_setup(args[1], args[2], args[3]);
+}
+DECL_COMMAND(command_config_i2c,
+             "config_i2c oid=%c bus=%u rate=%u addr=%u");
+void
+command_i2c_write(uint32_t *args)
+{
+    uint8_t oid = args[0];
+    struct i2cdev_s *i2c = oid_lookup(oid, command_config_i2c);
+    uint8_t data_len = args[1];
+    uint8_t *data = (void*)(size_t)args[2];
+    i2c_write(i2c->i2c_config, data_len, data);
+}
+DECL_COMMAND(command_i2c_write, "i2c_write oid=%c data=%*s");
+
+void
+command_i2c_read(uint32_t * args)
+{
+    uint8_t oid = args[0];
+    struct i2cdev_s *i2c = oid_lookup(oid, command_config_i2c);
+    uint8_t reg_len = args[1];
+    uint8_t *reg = (void*)(size_t)args[2];
+    uint32_t data_len = args[3];
+    uint8_t receive_array[data_len];
+    uint8_t *data = (void*)(size_t)receive_array;
+    i2c_read(i2c->i2c_config, reg_len, reg, data_len, data);
+    sendf("i2c_read_response oid=%c response=%*s", oid, data_len, data);
+}
+DECL_COMMAND(command_i2c_read, "i2c_read oid=%c reg=%*s read_len=%u");
+
+void
+command_i2c_modify_bits(uint32_t *args)
+{
+    uint8_t oid = args[0];
+    struct i2cdev_s *i2c = oid_lookup(oid, command_config_i2c);
+    uint8_t reg_len = args[1];
+    uint8_t *reg = (void*)(size_t)args[2];
+    uint32_t clear_set_len = args[3];
+    if (clear_set_len % 2 != 0) {
+        shutdown("i2c_modify_bits: Odd number of bits!");
+    }
+    uint8_t data_len = clear_set_len/2;
+    uint8_t *clear_set = (void*)(size_t)args[4];
+    uint8_t receive_array[reg_len + data_len];
+    uint8_t *receive_data = (void*)(size_t)receive_array;
+    for (int i = 0; i < reg_len; i++) {
+        *(receive_data + i) = *(reg + i);
+    }
+    i2c_read(i2c->i2c_config, reg_len, reg, data_len, receive_data + reg_len);
+    for (int i = 0; i < data_len; i++) {
+        *(receive_data + reg_len + i) &= ~(*(clear_set + i));
+        *(receive_data + reg_len + i) |= *(clear_set + clear_set_len/2 + i);
+    }
+    i2c_write(i2c->i2c_config, reg_len + data_len, receive_array);
+}
+DECL_COMMAND(command_i2c_modify_bits, "i2c_modify_bits oid=%c reg=%*s clear_set_bits=%*s");

--- a/src/sam4e8e/Kconfig
+++ b/src/sam4e8e/Kconfig
@@ -6,7 +6,7 @@ config SAM_SELECT
     bool
     default y
     select HAVE_GPIO
-#    select HAVE_GPIO_I2C
+    select HAVE_GPIO_I2C
     select HAVE_GPIO_ADC
     select HAVE_GPIO_SPI
     select HAVE_GPIO_BITBANGING

--- a/src/sam4e8e/Makefile
+++ b/src/sam4e8e/Makefile
@@ -19,6 +19,7 @@ src-y +=  ../lib/cmsis-sam4e/gcc/system_sam4e.c \
 		  ../lib/cmsis-sam4e/gcc/gcc/startup_sam4e.c
 
 src-$(CONFIG_HAVE_GPIO_SPI) += sam4e8e/spi.c
+src-$(CONFIG_HAVE_GPIO_I2C) += sam4e8e/i2c.c
 src-$(CONFIG_SERIAL) += sam4e8e/serial.c generic/serial_irq.c
 src-$(CONFIG_HAVE_GPIO) += sam4e8e/gpio.c
 src-y += generic/crc16_ccitt.c generic/alloc.c

--- a/src/sam4e8e/gpio.h
+++ b/src/sam4e8e/gpio.h
@@ -46,4 +46,16 @@ struct spi_config spi_setup(uint32_t bus, uint8_t mode, uint32_t rate);
 void spi_transfer(struct spi_config config, uint8_t receive_data
                   , uint8_t len, uint8_t *data);
 void spi_prepare(struct spi_config config);
+
+struct i2c_config {
+    void *twi;
+    uint8_t addr;
+};
+
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+void i2c_write(struct i2c_config config,
+                uint8_t write_len, uint8_t *write);
+void i2c_read(struct i2c_config config,
+              uint8_t reg_len, uint8_t *reg,
+              uint8_t read_len, uint8_t *read);
 #endif // gpio.h

--- a/src/sam4e8e/i2c.c
+++ b/src/sam4e8e/i2c.c
@@ -1,0 +1,166 @@
+// SAM4 I2C Port
+//
+// Copyright (C) 2018  Florian Heilmann <Florian.Heilmann@gmx.net>
+// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "gpio.h"
+#include "internal.h"
+#include "command.h" // shutdown
+#include "sched.h" // sched_shutdown
+#include "autoconf.h" // CONFIG_CLOCK_FREQ
+#include "board/misc.h" //timer_from_us
+
+void
+i2c_init(Twi *p_twi, uint32_t rate)
+{
+    uint32_t twi_id = (p_twi == TWI0) ? ID_TWI0 : ID_TWI1;
+    if ((PMC->PMC_PCSR0 & (1u << twi_id)) == 0) {
+        PMC->PMC_PCER0 = 1 << twi_id;
+    }
+    if (p_twi == TWI0) {
+        gpio_set_peripheral(TWI0_SCL_BANK, TWI0_SCL_PIN, TWI0_SCL_PERIPH, 0);
+        gpio_set_peripheral(TWI0_SDA_BANK, TWI0_SDA_PIN, TWI0_SDA_PERIPH, 0);
+    } else {
+        gpio_set_peripheral(TWI1_SCL_BANK, TWI1_SCL_PIN, TWI1_SCL_PERIPH, 0);
+        gpio_set_peripheral(TWI1_SDA_BANK, TWI1_SDA_PIN, TWI1_SDA_PERIPH, 0);
+    }
+    p_twi->TWI_IDR = 0xFFFFFFFF;
+    (void)p_twi->TWI_SR;
+    p_twi->TWI_CR = TWI_CR_SWRST;
+    (void)p_twi->TWI_RHR;
+    p_twi->TWI_CR = TWI_CR_MSDIS;
+    p_twi->TWI_CR = TWI_CR_SVDIS;
+    p_twi->TWI_CR = TWI_CR_MSEN;
+
+    uint32_t cldiv = 0;
+    uint32_t chdiv = 0;
+    uint32_t ckdiv = 0;
+
+    cldiv = CONFIG_CLOCK_FREQ / ((rate > 384000 ? 384000 : rate) * 2) - 4;
+
+    while((cldiv > 255) && (ckdiv < 7)) {
+        ckdiv++;
+        cldiv /= 2;
+    }
+
+    if (rate > 348000) {
+        chdiv = CONFIG_CLOCK_FREQ / ((2 * rate - 384000) * 2) - 4;
+        while((chdiv > 255) && (ckdiv < 7)) {
+            ckdiv++;
+            chdiv /= 2;
+        }
+    } else {
+        chdiv = cldiv;
+    }
+    p_twi->TWI_CWGR = TWI_CWGR_CLDIV(cldiv) | \
+                      TWI_CWGR_CHDIV(chdiv) | \
+                      TWI_CWGR_CKDIV(ckdiv);
+}
+
+uint32_t
+addr_to_u32(uint8_t addr_len, uint8_t *addr)
+{
+    uint32_t address = addr[0];
+    if (addr_len > 1) {
+        address <<= 8;
+        address |= addr[1];
+    }
+    if (addr_len > 2) {
+        address <<= 8;
+        address |= addr[2];
+    }
+    if (addr_len > 3) {
+        shutdown("Addresses larger than 3 bytes are not supported");
+    }
+    return address;
+}
+
+struct i2c_config
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+{
+    if ((bus > 1) | (rate > 400000))
+        shutdown("Invalid i2c_setup parameters!");
+    Twi *p_twi = (bus == 0) ? TWI0 : TWI1;
+    i2c_init(p_twi, rate);
+    return (struct i2c_config){ .twi=p_twi, .addr=addr};
+}
+
+void
+i2c_write(struct i2c_config config,
+                uint8_t write_len, uint8_t *write)
+{
+    Twi *p_twi = config.twi;
+    uint32_t status;
+    uint32_t bytes_to_send = write_len;
+    p_twi->TWI_MMR = TWI_MMR_DADR(config.addr);
+    for(;;) {
+        status = p_twi->TWI_SR;
+        if (status & TWI_SR_NACK)
+            shutdown("I2C NACK error encountered!");
+        if (!(status & TWI_SR_TXRDY))
+            continue;
+        if (!bytes_to_send)
+            break;
+        p_twi->TWI_THR = *write++;
+        bytes_to_send--;
+    }
+    p_twi->TWI_CR = TWI_CR_STOP;
+    while(!(p_twi->TWI_SR& TWI_SR_TXCOMP)) {
+    }
+}
+
+static void
+i2c_wait(Twi* p_twi, uint32_t bit, uint32_t timeout)
+{
+    for (;;) {
+        uint32_t flags = p_twi->TWI_SR;
+        if (flags & bit)
+            break;
+        if (!timer_is_before(timer_read_time(), timeout))
+            shutdown("I2C timeout occured");
+    }
+}
+
+void
+i2c_read(struct i2c_config config,
+              uint8_t reg_len, uint8_t *reg,
+              uint8_t read_len, uint8_t *read)
+{
+    Twi *p_twi = config.twi;
+    uint32_t status;
+    uint32_t bytes_to_send=read_len;
+    uint8_t stop = 0;
+    p_twi->TWI_MMR = 0;
+    p_twi->TWI_MMR = TWI_MMR_MREAD | TWI_MMR_DADR(config.addr) |
+                     ((reg_len << TWI_MMR_IADRSZ_Pos) &
+                     TWI_MMR_IADRSZ_Msk);
+    p_twi->TWI_IADR = 0;
+    p_twi->TWI_IADR = addr_to_u32(reg_len, reg);
+    if (bytes_to_send == 1) {
+        p_twi->TWI_CR = TWI_CR_START | TWI_CR_STOP;
+        stop = 1;
+    } else {
+        p_twi->TWI_CR = TWI_CR_START;
+        stop = 0;
+    }
+    while (bytes_to_send > 0) {
+        status = p_twi->TWI_SR;
+        if (status & TWI_SR_NACK) {
+            shutdown("I2C NACK error encountered!");
+        }
+        if (bytes_to_send == 1 && !stop) {
+            p_twi->TWI_CR = TWI_CR_STOP;
+            stop = 1;
+        }
+        i2c_wait(p_twi, TWI_SR_RXRDY, timer_read_time() + timer_from_us(5000));
+        if (!(status & TWI_SR_RXRDY)) {
+            continue;
+        }
+        *read++ = p_twi->TWI_RHR;
+        bytes_to_send--;
+    }
+    while (!(p_twi->TWI_SR & TWI_SR_TXCOMP)) {}
+    (void)p_twi->TWI_SR;
+}

--- a/src/sam4e8e/internal.h
+++ b/src/sam4e8e/internal.h
@@ -1,0 +1,18 @@
+#include "sam4e.h"
+
+// I2C pin definitions
+#define TWI0_SCL_BANK 'A'
+#define TWI0_SCL_PIN PIO_PA4A_TWCK0
+#define TWI0_SCL_PERIPH 'A'
+
+#define TWI0_SDA_BANK 'A'
+#define TWI0_SDA_PIN PIO_PA3A_TWD0
+#define TWI0_SDA_PERIPH 'A'
+
+#define TWI1_SCL_BANK 'B'
+#define TWI1_SCL_PIN PIO_PB5A_TWCK1
+#define TWI1_SCL_PERIPH 'A'
+
+#define TWI1_SDA_BANK 'B'
+#define TWI1_SDA_PIN PIO_PB4A_TWD1
+#define TWI1_SDA_PERIPH 'A'


### PR DESCRIPTION
This is my recent work to extend klipper to support i2c devices in a generic way and add an additional i2c device to the mix: The SX1509 I2C-to-16GPIO expander found on the duex5 and duex2 generation of boards.

I split the contribution into 3 commits to make bisecting the whole thing easier. Please let me know about any feedback you might have.

One thing that is definitely missing is to align the implementations of the mcp4451 extra and the lpc176x i2c implementation to use this more universal approach. Since I don't have a lpc176x myself, I think it would be best if someone else dealt with that. I can, of course, try and offer up my findings for review.

Bests,

Florian