### PR TITLE
packaging: Add a quick __main__ to compile c helper

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -180,3 +180,7 @@ def run_hub_ctrl(enable_power):
     hubdir = os.path.join(srcdir, HC_SOURCE_DIR)
     check_build_code(hubdir, HC_TARGET, HC_SOURCE_FILES, HC_COMPILE_CMD)
     os.system(HC_CMD % (hubdir, enable_power))
+
+
+if __name__ == '__main__':
+    get_ffi()


### PR DESCRIPTION
I'm writing packaging for Arch Linux for Klipper, and I would like to build the C modules while packaging. As such I've added a very simple `__main__` in the `chelper/__init__.py` which will ensure it gets compiled if it hasn't been already.