### PR TITLE
Fix typo in TMC2660 extra

### DIFF
--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -268,7 +268,7 @@ class TMC2660:
         reg_data = [(self.reg_drvctrl >> 16) & 0xff, (self.reg_drvctrl >> 8) & 0xff, self.reg_drvctrl & 0xff]
         params = self.spi_transfer_cmd.send_with_response([self.oid, reg_data], 'spi_transfer_response', self.oid)
         pr = bytearray(params['response'])
-        msg = "%-15s %08x" % ("RESPONSE:", ((pr[0] << 16) | (pr[1] << 8) | pr[2])
+        msg = "%-15s %08x" % ("RESPONSE:", ((pr[0] << 16) | (pr[1] << 8) | pr[2]))
         gcode.respond_info(msg)
 
 def load_config_prefix(config):


### PR DESCRIPTION
Somehow a typo was left uncaught when I rebased the commit.
I'm sorry. This PR fixes it.

Bests,
Florian

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>