### PR TITLE
config: Add default kill_pin to RAMPS' display-section

### DIFF
--- a/config/generic-ramps.cfg
+++ b/config/generic-ramps.cfg
@@ -103,3 +103,4 @@ max_z_accel: 100
 #sid_pin: ar17
 #encoder_pins: ^ar31, ^ar33
 #click_pin: ^!ar35
+#kill_pin: ^!ar41


### PR DESCRIPTION
I thought that this might come in handy if you're using a "RepRapDiscount 128x64 Full Graphic Smart Controller" type display as it becomes easier to halt a print if anything goes wrong.

Signed-off-by: Nils Friedchen <Nils.Friedchen@googlemail.com>