### PR TITLE
pause_resume: correctly handle absolute extrusion

### DIFF
--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -11,6 +11,7 @@ class PauseResume:
         self.recover_velocity = config.getfloat('recover_velocity', 50.)
         self.captured_position = None
         self.captured_speed = 0.
+        self.captured_epos = None
         self.toolhead = self.v_sd = None
         self.sd_paused = False
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
@@ -19,7 +20,15 @@ class PauseResume:
     def handle_ready(self):
         self.toolhead = self.printer.lookup_object('toolhead')
         self.v_sd = self.printer.lookup_object('virtual_sdcard', None)
+    def get_status(self, eventtime):
+        paused = self.captured_position is not None
+        return {
+            'is_paused': paused
+        }
     def cmd_PAUSE(self, params):
+        if self.captured_position is not None:
+            self.gcode.respond_info("Print already paused")
+            return
         if self.v_sd is not None and self.v_sd.is_active():
             # Printing from virtual sd, run pause command
             self.sd_paused = True
@@ -30,22 +39,29 @@ class PauseResume:
         self.toolhead.wait_moves()
         self.captured_position = self.toolhead.get_position()
         reactor = self.printer.get_reactor()
-        gc_status = self.gcode.get_status(reactor.monotonic())
-        self.captured_speed = gc_status['speed']
+        gcs = self.gcode.get_status(reactor.monotonic())
+        self.captured_speed = gcs['speed']
+        if gcs['abs_extrude']:
+            self.captured_epos = gcs['last_epos'] - gcs['base_epos']
     def cmd_RESUME(self, params):
+        if self.captured_position is None:
+            self.gcode.respond_info("Print is not paused, resume aborted")
+            return
         velocity = self.gcode.get_float(
             'VELOCITY', params, self.recover_velocity)
-        if self.captured_position is not None:
-            # restore previous xyz position
-            cur_pos = self.toolhead.get_position()
-            self.captured_position[3] = cur_pos[3]
-            self.toolhead.move(self.captured_position, velocity)
-            self.toolhead.get_last_move_time()
-            self.gcode.reset_last_position()
-            # restore previous speed
+
+        cur_pos = self.toolhead.get_position()
+        self.captured_position[3] = cur_pos[3]
+        self.toolhead.move(self.captured_position, velocity)
+        self.toolhead.get_last_move_time()
+        self.gcode.reset_last_position()
+        # restore previous speed
+        self.gcode.run_script_from_command(
+            "G1 F%.6f" % (self.captured_speed))
+        if self.captured_epos is not None:
             self.gcode.run_script_from_command(
-                "G1 F%.6f" % (self.captured_speed))
-        self.captured_position = None
+                "G92 E%.6f" % (self.captured_epos))
+        self.captured_position = self.captured_epos = None
         if self.sd_paused:
             # Printing from virtual sd, run pause command
             self.v_sd.cmd_M24({})

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -104,6 +104,7 @@ class GCodeParser:
             'speed_factor': self.speed_factor * 60.,
             'speed': self.speed,
             'extrude_factor': self.extrude_factor,
+            'abs_extrude': self.absoluteextrude,
             'busy': busy,
             'last_xpos': self.last_position[0],
             'last_ypos': self.last_position[1],


### PR DESCRIPTION
When a gcode is sliced using absolute extrusion the E axis gcode position needs to be captured after a pause so the offset can be correctly restored using G92.

@Hywelmartin @numanair, would you like to test these changes?  If so, slice an object using absolute extrusion, move the E-axis to unload during a pause, and make sure that it properly resumes extrusion. It works as it should in my tests.

Also included is a get_status() function that returns the paused state, it may be useful in combination with the status wrapper work.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>