### PR TITLE
Add endstop phase detection functionality to TMC2660 extra

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -333,7 +333,7 @@
 #   This specifies the number of phases of the given stepper motor
 #   driver (which is the number of micro-steps multiplied by four).
 #   This setting is automatically determined if one uses TMC2130,
-#   TMC2208, or TMC2224 drivers with run-time configuration.
+#   TMC2208, TMC2224 or TMC2660 drivers with run-time configuration.
 #   Otherwise, this parameter must be provided.
 #endstop_accuracy: 0.200
 #   Sets the expected accuracy (in mm) of the endstop. This represents

--- a/docs/Endstop_Phase.md
+++ b/docs/Endstop_Phase.md
@@ -26,9 +26,9 @@ the endstop trigger to improve the accuracy of the endstop.
 
 In order to use this functionality it is necessary to be able to
 identify the phase of the stepper motor. If one is using Trinamic
-TMC2130, TMC2208, or TMC2224 drivers in run-time configuration mode
-(ie, not stand-alone mode) then Klipper can query the stepper phase
-from the driver. (It is also possible to use this system on
+TMC2130, TMC2208, TMC2224 or TMC2660 drivers in run-time configuration
+mode (ie, not stand-alone mode) then Klipper can query the stepper
+phase from the driver. (It is also possible to use this system on
 traditional stepper drivers if one can reliably reset the stepper
 drivers - see below for details.)
 

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -6,7 +6,7 @@
 import math, logging
 import homing
 
-TRINAMIC_DRIVERS = ["tmc2130", "tmc2208"]
+TRINAMIC_DRIVERS = ["tmc2130", "tmc2208", "tmc2660"]
 
 class EndstopPhase:
     def __init__(self, config):


### PR DESCRIPTION
This adds the required functions for endstop phase detection to the TMC2660 extra.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>