### PR TITLE
Add support for SSD1306 display chips and optimize

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -863,11 +863,12 @@
 # Support for a display attached to the micro-controller.
 #[display]
 #lcd_type:
-#   The type of LCD chip in use. This may be "hd44780" (which is
-#   used in "RepRapDiscount 2004 Smart Controller" type displays),
-#   "st7920" (which is used in "RepRapDiscount 12864 Full Graphic
-#   Smart Controller" type displays) or "uc1701" (which is used in
-#   "MKS Mini 12864" type displays). This parameter must be provided.
+#   The type of LCD chip in use. This may be "hd44780" (which is used
+#   in "RepRapDiscount 2004 Smart Controller" type displays), "st7920"
+#   (which is used in "RepRapDiscount 12864 Full Graphic Smart
+#   Controller" type displays), "uc1701" (which is used in "MKS Mini
+#   12864" type displays), or "ssd1306". This parameter must be
+#   provided.
 #rs_pin:
 #e_pin:
 #d4_pin:
@@ -885,6 +886,10 @@
 #a0_pin
 #   The pins connected to an uc1701 type lcd. These parameters must be
 #   provided when using an uc1701 display.
+#cs_pin:
+#dc_pin
+#   The pins connected to an ssd1306 type lcd. These parameters must
+#   be provided when using an ssd1306 display.
 #menu_root:
 #   Entry point for menu, root menu container name. If this parameter
 #   is not provided then default menu root is used. When provided

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -11,7 +11,7 @@ import menu
 
 LCD_chips = {
     'st7920': st7920.ST7920, 'hd44780': hd44780.HD44780,
-    'uc1701' : uc1701.UC1701
+    'uc1701' : uc1701.UC1701, 'ssd1306': uc1701.SSD1306,
 }
 M73_TIMEOUT = 5.
 

--- a/klippy/extras/display/hd44780.py
+++ b/klippy/extras/display/hd44780.py
@@ -105,6 +105,8 @@ class HD44780:
         return 0
     def clear(self):
         self.text_framebuffer[:] = ' '*80
+    def get_dimensions(self):
+        return (20, 4)
 
 HD44780_chars = [
     # Extruder (a thermometer)

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -882,8 +882,6 @@ menu_items = {
     'deck': MenuDeck,
     'card': MenuCard
 }
-# Default dimensions for lcds (rows, cols)
-LCD_dims = {'st7920': (4, 16), 'hd44780': (4, 20), 'uc1701': (4, 16)}
 
 MENU_UPDATE_DELAY = .100
 TIMER_DELAY = .200
@@ -912,9 +910,7 @@ class MenuManager:
         self.objs = {}
         self.root = None
         self._root = config.get('menu_root', '__main')
-        dims = config.getchoice('lcd_type', LCD_dims)
-        self.rows = config.getint('rows', dims[0])
-        self.cols = config.getint('cols', dims[1])
+        self.cols, self.rows = lcd_chip.get_dimensions()
         self.timeout = config.getint('menu_timeout', 0)
         self.timer = 0
         # buttons

--- a/klippy/extras/display/st7920.py
+++ b/klippy/extras/display/st7920.py
@@ -164,3 +164,5 @@ class ST7920:
         zeros = bytearray(32)
         for gfb in self.graphics_framebuffers:
             gfb[:] = zeros
+    def get_dimensions(self):
+        return (16, 4)

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -39,9 +39,11 @@ class UC1701:
             cq=self.spi.get_command_queue())
     def send(self, cmds, is_data=False):
         if is_data:
-            self.update_pin_cmd.send([self.a0_oid, 1], reqclock=BACKGROUND_PRIORITY_CLOCK)
+            self.update_pin_cmd.send([self.a0_oid, 1],
+                                     reqclock=BACKGROUND_PRIORITY_CLOCK)
         else:
-            self.update_pin_cmd.send([self.a0_oid, 0], reqclock=BACKGROUND_PRIORITY_CLOCK)
+            self.update_pin_cmd.send([self.a0_oid, 0],
+                                     reqclock=BACKGROUND_PRIORITY_CLOCK)
         self.spi.spi_send(cmds, reqclock=BACKGROUND_PRIORITY_CLOCK)
     def init(self):
         init_cmds = [0xE2, # System reset

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -13,7 +13,6 @@ TextGlyphs = { 'right_arrow': '\x1a', 'degrees': '\xf8' }
 
 class UC1701:
     DATA_PIN_NAME = "a0_pin"
-    EMPTY_CHAR = (0, 32, 255)
     def __init__(self, config):
         self.spi = extras.bus.MCU_SPI_from_config(config, 0,
                                                   default_speed=10000000)
@@ -33,6 +32,13 @@ class UC1701:
         self.vram = [bytearray(128) for i in range(8)]
         self.all_framebuffers = [(self.vram[i], bytearray('~'*128), i)
                                  for i in range(8)]
+        # Cache fonts and icons in display byte order
+        self.font = [self._swizzle_bits(c) for c in font8x14.VGA_FONT]
+        self.icons = {}
+        for name, icon in icons.Icons16x16.items():
+            top1, bot1 = self._swizzle_bits([d >> 8 for d in icon])
+            top2, bot2 = self._swizzle_bits(icon)
+            self.icons[name] = (top1 + top2, bot1 + bot2)
     def build_config(self):
         self.update_pin_cmd = self.spi.get_mcu().lookup_command(
             "update_digital_out oid=%c value=%c",
@@ -93,60 +99,45 @@ class UC1701:
                 # Send Data
                 self.send(new_data[col_pos:col_pos+count], is_data=True)
             old_data[:] = new_data
-    def set_pixel(self, pix_x, pix_y, exclusive=True):
-        page_idx = pix_y // 8
-        page_byte = 0x01 << (pix_y % 8)
-        if exclusive and self.vram[page_idx][pix_x] & page_byte:
-            #invert pixel if it has alread been set
-            self.vram[page_idx][pix_x] &= ~page_byte
-        else:
-            #set the correct pixel in the vram buffer to 1
-            self.vram[page_idx][pix_x] |= page_byte
-    def clear_pixel(self, pix_x, pix_y):
-        page_idx = pix_y // 8
-        page_byte = ~(0x01 << (pix_y % 8))
-        #set the correct pixel in the vram buffer to 0
-        self.vram[page_idx][pix_x] &= page_byte
+    def _swizzle_bits(self, data):
+        # Convert 8x16 data into display col/row order
+        out1 = [0] * 8
+        out2 = [0] * 8
+        for row in range(8):
+            for col in range(8):
+                out1[col] |= ((data[row] >> (8 - col)) & 1) << row
+                out2[col] |= ((data[row + 8] >> (8 - col)) & 1) << row
+        return (out1, out2)
     def write_text(self, x, y, data):
         if x + len(data) > 16:
             data = data[:16 - min(x, 16)]
-        pix_x = x*8
-        pix_y = y*16
+        pix_x = x * 8
+        page_top = self.vram[y * 2]
+        page_bot = self.vram[y * 2 + 1]
         for c in data:
-            c_idx = ord(c) & 0xFF
-            if c_idx in self.EMPTY_CHAR:
-                # Empty char
-                pix_x += 8
-                continue
-            char = font8x14.VGA_FONT[c_idx]
-            bit_y = pix_y
-            for bits in char:
-                if bits:
-                    bit_x = pix_x
-                    for i in range(7, -1, -1):
-                        mask = 0x01 << i
-                        if bits & mask:
-                            self.set_pixel(bit_x, bit_y)
-                        bit_x += 1
-                bit_y += 1
+            bits_top, bits_bot = self.font[ord(c)]
+            page_top[pix_x:pix_x+8] = bits_top
+            page_bot[pix_x:pix_x+8] = bits_bot
             pix_x += 8
     def write_graphics(self, x, y, row, data):
         if x + len(data) > 16:
             data = data[:16 - min(x, 16)]
-        pix_x = x*8
-        pix_y = y*16 + row
+        page = self.vram[y * 2 + (row >= 8)]
+        bit = 1 << (row % 8)
+        pix_x = x * 8
         for bits in data:
-            for i in range(7, -1, -1):
-                mask = 0x01 << i
-                if bits & mask:
-                    self.set_pixel(pix_x, pix_y)
+            for col in range(8):
+                if (bits << col) & 0x80:
+                    page[pix_x] ^= bit
                 pix_x += 1
     def write_glyph(self, x, y, glyph_name):
-        icon = icons.Icons16x16.get(glyph_name)
-        if icon is not None:
+        icon = self.icons.get(glyph_name)
+        if icon is not None and x < 15:
             # Draw icon in graphics mode
-            for i, bits in enumerate(icon):
-                self.write_graphics(x, y, i, [(bits >> 8) & 0xff, bits & 0xff])
+            pix_x = x * 8
+            pix_y = y * 2
+            self.vram[pix_y][pix_x:pix_x+16] = icon[0]
+            self.vram[pix_y + 1][pix_x:pix_x+16] = icon[1]
             return 2
         char = TextGlyphs.get(glyph_name)
         if char is not None:

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -156,3 +156,5 @@ class UC1701:
         zeros = bytearray(128)
         for page in self.vram[self.CURRENT_BUF]:
             page[:] = zeros
+    def get_dimensions(self):
+        return (16, 4)


### PR DESCRIPTION
Hi @Arksine,

I went to add support for the SSD1306 display chips (these are common in low cost "0.96 inch displays"), and I noticed that the protocol is basically the same as the uc1701 display.  So, I made some changes to extend the uc1701 code.

During testing, I noticed that the framebuffer bit manipulations was noticeable on the host cpu while running "top".  It occurred to me that the bit manipulations could be reduced if we cached the fonts in display byte order.

Only the first two patches in this series are needed to support the SSD1306 chips.  The remaining patches implement some minor optimizations.

Let me know what you think.
-Kevin