### PR TITLE
Fix i2c addresses

### DIFF
--- a/config/generic-smoothieboard.cfg
+++ b/config/generic-smoothieboard.cfg
@@ -90,7 +90,7 @@ max_z_accel: 100
 pins: P1.18, P1.19, P1.20, P1.21, P4.28
 
 [mcp4451 stepper_digipot1]
-i2c_address: 88
+i2c_address: 44
 # Scale the config so that wiper values can be specified in amps.
 scale: 2.25
 # wiper 0 is X (aka alpha), 1 is Y, 2 is Z, 3 is E0
@@ -100,7 +100,7 @@ wiper_2: 1.0
 wiper_3: 1.0
 
 [mcp4451 stepper_digipot2]
-i2c_address: 90
+i2c_address: 45
 scale: 2.25
 # wiper 0 is E1
 wiper_0: 1.0

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -1,0 +1,9 @@
+This document covers recent software changes to the config file that
+are not backwards compatible. It is a good idea to review this
+document when upgrading the Klipper software.
+
+All dates in this document are approximate.
+
+# Changes
+
+20181220: Klipper v0.7.0 released

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,4 +6,9 @@ All dates in this document are approximate.
 
 # Changes
 
+20190107: The i2c_address parameter in the mcp4451 config section
+changed. This is a common setting on Smoothieboards. The new value is
+half the old value (88 should be changed to 44, and 90 should be
+changed to 45).
+
 20181220: Klipper v0.7.0 released

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -424,3 +424,7 @@ follow the full upgrade steps outlined above. Note that the RESTART
 and FIRMWARE_RESTART g-code commands do not load new software - the
 above "sudo service klipper restart" and "make flash" commands are
 needed for a software change to take effect.
+
+When upgrading the software, be sure to check the
+[config changes](Config_Changes.md) document for information on
+software changes that may require updates to your printer.cfg file.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -25,8 +25,11 @@ some common questions. The [G-Codes](G-Codes.md) document lists
 currently supported run-time commands.
 
 The history of Klipper releases is available at
-[releases](Releases.md). See [contact](Contact.md) for information on
-bug reporting and general communication with the developers.
+[releases](Releases.md). The [config changes](Config_Changes.md)
+document describes recent software changes that may require users to
+update their printer config file. See [contact](Contact.md) for
+information on bug reporting and general communication with the
+developers.
 
 Developer Documentation
 =======================

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -83,9 +83,11 @@ def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
 class MCU_I2C:
     def __init__(self, mcu, bus, addr, speed):
         self.mcu = mcu
+        self.i2c_address = addr
         self.oid = self.mcu.create_oid()
-        self.mcu.add_config_cmd("config_i2c oid=%d bus=%d rate=%d addr=%d" % (
-            self.oid, bus, speed, addr))
+        self.mcu.add_config_cmd(
+            "config_i2c oid=%d bus=%d rate=%d address=%d" % (
+                self.oid, bus, speed, addr))
         self.cmd_queue = self.mcu.alloc_command_queue()
         self.mcu.register_config_callback(self.build_config)
         self.i2c_write_cmd = self.i2c_read_cmd = self.i2c_modify_bits_cmd = None
@@ -93,6 +95,8 @@ class MCU_I2C:
         return self.oid
     def get_mcu(self):
         return self.mcu
+    def get_i2c_address(self):
+        return self.i2c_address
     def get_command_queue(self):
         return self.cmd_queue
     def build_config(self):
@@ -136,8 +140,8 @@ def MCU_I2C_from_config(config, default_addr=None, default_speed=100000):
     speed = config.getint('i2c_speed', default_speed, minval=100000)
     bus = config.getint('i2c_bus', 0, minval=0)
     if default_addr is None:
-        addr = config.getint('i2c_address')
+        addr = config.getint('i2c_address', minval=0, maxval=127)
     else:
-        addr = config.getint('i2c_address', default_addr)
+        addr = config.getint('i2c_address', default_addr, minval=0, maxval=127)
     # Create MCU_I2C object
     return MCU_I2C(i2c_mcu, bus, addr, speed)

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -177,11 +177,11 @@ class UC1701(DisplayBase):
         logging.info("uc1701 initialized")
 
 # The SSD1306 supports both i2c and "4-wire" spi
-class SSD1306(UC1701):
+class SSD1306(DisplayBase):
     def __init__(self, config):
         cs_pin = config.get("cs_pin", None)
         if cs_pin is None:
-            io = I2C(config, 120)
+            io = I2C(config, 60)
         else:
             io = SPI4wire(config, "dc_pin")
         DisplayBase.__init__(self, io)

--- a/klippy/extras/mcp4451.py
+++ b/klippy/extras/mcp4451.py
@@ -10,6 +10,9 @@ WiperRegisters = [0x00, 0x01, 0x06, 0x07]
 class mcp4451:
     def __init__(self, config):
         self.i2c = bus.MCU_I2C_from_config(config)
+        i2c_addr = self.i2c.get_i2c_address()
+        if i2c_addr < 44 or i2c_addr > 47:
+            raise config.error("mcp4451 address must be between 44 and 47")
         scale = config.getfloat('scale', 1., above=0.)
         # Configure registers
         self.set_register(0x04, 0xff)

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -41,8 +41,9 @@ class SX1509(object):
                          REG_INPUT_DISABLE : 0, REG_ANALOG_DRIVER_ENABLE : 0}
         self.reg_i_on_dict = {reg : 0 for reg in REG_I_ON}
     def _build_config(self):
-        self._mcu.add_config_cmd("config_i2c oid=%d bus=%d rate=%d addr=%d" % (
-            self._oid, self._bus, self._freq, self._chip_address))
+        self._mcu.add_config_cmd(
+            "config_i2c oid=%d bus=%d rate=%d address=%d" % (
+                self._oid, self._bus, self._freq, self._chip_address))
         # Reset the chip
         self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
             self._oid, REG_RESET, 0x12))

--- a/src/avr/i2c.c
+++ b/src/avr/i2c.c
@@ -45,7 +45,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
     if (bus)
         shutdown("Unsupported i2c bus");
     i2c_init();
-    return (struct i2c_config){ .addr=addr };
+    return (struct i2c_config){ .addr=addr<<1 };
 }
 
 static void

--- a/src/i2ccmds.c
+++ b/src/i2ccmds.c
@@ -16,15 +16,13 @@ struct i2cdev_s {
 void
 command_config_i2c(uint32_t *args)
 {
-    uint8_t addr = args[3];
-    if (addr & 1)
-        shutdown("Invalid I2C address");
+    uint8_t addr = args[3] & 0x7f;
     struct i2cdev_s *i2c = oid_alloc(args[0], command_config_i2c
                                      , sizeof(*i2c));
     i2c->i2c_config = i2c_setup(args[1], args[2], addr);
 }
 DECL_COMMAND(command_config_i2c,
-             "config_i2c oid=%c bus=%u rate=%u addr=%u");
+             "config_i2c oid=%c bus=%u rate=%u address=%u");
 
 void
 command_i2c_write(uint32_t *args)

--- a/src/lpc176x/i2c.c
+++ b/src/lpc176x/i2c.c
@@ -45,7 +45,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
     if (bus)
         shutdown("Unsupported i2c bus");
     i2c_init();
-    return (struct i2c_config){ .addr=addr };
+    return (struct i2c_config){ .addr=addr<<1 };
 }
 
 static void

--- a/src/samd21/i2c.c
+++ b/src/samd21/i2c.c
@@ -57,7 +57,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
     if (bus)
         shutdown("Unsupported i2c bus");
     i2c_init();
-    return (struct i2c_config){ .addr=addr };
+    return (struct i2c_config){ .addr=addr<<1 };
 }
 
 static void


### PR DESCRIPTION
Unfortunately, some of the Klipper code was using 7-bit i2c addresses (sam4e8e, linux mcu, replicape.py, sx1509.py) while some code was using 8-bit addresses with the low bit always zero (avr, lpc176x, samd21, mcp4451.py, uc1701.py).  The 7-bit i2c addresses are preferable, so change all the code to use this address format.

Alas, this makes a non-backwards compatible change to the printer config file for Smoothieboard users.  This change also updates the mcp4451 to validate the i2c address so the user is alerted to the problem.

-Kevin