### PR TITLE
gcode_id parameter for setup_heater: take a gcode_id when setting up a heater

### DIFF
--- a/klippy/extras/heater_bed.py
+++ b/klippy/extras/heater_bed.py
@@ -5,4 +5,4 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 def load_config(config):
-    return config.get_printer().lookup_object('heater').setup_heater(config)
+    return config.get_printer().lookup_object('heater').setup_heater(config, 'B')

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -52,7 +52,7 @@ class GCodeParser:
         # G-Code state
         self.need_ack = False
         self.toolhead = self.fan = self.extruder = None
-        self.heaters = []
+        self.heater = None
         self.speed = 25.0
         self.axis2pos = {'X': 0, 'Y': 1, 'Z': 2, 'E': 3}
     def register_command(self, cmd, func, when_not_ready=False, desc=None):
@@ -130,6 +130,7 @@ class GCodeParser:
         self.is_printer_ready = True
         self.gcode_handlers = self.ready_gcode_handlers
         # Lookup printer components
+        self.heater = self.printer.lookup_object('heater')
         self.toolhead = self.printer.lookup_object('toolhead')
         if self.move_transform is None:
             self.move_with_transform = self.toolhead.move
@@ -138,8 +139,6 @@ class GCodeParser:
         if extruders:
             self.extruder = extruders[0]
             self.toolhead.set_extruder(self.extruder)
-        self.heaters = [ e.get_heater() for e in extruders ]
-        self.heaters.append(self.printer.lookup_object('heater_bed', None))
         self.fan = self.printer.lookup_object('fan', None)
         if self.is_fileinput and self.fd_handle is None:
             self.fd_handle = self.reactor.register_fd(self.fd, self.process_data)
@@ -367,13 +366,11 @@ class GCodeParser:
     def get_temp(self, eventtime):
         # Tn:XXX /YYY B:XXX /YYY
         out = []
-        for i, heater in enumerate(self.heaters):
-            if heater is not None:
-                cur, target = heater.get_temp(eventtime)
-                name = "B"
-                if i < len(self.heaters) - 1:
-                    name = "T%d" % (i,)
-                out.append("%s:%.1f /%.1f" % (name, cur, target))
+        if self.heater is not None:
+            for heater in self.heater.get_all_heaters():
+                if heater is not None:
+                    cur, target = heater.get_temp(eventtime)
+                    out.append("%s:%.1f /%.1f" % (heater.gcode_id, cur, target))
         if not out:
             return "T:0"
         return " ".join(out)
@@ -389,13 +386,12 @@ class GCodeParser:
         temp = self.get_float('S', params, 0.)
         heater = None
         if is_bed:
-            heater = self.heaters[-1]
+            heater = self.heater.get_heater_by_gcode_id('B')
         elif 'T' in params:
-            index = self.get_int(
-                'T', params, minval=0, maxval=len(self.heaters)-2)
-            heater = self.heaters[index]
-        elif self.extruder is not None:
-            heater = self.extruder.get_heater()
+            index = self.get_int('T', params, minval=0)
+            heater = self.heater.get_heater_by_gcode_id('T%d' % (index,))
+        else:
+            heater = self.heater.get_heater_by_gcode_id('T0')
         if heater is None:
             if temp > 0.:
                 self.respond_error("Heater not configured")
@@ -672,9 +668,10 @@ class GCodeParser:
         if self.is_printer_ready:
             self.toolhead.motor_off()
             print_time = self.toolhead.get_last_move_time()
-            for heater in self.heaters:
-                if heater is not None:
-                    heater.set_temp(print_time, 0.)
+            if self.heater is not None:
+                for heater in self.heater.get_all_heaters():
+                    if heater is not None:
+                        heater.set_temp(print_time, 0.)
             if self.fan is not None:
                 self.fan.set_speed(print_time, 0.)
             self.toolhead.dwell(0.500)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -9,13 +9,14 @@ import stepper, homing, chelper
 EXTRUDE_DIFF_IGNORE = 1.02
 
 class PrinterExtruder:
-    def __init__(self, config):
+    def __init__(self, config, extruder_num):
         self.printer = config.get_printer()
         self.name = config.get_name()
         shared_heater = config.get('shared_heater', None)
         pheater = self.printer.lookup_object('heater')
+        gcode_id = 'T%d' % (extruder_num,)
         if shared_heater is None:
-            self.heater = pheater.setup_heater(config)
+            self.heater = pheater.setup_heater(config, gcode_id)
         else:
             self.heater = pheater.lookup_heater(shared_heater)
         self.stepper = stepper.PrinterStepper(config)
@@ -237,11 +238,11 @@ def add_printer_objects(config):
         section = 'extruder%d' % (i,)
         if not config.has_section(section):
             if not i and config.has_section('extruder'):
-                pe = PrinterExtruder(config.getsection('extruder'))
+                pe = PrinterExtruder(config.getsection('extruder'), 0)
                 printer.add_object('extruder0', pe)
                 continue
             break
-        printer.add_object(section, PrinterExtruder(config.getsection(section)))
+        printer.add_object(section, PrinterExtruder(config.getsection(section), i))
 
 def get_printer_extruders(printer):
     out = []


### PR DESCRIPTION
Allow an arbitrary gcode_id to be supplied during heater setup. This allows future extras to register additional IDs beyond B, and T# for M105 temperature reporting.

My end goal is to create a new extra for an additional type of heater, so  based of some discussion with Kevin in PR 855, this should help keep the new code isolated.

Any feedback welcome.