### PR TITLE
tmc2208: Decode register fields in DUMP_TMC

### DIFF
--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -38,9 +38,20 @@ def ffs(mask):
 # Provide a string description of a register
 def pretty_format(all_fields, reg_name, value):
     fields = [ " %s=%d" % (field_name, (value & mask) >> ffs(mask))
-               for field_name, mask in all_fields.get(reg_name, {}).items()
+               for field_name, mask in sorted(all_fields.get(
+                   reg_name, {}).items(), key = lambda f: f[1])
                if value & mask ]
     return "%-15s %08x%s" % (reg_name + ":", value, "".join(fields))
+
+# Returns value of the register field
+def get_field(all_fields, reg_name, field_name, reg_value):
+    mask = all_fields.get(reg_name, {})[field_name]
+    return (reg_value & mask) >> ffs(mask)
+
+# Returns register value with field bits filled with supplied field value
+def set_field(all_fields, reg_name, field_name, reg_value, field_value):
+    mask = all_fields.get(reg_name, {})[field_name]
+    return (reg_value & ~mask) | ((field_value << ffs(mask)) & mask)
 
 
 ######################################################################

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -26,15 +26,150 @@ ReadRegisters = [
 ]
 
 Fields = {}
-Fields["GCONF"] = {
-    "I_scale_analog": 0x01, "internal_Rsense": 0x02, "en_spreadCycle": 0x04,
-    "shaft": 0x08, "index_otpw": 0x10, "index_step": 0x20, "pdn_disable": 0x40,
-    "mstep_reg_select": 0x80, "multistep_filt": 0x100, "test_mode": 0x200 }
-Fields["GSTAT"] = { "reset": 0x01, "drv_err": 0x02, "uv_cp": 0x04 }
-Fields["IOIN"] = {
-    "ENN": 0x01, "PDN_UART": 0x02, "MS1": 0x04, "MS2": 0x08, "DIAG": 0x10,
-    "STEP": 0x80, "SEL_A": 0x100, "VERSION": 0xff000000 }
 
+Fields["GCONF"] = {
+    "I_scale_analog":      0x01,
+    "internal_Rsense":     0x01 << 1,
+    "en_spreadCycle":      0x01 << 2,
+    "shaft":               0x01 << 3,
+    "index_otpw":          0x01 << 4,
+    "index_step":          0x01 << 5,
+    "pdn_disable":         0x01 << 6,
+    "mstep_reg_select":    0x01 << 7,
+    "multistep_filt":      0x01 << 8,
+    "test_mode":           0x01 << 9
+}
+Fields["GSTAT"] = {
+    "reset":               0x01,
+    "drv_err":             0x01 << 1,
+    "uv_cp":               0x01 << 2
+}
+Fields["IFCNT"] = {
+    "IFCNT":               0xff
+}
+Fields["SLAVECONF"] = {
+    "SENDDELAY":           0x0f << 8
+}
+Fields["OTP_PROG"] = {
+    "OTPBIT":              0x07,
+    "OTPBYTE":             0x03 << 4,
+    "OTPMAGIC":            0xff << 8
+}
+Fields["OTP_READ"] = {
+    "OTP_FCLKTRIM":        0x1f,
+    "otp_OTTRIM":          0x01 << 5,
+    "otp_internalRsense":  0x01 << 6,
+    "otp_TBL":             0x01 << 7,
+    "OTP_PWM_GRAD":        0x0f << 8,
+    "otp_pwm_autograd":    0x01 << 12,
+    "OTP_TPWMTHRS":        0x07 << 13,
+    "otp_PWM_OFS":         0x01 << 16,
+    "otp_PWM_REG":         0x01 << 17,
+    "otp_PWM_FREQ":        0x01 << 18,
+    "OTP_IHOLDDELAY":      0x03 << 19,
+    "OTP_IHOLD":           0x03 << 21,
+    "otp_en_spreadCycle":  0x01 << 23
+}
+# IOIN mapping depends on the driver type (SEL_A field)
+# TMC222x (SEL_A == 0)
+Fields["IOIN@TMC222x"] = {
+    "PDN_UART":            0x01 << 1,
+    "SPREAD":              0x01 << 2,
+    "DIR":                 0x01 << 3,
+    "ENN":                 0x01 << 4,
+    "STEP":                0x01 << 5,
+    "MS1":                 0x01 << 6,
+    "MS2":                 0x01 << 7,
+    "SEL_A":               0x01 << 8,
+    "VERSION":             0xff << 24
+}
+# TMC220x (SEL_A == 1)
+Fields["IOIN@TMC220x"] = {
+    "ENN":                 0x01,
+    "MS1":                 0x01 << 2,
+    "MS2":                 0x01 << 3,
+    "DIAG":                0x01 << 4,
+    "PDN_UART":            0x01 << 6,
+    "STEP":                0x01 << 7,
+    "SEL_A":               0x01 << 8,
+    "DIR":                 0x01 << 9,
+    "VERSION":             0xff << 24,
+}
+Fields["FACTORY_CONF"] = {
+    "FCLKTRIM":            0x1f,
+    "OTTRIM":              0x03 << 8
+}
+Fields["IHOLD_IRUN"] = {
+    "IHOLD":               0x1f,
+    "IRUN":                0x1f << 8,
+    "IHOLDDELAY":          0x0f << 16
+}
+Fields["TPOWERDOWN"] = {
+    "TPOWERDOWN":          0xff
+}
+Fields["TSTEP"] = {
+    "TSTEP":               0xfffff
+}
+Fields["TPWMTHRS"] = {
+    "TPWMTHRS":            0xfffff
+}
+Fields["VACTUAL"] = {
+    "VACTUAL":             0xffffff
+}
+Fields["MSCNT"] = {
+    "MSCNT":               0x3ff
+}
+Fields["MSCURACT"] = {
+    "CUR_A":               0x1ff,
+    "CUR_B":               0x1ff << 16
+}
+Fields["CHOPCONF"] = {
+    "toff":                0x0f,
+    "hstrt":               0x07 << 4,
+    "hend":                0x0f << 7,
+    "TBL":                 0x03 << 15,
+    "vsense":              0x01 << 17,
+    "MRES":                0x0f << 24,
+    "intpol":              0x01 << 28,
+    "dedge":               0x01 << 29,
+    "diss2g":              0x01 << 30,
+    "diss2vs":             0x01 << 31
+}
+Fields["DRV_STATUS"] = {
+    "otpw":                0x01,
+    "ot":                  0x01 << 1,
+    "s2ga":                0x01 << 2,
+    "s2gb":                0x01 << 3,
+    "s2vsa":               0x01 << 4,
+    "s2vsb":               0x01 << 5,
+    "ola":                 0x01 << 6,
+    "olb":                 0x01 << 7,
+    "t120":                0x01 << 8,
+    "t143":                0x01 << 9,
+    "t150":                0x01 << 10,
+    "t157":                0x01 << 11,
+    "CS_ACTUAL":           0x1f << 16,
+    "stealth":             0x01 << 30,
+    "stst":                0x01 << 31
+}
+Fields["PWMCONF"] = {
+    "PWM_OFS":             0xff,
+    "PWM_GRAD":            0xff << 8,
+    "pwm_freq":            0x03 << 16,
+    "pwm_autoscale":       0x01 << 18,
+    "pwm_autograd":        0x01 << 19,
+    "freewheel":           0x03 << 20,
+    "PWM_REG":             0xf << 24,
+    "PWM_LIM":             0xf << 28
+}
+Fields["PWM_SCALE"] = {
+    "PWM_SCALE_SUM":       0xff,
+    "PWM_SCALE_AUTO":      0x1ff << 16
+}
+Fields["PWM_AUTO"] = {
+    "PWM_OFS_AUTO":        0xff,
+    "PWM_GRAD_AUTO":       0xff << 16
+}
 
 ######################################################################
 # TMC2208 communication
@@ -210,6 +345,8 @@ class TMC2208:
     def get_register(self, reg_name):
         reg = Registers[reg_name]
         msg = encode_tmc2208_read(0xf5, 0x00, reg)
+        if self.printer.get_start_args().get('debugoutput') is not None:
+            return 0
         for retry in range(5):
             params = self.tmcuart_send_cmd.send_with_response(
                 [self.oid, msg, 10], 'tmcuart_response', self.oid)
@@ -247,6 +384,11 @@ class TMC2208:
                 val = self.get_register(reg_name)
             except self.printer.config_error as e:
                 raise gcode.error(str(e))
+            # IOIN has different mappings depending on the driver type
+            # (SEL_A field of IOIN reg)
+            if reg_name is "IOIN":
+                drv_type = tmc2130.get_field(Fields, "IOIN@TMC222x", "SEL_A", val)
+                reg_name = "IOIN@TMC220x" if drv_type else "IOIN@TMC222x"
             msg = tmc2130.pretty_format(Fields, reg_name, val)
             logging.info(msg)
             gcode.respond_info(msg)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging, collections
+import tmc2130
 
 TMC_FREQUENCY=12000000.
 GCONF_PDN_DISABLE = 1<<6
@@ -23,6 +24,16 @@ ReadRegisters = [
     "MSCNT", "MSCURACT", "CHOPCONF", "DRV_STATUS",
     "PWMCONF", "PWM_SCALE", "PWM_AUTO"
 ]
+
+Fields = {}
+Fields["GCONF"] = {
+    "I_scale_analog": 0x01, "internal_Rsense": 0x02, "en_spreadCycle": 0x04,
+    "shaft": 0x08, "index_otpw": 0x10, "index_step": 0x20, "pdn_disable": 0x40,
+    "mstep_reg_select": 0x80, "multistep_filt": 0x100, "test_mode": 0x200 }
+Fields["GSTAT"] = { "reset": 0x01, "drv_err": 0x02, "uv_cp": 0x04 }
+Fields["IOIN"] = {
+    "ENN": 0x01, "PDN_UART": 0x02, "MS1": 0x04, "MS2": 0x08, "DIAG": 0x10,
+    "STEP": 0x80, "SEL_A": 0x100, "VERSION": 0xff000000 }
 
 
 ######################################################################
@@ -236,7 +247,7 @@ class TMC2208:
                 val = self.get_register(reg_name)
             except self.printer.config_error as e:
                 raise gcode.error(str(e))
-            msg = "%-15s %08x" % (reg_name + ":", val)
+            msg = tmc2130.pretty_format(Fields, reg_name, val)
             logging.info(msg)
             gcode.respond_info(msg)
 


### PR DESCRIPTION
Report decimal values for some of the TMC2208 register fields in
DUMP_TMC command if DECODE parameter is given. This helps in tuning and
diagnostics.

Sample output:
```
Send: DUMP_TMC STEPPER=stepper_a DECODE=1
Recv: // GCONF:          000001c4
Recv: // - I_scale_analog(ext VREF): 0
Recv: // - internal_Rsense:          0
Recv: // - en_spreadCycle:           1
Recv: // - shaft (inverse rot dir):  0
Recv: // - index_otpw:               0
Recv: // - index_step:               0
Recv: // - pdn_disable:              1
Recv: // - mstep_reg_select:         1
Recv: // - multistep_filt:           1
Recv: // - test_mode:                0
Recv: // GSTAT:          00000001
Recv: // - reset (driver was reset): 1
Recv: // - drv_err (error shutdown): 0
Recv: // - uv_cp (undervoltage):     0
Recv: // IFCNT:          00000066
Recv: // OTP_READ:       0000000d
Recv: // IOIN:           20000348
Recv: // - ENN pin:                  0
Recv: // - MS1 pin:                  0
Recv: // - MS2 pin:                  1
Recv: // - DIAG pin:                 0
Recv: // - PDN_UART pin:             1
Recv: // - STEP pin:                 0
Recv: // - SEL_A (driver type):      1 (TMC220x)
Recv: // - DIR pin:                  1
Recv: // - VERSION:                  0x20
Recv: // FACTORY_CONF:   0000000d
Recv: // - FCLKTRIM:                 13
Recv: // - OTTRIM (overtemp trim):   0 (OT=143C, OTPW=120C)
Recv: // TSTEP:          000fffff
Recv: // MSCNT:          0000038c
Recv: // - MSCNT A (position A):     908
Recv: // - MSCNT B (position B):     140
Recv: // MSCURACT:       00bb015f
Recv: // - CUR_A (current A):        -161
Recv: // - CUR_B (current B):        187
Recv: // CHOPCONF:       13030053
Recv: // - toff (slow decay time):   3 (108/fclk)
Recv: // - hstrt (start hysteresis): 5 (offset 3)
Recv: // - hend (end hysteresis):    0 (offset -3)
Recv: // - TBL (blank time):         2 (32/fclk)
Recv: // - vsense(high sensitivity): 1
Recv: // - MRES (microstep res):     3 (32 usteps/step)
Recv: // - intpol (interpolation):   1
Recv: // - dedge (double edge):      0
Recv: // - diss2g (short to GND protect off): 0
Recv: // - diss2vs (low side short protect off): 0
Recv: // DRV_STATUS:     80130080
Recv: // - otpw (overtemp warning):  0
Recv: // - ot (overtemperature):     0
Recv: // - s2ga (short to ground A): 0
Recv: // - s2gb (short to ground B): 0
Recv: // - s2vsa (low side short A): 0
Recv: // - s2vsb (low side short B): 0
Recv: // - ola (open load A):        0
Recv: // - olb (open load B):        1
Recv: // - t120 (120 C reached):     0
Recv: // - t143 (143 C reached):     0
Recv: // - t150 (150 C reached):     0
Recv: // - t157 (157 C reached):     0
Recv: // - CS_ACTUAL(current scale): 19
Recv: // - stealth (stealthChop):    0
Recv: // - stst (standstill):        1
Recv: // PWMCONF:        c80d0e24
Recv: // - PWM_OFS:                  36
Recv: // - PWM_GRAD:                 14
Recv: // - pwm_freq:                 1 (2/683 fclk)
Recv: // - pwm_autoscale:            1
Recv: // - pwm_autograd:             1
Recv: // - freewheel (brake mode):   0 (normal)
Recv: // - PWM_REG:                  8
Recv: // - PWM_LIM:                  12
Recv: // PWM_SCALE:      00000016
Recv: // - PWM_SCALE_SUM:            22
Recv: // - PWM_SCALE_AUTO:           0
Recv: // PWM_AUTO:       000e0024
Recv: // - PWM_OFS_AUTO:             36
Recv: // - PWM_GRAD_AUTO:            14
Recv: ok
```

Signed-off-by: Dmitry Frolov <dmitry.frolov@gmail.com>