### PR TITLE
Update printer-creality-ender3-2018.cfg

### DIFF
--- a/config/printer-creality-ender3-2018.cfg
+++ b/config/printer-creality-ender3-2018.cfg
@@ -18,7 +18,7 @@ enable_pin: !PD6
 step_distance: .0125
 endstop_pin: ^PC2
 position_endstop: 0
-position_max: 220
+position_max: 235
 homing_speed: 50
 
 [stepper_y]
@@ -28,7 +28,7 @@ enable_pin: !PD6
 step_distance: .0125
 endstop_pin: ^PC3
 position_endstop: 0
-position_max: 220
+position_max: 235
 homing_speed: 50
 
 [stepper_z]
@@ -37,11 +37,11 @@ dir_pin: PB2
 enable_pin: !PA5
 step_distance: .0025
 endstop_pin: ^PC4
-# If you don't like the 0.5 you should change this to 0.0
-position_endstop: 0.5
+position_endstop: 0.0
 position_max: 250
 
 [extruder]
+max_extrude_only_distance: 100.0
 step_pin: PB1
 dir_pin: !PB0
 enable_pin: !PD6


### PR DESCRIPTION
Added options necessary for basic extruder calibration expected of a new install. Fixed bed size to correct 235x235. Removed 0.5 position_endstop setting as this crashes hot end into the bed on stock Ender 3's.

Signed-off-by: Troy nadeau troyboy162@hotmail.com