### PR TITLE
stm32f1: Fix SPI issues

### DIFF
--- a/src/stm32f1/Makefile
+++ b/src/stm32f1/Makefile
@@ -11,6 +11,7 @@ CFLAGS += -mthumb -mcpu=cortex-m3
 CFLAGS += -Ilib/cmsis-core
 CFLAGS += -Ilib/cmsis-stm32f1/include -Ilib/hal-stm32f1/include
 CFLAGS += -DSTM32F103xB
+CFLAGS += -DUSE_FULL_LL_DRIVER
 
 CFLAGS_klipper.elf += -T $(OUT)stm32f1.ld
 CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs

--- a/src/stm32f1/gpio.h
+++ b/src/stm32f1/gpio.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "stm32f1xx.h"
+#include "stm32f1xx_ll_spi.h" // SPI_InitTypeDef
 
 void gpio_peripheral(char bank, uint32_t bit, char ptype, uint32_t pull_up);
 
@@ -33,7 +34,7 @@ uint16_t gpio_adc_read(struct gpio_adc g);
 void gpio_adc_cancel_sample(struct gpio_adc g);
 
 struct spi_config {
-    SPI_TypeDef config;
+    LL_SPI_InitTypeDef config;
 };
 struct spi_config spi_setup(uint32_t bus, uint8_t mode, uint32_t rate);
 void spi_prepare(struct spi_config config);

--- a/src/stm32f1/main.c
+++ b/src/stm32f1/main.c
@@ -112,8 +112,6 @@ void adc_config(void)
 void spi_config(void)
 {
     LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_SPI2);
-    LL_SPI_SetNSSMode(SPI2, LL_SPI_NSS_SOFT);
-    LL_SPI_SetMode(SPI2, LL_SPI_MODE_MASTER);
 }
 
 void io_config(void)

--- a/src/stm32f1/spi.c
+++ b/src/stm32f1/spi.c
@@ -97,9 +97,10 @@ spi_transfer(struct spi_config config, uint8_t receive_data,
     while (len--) {
         LL_SPI_TransmitData8(SPI2, *data);
         while (!LL_SPI_IsActiveFlag_TXE(SPI2));
+        while (!LL_SPI_IsActiveFlag_RXNE(SPI2));
+        uint8_t rdata = LL_SPI_ReceiveData8(SPI2);
         if (receive_data) {
-            while (!LL_SPI_IsActiveFlag_RXNE(SPI2));
-            *data = LL_SPI_ReceiveData8(SPI2);
+            *data = rdata;
         }
         data++;
     }


### PR DESCRIPTION
The SPI implementation of the STM32F1 reads wrong bytes when the previous transfer did not read bytes at all but only sent data.

This PR ensures that the receive buffer is empty in case it will be read.

Before, the first byte of an SPI transfer could be the last byte received by the previous transfer (in case it did not read the receive buffer).