### PR TITLE
menu: allow item names in card content

### DIFF
--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -6,6 +6,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, logging, sys, ast, re
+import string
 
 
 class error(Exception):
@@ -569,7 +570,7 @@ class MenuGroup(MenuContainer):
         self._sep = sep
         self._show_back = False
         self.selected = None
-        self.items = config.get('items')
+        self.items = config.get('items', '')
 
     def is_accepted(self, item):
         return (super(MenuGroup, self).is_accepted(item)
@@ -795,6 +796,32 @@ class MenuCard(MenuGroup):
     def __init__(self, manager, config, namespace=''):
         super(MenuCard, self).__init__(manager, config, namespace)
         self.content = config.get('content')
+        if not self.items:
+            self.content = self._parse_content_items(self.content)
+
+    def _parse_content_items(self, content):
+        formatter = string.Formatter()
+        out = ""
+        items = []
+
+        try:
+            parsed_content = list(formatter.parse(content))
+        except Exception:
+            logging.exception("Card content parsing error")
+
+        for part in parsed_content:
+            # (literal_text, field_name, format_spec, conversion)
+            out += part[0]
+            if part[1]:
+                out += "{%s%s%s}" % (
+                    len(items),
+                    ("!" + part[3]) if part[3] else '',
+                    (":" + part[2]) if part[2] else '',
+                )
+                items.append(str(part[1]))
+
+        self.items = "\n".join(items)
+        return out
 
     def _names_aslist(self):
         return self._lines_aslist(self.items)


### PR DESCRIPTION
This makes possible to directly use menu item names in card content.
PR for #858
Now card item can be defined in 2 ways.

By inserting menu items to `items` attribute and then use index in content text.
```py
[menu __card2004_static]
type: card
name: Card 20x04
content:
    "\x00{0:3s}\x04\x7e{1:3s}\x04   {2}"
    "\x01{3:3s}\x04\x7e{4:3s}\x04   \xa5{8}"
    "\x07{6}  \x02{5} {7}"
    "{9}"
items:
    __card_hotend0_current
    __card_hotend0_target
    __card_zpos
    __card_hotbed_current
    __card_hotbed_target
    __card_frpeed
    __card_fnspeed
    5,__card_prt_time, __card_usb_progress, __card_sdcard_progress
    __card_status
    __card_msg,__card_xpos|__card_ypos|__card_epos
```
Or by leaving `items` attribute out or empty and use menu items names directly in content.
You cannot use `:`,  `!` letters used in python format in your item names
```py
[menu __card2004_static]
type: card
name: Card 20x04
content:
    "\x00{__card_hotend0_current:3s}\x04\x7e{__card_hotend0_target:3s}\x04   {__card_zpos}"
    "\x01{__card_hotbed_current:3s}\x04\x7e{__card_hotbed_target:3s}\x04   \xa5{__card_status}"
    "\x07{__card_fnspeed}  \x02{__card_frpeed} {5,__card_prt_time, __card_usb_progress, __card_sdcard_progress}"
    "{__card_msg,__card_xpos|__card_ypos|__card_epos}"
```

NB! You cannot mix both ways.

PS. I'll add description to `example-menu.cfg`