### PR TITLE
Generic SPI helper code

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -745,14 +745,14 @@
 #   The pin corresponding to the TMC2660 chip select line. This pin
 #   will be set to low at the start of SPI messages and set to high
 #   after the message transfer completes. This parameter must be provided.
-#bus:
-#   Select the SPI bus the TMC2660 stepper driver is connected to. This
-#   depends on the physical connections on your board, as well as the
-#   SPI implementation of your particular microcontroller. This parameter
-#   must be provided.
-#freq: 2000000
+#spi_bus:
+#   Select the SPI bus the TMC2660 stepper driver is connected to.
+#   This depends on the physical connections on your board, as well as
+#   the SPI implementation of your particular micro-controller. The
+#   default is bus 0.
+#spi_speed: 2000000
 #   SPI bus frequency used to communicate with the TMC2660 stepper
-#   driver. the default is 2000000.
+#   driver. The default is 2000000.
 #microsteps:
 #   The number of microsteps to configure the driver to use. Valid
 #   values are 1, 2, 4, 8, 16, 32, 64, 128, 256. This parameter must

--- a/config/generic-duet2.cfg
+++ b/config/generic-duet2.cfg
@@ -94,7 +94,7 @@ position_max: 250
 
 [tmc2660 stepper_x]
 cs_pin: PD14 # X_SPI_EN Required for communication
-bus: 1 # All TMC2660 drivers are connected to USART1, which is bus 1 on the sam4e port
+spi_bus: 1 # All TMC2660 drivers are connected to USART1, which is bus 1 on the sam4e port
 microsteps: 16
 interpolate: True # 1/16 micro-steps interpolated to 1/256
 run_current: 1.000
@@ -111,7 +111,7 @@ position_max: 210
 
 [tmc2660 stepper_y]
 cs_pin: PC9
-bus: 1
+spi_bus: 1
 microsteps: 16
 interpolate: True
 run_current: 1.000
@@ -128,7 +128,7 @@ position_max: 200
 
 [tmc2660 stepper_z]
 cs_pin: PC10
-bus: 1
+spi_bus: 1
 microsteps: 16
 interpolate: True
 run_current: 1.000
@@ -142,7 +142,7 @@ step_distance: .0025
 
 [tmc2660 stepper_z1]
 cs_pin: PD25
-bus: 1
+spi_bus: 1
 microsteps: 16
 interpolate: True
 run_current: 1.000
@@ -156,7 +156,7 @@ step_distance: .0025
 
 [tmc2660 stepper_z2]
 cs_pin: PD26
-bus: 1
+spi_bus: 1
 microsteps: 16
 interpolate: True
 run_current: 1.000
@@ -170,7 +170,7 @@ step_distance: .0025
 
 [tmc2660 stepper_z3]
 cs_pin: PC28
-bus: 1
+spi_bus: 1
 microsteps: 16
 interpolate: True
 run_current: 1.000
@@ -195,7 +195,7 @@ max_temp: 250
 
 [tmc2660 extruder0]
 cs_pin: PC17
-bus: 1
+spi_bus: 1
 microsteps: 16
 interpolate: True
 run_current: 1.000
@@ -220,7 +220,7 @@ max_temp: 250
 
 [tmc2660 extruder1]
 cs_pin: PC25
-bus: 1
+spi_bus: 1
 microsteps: 16
 interpolate: True
 run_current: 1.000
@@ -245,7 +245,7 @@ max_temp: 250
 
 [tmc2660 extruder2]
 cs_pin: PD23
-bus: 1
+spi_bus: 1
 microsteps: 16
 interpolate: True
 run_current: 1.000
@@ -270,7 +270,7 @@ max_temp: 250
 
 [tmc2660 extruder3]
 cs_pin: PD24
-bus: 1
+spi_bus: 1
 microsteps: 16
 interpolate: True
 run_current: 1.000

--- a/klippy/extras/ad5206.py
+++ b/klippy/extras/ad5206.py
@@ -3,30 +3,20 @@
 # Copyright (C) 2017,2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import bus
 
 class ad5206:
     def __init__(self, config):
-        ppins = config.get_printer().lookup_object('pins')
-        enable_pin = config.get('enable_pin')
-        enable_pin_params = ppins.lookup_pin(enable_pin)
-        mcu = enable_pin_params['chip']
-        pin = enable_pin_params['pin']
+        self.spi = bus.MCU_SPI_from_config(
+            config, 0, pin_option="enable_pin", default_speed=25000000)
         scale = config.getfloat('scale', 1., above=0.)
-        channels = [None]*6
-        for i in range(len(channels)):
+        for i in range(6):
             val = config.getfloat('channel_%d' % (i+1,), None,
                                   minval=0., maxval=scale)
             if val is not None:
-                channels[i] = int(val * 256. / scale + .5)
-        oid = mcu.create_oid()
-        mcu.add_config_cmd(
-            "config_spi oid=%d bus=%d pin=%s mode=%u rate=%u shutdown_msg=" % (
-                oid, 0, pin, 0, 25000000))
-        for i, val in enumerate(channels):
-            if val is not None:
-                mcu.add_config_cmd(
-                    "spi_send oid=%d data=%02x%02x" % (oid, i, val),
-                    is_init=True)
+                self.set_register(i, int(val * 256. / scale + .5))
+    def set_register(self, reg, value):
+        self.spi.spi_send([reg, value])
 
 def load_config_prefix(config):
     return ad5206(config)

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -1,0 +1,65 @@
+# Helper code for SPI bus communication
+#
+# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+# Helper code for working with devices conntect to an MCU via an SPI bus
+class MCU_SPI:
+    def __init__(self, mcu, bus, pin, mode, speed, shutdown_seq):
+        self.mcu = mcu
+        shutdown_msg = "".join(["%02x" % (x,) for x in shutdown_seq])
+        self.oid = self.mcu.create_oid()
+        if pin is None:
+            self.mcu.add_config_cmd(
+                "config_spi_without_cs oid=%d bus=%d mode=%d rate=%d"
+                " shutdown_msg=%s" % (
+                    self.oid, bus, mode, speed, shutdown_msg))
+        else:
+            self.mcu.add_config_cmd(
+                "config_spi oid=%d bus=%d pin=%s mode=%d rate=%d"
+                " shutdown_msg=%s" % (
+                    self.oid, bus, pin, mode, speed, shutdown_msg))
+        self.cmd_queue = self.mcu.alloc_command_queue()
+        self.mcu.register_config_callback(self.build_config)
+        self.spi_send_cmd = self.spi_transfer_cmd = None
+    def get_oid(self):
+        return self.oid
+    def get_mcu(self):
+        return self.mcu
+    def get_command_queue(self):
+        return self.cmd_queue
+    def build_config(self):
+        self.spi_send_cmd = self.mcu.lookup_command(
+            "spi_send oid=%c data=%*s", cq=self.cmd_queue)
+        self.spi_transfer_cmd = self.mcu.lookup_command(
+            "spi_transfer oid=%c data=%*s", cq=self.cmd_queue)
+    def spi_send(self, data, minclock=0, reqclock=0):
+        if self.spi_send_cmd is None:
+            # Send setup message via mcu initialization
+            data_msg = "".join(["%02x" % (x,) for x in data])
+            self.mcu.add_config_cmd("spi_send oid=%d data=%s" % (
+                self.oid, data_msg), is_init=True)
+            return
+        self.spi_send_cmd.send([self.oid, data],
+                               minclock=minclock, reqclock=reqclock)
+    def spi_transfer(self, data):
+        return self.spi_transfer_cmd.send_with_response(
+            [self.oid, data], 'spi_transfer_response', self.oid)
+
+# Helper to setup an spi bus from settings in a config section
+def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
+                        default_speed=100000, shutdown_seq=()):
+    # Determine pin from config
+    ppins = config.get_printer().lookup_object("pins")
+    cs_pin = config.get(pin_option)
+    cs_pin_params = ppins.lookup_pin(cs_pin)
+    pin = cs_pin_params['pin']
+    if pin == 'None':
+        pin = None
+    # Load bus parameters
+    speed = config.getint('spi_speed', default_speed, minval=100000)
+    bus = config.getint('spi_bus', 0, minval=0)
+    # Create MCU_SPI object
+    mcu = cs_pin_params['chip']
+    return MCU_SPI(mcu, bus, pin, mode, speed, shutdown_seq)

--- a/klippy/extras/replicape.py
+++ b/klippy/extras/replicape.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import pins, mcu
+import pins, mcu, bus
 
 REPLICAPE_MAX_CURRENT = 3.84
 REPLICAPE_SHIFT_REGISTER_BUS = 0x0101
@@ -136,7 +136,6 @@ class Replicape:
             "power_fan0": (pca9685_pwm, 7), "power_fan1": (pca9685_pwm, 8),
             "power_fan2": (pca9685_pwm, 9), "power_fan3": (pca9685_pwm, 10) }
         # Setup stepper config
-        self.spi_send_cmd = None
         self.last_stepper_time = 0.
         self.stepper_dacs = {}
         shift_registers = [1, 0, 0, 1, 1]
@@ -175,19 +174,9 @@ class Replicape:
             and self.stepper_dacs):
             shift_registers[4] &= ~1
         self.sr_enabled = tuple(reversed(shift_registers))
-        self.host_mcu.register_config_callback(self._build_config)
-        self.sr_oid = self.host_mcu.create_oid()
-        str_sr_disabled = "".join(["%02x" % (x,) for x in self.sr_disabled])
-        self.host_mcu.add_config_cmd(
-            "config_spi_without_cs oid=%d bus=%d mode=0 rate=50000000"
-            " shutdown_msg=%s" % (
-                self.sr_oid, REPLICAPE_SHIFT_REGISTER_BUS, str_sr_disabled))
-        self.host_mcu.add_config_cmd("spi_send oid=%d data=%s" % (
-            self.sr_oid, str_sr_disabled), is_init=True)
-    def _build_config(self):
-        cmd_queue = self.host_mcu.alloc_command_queue()
-        self.spi_send_cmd = self.host_mcu.lookup_command(
-            "spi_send oid=%c data=%*s", cq=cmd_queue)
+        self.sr_spi = bus.MCU_SPI(self.host_mcu, REPLICAPE_SHIFT_REGISTER_BUS,
+                                  None, 0, 50000000, self.sr_disabled)
+        self.sr_spi.spi_send(self.sr_disabled)
     def note_pwm_start_value(self, channel, start_value, shutdown_value):
         self.mcu_pwm_start_value |= not not start_value
         self.mcu_pwm_shutdown_value |= not not shutdown_value
@@ -219,8 +208,7 @@ class Replicape:
             return
         print_time = max(print_time, self.last_stepper_time + PIN_MIN_TIME)
         clock = self.host_mcu.print_time_to_clock(print_time)
-        # XXX - the spi_send message should be scheduled
-        self.spi_send_cmd.send([self.sr_oid, sr], minclock=clock, reqclock=clock)
+        self.sr_spi.spi_send(sr, minclock=clock, reqclock=clock)
     def setup_pin(self, pin_type, pin_params):
         pin = pin_params['pin']
         if pin not in self.pins:

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -138,7 +138,7 @@ class TMC2130VirtualEndstop:
             raise pins.error("tmc2130 virtual endstop requires diag1_pin")
         ppins = tmc2130.printer.lookup_object('pins')
         self.mcu_endstop = ppins.setup_pin('endstop', tmc2130.diag1_pin)
-        if self.mcu_endstop.get_mcu() is not tmc2130.mcu:
+        if self.mcu_endstop.get_mcu() is not tmc2130.spi.get_mcu():
             raise pins.error("tmc2130 virtual endstop must be on same mcu")
         # Wrappers
         self.get_mcu = self.mcu_endstop.get_mcu

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
+import bus
 
 TMC_FREQUENCY=13200000.
 GCONF_EN_PWM_MODE=1<<2
@@ -27,20 +28,10 @@ class TMC2130:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[1]
-        # pin setup
-        ppins = self.printer.lookup_object("pins")
-        cs_pin = config.get('cs_pin')
-        cs_pin_params = ppins.lookup_pin(cs_pin)
-        self.mcu = cs_pin_params['chip']
-        pin = cs_pin_params['pin']
-        self.oid = self.mcu.create_oid()
-        self.mcu.add_config_cmd(
-            "config_spi oid=%d bus=%d pin=%s mode=%d rate=%d shutdown_msg=" % (
-                self.oid, 0, cs_pin_params['pin'], 3, 4000000))
-        self.spi_send_cmd = self.spi_transfer_cmd = None
-        self.mcu.register_config_callback(self.build_config)
+        self.spi = bus.MCU_SPI_from_config(config, 3, default_speed=4000000)
         # Allow virtual endstop to be created
         self.diag1_pin = config.get('diag1_pin', None)
+        ppins = self.printer.lookup_object("pins")
         ppins.register_chip("tmc2130_" + self.name, self)
         # Add DUMP_TMC command
         gcode = self.printer.lookup_object("gcode")
@@ -113,30 +104,17 @@ class TMC2130:
         if pin_params['invert'] or pin_params['pullup']:
             raise pins.error("Can not pullup/invert tmc2130 virtual endstop")
         return TMC2130VirtualEndstop(self)
-    def build_config(self):
-        cmd_queue = self.mcu.alloc_command_queue()
-        self.spi_send_cmd = self.mcu.lookup_command(
-            "spi_send oid=%c data=%*s", cq=cmd_queue)
-        self.spi_transfer_cmd = self.mcu.lookup_command(
-            "spi_transfer oid=%c data=%*s", cq=cmd_queue)
     def get_register(self, reg_name):
         reg = Registers[reg_name]
-        self.spi_send_cmd.send([self.oid, [reg, 0x00, 0x00, 0x00, 0x00]])
-        params = self.spi_transfer_cmd.send_with_response(
-            [self.oid, [reg, 0x00, 0x00, 0x00, 0x00]],
-            'spi_transfer_response', self.oid)
+        self.spi.spi_send([reg, 0x00, 0x00, 0x00, 0x00])
+        params = self.spi.spi_transfer([reg, 0x00, 0x00, 0x00, 0x00])
         pr = bytearray(params['response'])
         return (pr[1] << 24) | (pr[2] << 16) | (pr[3] << 8) | pr[4]
     def set_register(self, reg_name, val):
         reg = Registers[reg_name]
-        if self.spi_send_cmd is None:
-            # Setup register via chip initialization
-            self.mcu.add_config_cmd("spi_send oid=%d data=%02x%08x" % (
-                self.oid, (reg | 0x80) & 0xff, val & 0xffffffff), is_init=True)
-            return
         data = [(reg | 0x80) & 0xff, (val >> 24) & 0xff, (val >> 16) & 0xff,
                 (val >> 8) & 0xff, val & 0xff]
-        self.spi_send_cmd.send([self.oid, data])
+        self.spi.spi_send(data)
     def get_microsteps(self):
         return 256 >> self.mres
     def get_phase(self):

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Florian Heilmann <Florian.Heilmann@gmx.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import bus
 
 CURRENT_MAX = 2.4
 CURRENT_MIN = 0.1
@@ -80,24 +81,7 @@ class TMC2660:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[1]
-        self.toolhead = None
-
-        # Generic setup
-        ppins = self.printer.lookup_object("pins")
-        cs_pin = config.get('cs_pin')
-        cs_pin_params = ppins.lookup_pin(cs_pin)
-        self.mcu = cs_pin_params['chip']
-        if cs_pin_params['invert']:
-            raise pins.error("tmc2660 can not invert pin")
-        pin = cs_pin_params['pin']
-        self.oid = self.mcu.create_oid()
-        self.bus = config.getint('bus', minval=0, maxval=3)
-        self.freq = config.getint('freq', default=2000000, minval=1000000, maxval=4000000)
-        self.mcu.add_config_cmd(
-            "config_spi oid=%d bus=%d pin=%s mode=%d rate=%d shutdown_msg=" % (
-                self.oid, self.bus, cs_pin_params['pin'], 0, self.freq))
-        self.spi_send_cmd = self.spi_transfer_cmd = None
-        self.mcu.register_config_callback(self.build_config)
+        self.spi = bus.MCU_SPI_from_config(config, 0, default_speed=2000000)
         # Add SET_CURRENT and DUMP_TMC commands
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command(
@@ -213,15 +197,8 @@ class TMC2660:
                                                 self.handle_ready)
 
     def add_config_cmd(self, val):
-        self.mcu.add_config_cmd("spi_send oid=%d data=%06x" % (
-            self.oid, val & 0xffffff))
-
-    def build_config(self):
-        cmd_queue = self.mcu.alloc_command_queue()
-        self.spi_send_cmd = self.mcu.lookup_command(
-            "spi_send oid=%c data=%*s", cq=cmd_queue)
-        self.spi_transfer_cmd = self.mcu.lookup_command(
-            "spi_transfer oid=%c data=%*s", cq=cmd_queue)
+        data = [(val >> 16) & 0xff, (val >> 8) & 0xff, val & 0xff]
+        self.spi.spi_send(data)
 
     def get_microsteps(self):
         return 256 >> self.driver_mres
@@ -229,7 +206,7 @@ class TMC2660:
     def get_phase(self):
         # Send DRVCTRL to get a response
         reg_data = [(self.reg_drvctrl >> 16) & 0xff, (self.reg_drvctrl >> 8) & 0xff, self.reg_drvctrl & 0xff]
-        params = self.spi_transfer_cmd.send_with_response([self.oid, reg_data], 'spi_transfer_response', self.oid)
+        params = self.spi.spi_transfer(reg_data)
         pr = bytearray(params['response'])
         steps = (((pr[0] << 16) | (pr[1] << 8) | pr[2]) & READRSP['MSTEP'][1]) >> READRSP['MSTEP'][0]
         return steps >> self.driver_mres
@@ -247,7 +224,7 @@ class TMC2660:
         reg |= get_bits(SGCSCONF, "CS", self.driver_cs)
         reg_data = [(reg >> 16) & 0xff, (reg >> 8) & 0xff, reg & 0xff]
         clock = self.mcu.print_time_to_clock(print_time)
-        params = self.spi_send_cmd.send([self.oid, reg_data], minclock=clock, reqclock=clock)
+        self.spi.spi_send(reg_data, minclock=clock, reqclock=clock)
 
     cmd_SET_TMC_CURRENT_help = "Set the current of a TMC2660 driver (between %d and %d)" % (CURRENT_MIN, CURRENT_MAX)
     def cmd_SET_TMC_CURRENT(self, params):
@@ -266,7 +243,7 @@ class TMC2660:
             gcode.respond_info(msg)
         # Send one register to get the return data
         reg_data = [(self.reg_drvctrl >> 16) & 0xff, (self.reg_drvctrl >> 8) & 0xff, self.reg_drvctrl & 0xff]
-        params = self.spi_transfer_cmd.send_with_response([self.oid, reg_data], 'spi_transfer_response', self.oid)
+        params = self.spi.spi_transfer(reg_data)
         pr = bytearray(params['response'])
         msg = "%-15s %08x" % ("RESPONSE:", ((pr[0] << 16) | (pr[1] << 8) | pr[2]))
         gcode.respond_info(msg)

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -223,7 +223,7 @@ class TMC2660:
         reg &= ~(SGCSCONF["CS"][1])
         reg |= get_bits(SGCSCONF, "CS", self.driver_cs)
         reg_data = [(reg >> 16) & 0xff, (reg >> 8) & 0xff, reg & 0xff]
-        clock = self.mcu.print_time_to_clock(print_time)
+        clock = self.spi.get_mcu().print_time_to_clock(print_time)
         self.spi.spi_send(reg_data, minclock=clock, reqclock=clock)
 
     cmd_SET_TMC_CURRENT_help = "Set the current of a TMC2660 driver (between %d and %d)" % (CURRENT_MIN, CURRENT_MAX)


### PR DESCRIPTION
This code simplifies the python SPI setup code for several devices.  It also makes it possible to configure the spi speed and spi bus across all devices.  (I haven't documented all the options for all the devices, but an "spi_bus" and "spi_speed" options should now be available universally.)

@ramezquitao - with this code, I think you should be able to specify a thermocouple pin of "host:None" and be able to set an explicit spi_bus.

@FHeilmann - if you get a chance, could you verify that the changes to tmc2660.py look okay?  Also, note that this change would break current configs as the "bus" field is now "spi_bus" and the "freq" field is now "spi_speed" (though I don't think "freq" could ever have been used before as the range checks appear crossed).

@Arksine - if you get a chance, could you verify that the changes to tmc2130.py and uc1701.py look okay?

Thanks,
-Kevin