### PR TITLE
bed_mesh: Fix some fragile identity comparisons

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -211,7 +211,7 @@ class BedMeshCalibrate:
         stored_profs = config.get_prefix_sections(self.name)
         # Remove primary bed_mesh section, as it is not a stored profile
         stored_profs = [s for s in stored_profs
-                        if s.get_name() is not self.name]
+                        if s.get_name() != self.name]
         for profile in stored_profs:
             name = profile.get_name().split(' ', 1)[1]
             self.profiles[name] = {}
@@ -292,7 +292,7 @@ class BedMeshCalibrate:
         for key in options:
             name = self.gcode.get_str(key, params, None)
             if name is not None:
-                if name == "default" and key is not 'LOAD':
+                if name == "default" and key != 'LOAD':
                     self.gcode.respond_info(
                         "Profile 'default' is reserved, please chose"
                         " another profile name.")


### PR DESCRIPTION
@Arksine

https://github.com/KevinOConnor/klipper/blob/24bbc43fd04033decde51097f6194db6cb54fda9/klippy/extras/bed_mesh.py#L295

I noticed while poking around on LGTM's static analysis (intriguing tool, seems to bring up some potentially-valid issues) that there were some identity comparisons between strings in the bed_mesh code. These are probably safe and functional right now because the compiler will put them in the same constant slot due to the comparison being in the same method as the assignment, thus they would have the same identity, but they would be really fragile if the code were ever refactored.

This pull request updates them to equality comparisons.