### PR TITLE
Use 10 degree probing for BLTouch and check for errors

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -55,9 +55,13 @@
 #control_pin:
 #   Pin connected to the BLTouch control pin. This parameter must be
 #   provided.
-#pin_move_time: 0.200
+#pin_move_time: 1.0
 #   The amount of time (in seconds) that it takes the BLTouch pin to
-#   move up or down. The default is 0.200 seconds.
+#   move up or down and detect errors during the movement. The default is
+#   1.0 seconds. I higher value can slow down the probing, but on the,
+#   other hand, if the value is too low, it can cause the nozzle to crash
+#   into the bed. A value of 1 seconds should be safe, but you can probably
+#   go lower if everything is working perfectly
 #x_offset:
 #y_offset:
 #z_offset:

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -62,6 +62,12 @@
 #   other hand, if the value is too low, it can cause the nozzle to crash
 #   into the bed. A value of 1 seconds should be safe, but you can probably
 #   go lower if everything is working perfectly
+#test_sensor_pin: True
+#   When test_sensor_pin is set to True, an additional wiring test is performed
+#   every 5 minutes. This test adds a few seconds, depending on the the
+#   pin_move_time, to each probe when it's performed. If you don't like the
+#   extra time, you can with some caution disable the test. Some BLTouch
+#   clones will not work with this option enabled.
 #x_offset:
 #y_offset:
 #z_offset:

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -78,6 +78,7 @@ class BLTouchEndstopWrapper:
         toolhead = self.printer.lookup_object('toolhead')
         print_time = toolhead.get_last_move_time()
         self.send_cmd(print_time, cmd)
+        self.send_cmd(print_time + MIN_CMD_TIME, None)
         toolhead.dwell(self.pin_move_time)
         toolhead.wait_moves()
         self.mcu_endstop.query_endstop(toolhead.get_last_move_time())

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -39,7 +39,7 @@ class BLTouchEndstopWrapper:
         self.next_test_time = 0.
         self.test_sensor_pin = config.getboolean('test_sensor_pin', True)
         # Calculate pin move time
-        pmt = max(config.getfloat('pin_move_time', 0.200), MIN_CMD_TIME)
+        pmt = max(config.getfloat('pin_move_time', 1.0), MIN_CMD_TIME)
         self.pin_move_time = math.ceil(pmt / SIGNAL_PERIOD) * SIGNAL_PERIOD
         # Wrappers
         self.get_mcu = self.mcu_endstop.get_mcu

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, re, logging, collections, shlex
-import homing, kinematics.extruder
+import homing, kinematics.extruder, mcu
 
 class error(Exception):
     pass
@@ -189,6 +189,13 @@ class GCodeParser:
             except error as e:
                 self.respond_error(str(e))
                 self.reset_last_position()
+                if not need_ack:
+                    raise
+            except mcu.error as e:
+                msg = 'MCU error:"%s" when running command: "%s"' % (str(e), cmd)
+                logging.exception(msg)
+                self.printer.invoke_shutdown(msg)
+                self.respond_error(msg)
                 if not need_ack:
                     raise
             except:


### PR DESCRIPTION
This also enables the BLTouch built in error checking. If there's a
fatal error the printer will shutdown. This is to prevent moving around
with the BLTouch probe in the down state.

Signed-off-by: Fred Sundvik <fsundvik@gmail.com>

**NOTE** I'm sending a pull request now, so that it can be tested. But I would like to add some further improvements. For example doing touch mode testing, if it's enabled by the configuration. The `pin_move_time` setting also needs to be much higher than before. I had unreliable error reporting with a move time of 500ms. Now I'm running with 1.5 seconds, but it could probably be smaller than that. I'm not sure how to handle a configuration change like that, should it be a warning, or a configuration error?