### PR TITLE
BLTouch improvements

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -58,6 +58,11 @@
 #pin_move_time: 0.200
 #   The amount of time (in seconds) that it takes the BLTouch pin to
 #   move up or down. The default is 0.200 seconds.
+#pin_up_reports_not_triggered: True
+#   Set if the BLTouch consistently reports the probe in a "not
+#   triggered" state after a successful "pin_up" command. This should
+#   be True for a genuine BLTouch; some BLTouch clones may require
+#   False.  The default is True.
 #x_offset:
 #y_offset:
 #z_offset:

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -63,6 +63,11 @@
 #   triggered" state after a successful "pin_up" command. This should
 #   be True for a genuine BLTouch; some BLTouch clones may require
 #   False.  The default is True.
+#pin_up_touch_mode_reports_triggered: True
+#   Set if the BLTouch consistently reports a "triggered" state after
+#   the commands "pin_up" followed by "touch_mode". This should be
+#   True for a genuine BLTouch; some BLTouch clones may require
+#   False. The default is True.
 #x_offset:
 #y_offset:
 #z_offset:

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -42,7 +42,8 @@ class BLTouchEndstopWrapper:
         self.next_test_time = 0.
         self.pin_up_not_triggered = config.getboolean(
             'pin_up_reports_not_triggered', True)
-        self.test_sensor_pin = config.getboolean('test_sensor_pin', True)
+        self.pin_up_touch_triggered = config.getboolean(
+            'pin_up_touch_mode_reports_triggered', True)
         self.start_mcu_pos = []
         # Calculate pin move time
         pmt = max(config.getfloat('pin_move_time', 0.200), MIN_CMD_TIME)
@@ -105,7 +106,8 @@ class BLTouchEndstopWrapper:
             self.verify_state(check_start_time, check_end_time,
                               False, "raise probe")
     def test_sensor(self):
-        if not self.test_sensor_pin:
+        if not self.pin_up_touch_triggered:
+            # Nothing to test
             return
         toolhead = self.printer.lookup_object('toolhead')
         print_time = toolhead.get_last_move_time()

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-import homing, probe
+import homing, probe, buttons
 
 SIGNAL_PERIOD = 0.025600
 MIN_CMD_TIME = 4 * SIGNAL_PERIOD
@@ -60,6 +60,12 @@ class BLTouchEndstopWrapper:
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("BLTOUCH_DEBUG", self.cmd_BLTOUCH_DEBUG,
                                     desc=self.cmd_BLTOUCH_DEBUG_help)
+        # Debugging code to report sensor pin state changes
+        ppins.reset_pin_sharing(pin_params)
+        buttons = self.printer.try_load_module(config, "buttons")
+        buttons.register_buttons([pin], self.sensor_debug_callback)
+    def sensor_debug_callback(self, eventtime, state):
+        logging.info("bltouch sensor @ %.6f is %s", eventtime, state)
     def _build_config(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         for stepper in kin.get_steppers('Z'):

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -78,7 +78,11 @@ class Homing:
         else:
             self.toolhead.set_position(movepos)
         for mcu_endstop, name in endstops:
-            mcu_endstop.home_finalize()
+            try:
+                mcu_endstop.home_finalize()
+            except EndstopError as e:
+                if error is None:
+                    error = str(e)
         if error is not None:
             raise EndstopError(error)
         # Check if some movement occurred

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -181,7 +181,8 @@ class MCU_endstop:
                                , self._oid)
     def home_prepare(self):
         pass
-    def home_start(self, print_time, sample_time, sample_count, rest_time):
+    def home_start(self, print_time, sample_time, sample_count, rest_time,
+                   triggered=True):
         clock = self._mcu.print_time_to_clock(print_time)
         rest_ticks = int(rest_time * self._mcu.get_adjusted_freq())
         self._homing = True
@@ -189,7 +190,8 @@ class MCU_endstop:
         self._next_query_print_time = print_time + self.RETRY_QUERY
         self._home_cmd.send(
             [self._oid, clock, self._mcu.seconds_to_clock(sample_time),
-             sample_count, rest_ticks, 1 ^ self._invert], reqclock=clock)
+             sample_count, rest_ticks, triggered ^ self._invert],
+            reqclock=clock)
         for s in self._steppers:
             s.note_homing_start(clock)
     def home_wait(self, home_end_time):


### PR DESCRIPTION
This is a development branch that improves the BLTouch error handling.  I have not tested this branch on real hardware.

The code is intended to address five known deficiencies in the current bltouch code:
1. touch_mode is not as accurate as pin_down mode on some hardware
2. sending repeat touch_mode commands during probing causes bad behaviour on some clones
3. the code should issue a pin_up on startup
4. it would be useful for the code to verify that pin_up succeeds (for hardware that can verify it)
5. the current sensor test code does not work as intended on "probe:z_virtual_endstop" with "homing_retract_dist=0"

To test with this branch, ssh into the rpi and run:

cd ~/klipper ; git fetch ; git checkout origin/work-bltouch-debug-20181211 ; sudo service klipper restart

If you are running a bltouch clone, it may be necessary to configure two new config options: triggered_on_pin_up and triggered_on_pin_up_touch_mode.  See the updated config/example-extras.cfg file for details.

If you run this code, please report the results here (success or failure).  Please also attach the klipper log file (see https://github.com/KevinOConnor/klipper/blob/master/docs/Contact.md for details on attaching the log file).

-Kevin