### PR TITLE
docs: Clarify in G Code documentation that M109/M190 wait for cool also

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -19,8 +19,10 @@ Klipper supports the following standard G-Code commands:
 - Get extruder temperature: `M105`
 - Set extruder temperature: `M104 [T<index>] [S<temperature>]`
 - Set extruder temperature and wait: `M109 [T<index>] S<temperature>`
+  (note: this waits for both heat and cool)
 - Set bed temperature: `M140 [S<temperature>]`
 - Set bed temperature and wait: `M190 S<temperature>`
+  (note: this waits for both heat and cool)
 - Set fan speed: `M106 S<value>`
 - Turn fan off: `M107`
 - Emergency stop: `M112`


### PR DESCRIPTION
This is actually a slight incompatibility with Marlin G code because Marlin only waits for heating if given an S parameter, requiring a R parameter if you want to wait for cooling as well.

Regardless, the docs should clarify this fact, because it is not the same as the more thoroughly documented Marlin G code reference (I do have a patch to allow klipper to accept R parameters exactly the same as S parameters, however I don't plan on submitting it because I haven't heard of any slicers emitting these automatically, so it's just start/end G code which is affected by this).

Use case for the R parameter in Marlin is printers which need to wait for hot ends to cool off before automatically switching themselves off.

See: http://marlinfw.org/docs/gcode/M109.html