### PR TITLE
[DO NOT MERGE] Proof of concept for a pinmap system

### DIFF
--- a/klippy/pinmaps/__init__.py
+++ b/klippy/pinmaps/__init__.py
@@ -1,0 +1,5 @@
+# Package definition for the pinmaps directory
+#
+# Copyright (C) 2018  Florian Heilmann <Florian.Heilmann@gmx.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.

--- a/klippy/pinmaps/duet2.py
+++ b/klippy/pinmaps/duet2.py
@@ -43,4 +43,3 @@ def update_pinmap(pins, mcu_type):
         raise error("Duet2 Wifi/Ethernet pinmap can only be used on sam4e8e boards")
     for pin, gpio in duet2_pinmap.items():
         pins[pin] = pins[gpio]
-    return pins

--- a/klippy/pinmaps/duet2.py
+++ b/klippy/pinmaps/duet2.py
@@ -1,0 +1,46 @@
+# Duet2 Wifi/Ethernet pinmap
+#
+# Copyright (C) 2018  Florian Heilmann <Florian.Heilmann@gmx.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+duet2_pinmap = {
+    # FANS
+    'FAN0': 'PC23', 'FAN1': 'PC26', 'FAN2': 'PA0',
+    # TMC2660 Drives
+    'X_DIR': 'PD11', 'X_STEP': 'PD6', 'X_SPI_EN': 'PD14', 'X_STOP': 'PC14',
+    'Y_DIR': 'PD12', 'Y_STEP': 'PD7', 'Y_SPI_EN': 'PC9', 'Y_STOP': 'PA2',
+    'Z_DIR': 'PD13', 'Z_STEP': 'PD8', 'Z_SPI_EN': 'PC10', 'Z_STOP': 'PD29',
+    'E0_DIR': 'PA1', 'E0_STEP': 'PD5', 'E0_SPI_EN': 'PC17', 'E0_STOP': 'PD10',
+    'E1_DIR': 'PD9', 'E1_STEP': 'PD4', 'E1_SPI_EN': 'PC25', 'E1_STOP': 'PC16',
+    'E2_DIR': 'PD28', 'E2_STEP': 'PD2', 'E2_SPI_EN': 'PD23', 'E2_STOP': 'PE0',
+    'E3_DIR': 'PD22', 'E3_STEP': 'PD1', 'E3_SPI_EN': 'PD24', 'E3_STOP': 'PE1',
+    'E4_DIR': 'PD16', 'E4_STEP': 'PD0', 'E4_SPI_EN': 'PD25', 'E4_STOP': 'PE2',
+    'E5_DIR': 'PD17', 'E5_STEP': 'PD3', 'E5_SPI_EN': 'PD26', 'E5_STOP': 'PE3',
+    'TMC_EN': 'PC6',
+    # Thermistors
+    'BED_TEMP': 'PC13', 'E0_TEMP': 'PC15', 'E1_TEMP': 'PC12',
+    'E2_TEMP': 'PC29', 'E3_TEMP': 'PC30', 'E4_TEMP': 'PC31',
+    'E5_TEMP': 'PC27', 'E6_TEMP' : 'PA18',
+    # Heaters (HEATER0 = bed)
+    'BED_HEAT': 'PA19', 'E0_HEAT': 'PA20', 'E1_HEAT': 'PA16', 'E2_HEAT': 'PC3',
+    'E3_HEAT': 'PC5', 'E4_HEAT': 'PC8', 'E5_HEAT': 'PC11', 'E6_HEAT': 'PA15',
+    # LCD
+    'ENC_SW': 'PA7', 'ENC_A': 'PA8', 'ENC_B': 'PC7','LCD_E': 'PA25',
+    'LCD_RS': 'PC28', 'LCD_DB7': 'PD18', 'LCD_DB6': 'PD19', 'LCD_DB5': 'PD20',
+    'LCD_DB4': 'PD21',
+    # SPI0 CS
+    'SPI0_CS0': 'PC24', 'SPI0_CS1': 'PB2', 'SPI0_CS2': 'PC18',
+    'SPI0_CS3': 'PC19', 'SPI0_CS4': 'PC20', 'SPI0_CS5' : 'PA24',
+    'SPI0_CS6' : 'PE1', 'SPI0_CS7': 'PE2', 'SPI0_CS8': 'PE3',
+    # Misc
+    'ZPROBE_IN': 'PC1',  'PS_ON': 'PD15', 'LED_ONBOARD': 'PC2',
+    'SX1509_IRQ': 'PA17', 'DUEX_SG_TST': 'PE0',
+}
+
+def update_pinmap(pins, mcu_type):
+    if mcu_type != 'sam4e8e':
+        raise error("Duet2 Wifi/Ethernet pinmap can only be used on sam4e8e boards")
+    for pin, gpio in duet2_pinmap.items():
+        pins[pin] = pins[gpio]
+    return pins

--- a/klippy/pinmaps/sam4e8e.py
+++ b/klippy/pinmaps/sam4e8e.py
@@ -1,0 +1,16 @@
+# SAM4E8E pinmap
+#
+# Copyright (C) 2018  Florian Heilmann <Florian.Heilmann@gmx.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+def update_pinmap(pins, mcu_type):
+    if mcu_type != 'sam4e8e':
+        raise error("Incompatible mcu_type for sam4e8e pinmap: %s" % (mcu_type))
+    for port in range(5):
+        portchr = chr(65 + port)
+        if portchr == 'I':
+            continue
+        for portbit in range(32):
+            pins['P%c%d' % (portchr, portbit)] = port * 32 + portbit
+    return pins

--- a/klippy/pinmaps/sam4e8e.py
+++ b/klippy/pinmaps/sam4e8e.py
@@ -13,4 +13,3 @@ def update_pinmap(pins, mcu_type):
             continue
         for portbit in range(32):
             pins['P%c%d' % (portchr, portbit)] = port * 32 + portbit
-    return pins

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -217,7 +217,7 @@ class PinResolver:
         pinmap_func = 'update_pinmap'
         pinmap_func = getattr(mod, pinmap_func, None)
         if pinmap_func is not None:
-            self.pins = pinmap_func(self.pins, self.mcu_type)
+            pinmap_func(self.pins, self.mcu_type)
 
 ######################################################################
 # Pin to chip mapping


### PR DESCRIPTION
After our last discussion in my last PR, I wanted to find another way to get pinmaps to make the life of users of different boards easier and cooked up this pinmap system.

Basically it uses the same technique (which is brilliant by the way) which you used to load modules based on the configuration. Using this, pins.py stays free of modifications, even when new mcu ports are added. All users have to do is add a new pinmap.py in the pinmaps subfolder. The same goes for pin_maps configured using the `pin_map` parameter of the mcu block. 

Before I go through the work of porting the existing pinmaps over (arduino will need some thinking how to do it nicely) and put in some more error handling I wanted to get your feedback on this. The new system is applied for the sam4e8e mcu and a duet2 pin_map.

Have a nice weekend!

Florian

edit: I'm aware of the travis complaints, ofc I'll fix those as well