### PR TITLE
docs: Update duet2 benchmarks

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -308,18 +308,21 @@ stepper result is `SET ticks 553`, the best dual stepper result is
 
 The following configuration sequence is used on the Duet Wifi:
 ```
-allocate_oids count=3
+allocate_oids count=4
 config_stepper oid=0 step_pin=PD6 dir_pin=PD11 min_stop_interval=0 invert_step=0
 config_stepper oid=1 step_pin=PD7 dir_pin=PD12 min_stop_interval=0 invert_step=0
 config_stepper oid=2 step_pin=PD8 dir_pin=PD13 min_stop_interval=0 invert_step=0
+config_stepper oid=3 step_pin=PD5 dir_pin=PA1 min_stop_interval=0 invert_step=0
 finalize_config crc=0
+
 ```
 
-The test was last run on commit `9f3517fd` with gcc version
+The test was last run on commit `59a60d68` with gcc version
 `arm-none-eabi-gcc 7.3.1 20180622 (release)
 [ARM/embedded-7-branch revision 261907]`. The best single stepper
-result is `SET ticks 526`, the best dual stepper result is `SET ticks
-524`, and the best three stepper result is `SET ticks 552`.
+result is `SET ticks 519`, the best dual stepper result is `SET ticks
+520`, and the best three stepper result is `SET ticks 525`, and the
+best four stepper result is `SET ticks 703`.
 
 ### Beaglebone PRU step rate benchmark ###
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -136,9 +136,9 @@ represent total number of steps per second on the micro-controller.
 | Arduino Due (SAM3X8E)       | 438K              | 438K              |
 | Smoothieboard (LPC1768)     | 574K              | 574K              |
 | SAM4S8C                     | 578K              | 578K              |
-| Duet2 Wifi/Eth (SAM4E8E)    | 652K              | 652K              |
 | Smoothieboard (LPC1769)     | 661K              | 661K              |
 | Beaglebone PRU              | 680K              | 680K              |
+| Duet2 Wifi/Eth (SAM4E8E)    | 686K              | 686K              |
 | Adafruit Metro M4 (SAMD51)  | 733K              | 733K              |
 
 On AVR platforms, the highest achievable step rate is with just one


### PR DESCRIPTION
Latest benchmark with the armcm timer and sram matrix improvements.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>