### PR TITLE
tmc2208: Add support for formatting register fields

### DIFF
--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -35,6 +35,12 @@ Fields = {}
 def ffs(mask):
     return (mask & -mask).bit_length() - 1
 
+# Decode two's complement signed integer
+def decode_signed_int(val, bits):
+    if ((val >> (bits - 1)) & 1):
+        return val - (1 << bits)
+    return val
+
 class FieldHelper:
     def __init__(self, all_fields, field_formatters={}):
         self.all_fields = all_fields

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -267,6 +267,7 @@ class TMC2208:
             "DUMP_TMC", "STEPPER", self.name,
             self.cmd_DUMP_TMC, desc=self.cmd_DUMP_TMC_help)
         # Get config for initial driver settings
+        self.field_helper = tmc2130.FieldHelper(Fields)
         run_current = config.getfloat('run_current', above=0., maxval=2.)
         hold_current = config.getfloat('hold_current', run_current,
                                        above=0., maxval=2.)
@@ -386,10 +387,11 @@ class TMC2208:
                 raise gcode.error(str(e))
             # IOIN has different mappings depending on the driver type
             # (SEL_A field of IOIN reg)
-            if reg_name is "IOIN":
-                drv_type = tmc2130.get_field(Fields, "IOIN@TMC222x", "SEL_A", val)
+            if reg_name == "IOIN":
+                drv_type = self.field_helper.get_field("IOIN@TMC222x", "SEL_A",
+                                                       val)
                 reg_name = "IOIN@TMC220x" if drv_type else "IOIN@TMC222x"
-            msg = tmc2130.pretty_format(Fields, reg_name, val)
+            msg = self.field_helper.pretty_format(reg_name, val)
             logging.info(msg)
             gcode.respond_info(msg)
 

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -171,6 +171,12 @@ Fields["PWM_AUTO"] = {
     "PWM_GRAD_AUTO":       0xff << 16
 }
 
+FieldFormatters = {
+    "VERSION": hex,
+    "s2vsb": (lambda v: "SHORT!" if v else ""),
+}
+
+
 ######################################################################
 # TMC2208 communication
 ######################################################################
@@ -267,7 +273,7 @@ class TMC2208:
             "DUMP_TMC", "STEPPER", self.name,
             self.cmd_DUMP_TMC, desc=self.cmd_DUMP_TMC_help)
         # Get config for initial driver settings
-        self.field_helper = tmc2130.FieldHelper(Fields)
+        self.field_helper = tmc2130.FieldHelper(Fields, FieldFormatters)
         run_current = config.getfloat('run_current', above=0., maxval=2.)
         hold_current = config.getfloat('hold_current', run_current,
                                        above=0., maxval=2.)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -172,8 +172,24 @@ Fields["PWM_AUTO"] = {
 }
 
 FieldFormatters = {
-    "VERSION": hex,
-    "s2vsb": (lambda v: "SHORT!" if v else ""),
+    "I_scale_analog":   (lambda v: "1(ExtVREF)" if v else ""),
+    "shaft":            (lambda v: "1(Reverse)" if v else ""),
+    "drv_err":          (lambda v: "1(ErrorShutdown!)" if v else ""),
+    "uv_cp":            (lambda v: "1(Undervoltage!)" if v else ""),
+    "SEL_A":            (lambda v: "%d(%s)" % (v, ["TMC222x", "TMC220x"][v])),
+    "VERSION":          (lambda v: "%#x" % v),
+    "CUR_A":            (lambda v: str(tmc2130.decode_signed_int(v, 9))),
+    "CUR_B":            (lambda v: str(tmc2130.decode_signed_int(v, 9))),
+    "MRES":             (lambda v: "%d(%dusteps)" % (v, 0x100 >> v)),
+    "otpw":             (lambda v: "1(OvertempWarning!)" if v else ""),
+    "ot":               (lambda v: "1(OvertempError!)" if v else ""),
+    "s2ga":             (lambda v: "1(ShortToGND_A!)" if v else ""),
+    "s2gb":             (lambda v: "1(ShortToGND_B!)" if v else ""),
+    "s2vsa":            (lambda v: "1(LowSideShort_A!)" if v else ""),
+    "s2vsb":            (lambda v: "1(LowSideShort_B!)" if v else ""),
+    "ola":              (lambda v: "1(OpenLoad_A!)" if v else ""),
+    "olb":              (lambda v: "1(OpenLoad_B!)" if v else ""),
+    "PWM_SCALE_AUTO":   (lambda v: str(tmc2130.decode_signed_int(v, 9)))
 }
 
 


### PR DESCRIPTION
To continue conversation started in #1156. Based on a prototype I added formatters for a minimal set of fields, trying to keep the output short:
```
DUMP_TMC stepper_a
GCONF:      000001c4 en_spreadCycle=1 pdn_disable=1 mstep_reg_select=1 multistep_filt=1
GSTAT:      00000001 reset=1
IFCNT:      00000036 IFCNT=54
OTP_READ:   0000000d OTP_FCLKTRIM=13
IOIN@TMC220x: 20000149 ENN=1 MS2=1 PDN_UART=1 SEL_A=1(TMC220x) VERSION=0x20
FACTORY_CONF: 0000000d FCLKTRIM=13
TSTEP:      000fffff TSTEP=1048575
MSCNT:      00000044 MSCNT=68
MSCURACT:   00e10064 CUR_A=100 CUR_B=225
CHOPCONF:   13030053 toff=3 hstrt=5 TBL=2 vsense=1 MRES=3(32usteps) intpol=1
DRV_STATUS: 80130000 CS_ACTUAL=19 stst=1
PWMCONF:    c80d0e24 PWM_OFS=36 PWM_GRAD=14 pwm_freq=1 pwm_autoscale=1 pwm_autograd=1 PWM_REG=8 PWM_LIM=12
PWM_SCALE:  00000016 PWM_SCALE_SUM=22
PWM_AUTO:   000e0024 PWM_OFS_AUTO=36 PWM_GRAD_AUTO=14
```