### PR TITLE
Add support for printing, ready, and idle events

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -567,6 +567,11 @@
 #   highest resistance and 0.0 being the lowest resistance. However,
 #   the range may be changed with the 'scale' parameter (see below).
 #   If a channel is not specified then it is left unconfigured.
+#channel_<x>_while_printing:
+#   If specified then the given channel is set to the given value when
+#   the printer starts printing and will be set back to the default
+#   value after printing stops. The default is to not change the
+#   channel value at run-time.
 #scale:
 #   This parameter can be used to alter how the 'channel_x' parameters
 #   are interpreted. If provided, then the 'channel_x' parameters

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -517,6 +517,11 @@
 #shutdown_value:
 #   The value to set the pin to on an MCU shutdown event. The default
 #   is 0 (for low voltage).
+#printing_value:
+#   If specified then the pin is set to the given value when the
+#   printer starts printing and will be set back to the regular value
+#   after printing stops. The default is to not change the pin state
+#   during these events.
 #cycle_time: 0.100
 #   The amount of time (in seconds) per PWM cycle. It is recommended
 #   this be 10 milliseconds or greater when using software based

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -606,6 +606,11 @@
 #   highest resistance and 0.0 being the lowest resistance. However,
 #   the range may be changed with the 'scale' parameter (see
 #   below). If a wiper is not specified then it is left unconfigured.
+#wiper_<x>_while_printing:
+#   If specified then the given wiper is set to the given value when
+#   the printer starts printing and will be set back to the default
+#   value after printing stops. The default is to not change the wiper
+#   value at run-time.
 #scale:
 #   This parameter can be used to alter how the 'wiper_x' parameters
 #   are interpreted. If provided, then the 'wiper_x' parameters should

--- a/config/generic-mini-rambo.cfg
+++ b/config/generic-mini-rambo.cfg
@@ -80,7 +80,8 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.3
+printing_value: 0.4
+value: 1.3
 
 [output_pin stepper_z_current]
 pin: PL4
@@ -96,7 +97,8 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.25
+printing_value: 1.25
+value: 0.4
 
 [static_digital_output stepper_config]
 pins:

--- a/config/generic-rambo.cfg
+++ b/config/generic-rambo.cfg
@@ -90,11 +90,16 @@ enable_pin: PD7
 # (For Rambo v1.0d boards, use 1.56 instead.)
 scale: 2.08
 # Channel 1 is E0, 2 is E1, 3 is unused, 4 is Z, 5 is X, 6 is Y
-channel_1: 1.34
-channel_2: 1.0
+channel_1: 0.4
+channel_1_while_printing: 1.34
+channel_2: 0.4
+channel_2_while_printing: 1.0
 channel_4: 1.1
-channel_5: 1.1
-channel_6: 1.1
+channel_4_while_printing: 1.1
+channel_5: 0.4
+channel_5_while_printing: 1.1
+channel_6: 0.4
+channel_6_while_printing: 1.1
 
 # Enable 16 micro-steps on steppers X, Y, Z, E0, E1
 [static_digital_output stepper_config]

--- a/klippy/extras/ad5206.py
+++ b/klippy/extras/ad5206.py
@@ -6,27 +6,63 @@
 
 class ad5206:
     def __init__(self, config):
-        ppins = config.get_printer().lookup_object('pins')
+        # Get enable pin config
+        printer = config.get_printer()
+        ppins = printer.lookup_object('pins')
         enable_pin = config.get('enable_pin')
         enable_pin_params = ppins.lookup_pin(enable_pin)
-        mcu = enable_pin_params['chip']
+        self.mcu = enable_pin_params['chip']
         pin = enable_pin_params['pin']
+        # Get channel config
+        self.spi_send_cmd = None
         scale = config.getfloat('scale', 1., above=0.)
-        channels = [None]*6
-        for i in range(len(channels)):
+        self.channels = [None]*6
+        self.printing_values = list(self.channels)
+        for i in range(len(self.channels)):
             val = config.getfloat('channel_%d' % (i+1,), None,
                                   minval=0., maxval=scale)
+            if val is None:
+                continue
+            self.channels[i] = int(val * 256. / scale + .5)
+            val = config.getfloat('channel_%d_while_printing' % (i+1,), None,
+                                  minval=0., maxval=scale)
             if val is not None:
-                channels[i] = int(val * 256. / scale + .5)
-        oid = mcu.create_oid()
-        mcu.add_config_cmd(
+                self.printing_values[i] = int(val * 256. / scale + .5)
+        if self.printing_values != [None]*6:
+            printer.register_event_handler("idle_timeout:printing",
+                                           self.handle_printing)
+            printer.register_event_handler("idle_timeout:ready",
+                                           self.handle_ready)
+        # Setup initial configuration
+        self.mcu.register_config_callback(self.build_config)
+        self.oid = self.mcu.create_oid()
+        self.mcu.add_config_cmd(
             "config_spi oid=%d bus=%d pin=%s mode=%u rate=%u shutdown_msg=" % (
-                oid, 0, pin, 0, 25000000))
-        for i, val in enumerate(channels):
+                self.oid, 0, pin, 0, 25000000))
+        for i, val in enumerate(self.channels):
             if val is not None:
-                mcu.add_config_cmd(
-                    "spi_send oid=%d data=%02x%02x" % (oid, i, val),
-                    is_init=True)
+                self.set_channel(None, i, val)
+    def build_config(self):
+        cmd_queue = self.mcu.alloc_command_queue()
+        self.spi_send_cmd = self.mcu.lookup_command(
+            "spi_send oid=%c data=%*s", cq=cmd_queue)
+    def set_channel(self, print_time, channel, val):
+        if self.spi_send_cmd is None:
+            self.mcu.add_config_cmd(
+                "spi_send oid=%d data=%02x%02x" % (self.oid, channel, val),
+                is_init=True)
+            return
+        clock = self.mcu.print_time_to_clock(print_time)
+        self.spi_send_cmd.send([self.oid, [channel, val]],
+                               minclock=clock, reqclock=clock)
+    def handle_printing(self, print_time):
+        for i, pv in enumerate(self.printing_values):
+            if pv is not None:
+                self.set_channel(print_time, i, pv)
+    def handle_ready(self, print_time):
+        for i, (val, pv) in enumerate(zip(self.channels, self.printing_values)):
+            if pv is not None:
+                self.set_channel(print_time, i, val)
 
 def load_config_prefix(config):
     return ad5206(config)

--- a/klippy/extras/mcp4451.py
+++ b/klippy/extras/mcp4451.py
@@ -9,31 +9,61 @@ WiperRegisters = [0x00, 0x01, 0x06, 0x07]
 
 class mcp4451:
     def __init__(self, config):
+        # Configure i2c bus
         printer = config.get_printer()
-        # Read config parameters
         self.mcu = mcu.get_printer_mcu(printer, config.get('mcu', 'mcu'))
-        i2c_addr = config.getint('i2c_address')
-        scale = config.getfloat('scale', 1., above=0.)
-        wipers = [None]*4
-        for i in range(len(wipers)):
-            val = config.getfloat('wiper_%d' % (i,), None,
-                                  minval=0., maxval=scale)
-            if val is not None:
-                wipers[i] = int(val * 255. / scale + .5)
-        # Setup i2c
+        self.mcu.register_config_callback(self.build_config)
+        self.i2c_write_cmd = None
         self.oid = self.mcu.create_oid()
         self.mcu.add_config_cmd(
             "config_i2c oid=%d bus=0 rate=100000 addr=%d" % (
-                self.oid, i2c_addr))
-        # Configure registers
-        self.add_config_cmd(0x04, 0xff)
-        self.add_config_cmd(0x0a, 0xff)
-        for reg, val in zip(WiperRegisters, wipers):
+                self.oid, config.getint('i2c_address')))
+        # Configure output values
+        scale = config.getfloat('scale', 1., above=0.)
+        self.wipers = [None]*4
+        self.printing_values = list(self.wipers)
+        for i in range(len(self.wipers)):
+            val = config.getfloat('wiper_%d' % (i,), None,
+                                  minval=0., maxval=scale)
+            if val is None:
+                continue
+            self.wipers[i] = int(val * 255. / scale + .5)
+            val = config.getfloat('wiper_%d_while_printing' % (i+1,), None,
+                                  minval=0., maxval=scale)
             if val is not None:
-                self.add_config_cmd(reg, val)
-    def add_config_cmd(self, reg, val):
-        self.mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
-            self.oid, (reg << 4) | ((val >> 8) & 0x03), val), is_init=True)
+                self.printing_values[i] = int(val * 255. / scale + .5)
+        if self.printing_values != [None]*4:
+            printer.register_event_handler("idle_timeout:printing",
+                                           self.handle_printing)
+            printer.register_event_handler("idle_timeout:ready",
+                                           self.handle_ready)
+        # Setup initial configuration
+        self.set_register(None, 0x04, 0xff)
+        self.set_register(None, 0x0a, 0xff)
+        for reg, val in zip(WiperRegisters, self.wipers):
+            if val is not None:
+                self.set_register(None, reg, val)
+    def build_config(self):
+        cmd_queue = self.mcu.alloc_command_queue()
+        self.i2c_write_cmd = self.mcu.lookup_command(
+            "i2c_write oid=%c data=%*s", cq=cmd_queue)
+    def set_register(self, print_time, reg, val):
+        if self.i2c_write_cmd is None:
+            self.mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
+                self.oid, (reg << 4) | ((val >> 8) & 0x03), val), is_init=True)
+            return
+        clock = self.mcu.print_time_to_clock(print_time)
+        self.i2c_write_cmd.send([self.oid, [reg, val]],
+                                minclock=clock, reqclock=clock)
+    def handle_printing(self, print_time):
+        for reg, pv in zip(WiperRegisters, self.printing_values):
+            if pv is not None:
+                self.set_register(print_time, reg, pv)
+    def handle_ready(self, print_time):
+        for reg, val, pv in zip(WiperRegisters, self.wipers,
+                                self.printing_values):
+            if pv is not None:
+                self.set_register(print_time, reg, val)
 
 def load_config_prefix(config):
     return mcp4451(config)


### PR DESCRIPTION
This series adds support for internally signalling when the printing state changes.  It also hooks up the ad5206, mcp4451, and output_pin classes so that they can change values during a state change.  This support may be useful to reduce stepper motor current when the printer is not actively printing.

cd ~/klipper ; git fetch ; git checkout origin/work-idleevent-20181018 ; sudo service klipper restart

The new config options are listed in the config/example-extras.cfg file on the above branch.

The mcp4451 (smoothieboard current control) support needs to be tested.

@FHeilmann - I have not hooked up the tmc2660 code.  I think it should be straight forward to do that.

-Kevin