### PR TITLE
idle_timeout: Added a missing logging import

### DIFF
--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
 
 DEFAULT_IDLE_GCODE = """
 TURN_OFF_HEATERS


### PR DESCRIPTION
I noticed Octoprint was disconnecting after a while, and after reading the logs, I came across this error:

```
Unhandled exception during run
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/klippy.py", line 171, in run
    self.reactor.run()
  File "/home/pi/klipper/klippy/reactor.py", line 176, in run
    g_next.switch()
  File "/home/pi/klipper/klippy/reactor.py", line 203, in _dispatch_loop
    timeout = self._check_timers(eventtime)
  File "/home/pi/klipper/klippy/reactor.py", line 82, in _check_timers
    t.waketime = t.callback(eventtime)
  File "/home/pi/klipper/klippy/extras/idle_timeout.py", line 62, in timeout_handler
    return self.check_idle_timeout(eventtime)
  File "/home/pi/klipper/klippy/extras/idle_timeout.py", line 59, in check_idle_timeout
    return self.transition_idle_state(eventtime)
  File "/home/pi/klipper/klippy/extras/idle_timeout.py", line 35, in transition_idle_state
    logging.exception("idle timeout gcode execution")
NameError: global name 'logging' is not defined
```

I therefore added the missing import.

Signed-off-by: Samori Gorse <samori.gorse+github@gmail.com>