### PR TITLE
pause_resume: advanced pause resume functionality for Klipper

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1142,3 +1142,9 @@
 # default_prefix: echo:
 #    Directly sets the default prefix. If present, this value will override
 #    the "default_type".
+
+# Pause/Resume functionality with support of position capture and restore
+#[pause_resume]
+#recover_velocity: 50.
+#  When capture/restore is enabled, the speed at which to return to
+#  the captured position (in mm/s).  Default is 50.0 mm/s.

--- a/config/sample-macros.cfg
+++ b/config/sample-macros.cfg
@@ -34,3 +34,24 @@
 #gcode:  SET_PIN PIN=BEEPER_pin VALUE={S}
 #        G4 P{P}
 #        SET_PIN PIN=BEEPER_pin VALUE=0
+
+# M600: Filament Change.  This macro will pause the printer, move
+# the tool to the change position, and retract the filament 50mm.
+# Adjust the retraction settings for your own extruder.  After filament
+# has been changed, the print can be resumed from its previous position
+# with the "RESUME" gcode
+#
+#[gcode_macro M600]
+#default_parameter_X: 50
+#default_parameter_Y: 0
+#default_parameter_Z: 10
+#gcode:
+# PAUSE
+# G91
+# G1 E-.8 F2700
+# G1 Z{Z}
+# G90
+# G1 X{X} Y{Y} F3000
+# G91
+# G1 E-50 F1000
+# G90

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -291,3 +291,13 @@ enabled.
   - `RESPOND TYPE=error MSG="<message>"`: echo the message prepended with `!! `.
   - `RESPOND PREFIX=<prefix> MSG="<message>"`: echo the message prepended with `<prefix>`
     (The `PREFIX` parameter will take priority over the `TYPE` parameter)
+
+## Pause Resume
+
+The following commands are available when the "pause_resume" config section
+is enabled:
+  - `PAUSE`:  Pauses the current print.  The current position is captured for
+  restoration upon resume.
+  - `RESUME [VELOCITY=<value>]`: Resumes the print from a pause, first restoring
+  the previously captured position.  The VELOCITY parameter determines the speed
+  at which the tool should return to the original captured position.

--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -1,0 +1,56 @@
+# Pause/Resume functionality with position capture/restore
+#
+# Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+class PauseResume:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.recover_velocity = config.getfloat('recover_velocity', 50.)
+        self.captured_position = None
+        self.captured_speed = 0.
+        self.toolhead = self.v_sd = None
+        self.sd_paused = False
+        self.printer.register_event_handler("klippy:ready", self.handle_ready)
+        self.gcode.register_command("PAUSE", self.cmd_PAUSE)
+        self.gcode.register_command("RESUME", self.cmd_RESUME)
+    def handle_ready(self):
+        self.toolhead = self.printer.lookup_object('toolhead')
+        self.v_sd = self.printer.lookup_object('virtual_sdcard', None)
+    def cmd_PAUSE(self, params):
+        if self.v_sd is not None and self.v_sd.is_active():
+            # Printing from virtual sd, run pause command
+            self.sd_paused = True
+            self.v_sd.cmd_M25({})
+        else:
+            self.sd_paused = False
+            self.gcode.respond_info("action:pause")
+        self.toolhead.wait_moves()
+        self.captured_position = self.toolhead.get_position()
+        reactor = self.printer.get_reactor()
+        gc_status = self.gcode.get_status(reactor.monotonic())
+        self.captured_speed = gc_status['speed']
+    def cmd_RESUME(self, params):
+        velocity = self.gcode.get_float(
+            'VELOCITY', params, self.recover_velocity)
+        if self.captured_position is not None:
+            # restore previous xyz position
+            cur_pos = self.toolhead.get_position()
+            self.captured_position[3] = cur_pos[3]
+            self.toolhead.move(self.captured_position, velocity)
+            self.toolhead.get_last_move_time()
+            self.gcode.reset_last_position()
+            # restore previous speed
+            self.gcode.run_script_from_command(
+                "G1 F%.6f" % (self.captured_speed))
+        self.captured_position = None
+        if self.sd_paused:
+            # Printing from virtual sd, run pause command
+            self.v_sd.cmd_M24({})
+        else:
+            self.gcode.respond_info("action:resume")
+
+def load_config(config):
+    return PauseResume(config)

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -57,6 +57,8 @@ class VirtualSD:
         if self.work_timer is not None and self.file_size:
             progress = float(self.file_position) / self.file_size
         return {'progress': progress}
+    def is_active(self):
+        return self.work_timer is not None
     # G-Code commands
     def cmd_error(self, params):
         raise self.gcode.error("SD write not supported")
@@ -123,7 +125,7 @@ class VirtualSD:
         self.file_position = pos
     def cmd_M27(self, params):
         # Report SD print status
-        if self.current_file is None or self.work_timer is None:
+        if self.current_file is None:
             self.gcode.respond("Not SD printing.")
             return
         self.gcode.respond("SD printing byte %d/%d" % (

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -102,6 +102,7 @@ class GCodeParser:
         busy = self.is_processing_data
         return {
             'speed_factor': self.speed_factor * 60.,
+            'speed': self.speed,
             'extrude_factor': self.extrude_factor,
             'busy': busy,
             'last_xpos': self.last_position[0],


### PR DESCRIPTION
This pull request implements an advanced version of Pause/Resume functionality.  Initially this was part of my filament sensor work, however I realized that it would be useful for other situations.  For example, it can be used to implement the M600 Filament Change gcode for manual color changes during a print, as illustrated in sample-macros.cfg.

The module determines if the source gcode is printing from virtual sd or octoprint, then calls the appropriate handler to pause and resume.  It can optionally capture the current toolhead position on pause, then move back to that position on resume.  Position data is captured and restored using the toolhead directly to avoid any potential conflict with absolute vs relative coordinate movement or a change in the base position.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>