### PR TITLE
Enforce exclusive access on POSIX, this is default behavior on windows.

### DIFF
--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -59,7 +59,7 @@ class SerialReader:
             try:
                 if self.baud:
                     self.ser = serial.Serial(
-                        self.serialport, self.baud, timeout=0)
+                        self.serialport, self.baud, timeout=0, exclusive=True)
                 else:
                     self.ser = open(self.serialport, 'rb+')
             except (OSError, IOError, serial.SerialException) as e:
@@ -285,7 +285,7 @@ def stk500v2_leave(ser, reactor):
 # Attempt an arduino style reset on a serial port
 def arduino_reset(serialport, reactor):
     # First try opening the port at a different baud
-    ser = serial.Serial(serialport, 2400, timeout=0)
+    ser = serial.Serial(serialport, 2400, timeout=0, exclusive=True)
     ser.read(1)
     reactor.pause(reactor.monotonic() + 0.100)
     # Then toggle DTR


### PR DESCRIPTION
module: klippy/serialhdl.py

Set exclusive=True in serial.Serial commands to ensure they are opened in exclusive mode on Posix systems. This will help prevent misconfigurations when setting up multiple printers on the same host. Exclusive access is the default behavior on windows, and adding this flag won't affect them ( it is ignored ).

Resolves #1210 

Signed-off-by: Daniel Joyce <daniel.a.joyce@gmail.com>