### PR TITLE
avr: Add support for atmega32u4

### DIFF
--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -38,7 +38,7 @@ def beaglebone_pins():
     return gpios
 
 MCU_PINS = {
-    "atmega168": port_pins(5),
+    "atmega168": port_pins(5), "atmega32u4": port_pins(5),
     "atmega328": port_pins(5), "atmega328p": port_pins(5),
     "atmega644p": port_pins(4), "atmega1284p": port_pins(4),
     "at90usb1286": port_pins(6), "at90usb646": port_pins(6),
@@ -109,6 +109,7 @@ Arduino_from_mcu = {
     "atmega168": (Arduino_standard, Arduino_analog_standard),
     "atmega328": (Arduino_standard, Arduino_analog_standard),
     "atmega328p": (Arduino_standard, Arduino_analog_standard),
+    "atmega32u4": (Arduino_standard, Arduino_analog_standard),
     "atmega644p": (Sanguino, Sanguino_analog),
     "atmega1280": (Arduino_mega, Arduino_analog_mega),
     "atmega2560": (Arduino_mega, Arduino_analog_mega),

--- a/src/avr/Kconfig
+++ b/src/avr/Kconfig
@@ -37,7 +37,7 @@ choice
     config MACH_atmega168
         bool "atmega168"
     config MACH_atmega32u4
-	    bool "atmega32u4"
+        bool "atmega32u4"
 endchoice
 
 config MCU

--- a/src/avr/Kconfig
+++ b/src/avr/Kconfig
@@ -36,10 +36,13 @@ choice
         bool "atmega328"
     config MACH_atmega168
         bool "atmega168"
+    config MACH_atmega32u4
+	    bool "atmega32u4"
 endchoice
 
 config MCU
     string
+    default "atmega32u4" if MACH_atmega32u4
     default "atmega168" if MACH_atmega168
     default "atmega328" if MACH_atmega328
     default "atmega328p" if MACH_atmega328p
@@ -53,6 +56,7 @@ config MCU
 config AVRDUDE_PROTOCOL
     string
     default "wiring" if MACH_atmega2560
+    default "avr109" if MACH_atmega32u4
     default "avr109" if MACH_at90usb1286
     default "avr109" if MACH_at90usb646
     default "arduino"
@@ -96,10 +100,12 @@ config AVR_STACK_SIZE
 config AVR_WATCHDOG
     bool
     default y
+
 config AVR_USBSERIAL
     bool "Use USB for communication (instead of serial)"
-    depends on MACH_at90usb1286 || MACH_at90usb646
+    depends on MACH_at90usb1286 || MACH_at90usb646 || MACH_atmega32u4
     default y
+
 config AVR_SERIAL
     depends on !AVR_USBSERIAL
     bool
@@ -119,6 +125,7 @@ choice
     config AVR_SERIAL_UART3
         bool "UART3" if MACH_atmega2560 || MACH_atmega1280
 endchoice
+
 config SERIAL_BAUD
     depends on AVR_SERIAL
     int "Baud rate for serial port"
@@ -132,7 +139,7 @@ config SERIAL_PORT
     int
     default 3 if AVR_SERIAL_UART3
     default 2 if AVR_SERIAL_UART2
-    default 1 if MACH_at90usb1286 || MACH_at90usb646 || AVR_SERIAL_UART1
+    default 1 if MACH_at90usb1286 || MACH_at90usb646 || MACH_atmega32u4 || AVR_SERIAL_UART1
     default 0
 
 config SIMULAVR

--- a/src/avr/gpio.c
+++ b/src/avr/gpio.c
@@ -139,8 +139,10 @@ static const struct gpio_pwm_info pwm_regs[] PROGMEM = {
 #ifdef OCR1C
     { &OCR1C, &TCCR1A, &TCCR1B, 1<<COM1C1, 0 },
 #endif
+#ifdef OCR2A
     { &OCR2A, &TCCR2A, &TCCR2B, 1<<COM2A1, GP_8BIT|GP_AFMT },
     { &OCR2B, &TCCR2A, &TCCR2B, 1<<COM2B1, GP_8BIT|GP_AFMT },
+#endif
 #ifdef OCR3A
     { &OCR3A, &TCCR3A, &TCCR3B, 1<<COM3A1, 0 },
     { &OCR3B, &TCCR3A, &TCCR3B, 1<<COM3B1, 0 },
@@ -151,7 +153,11 @@ static const struct gpio_pwm_info pwm_regs[] PROGMEM = {
 #ifdef OCR4A
     { &OCR4A, &TCCR4A, &TCCR4B, 1<<COM4A1, 0 },
     { &OCR4B, &TCCR4A, &TCCR4B, 1<<COM4B1, 0 },
+#ifdef COM4C1
     { &OCR4C, &TCCR4A, &TCCR4B, 1<<COM4C1, 0 },
+#endif
+#endif
+#ifdef OCR5A
     { &OCR5A, &TCCR5A, &TCCR5B, 1<<COM5A1, 0 },
     { &OCR5B, &TCCR5A, &TCCR5B, 1<<COM5B1, 0 },
     { &OCR5C, &TCCR5A, &TCCR5B, 1<<COM5C1, 0 },
@@ -159,7 +165,7 @@ static const struct gpio_pwm_info pwm_regs[] PROGMEM = {
 };
 
 static const uint8_t pwm_pins[ARRAY_SIZE(pwm_regs)] PROGMEM = {
-#if CONFIG_MACH_atmega168 || CONFIG_MACH_atmega328 || CONFIG_MACH_atmega328p
+#if CONFIG_MACH_atmega168 || CONFIG_MACH_atmega328 || CONFIG_MACH_atmega328p || CONFIG_MACH_atmega32u4
     GPIO('D', 6), GPIO('D', 5),
     GPIO('B', 1), GPIO('B', 2),
     GPIO('B', 3), GPIO('D', 3),
@@ -264,7 +270,7 @@ gpio_pwm_write(struct gpio_pwm g, uint8_t val)
  ****************************************************************/
 
 static const uint8_t adc_pins[] PROGMEM = {
-#if CONFIG_MACH_atmega168 || CONFIG_MACH_atmega328 || CONFIG_MACH_atmega328p
+#if CONFIG_MACH_atmega168 || CONFIG_MACH_atmega328 || CONFIG_MACH_atmega328p || CONFIG_MACH_atmega32u4
     GPIO('C', 0), GPIO('C', 1), GPIO('C', 2), GPIO('C', 3),
     GPIO('C', 4), GPIO('C', 5), GPIO('E', 0), GPIO('E', 1),
 #elif CONFIG_MACH_atmega644p || CONFIG_MACH_atmega1284p
@@ -369,7 +375,7 @@ gpio_adc_cancel_sample(struct gpio_adc g)
  * Serial Peripheral Interface (SPI) hardware
  ****************************************************************/
 
-#if CONFIG_MACH_atmega168 || CONFIG_MACH_atmega328 || CONFIG_MACH_atmega328p
+#if CONFIG_MACH_atmega168 || CONFIG_MACH_atmega328 || CONFIG_MACH_atmega328p || CONFIG_MACH_atmega32u4
 static const uint8_t SS = GPIO('B', 2), SCK = GPIO('B', 5);
 static const uint8_t MOSI = GPIO('B', 3), MISO = GPIO('B', 4);
 #elif CONFIG_MACH_atmega644p || CONFIG_MACH_atmega1284p

--- a/src/avr/usbserial.c
+++ b/src/avr/usbserial.c
@@ -6,7 +6,7 @@
 
 #include <avr/interrupt.h> // USB_COM_vect
 #include <string.h> // NULL
-#include "autoconf.h" // CONFIG_MACH_at90usb1286
+#include "autoconf.h" // CONFIG_MACH_*
 #include "board/usb_cdc.h" // usb_notify_ep0
 #include "board/usb_cdc_ep.h" // USB_CDC_EP_BULK_IN
 #include "pgm.h" // READP
@@ -182,14 +182,22 @@ void
 usbserial_init(void)
 {
     // Set USB controller to device mode
+#if CONFIG_MACH_atmega32u4
+    UHWCON = (1<<UVREGE);
+#else
     UHWCON = (1<<UIMOD) | (1<<UVREGE);
+#endif
 
     // Enable USB clock
     USBCON = (1<<USBE) | (1<<FRZCLK);
-    if (CONFIG_MACH_at90usb1286)
-        PLLCSR = (1<<PLLP2) | (1<<PLLP0) | (1<<PLLE);
-    else
-        PLLCSR = (1<<PLLP2) | (1<<PLLP1) | (1<<PLLE);
+#if CONFIG_MACH_at90usb1286
+    PLLCSR = (1<<PLLP2) | (1<<PLLP0) | (1<<PLLE);
+#elif CONFIG_MACH_atmega32u4
+    PLLCSR = (1<<PINDIV) | (1<<PLLE);
+#else
+    PLLCSR = (1<<PLLP2) | (1<<PLLP1) | (1<<PLLE);
+#endif
+
     while (!(PLLCSR & (1<<PLOCK)))
         ;
     USBCON = (1<<USBE) | (1<<OTGPADE);


### PR DESCRIPTION
I am not sure how to further validate this is correct. It builds and flashing to my mmu2 board works and I can communicate with it via console.py but that is as far as I have gotten.  

All the step dir and LED's on the mmu are via two shift registers and it seems I will need some sort of extras in place before I can hit those pins correctly.

The pin maps are just a guess by me based on the similarity of a 328p via uno vs the 32u4 on Leonardo. The spec PDF is still pretty foreign language to me so any education there would be appreciated.