### PR TITLE
Add printline option

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -38,7 +38,7 @@ class GCodeMacro:
             raise self.gcode.error(msg)
         self.in_script = True
         try:
-            self.gcode.run_script_from_command(script)
+            self.gcode.run_script_from_command(script, params['#filepos'])
         finally:
             self.in_script = False
 

--- a/klippy/extras/homing_override.py
+++ b/klippy/extras/homing_override.py
@@ -54,7 +54,7 @@ class HomingOverride:
         # Perform homing
         try:
             self.in_script = True
-            self.gcode.run_script_from_command(self.script)
+            self.gcode.run_script_from_command(self.script, params['#filepos'])
         finally:
             self.in_script = False
 

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -102,12 +102,12 @@ class ProbeEndstopWrapper:
     def home_prepare(self):
         if self.activate_gcode is not None:
             gcode = self.printer.lookup_object('gcode')
-            gcode.run_script_from_command(self.activate_gcode)
+            gcode.run_script_from_command(self.activate_gcode, None)
         self.mcu_endstop.home_prepare()
     def home_finalize(self):
         if self.deactivate_gcode is not None:
             gcode = self.printer.lookup_object('gcode')
-            gcode.run_script_from_command(self.deactivate_gcode)
+            gcode.run_script_from_command(self.deactivate_gcode, None)
         self.mcu_endstop.home_finalize()
     def get_position_endstop(self):
         return self.position_endstop
@@ -182,7 +182,7 @@ class ProbePointsHelper:
         positions = []
         for i in range(self.samples):
             try:
-                self.gcode.run_script_from_command("PROBE")
+                self.gcode.run_script_from_command("PROBE", None)
             except self.gcode.error as e:
                 self._finalize(False)
                 raise

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -274,10 +274,10 @@ class GCodeParser:
             self.process_pending()
         self.is_processing_data = False
         return True
-    def run_script_from_command(self, script):
+    def run_script_from_command(self, script, filepos):
         prev_need_ack = self.need_ack
         try:
-            self.process_commands(script.split('\n'), need_ack=False)
+            self.process_commands(((x, filepos) for x in script.split('\n')), need_ack=False)
         finally:
             self.need_ack = prev_need_ack
     def run_script(self, script):
@@ -453,7 +453,7 @@ class GCodeParser:
         e = extruders[index]
         if self.extruder is e:
             return
-        self.run_script_from_command(self.extruder.get_activate_gcode(False))
+        self.run_script_from_command(self.extruder.get_activate_gcode(False), params['#filepos'])
         try:
             self.toolhead.set_extruder(e)
         except homing.EndstopError as e:
@@ -462,7 +462,7 @@ class GCodeParser:
         self.reset_last_position()
         self.extrude_factor = 1.
         self.base_position[3] = self.last_position[3]
-        self.run_script_from_command(self.extruder.get_activate_gcode(True))
+        self.run_script_from_command(self.extruder.get_activate_gcode(True), params['#filepos'])
     def cmd_mux(self, params):
         key, values = self.mux_commands[params['#command']]
         if None in values:

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -226,6 +226,9 @@ def main():
     opts.add_option("-d", "--dictionary", dest="dictionary", type="string",
                     action="callback", callback=arg_dictionary,
                     help="file to read for mcu protocol dictionary")
+    opts.add_option("--printline", dest="printline", type="string",
+                    help='format line to display for each line of gcode'
+                    ' (try "{}" or "The print time is: {[#print_time]}")')
     options, args = opts.parse_args()
     if len(args) != 1:
         opts.error("Incorrect number of arguments")
@@ -245,6 +248,7 @@ def main():
     if options.debugoutput:
         start_args['debugoutput'] = options.debugoutput
         start_args.update(options.dictionary)
+    start_args['printline'] = options.printline
     if options.logfile:
         bglogger = queuelogger.setup_bg_logging(options.logfile, debuglevel)
     else:


### PR DESCRIPTION
This adds an option to output statistics for each line of input gcode.  To use, get the dictionary from #830 and try to run:

`python klippy/klippy.py config/example.cfg -i test/klippy/move.gcode -v -o /dev/null -d local/atmega2560-16mhz.dict --printline "XXX: About to run command '{#original}' which starts at byte {#filepos} and so far we've been printing for {#print_time} seconds.  The entire dict of variables that we could use in the format string is: {}"
`

The output will include a lot of lines that look like this:

`XXX: About to run command 'G1 X0 Y1 Z1' which starts at byte 196 and so far we've been printing for 4.38199597774 seconds.  The entire dict of variables that we could use in the format string is: {'Z': '1', 'G': '1', '#command': 'G1', '#filepos': 196, '#print_time': 4.381995977736647, 'Y': '1', 'X': '0', '#original': 'G1 X0 Y1 Z1'}
`

Post-processors can then process the output and extract data about the time to print each line.

This fixes #862 .  I hope.