### PR TITLE
Support "stepper phase adjusted endstops" on Trinamic stepper drivers

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -326,7 +326,8 @@
 # config section with an "endstop_phase" prefix followed by the name
 # of the corresponding stepper config section (for example,
 # "[endstop_phase stepper_z]"). This feature can improve the accuracy
-# of endstop switches.
+# of endstop switches. Add a bare "[endstop_phase]" declaration to
+# enable the ENDSTOP_PHASE_CALIBRATE command.
 #[endstop_phase stepper_z]
 #phases:
 #   This specifies the number of phases of the given stepper motor

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -322,33 +322,34 @@
 #   axis is triggered.
 
 
-# Stepper phase adjusted endstops. The following additional parameters
-# may be added to a stepper axis definition to improve the accuracy of
-# endstop switches.
-#[stepper_z]
-#homing_stepper_phases:
-#   One may set this to the number of phases of the stepper motor
-#   driver (which is the number of micro-steps multiplied by
-#   four). This parameter must be provided if using stepper phase
-#   adjustments.
-#homing_endstop_accuracy: 0.200
+# Stepper phase adjusted endstops. To use this feature, define a
+# config section with an "endstop_phase" prefix followed by the name
+# of the corresponding stepper config section (for example,
+# "[endstop_phase stepper_z]"). This feature can improve the accuracy
+# of endstop switches.
+#[endstop_phase stepper_z]
+#phases:
+#   Set this to the number of phases of the given stepper motor driver
+#   (which is the number of micro-steps multiplied by four). This
+#   parameter must be provided.
+#endstop_accuracy: 0.200
 #   Sets the expected accuracy (in mm) of the endstop. This represents
 #   the maximum error distance the endstop may trigger (eg, if an
 #   endstop may occasionally trigger 100um early or up to 100um late
 #   then set this to 0.200 for 200um). The default is
-#   homing_stepper_phases*step_distance.
-#homing_endstop_phase:
+#   phases*step_distance.
+#endstop_phase:
 #   This specifies the phase of the stepper motor driver to expect
 #   when hitting the endstop. Only set this value if one is sure the
 #   stepper motor driver is reset every time the mcu is reset. If this
 #   is not set, then the stepper phase will be detected on the first
 #   home and that phase will be used on all subsequent homes.
-#homing_endstop_align_zero: False
-#   If true then the code will arrange for the zero position on the
-#   axis to occur at a full step on the stepper motor. (If used on the
-#   Z axis and the print layer height is a multiple of a full step
-#   distance then every layer will occur on a full step.) The default
-#   is False.
+#endstop_align_zero: False
+#   If true then the position_endstop of the axis will effectively be
+#   modified so that the zero position for the axis occurs at a full
+#   step on the stepper motor. (If used on the Z axis and the print
+#   layer height is a multiple of a full step distance then every
+#   layer will occur on a full step.) The default is False.
 
 
 # Heater cooling fans (one may define any number of sections with a

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -329,9 +329,11 @@
 # of endstop switches.
 #[endstop_phase stepper_z]
 #phases:
-#   Set this to the number of phases of the given stepper motor driver
-#   (which is the number of micro-steps multiplied by four). This
-#   parameter must be provided.
+#   This specifies the number of phases of the given stepper motor
+#   driver (which is the number of micro-steps multiplied by four).
+#   This setting is automatically determined if one uses TMC2130,
+#   TMC2208, or TMC2224 drivers with run-time configuration.
+#   Otherwise, this parameter must be provided.
 #endstop_accuracy: 0.200
 #   Sets the expected accuracy (in mm) of the endstop. This represents
 #   the maximum error distance the endstop may trigger (eg, if an

--- a/config/printer-makergear-m2-2012.cfg
+++ b/config/printer-makergear-m2-2012.cfg
@@ -12,8 +12,10 @@ endstop_pin: ^!PB6
 position_endstop: 0.0
 position_max: 200
 homing_speed: 50
-homing_stepper_phases: 32
-homing_endstop_accuracy: .200
+
+[endstop_phase stepper_x]
+phases: 32
+endstop_accuracy: .200
 
 [stepper_y]
 step_pin: PC1
@@ -24,8 +26,10 @@ endstop_pin: ^!PB5
 position_endstop: 0.0
 position_max: 250
 homing_speed: 50
-homing_stepper_phases: 32
-homing_endstop_accuracy: .200
+
+[endstop_phase stepper_y]
+phases: 32
+endstop_accuracy: .200
 
 [stepper_z]
 step_pin: PC2
@@ -37,8 +41,10 @@ position_min: 0.1
 position_endstop: 0.7
 position_max: 200
 homing_retract_dist: 2.0
-homing_stepper_phases: 32
-homing_endstop_accuracy: .070
+
+[endstop_phase stepper_z]
+phases: 32
+endstop_accuracy: .070
 
 [extruder]
 step_pin: PC3

--- a/docs/Config_checks.md
+++ b/docs/Config_checks.md
@@ -156,3 +156,11 @@ in the Klipper configuration file. It may be necessary to perform
 detailed printer calibration - a number of guides are available online
 to help with this (for example, do a web search for "3d printer
 calibration").
+
+If one is using traditional endstop switches with Trinamic stepper
+motor drivers then see the [Endstop Phase](Endstop_Phase.md)
+document. If using a delta printer, see the
+[Delta Calibrate](Delta_Calibrate.md) document.
+
+After one has verified that basic printing works, it is a good idea to
+consider calibrating [pressure advance](Pressure_Advance.md).

--- a/docs/Endstop_Phase.md
+++ b/docs/Endstop_Phase.md
@@ -1,0 +1,114 @@
+This document describes Klipper's stepper phase adjusted endstop
+system. This functionality can improve the accuracy of traditional
+endstop switches. It is most useful when using a Trinamic stepper
+motor driver that has run-time configuration.
+
+A typical endstop switch has an accuracy of around 100 microns. (Each
+time an axis is homed the switch may trigger slightly earlier or
+slightly later.) Although this is a relatively small error, it can
+result in unwanted artifacts. In particular, this positional deviation
+may be noticeable when printing the first layer of an object. In
+contrast, typical stepper motors can obtain significantly higher
+precision.
+
+The stepper phase adjusted endstop mechanism can use the precision of
+the stepper motors to improve the precision of the endstop switches.
+When a stepper motor moves it cycles through a series of phases until
+in completes four "full steps". So, a stepper motor using 16
+micro-steps would have 64 phases and when moving in a positive
+direction it would cycle through phases: 0, 1, 2, ... 61, 62, 63, 0,
+1, 2, etc. Crucially, when the stepper motor is at a particular
+position on a linear rail it should always be at the same stepper
+phase. Thus, when a carriage triggers the endstop switch the stepper
+controlling that carriage should always be at the same stepper motor
+phase. Klipper's endstop phase system combines the stepper phase with
+the endstop trigger to improve the accuracy of the endstop.
+
+In order to use this functionality it is necessary to be able to
+identify the phase of the stepper motor. If one is using Trinamic
+TMC2130, TMC2208, or TMC2224 drivers in run-time configuration mode
+(ie, not stand-alone mode) then Klipper can query the stepper phase
+from the driver. (It is also possible to use this system on
+traditional stepper drivers if one can reliably reset the stepper
+drivers - see below for details.)
+
+Calibrating endstop phases
+==========================
+
+If using Trinamic stepper motor drivers with run-time configuration
+then one can calibrate the endstop phases using the
+ENDSTOP_PHASE_CALIBRATE command. Start by adding the following to the
+config file:
+```
+[endstop_phase]
+```
+
+Then RESTART the printer and run a `G28` command followed by an
+`ENDSTOP_PHASE_CALIBRATE` command. Then move the toolhead to a new
+location and run `G28` again. Try moving the toolhead to several
+different locations and rerun `G28` from each position. Run at least
+five `G28` commands.
+
+After performing the above, the `ENDSTOP_PHASE_CALIBRATE` command will
+often report the same (or nearly the same) phase for the stepper. This
+phase can be saved in the config file so that all future G28 commands
+use that phase. (So, in future homing operations, Klipper will obtain
+the same position even if the endstop triggers a little earlier or a
+little later.)
+
+To save the endstop phase for a particular stepper motor, run
+something like the following:
+```
+ENDSTOP_PHASE_CALIBRATE STEPPER=stepper_z
+```
+
+Run the above for all the steppers one wishes to save. Typically, one
+would use this on stepper_z for cartesian and corexy printers, and for
+stepper_a, stepper_b, and stepper_c on delta printers. Finally, run
+the following to update the configuration file with the data:
+```
+SAVE_CONFIG
+```
+
+Additional notes
+----------------
+
+* After calibrating the endstop phase, if the endstop is later moved
+  or adjusted then it will be necessary to recalibrate the endstop.
+  Remove the calibration data from the config file and rerun the steps
+  above.
+
+* In order to use this system the endstop must be accurate enough to
+  identify the stepper position within two "full steps". So, for
+  example, if a stepper is using 16 micro-steps with a step distance
+  of 0.005mm then the endstop must have an accuracy of at least
+  0.160mm. If one gets "Endstop stepper_z incorrect phase" type error
+  messages than in may be due to an endstop that is not sufficiently
+  accurate. If recalibration does not help then disable endstop phase
+  adjustments by removing them from the config file.
+
+* If one is using a traditional stepper controlled Z axis (as on a
+  cartesian or corexy printer) along with traditional bed leveling
+  screws then it is also possible to use this system to arrange for
+  each print layer to be performed on a "full step" boundary. To
+  enable this feature be sure the G-Code slicer is configured with a
+  layer height that is a multiple of a "full step", manually enable
+  the endstop_align_zero option in the endstop_phase config section
+  (see config/example-extras.cfg for further details), and then
+  re-level the bed screws.
+
+* It is possible to use this system with traditional (non-Trinamic)
+  stepper motor drivers. However, doing this requires making sure that
+  the stepper motor drivers are reset every time the micro-controller
+  is reset. (If the two are always reset together then Klipper can
+  determine the stepper phase by tracking the total number of steps it
+  has commanded the stepper to move.) Currently, the only way to do
+  this reliably is if both the micro-controller and stepper motor
+  drivers are powered solely from USB and that USB power is provided
+  from a host running on a Raspberry Pi. In this situation one can
+  specify an mcu config with "restart_method: rpi_usb" - that option
+  will arrange for the micro-controller to always be reset via a USB
+  power reset, which would arrange for both the micro-controller and
+  stepper motor drivers to be reset together. If using this mechanism,
+  one would then need to manually configure the "endstop_phase" config
+  sections (see config/example-extras.cfg for the details).

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -221,6 +221,17 @@ is enabled:
 - `DUMP_TMC STEPPER=<name>`: This command will read the TMC2130 driver
   registers and report their values.
 
+## Endstop adjustments by stepper phase
+
+The following commands are available when an "endstop_phase" config
+section is enabled:
+- `ENDSTOP_PHASE_CALIBRATE [STEPPER=<config_name>]`: If no STEPPER
+  parameter is provided then this command will reports statistics on
+  endstop stepper phases during past homing operations. When a STEPPER
+  parameter is provided it arranges for the given endstop phase
+  setting to be written to the config file (in conjunction with the
+  SAVE_CONFIG command).
+
 ## Force movement
 
 The following commands are available when the "force_move" config

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -11,6 +11,8 @@ settings in the config file.
 The Klipper configuration is stored in a simple text file on the host
 machine. The [config/example.cfg](../config/example.cfg) file serves
 as a reference for the config file. See the
+[Endstop Phase](Endstop_Phase.md) document for information on
+Klipper's "stepper phase adjusted endstop" system. See the
 [Delta Calibrate](Delta_Calibrate.md) document for information on
 calibrating delta printers. The
 [Pressure Advance](Pressure_Advance.md) document contains information

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -1,0 +1,75 @@
+# Endstop accuracy improvement via stepper phase tracking
+#
+# Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import math, logging
+import homing
+
+class EndstopPhase:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[1]
+        stepper_config = config.getsection(self.name)
+        self.step_dist = step_dist = stepper_config.getfloat('step_distance')
+        self.phases = config.getint('phases', minval=1)
+        self.endstop_phase = config.getint('endstop_phase', None,
+                                           minval=0, maxval=self.phases-1)
+        self.endstop_align_zero = config.getboolean('endstop_align_zero', False)
+        # Determine endstop accuracy
+        endstop_accuracy = config.getfloat('endstop_accuracy', None, above=0.)
+        if endstop_accuracy is None:
+            self.endstop_accuracy = self.phases//2 - 1
+        elif self.endstop_phase is not None:
+            self.endstop_accuracy = int(
+                math.ceil(endstop_accuracy * .5 / step_dist))
+        else:
+            self.endstop_accuracy = int(math.ceil(endstop_accuracy / step_dist))
+        if self.endstop_accuracy >= self.phases // 2:
+            raise config.error("Endstop for %s is not accurate enough for"
+                               " stepper phase adjustment" % (self.name,))
+        if self.printer.get_start_args().get('debugoutput') is not None:
+            self.endstop_accuracy = self.phases
+        # Register event handler
+        self.printer.register_event_handler(
+            "homing:homed_rails", self.handle_homed_rails)
+    def align_endstop(self, pos):
+        if not self.endstop_align_zero or self.endstop_phase is None:
+            return pos
+        # Adjust the endstop position so 0.0 is always at a full step
+        microsteps = self.phases // 4
+        half_microsteps = microsteps // 2
+        phase_offset = (((self.endstop_phase + half_microsteps) % microsteps)
+                        - half_microsteps) * self.step_dist
+        full_step = microsteps * self.step_dist
+        return int(pos / full_step + .5) * full_step + phase_offset
+    def get_homed_offset(self, stepper):
+        pos = stepper.get_mcu_position()
+        phase = pos % self.phases
+        if self.endstop_phase is None:
+            logging.info("Setting %s endstop phase to %d", self.name, phase)
+            self.endstop_phase = phase
+            return 0.
+        delta = (phase - self.endstop_phase) % self.phases
+        if delta >= self.phases - self.endstop_accuracy:
+            delta -= self.phases
+        elif delta > self.endstop_accuracy:
+            raise homing.EndstopError(
+                "Endstop %s incorrect phase (got %d vs %d)" % (
+                    self.name, phase, self.endstop_phase))
+        return delta * self.step_dist
+    def handle_homed_rails(self, homing_state, rails):
+        for rail in rails:
+            stepper = rail.get_steppers()[0]
+            if stepper.get_name() != self.name:
+                continue
+            orig_pos = rail.get_commanded_position()
+            offset = self.get_homed_offset(stepper)
+            pos = self.align_endstop(orig_pos) + offset
+            if pos == orig_pos:
+                return False
+            rail.set_commanded_position(pos)
+            return True
+
+def load_config_prefix(config):
+    return EndstopPhase(config)

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -6,17 +6,30 @@
 import math, logging
 import homing
 
+TRINAMIC_DRIVERS = ["tmc2130", "tmc2208"]
+
 class EndstopPhase:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[1]
-        stepper_config = config.getsection(self.name)
-        self.step_dist = step_dist = stepper_config.getfloat('step_distance')
-        self.phases = config.getint('phases', minval=1)
+        # Determine number of stepper phases
+        for driver in TRINAMIC_DRIVERS:
+            driver_name = "%s %s" % (driver, self.name)
+            if config.has_section(driver_name):
+                module = self.printer.try_load_module(config, driver_name)
+                self.get_phase = module.get_phase
+                self.phases = module.get_microsteps() * 4
+                break
+        else:
+            self.get_phase = None
+            self.phases = config.getint('phases', minval=1)
+        # Determine endstop phase position
         self.endstop_phase = config.getint('endstop_phase', None,
                                            minval=0, maxval=self.phases-1)
         self.endstop_align_zero = config.getboolean('endstop_align_zero', False)
         # Determine endstop accuracy
+        stepper_config = config.getsection(self.name)
+        self.step_dist = step_dist = stepper_config.getfloat('step_distance')
         endstop_accuracy = config.getfloat('endstop_accuracy', None, above=0.)
         if endstop_accuracy is None:
             self.endstop_accuracy = self.phases//2 - 1
@@ -44,8 +57,15 @@ class EndstopPhase:
         full_step = microsteps * self.step_dist
         return int(pos / full_step + .5) * full_step + phase_offset
     def get_homed_offset(self, stepper):
-        pos = stepper.get_mcu_position()
-        phase = pos % self.phases
+        if self.get_phase is not None:
+            try:
+                phase = self.get_phase()
+            except Exception as e:
+                msg = "Unable to get stepper %s phase: %s" % (self.name, str(e))
+                logging.exception(msg)
+                raise homing.EndstopError(msg)
+        else:
+            phase = stepper.get_mcu_position() % self.phases
         if self.endstop_phase is None:
             logging.info("Setting %s endstop phase to %d", self.name, phase)
             self.endstop_phase = phase

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -47,7 +47,7 @@ class PrinterProbe:
     cmd_PROBE_help = "Probe Z-height at current XY position"
     def cmd_PROBE(self, params):
         toolhead = self.printer.lookup_object('toolhead')
-        homing_state = homing.Homing(toolhead)
+        homing_state = homing.Homing(self.printer)
         pos = toolhead.get_position()
         pos[2] = self.z_position
         endstops = [(self.mcu_probe, "probe")]

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -137,6 +137,10 @@ class TMC2130:
         data = [(reg | 0x80) & 0xff, (val >> 24) & 0xff, (val >> 16) & 0xff,
                 (val >> 8) & 0xff, val & 0xff]
         self.spi_send_cmd.send([self.oid, data])
+    def get_microsteps(self):
+        return 256 >> self.mres
+    def get_phase(self):
+        return (self.get_register("MSCNT") & 0x3ff) >> self.mres
     cmd_DUMP_TMC_help = "Read and display TMC stepper driver registers"
     def cmd_DUMP_TMC(self, params):
         self.printer.lookup_object('toolhead').get_last_move_time()

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -219,6 +219,10 @@ class TMC2208:
                 return
         raise self.printer.config_error(
             "Unable to write tmc2208 '%s' register %s" % (self.name, reg_name))
+    def get_microsteps(self):
+        return 256 >> self.mres
+    def get_phase(self):
+        return (self.get_register("MSCNT") & 0x3ff) >> self.mres
     cmd_DUMP_TMC_help = "Read and display TMC stepper driver registers"
     def cmd_DUMP_TMC(self, params):
         self.printer.lookup_object('toolhead').get_last_move_time()

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -513,7 +513,7 @@ class GCodeParser:
                 axes.append(self.axis2pos[axis])
         if not axes:
             axes = [0, 1, 2]
-        homing_state = homing.Homing(self.toolhead)
+        homing_state = homing.Homing(self.printer)
         if self.is_fileinput:
             homing_state.set_no_verify_retract()
         try:

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -10,8 +10,9 @@ ENDSTOP_SAMPLE_TIME = .000015
 ENDSTOP_SAMPLE_COUNT = 4
 
 class Homing:
-    def __init__(self, toolhead):
-        self.toolhead = toolhead
+    def __init__(self, printer):
+        self.printer = printer
+        self.toolhead = printer.lookup_object('toolhead')
         self.changed_axes = []
         self.verify_retract = True
     def set_no_verify_retract(self):

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -124,14 +124,14 @@ class Homing:
             self.toolhead.set_position(forcepos)
             self.homing_move(movepos, endstops, second_homing_speed,
                              verify_movement=self.verify_retract)
-        # Apply homing offsets
-        for rail in rails:
-            cp = rail.get_commanded_position()
-            rail.set_commanded_position(cp + rail.get_homed_offset())
-        adjustpos = self.toolhead.get_kinematics().calc_position()
-        for axis in homing_axes:
-            movepos[axis] = adjustpos[axis]
-        self.toolhead.set_position(movepos)
+        # Signal home operation complete
+        ret = self.printer.send_event("homing:homed_rails", self, rails)
+        if any(ret):
+            # Apply any homing offsets
+            adjustpos = self.toolhead.get_kinematics().calc_position()
+            for axis in homing_axes:
+                movepos[axis] = adjustpos[axis]
+            self.toolhead.set_position(movepos)
     def home_axes(self, axes):
         self.changed_axes = axes
         try:

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -58,6 +58,7 @@ class Printer:
         self.is_shutdown = False
         self.run_result = None
         self.state_cb = [gc.printer_state]
+        self.event_handlers = {}
     def get_start_args(self):
         return self.start_args
     def get_reactor(self):
@@ -188,6 +189,10 @@ class Printer:
     def invoke_async_shutdown(self, msg):
         self.reactor.register_async_callback(
             (lambda e: self.invoke_shutdown(msg)))
+    def register_event_handler(self, event, callback):
+        self.event_handlers.setdefault(event, []).append(callback)
+    def send_event(self, event, *params):
+        return [cb(*params) for cb in self.event_handlers.get(event, [])]
     def request_exit(self, result):
         self.run_result = result
         self.reactor.end()


### PR DESCRIPTION
This pull request enhances Klipper's existing "stepper phase adjusted endstops" system.  Although this system has been in Klipper for a couple of years, it was difficult to configure correctly.  This series adds support for obtaining the stepper phase directly from TMC drivers, which should make using this system dramatically easier.  For some details on how it works, see the guide on this new development branch: https://github.com/KevinOConnor/klipper/blob/work-endstopphase-20181009/docs/Endstop_Phase.md

This series does make some non-backwards compatible changes to existing users of stepper phase adjusted endstops (although I suspect there were few if any users).  The config entries will need to be moved from the stepper sections to new endstop_phase config sections - see the updated example-extras.cfg file for details.

cd ~/klipper ; git fetch ; git checkout origin/work-endstopphase-20181009 ; sudo service klipper restart

@FHeilmann - could you see if it's possible to add equivalent get_microsteps() and get_phase() methods to the TMC2660 code?  That should make it possible to use this support on those drivers as well.

@mcmatrix - FYI, this series uses the "event" system we discussed separately.

-Kevin