### PR TITLE
Update generic-rumba.cfg for LCD encoder on 2004

### DIFF
--- a/config/generic-rumba.cfg
+++ b/config/generic-rumba.cfg
@@ -102,6 +102,9 @@ max_z_accel: 100
 #d5_pin: ar38
 #d6_pin: ar41
 #d7_pin: ar40
+#encoder_pins: ^!ar11, ^!ar12
+#click_pin: ^!ar43
+#kill_pin: ar46
 
 # "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
 #[display]


### PR DESCRIPTION
 Added definitions for encoder_pins, click_pin, and kill_pin for a RRD 2004 Smart Controller LCD display attached to a RUMBA board to enable use of the encoder to navigate the menu and make selections on the LCD panel.