### PR TITLE
CONFIG: ADIMlab Add support for LCD knob and caselight

### DIFF
--- a/config/printer-adimlab-2018.cfg
+++ b/config/printer-adimlab-2018.cfg
@@ -97,11 +97,18 @@ cycle_time: .000030
 hardware_pwm: True
 static_value: 1.25
 
-# [heater_fan stepstick_fan]
-# pin: ar7
-
 [display]
 lcd_type: st7920
 cs_pin: ar20
 sclk_pin: ar14
 sid_pin: ar15
+encoder_pins: ^ar41, ^ar40
+click_pin: ^!ar19
+
+# This is the right pin for the ADIMLab printer, but I can't find out what the format is for this section.
+# [output_pin filament_runout_sensor 0]
+# pin = ar24
+
+[output_pin case_light]
+pin = ar7
+value = 1

--- a/config/printer-adimlab-2018.cfg
+++ b/config/printer-adimlab-2018.cfg
@@ -3,6 +3,9 @@
 
 # See the example.cfg file for a description of available parameters.
 
+# If this is supported the filament runout sensor for the ADIMLab is 
+# pin: ar24
+
 [stepper_x]
 step_pin: ar25
 dir_pin: !ar23
@@ -112,10 +115,6 @@ sid_pin: ar15
 encoder_pins: ^ar41, ^ar40
 click_pin: ^!ar19
 
-# Waiting for the run out code PR to be comitted
-# [output_pin filament_runout_sensor 0]
-# pin = ar24
-
 [output_pin case_light]
-pin = ar7
-value = 1
+pin: ar7
+value: 1

--- a/config/printer-adimlab-2018.cfg
+++ b/config/printer-adimlab-2018.cfg
@@ -62,6 +62,13 @@ pid_Kd: 775.038
 min_temp: 0
 max_temp: 110
 
+[verify_heater heater_bed]
+# adjust for personal bed setup, this prevents stock heated bed from issuing
+# false positive heating errors due to slow temperature increase
+# 1 deg per 2 minutes.
+heating_gain: 1
+check_gain_time: 120
+
 [mcu]
 serial: /dev/ttyUSB0
 pin_map: arduino
@@ -105,7 +112,7 @@ sid_pin: ar15
 encoder_pins: ^ar41, ^ar40
 click_pin: ^!ar19
 
-# This is the right pin for the ADIMLab printer, but I can't find out what the format is for this section.
+# Waiting for the run out code PR to be comitted
 # [output_pin filament_runout_sensor 0]
 # pin = ar24
 

--- a/config/printer-adimlab-2018.cfg
+++ b/config/printer-adimlab-2018.cfg
@@ -3,7 +3,7 @@
 
 # See the example.cfg file for a description of available parameters.
 
-# If this is supported the filament runout sensor for the ADIMLab is 
+# If this is supported the filament runout sensor for the ADIMLab is
 # pin: ar24
 
 [stepper_x]


### PR DESCRIPTION
Added support for knob / Menus

Added support for the LED Case light. defaults on like the original firmware.

Also lowered the heated bed checking to be 1 deg every 2 minutes.

signed-off-by: Jason Rahaim <jason@jasonr.com>