### PR TITLE
Is SAM4 cache on by default?

### DIFF
--- a/src/sam4e8e/main.c
+++ b/src/sam4e8e/main.c
@@ -43,6 +43,12 @@ int
 main(void)
 {
     SystemInit();
+
+    // Enable Cache
+    if (!(CMCC->CMCC_SR & CMCC_SR_CSTS))
+        CMCC->CMCC_CTRL = CMCC_CTRL_CEN;
+
+    // Start main loop
     sched_main();
     return 0;
 }


### PR DESCRIPTION
Hi @FHeilmann ,

I was looking at performance on the ARM chips recently.  When you submitted the latest benchmarks (pr #562 ) you indicated a recent degradation in performance.  I think this may have been due to gcc no longer inlining the try_shutdown() method.  If you get a chance, I'd be curious if the latest code (specifically commit fb798e3c) improves the performance on the SAM4 chip?  I suspect it will, as it fixed regressions on several of my test chips.

Also, I noticed that the SAM4 controller has a cache.  (I was able to dramatically improve SAM3 performance by tuning the build to the SAM3 instruction fetch mechanics.)  The docs seem to indicate that the cache is disabled on startup.  Do you know if that is correct?  If so, does explicitly enabling the cache (as is done in this PR) further improve performance?

Thanks,
-Kevin