### PR TITLE
bed_mesh:  Address fade issues

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -81,7 +81,10 @@
 # Mesh Bed Leveling. One may define a [bed_mesh] config section
 # to enable move transformations that offset the z axis based
 # on a mesh generated from probed points. Note that bed_mesh
-# and bed_tilt are incompatible, both cannot be defined.
+# and bed_tilt are incompatible, both cannot be defined.  When
+# using a probe to home the z-axis, it is recommended to define
+# a [homing_override] section in printer.cfg to home toward the
+# center of the print area.
 #[bed_mesh]
 #speed: 50
 #   The speed (in mm/s) of non-probing moves during the
@@ -111,12 +114,19 @@
 #   in which case that value will be for both axes. Default is 3,3
 #   which probes a 3x3 grid.
 #fade_start: 1.0
-#   The z-axis position in which to start phasing z-adjustment out.
-#   Default is 1.0.
-#fade_end: 10.0
-#   The z-axis position in which phase out is complete. If this
-#   value is less than or equal to fade_start then phasing out
-#   is disabled. Default is 10.0.
+#   The gcode z position in which to start phasing out z-adjustment
+#   when fade is enabled.  Default is 1.0.
+#fade_end: 0.0
+#   The gcode z position in which phasing out completes.  When set
+#   to a value below fade_start, fade is disabled. It should be
+#   noted that fade may add unwanted scaling along the z-axis of a
+#   print.  If a user wishes to enable fade, a value of 10.0 is
+#   recommended. Default is 0.0, which disables fade.
+#fade_target:
+#   The z position in which fade should converge. When this value is set
+#   to a non-zero value it must be within the range of z-values in the mesh.
+#   Users that wish to converge to the z homing position should set this to 0.
+#   Default is the average z value of the mesh.
 #split_delta_z: .025
 #   The amount of Z difference (in mm) along a move that will
 #   trigger a split. Default is .025.

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -59,7 +59,7 @@ class BedMesh:
         self.toolhead = None
         self.horizontal_move_z = config.getfloat('horizontal_move_z', 5.)
         self.fade_start = config.getfloat('fade_start', 1.)
-        self.fade_end = config.getfloat('fade_end', 10.)
+        self.fade_end = config.getfloat('fade_end', 0.)
         self.fade_dist = self.fade_end - self.fade_start
         if self.fade_dist <= 0.:
             self.fade_start = self.fade_end = self.FADE_DISABLE


### PR DESCRIPTION
This pull addresses mesh fade concerns referenced in issue #926 .  Fade is now disabled by default.  Also included is a new option, fade_target, to help mitigate the z scaling affect when fade is enabled.  The fade_target is the value in which fade should converge.   A fade_target of 0.0 will exhibit previous behavior, where adjustment is phased out completely.   By default this value will be calculated as the average z position within the mesh.

If the fade_target is non-zero and lies outside of the mesh then an error will be generated, as this would add additional and likely unwanted adjustment to the mesh.

Signed-off-by: Eric Callahan <arksine.code@gmail.com>