### PR TITLE
adc: Enable ADC support for samd51 devices

### DIFF
--- a/src/atsamd/Kconfig
+++ b/src/atsamd/Kconfig
@@ -6,7 +6,7 @@ config ATSAMD_SELECT
     bool
     default y
     select HAVE_GPIO
-    select HAVE_GPIO_ADC if MACH_SAMD21
+    select HAVE_GPIO_ADC
     select HAVE_GPIO_I2C
     select HAVE_GPIO_SPI if MACH_SAMD21
     select HAVE_GPIO_HARD_PWM if MACH_SAMD21

--- a/src/atsamd/adc.c
+++ b/src/atsamd/adc.c
@@ -9,12 +9,27 @@
 #include "internal.h" // GPIO
 #include "sched.h" // sched_shutdown
 
+#if CONFIG_MACH_SAMD21
 static const uint8_t adc_pins[] = {
     GPIO('A', 2), GPIO('A', 3), GPIO('B', 8), GPIO('B', 9), GPIO('A', 4),
     GPIO('A', 5), GPIO('A', 6), GPIO('A', 7), GPIO('B', 0), GPIO('B', 1),
     GPIO('B', 2), GPIO('B', 3), GPIO('B', 4), GPIO('B', 5), GPIO('B', 6),
     GPIO('B', 7), GPIO('A', 8), GPIO('A', 9), GPIO('A', 10), GPIO('A', 11)
 };
+#elif CONFIG_MACH_SAMD51
+static const uint8_t adc_pins[] = {
+    /* ADC0 */
+    GPIO('A', 2), GPIO('A', 3), GPIO('B', 8), GPIO('B', 9), GPIO('A', 4),
+    GPIO('A', 5), GPIO('A', 6), GPIO('A', 7), GPIO('A', 8), GPIO('A', 9),
+    GPIO('A', 10), GPIO('A', 11), GPIO('B', 0), GPIO('B', 1), GPIO('B', 2),
+    GPIO('B', 3),
+    /* ADC1 */
+    GPIO('B', 8), GPIO('B', 9), GPIO('A', 8), GPIO('A', 9), GPIO('C', 2),
+    GPIO('C', 3), GPIO('B', 4), GPIO('B', 5), GPIO('B', 6), GPIO('B', 7),
+    GPIO('C', 0), GPIO('C', 1), GPIO('C', 30), GPIO('C', 31), GPIO('D', 0),
+    GPIO('D', 1)
+};
+#endif
 
 DECL_CONSTANT(ADC_MAX, 4095);
 
@@ -27,8 +42,14 @@ adc_init(void)
     have_run_init = 1;
 
     // Enable adc clock
+#if CONFIG_MACH_SAMD21
     enable_pclock(ADC_GCLK_ID, ID_ADC);
+#elif CONFIG_MACH_SAMD51
+    enable_pclock(ADC0_GCLK_ID, ID_ADC0);
+    enable_pclock(ADC1_GCLK_ID, ID_ADC1);
+#endif
 
+#if CONFIG_MACH_SAMD21
     // Load calibraiton info
     uint32_t v = *((uint32_t*)ADC_FUSES_BIASCAL_ADDR);
     uint32_t bias = (v & ADC_FUSES_BIASCAL_Msk) >> ADC_FUSES_BIASCAL_Pos;
@@ -44,6 +65,42 @@ adc_init(void)
     ADC->CTRLB.reg = ADC_CTRLB_PRESCALER_DIV128;
     ADC->SAMPCTRL.reg = 63;
     ADC->CTRLA.reg = ADC_CTRLA_ENABLE;
+
+#elif CONFIG_MACH_SAMD51
+    // Load calibration info
+    // ADC0
+    uint32_t v = *((uint32_t*)ADC0_FUSES_BIASREFBUF_ADDR);
+    uint32_t refbuf = (v & ADC0_FUSES_BIASREFBUF_Msk) >> ADC0_FUSES_BIASREFBUF_Pos;
+    v = *((uint32_t*)ADC0_FUSES_BIASR2R_ADDR);
+    uint32_t r2r = (v & ADC0_FUSES_BIASR2R_Msk) >> ADC0_FUSES_BIASR2R_Pos;
+    v = *((uint32_t*)ADC0_FUSES_BIASCOMP_ADDR);
+    uint32_t comp = (v & ADC0_FUSES_BIASCOMP_Msk) >> ADC0_FUSES_BIASCOMP_Pos;
+    ADC0->CALIB.reg = ADC0_FUSES_BIASREFBUF(refbuf) | ADC0_FUSES_BIASR2R(r2r) | ADC0_FUSES_BIASCOMP(comp);
+
+    // ADC1
+    v = *((uint32_t*)ADC1_FUSES_BIASREFBUF_ADDR);
+    refbuf = (v & ADC1_FUSES_BIASREFBUF_Msk) >> ADC1_FUSES_BIASREFBUF_Pos;
+    v = *((uint32_t*)ADC1_FUSES_BIASR2R_ADDR);
+    r2r = (v & ADC1_FUSES_BIASR2R_Msk) >> ADC1_FUSES_BIASR2R_Pos;
+    v = *((uint32_t*)ADC1_FUSES_BIASCOMP_ADDR);
+    comp = (v & ADC1_FUSES_BIASCOMP_Msk) >> ADC1_FUSES_BIASCOMP_Pos;
+    ADC1->CALIB.reg = ADC1_FUSES_BIASREFBUF(refbuf) | ADC1_FUSES_BIASR2R(r2r) | ADC1_FUSES_BIASCOMP(comp);
+
+    // Setup and enable
+    // ADC0
+    ADC0->REFCTRL.reg = ADC_REFCTRL_REFSEL_INTVCC1;
+    while(ADC0->SYNCBUSY.reg & ADC_SYNCBUSY_REFCTRL);
+    ADC0->SAMPCTRL.reg = ADC_SAMPCTRL_SAMPLEN(63);
+    while (ADC0->SYNCBUSY.reg & ADC_SYNCBUSY_SAMPCTRL);
+    ADC0->CTRLA.reg = ADC_CTRLA_PRESCALER(ADC_CTRLA_PRESCALER_DIV128_Val) | ADC_CTRLA_ENABLE;
+
+    // ADC1
+    ADC1->REFCTRL.reg = ADC_REFCTRL_REFSEL_INTVCC1;
+    while(ADC1->SYNCBUSY.reg & ADC_SYNCBUSY_REFCTRL);
+    ADC1->SAMPCTRL.reg = ADC_SAMPCTRL_SAMPLEN(63);
+    while(ADC1->SYNCBUSY.reg & ADC_SYNCBUSY_SAMPCTRL);
+    ADC1->CTRLA.reg = ADC_CTRLA_PRESCALER(ADC_CTRLA_PRESCALER_DIV128_Val) | ADC_CTRLA_ENABLE;
+#endif
 }
 
 struct gpio_adc
@@ -57,14 +114,19 @@ gpio_adc_setup(uint8_t pin)
         if (adc_pins[chan] == pin)
             break;
     }
-
+#if CONFIG_MACH_SAMD21
+    Adc* reg = ADC;
+#elif CONFIG_MACH_SAMD51
+    Adc* reg = (chan < 16 ? ADC0 : ADC1);
+    chan %= 16;
+#endif
     // Enable ADC
     adc_init();
 
     // Set pin in ADC mode
     gpio_peripheral(pin, 'B', 0);
 
-    return (struct gpio_adc){ chan };
+    return (struct gpio_adc){ .regs=reg, .chan=chan };
 }
 
 enum { ADC_DUMMY=0xff };
@@ -76,8 +138,9 @@ static uint8_t last_analog_read = ADC_DUMMY;
 uint32_t
 gpio_adc_sample(struct gpio_adc g)
 {
+    Adc *reg = g.regs;
     if (last_analog_read == g.chan) {
-        if (ADC->INTFLAG.reg & ADC_INTFLAG_RESRDY)
+        if (reg->INTFLAG.reg & ADC_INTFLAG_RESRDY)
             // Sample now ready
             return 0;
         // ADC is still busy
@@ -89,11 +152,20 @@ gpio_adc_sample(struct gpio_adc g)
     last_analog_read = g.chan;
 
     // Set the channel to sample
-    ADC->INPUTCTRL.reg = (ADC_INPUTCTRL_MUXPOS(g.chan)
-                          | ADC_INPUTCTRL_MUXNEG_GND | ADC_INPUTCTRL_GAIN_DIV2);
+    reg->INPUTCTRL.reg = (ADC_INPUTCTRL_MUXPOS(g.chan) |
+                          ADC_INPUTCTRL_MUXNEG_GND |
+#if CONFIG_MACH_SAMD21
+                          ADC_INPUTCTRL_GAIN_DIV2);
+#elif CONFIG_MACH_SAMD51
+                          0);
+    while(reg->SYNCBUSY.reg & ADC_SYNCBUSY_INPUTCTRL);
+#endif
 
     // Start the sample
-    ADC->SWTRIG.reg = ADC_SWTRIG_START;
+    reg->SWTRIG.reg = ADC_SWTRIG_START;
+#if CONFIG_MACH_SAMD51
+    while(reg->SYNCBUSY.reg & ADC_SYNCBUSY_SWTRIG);
+#endif
 
     // Schedule next attempt after sample is likely to be complete
 need_delay:
@@ -105,16 +177,20 @@ uint16_t
 gpio_adc_read(struct gpio_adc g)
 {
     last_analog_read = ADC_DUMMY;
-    return ADC->RESULT.reg;
+    return ((Adc *)g.regs)->RESULT.reg;
 }
 
 // Cancel a sample that may have been started with gpio_adc_sample()
 void
 gpio_adc_cancel_sample(struct gpio_adc g)
 {
+    Adc * reg = g.regs;
     if (last_analog_read == g.chan) {
-        ADC->SWTRIG.reg = ADC_SWTRIG_FLUSH;
-        ADC->INTFLAG.reg = ADC_INTFLAG_RESRDY;
+        reg->SWTRIG.reg = ADC_SWTRIG_FLUSH;
+#if CONFIG_MACH_SAMD51
+        while(reg->SYNCBUSY.reg & ADC_SYNCBUSY_SWTRIG);
+#endif
+        reg->INTFLAG.reg = ADC_INTFLAG_RESRDY;
         last_analog_read = ADC_DUMMY;
     }
 }

--- a/src/atsamd/gpio.h
+++ b/src/atsamd/gpio.h
@@ -28,6 +28,7 @@ struct gpio_pwm gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint8_t val);
 void gpio_pwm_write(struct gpio_pwm g, uint8_t val);
 
 struct gpio_adc {
+    void *regs;
     uint32_t chan;
 };
 struct gpio_adc gpio_adc_setup(uint8_t pin);


### PR DESCRIPTION
This enables ADC support on the samd51 port.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>