### PR TITLE
Add servo enable/disable support

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -478,7 +478,9 @@
 #   the mcu resets.  Must be between minimum_pulse_width and maximum_pulse_width.
 #   This parameter is optional.  If both initial_angle and initial_pulse_width
 #   are set initial_angle will be used
-
+#enable: True
+#   Enable or disable servo. It can be enabled or disabled later using
+#   SET_SERVO SERVO=my_servo ENABLE=<0|1> g-command. The default is True (=enabled)
 
 # Statically configured digital output pins (one may define any number
 # of sections with a "static_digital_output" prefix). Pins configured

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -142,8 +142,8 @@ is enabled:
 
 The following commands are available when a "servo" config section is
 enabled:
-- `SET_SERVO SERVO=config_name WIDTH=<seconds>`
-- `SET_SERVO SERVO=config_name ANGLE=<degrees>`
+- `SET_SERVO SERVO=config_name [WIDTH=<seconds>] [ENABLE=<0|1>]`
+- `SET_SERVO SERVO=config_name [ANGLE=<degrees>] [ENABLE=<0|1>]`
 
 ## Probe
 


### PR DESCRIPTION
This patch create ability to enable/disable attached servo. 
Cheap mechanical servos have small flickering. When this servo stay on one position, this flickering slowly destroy internal potentiometer and make servo unusable.  Many mechanisms need servo only to change position. Therefore I create this minor path to enable/disable servo. It stop pulses for this servo, that's all.

Corresponding G-code is:
    SET_SERVO SERVO=config_name [WIDTH=<seconds>] [ENABLE=<0|1>]
    SET_SERVO SERVO=config_name [ANGLE=<degrees>] [ENABLE=<0|1>]

For example:
    SET_SERVO SERVO=touch ANGLE=80 ENABLE=1 ; enable servo and set position
    G4 P200 ; wait 200ms
    SET_SERVO SERVO=touch ENABLE=0 ; disable servo

This patch add one option to servo configuration:
enable: <False/True> # default True

It not have impact to user code existing already because it is optional parameter and default value is same as original behavior.

PS: thanks for this project to ALL authors. Amazing piece of code!
