### PR TITLE
util: Fix versioning when gitdir is absent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out
 *.pyc
 .config
 .config.old
+klippy/.version

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -1,0 +1,31 @@
+# Packaging klipper
+
+Klipper is somewhat of a packaging anomaly among python programs, as it doesn't
+use setuptools to build and install. Some notes regarding how best to package it
+are as follows:
+
+## C modules
+
+Klipper uses a C module to handle some kinematics calculations more quickly.
+This module needs to be compiled at packaging time to avoid introducing a
+runtime dependency on a compiler. To compile the C module, run `python2
+klippy/chelper/__init__.py`.
+
+## Compiling python code
+
+Many distributions have a policy of compiling all python code before packaging
+to improve startup time. You can do this by running `python2 -m compileall
+klippy`.
+
+## Versioning
+
+If you are building a package of Klipper from git, it is usual practice not to
+ship a .git directory, so the versioning must be handled without git.  To do
+this, use the script shipped in `scripts/make_version.py` which should be run as
+follows: `python2 scripts/make_version.py YOURDISTRONAME > klippy/.version`.
+
+## Sample packaging script
+
+klipper-git is packaged for Arch Linux, and has a PKGBUILD (package build
+script) available at
+https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=klipper-git.

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -54,17 +54,24 @@ def get_cpu_info():
     return "%d core %s" % (core_count, model_name)
 
 def get_git_version():
-    # Obtain version info from "git" program
-    gitdir = os.path.join(sys.path[0], '..')
-    if not os.path.exists(gitdir):
-        logging.debug("No '.git' file/directory found")
-        return "?"
-    prog = "git -C %s describe --always --tags --long --dirty" % (gitdir,)
+    klippy_src = os.path.dirname(__file__)
     try:
-        process = subprocess.Popen(shlex.split(prog), stdout=subprocess.PIPE)
-        output = process.communicate()[0]
-        retcode = process.poll()
+        with open(os.path.join(klippy_src, 'version')) as h:
+            return h.read().rstrip()
+    except IOError:
+        pass
+
+    # Obtain version info from "git" program
+    gitdir = os.path.join(klippy_src, '..')
+    prog = ('git', '-C', gitdir, 'describe', '--always', '--tags', '--long', '--dirty')
+    try:
+        process = subprocess.Popen(prog, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        ver, err = process.communicate()
+        retcode = process.wait()
+        if retcode != 0:
+            logging.debug("Error getting git version: %s", err)
+            return "?"
     except OSError:
         logging.debug("Exception on run: %s", traceback.format_exc())
         return "?"
-    return output.strip()
+    return ver.strip()

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -53,7 +53,15 @@ def get_cpu_info():
     model_name = dict(lines).get("model name", "?")
     return "%d core %s" % (core_count, model_name)
 
-def get_git_version():
+def get_version_from_file(klippy_src):
+    try:
+        with open(os.path.join(klippy_src, '.version')) as h:
+            return h.read().rstrip()
+    except IOError:
+        pass
+    return "?"
+
+def get_git_version(from_file=True):
     klippy_src = os.path.dirname(__file__)
 
     # Obtain version info from "git" program
@@ -70,9 +78,6 @@ def get_git_version():
     except OSError:
         logging.debug("Exception on run: %s", traceback.format_exc())
 
-    try:
-        with open(os.path.join(klippy_src, '.version')) as h:
-            return h.read().rstrip()
-    except IOError:
-        pass
+    if from_file:
+        return get_version_from_file(klippy_src)
     return "?"

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -55,11 +55,6 @@ def get_cpu_info():
 
 def get_git_version():
     klippy_src = os.path.dirname(__file__)
-    try:
-        with open(os.path.join(klippy_src, 'version')) as h:
-            return h.read().rstrip()
-    except IOError:
-        pass
 
     # Obtain version info from "git" program
     gitdir = os.path.join(klippy_src, '..')
@@ -68,10 +63,16 @@ def get_git_version():
         process = subprocess.Popen(prog, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         ver, err = process.communicate()
         retcode = process.wait()
-        if retcode != 0:
+        if retcode == 0:
+            return ver.strip()
+        else:
             logging.debug("Error getting git version: %s", err)
-            return "?"
     except OSError:
         logging.debug("Exception on run: %s", traceback.format_exc())
-        return "?"
-    return ver.strip()
+
+    try:
+        with open(os.path.join(klippy_src, '.version')) as h:
+            return h.read().rstrip()
+    except IOError:
+        pass
+    return "?"

--- a/scripts/make_version.py
+++ b/scripts/make_version.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../klippy'))
+
+import util
+
+
+def main(argv):
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        'distroname',
+        help='Name of distro this package is intended for'
+    )
+    args = p.parse_args()
+    print(util.get_git_version(),
+          args.distroname.replace(' ', ''), sep='-')
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/scripts/make_version.py
+++ b/scripts/make_version.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python2
+# Get the version number for klippy
+#
+# Copyright (C) 2018  Lucas Fink <software@lfcode.ca>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
 from __future__ import print_function
 
 import argparse
@@ -16,7 +23,7 @@ def main(argv):
         help='Name of distro this package is intended for'
     )
     args = p.parse_args()
-    print(util.get_git_version(),
+    print(util.get_git_version(from_file=False),
           args.distroname.replace(' ', ''), sep='-')
 
 


### PR DESCRIPTION
The gitdir previously could be absent and produce a version of "" in
spite of checks for it.

Parent directories with shlex-interpreted characters in their names
could be misinterpreted, potentially causing shell injection (but more likely just confusion). Removed shlex parsing of user supplied strings.

Packagers may want to remove the git history to slim down the package
size, so add an option for using a file 'version' in the klippy
directory to set version without using git.