### PR TITLE
Add support for chamber heater (M141)

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -994,3 +994,18 @@
 # Replicape support - see the generic-replicape.cfg file for further
 # details.
 #[replicape]
+
+
+## The heater_chamber section describes a chamber heater
+#[heater_chamber]
+#heater_pin: ar8
+#sensor_type: EPCOS 100K B57560G104F
+#sensor_pin: analog14
+#control: watermark
+##max_delta: 2.0
+##   On 'watermark' controlled heaters this is the number of degrees in
+##   Celsius above the target temperature before disabling the heater
+##   as well as the number of degrees below the target before
+##   re-enabling the heater. The default is 2 degrees Celsius.
+#min_temp: 0
+#max_temp: 110

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -20,6 +20,7 @@ Klipper supports the following standard G-Code commands:
 - Set extruder temperature: `M104 [T<index>] [S<temperature>]`
 - Set extruder temperature and wait: `M109 [T<index>] S<temperature>`
 - Set bed temperature: `M140 [S<temperature>]`
+- Set chamber temperature: `M141 [S<temperature>]`
 - Set bed temperature and wait: `M190 S<temperature>`
 - Set fan speed: `M106 S<value>`
 - Turn fan off: `M107`

--- a/klippy/extras/heater_chamber.py
+++ b/klippy/extras/heater_chamber.py
@@ -1,0 +1,8 @@
+# Support for a heated chamber.
+#
+# Copyright (C) 2018  John Jardine <john@gprime.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+def load_config(config):
+    return config.get_printer().lookup_object('heater').setup_heater(config)


### PR DESCRIPTION
This is to address #804 which requests support for M141 (a chamber heater).
This is very straight forward and I basically just followed the same pattern as heated_bed.
I've tested it and it seems to work fine. Temperatures are reported via the M105 with a "C" prefix when a chamber heater is configured. The only other example I could find of this was in RepRapFirmware so I followed their convention (T#=tool, B=bed, C=chamber).
I wasn't entirely sure the best way to provide a config example for this because heaters tend to be partially baked in and partially a extra. I noted it as an extra.