### PR TITLE
Implement idle event and DUMP_TMC support to the TMC2660 extra

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -739,8 +739,8 @@
 #[tmc2660 stepper_x]
 #cs_pin:
 #   The pin corresponding to the TMC2660 chip select line. This pin
-#   will be set to low at the start of SPI messages and raised to high
-#   after the message completes. This parameter must be provided.
+#   will be set to low at the start of SPI messages and set to high
+#   after the message transfer completes. This parameter must be provided.
 #bus:
 #   Select the SPI bus the TMC2660 stepper driver is connected to. This
 #   depends on the physical connections on your board, as well as the
@@ -758,20 +758,17 @@
 #   step at a rate of 256 micro-steps). This only works if microsteps
 #   is set to 16. The default is True.
 #run_current:
-#   The amount of current (in amps) to configure the driver to use
-#   during stepper movement. This parameter must be provided.
-#idle_timeout: 0
-#   The amount of time in seconds after which the run_current of the
-#   stepper driver will be lowered to this percentage of run_current.
-#   Set to 0 to disable the idle timeout. The default is 0.
-#idle_current_percent: 30
+#   The amount of current (in ampere) used by the driver during stepper
+#   movement. This parameter must be provided.
+#idle_current_percent: 100
 #   The percentage of the run_current the stepper driver will be
-#   lowered to after the idle_timeout has expired. The current will
+#   lowered to when the idle timeout expires (you need to set up the
+#   timeout using a [idle_timeout] config section). The current will
 #   be raised again once the stepper has to move again. Make sure to
 #   set this to a high enough value such that the steppers do not lose
-#   their position. There is also a delay of up to 100 ms until the
-#   current is raised again, so take this into account commanding fast
-#   moves when the stepper is idling. The default is 30.
+#   their position. There is also small delay until the  current is
+#   raised again, so take this into account when commanding fast moves
+#   while the stepper is idling. The default is 100 (no reduction).
 #driver_DEDGE: False
 #driver_TBL: 36
 #   Valid values are 16, 24, 36, 54.
@@ -802,10 +799,10 @@
 #driver_VSENSE: high
 #   Valid values are 'high' and 'low'
 #
-#   Set the given register during the configuration of the TMC2660
-#   chip. This may be used to set custom motor parameters. The
+#   Set the given parameter during the configuration of the TMC2660
+#   chip. This may be used to set custom driver parameters. The
 #   defaults for each parameter are next to the parameter name in the
-#   above list. See the TMC2660 datasheet about what each parameter
+#   list above. See the TMC2660 datasheet about what each parameter
 #   does and what the restrictions on parameter combinations are.
 
 


### PR DESCRIPTION
This removes the custom timeout code in favor of the new event system to detect ready and printing states.

While I'm at it I also added the DUMP_TMC command to the TMC2660 extra.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>