### PR TITLE
Use a median filter for temperature smoothing

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -165,10 +165,10 @@ sensor_pin: analog13
 #adc_voltage: 5.0
 #   The ADC comparison voltage. This parameter is only valid when the
 #   sensor is an AD595 or "PT100 INA826". The default is 5 volts.
-#smooth_time: 2.0
+#smooth_time: 1.5
 #   A time value (in seconds) over which temperature measurements will
 #   be smoothed to reduce the impact of measurement noise. The default
-#   is 2 seconds.
+#   is 1.5 seconds.
 control: pid
 #   Control algorithm (either pid or watermark). This parameter must
 #   be provided.

--- a/config/generic-smoothieboard.cfg
+++ b/config/generic-smoothieboard.cfg
@@ -50,6 +50,7 @@ filament_diameter: 1.750
 heater_pin: P2.7
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: P0.24
+smooth_time: 2.7
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -69,6 +70,7 @@ max_temp: 250
 heater_pin: P2.5
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: P0.23
+smooth_time: 2.7
 control: watermark
 min_temp: 0
 max_temp: 130

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -73,7 +73,7 @@ class ControlAutoTune:
                 (read_time + self.heater.get_pwm_delay(), value))
             self.last_pwm = value
         self.heater.set_pwm(read_time, value)
-    def temperature_update(self, read_time, temp, target_temp):
+    def temperature_update(self, read_time, temp, smoothed_temp, target_temp):
         self.temp_samples.append((read_time, temp))
         # Check if the temperature has crossed the target and
         # enable/disable the heater if so.

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -77,24 +77,24 @@ class ControlAutoTune:
         self.temp_samples.append((read_time, temp))
         # Check if the temperature has crossed the target and
         # enable/disable the heater if so.
-        if self.heating and temp >= target_temp:
+        if self.heating and smoothed_temp >= target_temp:
             self.heating = False
             self.check_peaks()
             self.heater.alter_target(self.calibrate_temp - TUNE_PID_DELTA)
-        elif not self.heating and temp <= target_temp:
+        elif not self.heating and smoothed_temp <= target_temp:
             self.heating = True
             self.check_peaks()
             self.heater.alter_target(self.calibrate_temp)
         # Check if this temperature is a peak and record it if so
         if self.heating:
             self.set_pwm(read_time, self.heater_max_power)
-            if temp < self.peak:
-                self.peak = temp
+            if smoothed_temp < self.peak:
+                self.peak = smoothed_temp
                 self.peak_time = read_time
         else:
             self.set_pwm(read_time, 0.)
-            if temp > self.peak:
-                self.peak = temp
+            if smoothed_temp > self.peak:
+                self.peak = smoothed_temp
                 self.peak_time = read_time
     def check_busy(self, eventtime, smoothed_temp, target_temp):
         if self.heating or len(self.peaks) < 12:


### PR DESCRIPTION
This change replaces the current "exponential average" temperature filter with a median filter.  A median filter is better at rejecting spikes, which is important for Smoothieboard users.  It shouldn't have any adverse impact, so the plan is to use the median filter for all boards.

This is a change to overall heater operation for all Klipper users.  So, testing on a variety of boards would be appreciated.
