### PR TITLE
display: pin mapping for ender 3 stock display and encoder on MKS GEN…

### DIFF
--- a/config/generic-ramps.cfg
+++ b/config/generic-ramps.cfg
@@ -112,3 +112,4 @@ max_z_accel: 100
 #sid_pin: ar29
 #encoder_pins: ^ar23, ^ar17
 #click_pin: ^!ar35
+

--- a/config/generic-ramps.cfg
+++ b/config/generic-ramps.cfg
@@ -103,3 +103,12 @@ max_z_accel: 100
 #sid_pin: ar17
 #encoder_pins: ^ar31, ^ar33
 #click_pin: ^!ar35
+
+# 128x64 Full Graphic Creality CR10 / ENDER 3 stockdisplay
+#[display]
+#lcd_type: st7920
+#cs_pin: ar27
+#sclk_pin: ar25
+#sid_pin: ar29
+#encoder_pins: ^ar23, ^ar17
+#click_pin: ^!ar35


### PR DESCRIPTION
display: pin mapping for ender 3 stock display and encoder on MKS GEN L / RAMPS EXP1

Signed-off-by: Patrick Balsiger <patrick.balsiger@wirelos.net>