### PR TITLE
config: CR10s config on melzi, capacitive ABL, z-safe-home

### DIFF
--- a/config/printer-creality-cr10s-2018-capacitive-bed-mesh.cfg
+++ b/config/printer-creality-cr10s-2018-capacitive-bed-mesh.cfg
@@ -1,0 +1,121 @@
+# This file contains pin mappings for the 2017 Creality CR-10S. To use
+# this config, the firmware should be compiled for the AVR atmega2560.
+# This file also contains configuration for auto bed leveling with a capacitive sensor
+# with homing override for safe z-homing
+# please have a look at the G-Codes help to use calibration correctly
+# https://github.com/KevinOConnor/klipper/blob/master/docs/G-Codes.md#mesh-bed-leveling
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: ar54
+dir_pin: ar55
+enable_pin: !ar38
+step_distance: .0125
+endstop_pin: ^ar3
+position_endstop: 0
+position_max: 300
+homing_speed: 40
+
+[stepper_y]
+step_pin: ar60
+dir_pin: ar61
+enable_pin: !ar56
+step_distance: .0125
+endstop_pin: ^ar14
+position_endstop: 0
+position_max: 300
+homing_speed: 40
+
+[stepper_z]
+step_pin: ar46
+dir_pin: !ar48
+enable_pin: !ar62
+step_distance: .0025
+endstop_pin: probe:z_virtual_endstop
+position_min: -0.2
+position_max: 400
+
+[extruder]
+step_pin: ar26
+dir_pin: ar28
+enable_pin: !ar24
+step_distance: .010526
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: ar8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+control: pid
+pid_Kp: 690.34
+pid_Ki: 111.47
+pid_Kd: 1068.83
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: ar9
+
+[mcu]
+baud: 250000
+serial: /dev/ttyUSB0
+pin_map: arduino
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[display]
+lcd_type: st7920
+cs_pin: ar16
+sclk_pin: ar23
+sid_pin: ar17
+encoder_pins: ^ar33, ^ar31
+click_pin: ^!ar35
+
+[homing_override]
+set_position_z: 5
+axes: z
+gcode:
+ G90   ; Uncomment these 2 lines to blindly lift the Z 2mm at start
+ G1 Z7 F600
+ G28 X0 Y0
+ G1 X150 Y150 F3600
+ G28 Z0
+
+[probe]
+# pls check if pin has to be inverted like here or not
+pin: ^!ar18
+x_offset: -47.0
+y_offset: -10.0
+z_offset: 1.5
+speed: 2.0
+
+[bed_mesh]
+speed: 100
+horizontal_move_z: 5
+samples: 2
+sample_retract_dist: 2
+min_point: 60,20
+max_point: 300,290
+probe_count: 5,5
+fade_start: 1.0
+fade_end: 10.0
+split_delta_z: .025
+move_check_distance: 5.0
+mesh_pps: 2,2
+algorithm: lagrange


### PR DESCRIPTION
Configuration based on the 2017 CR10s Configuration with Display expanded with z-safe-homing and ABL for capacitive sensor

Signed-off-by: Roman Gräbner <roman@graebner.at>