### PR TITLE
add rotary encoder pins to anycubic kossel plus config template

### DIFF
--- a/config/printer-anycubic-kossel-plus-2017.cfg
+++ b/config/printer-anycubic-kossel-plus-2017.cfg
@@ -107,3 +107,8 @@ d4_pin: ar23
 d5_pin: ar25
 d6_pin: ar27
 d7_pin: ar29
+# pins for rotary encoder
+encoder_pins: ^ar31, ^ar33
+click_pin: ^!ar35
+kill_pin: ^!ar41
+


### PR DESCRIPTION
tested and working in my printer