### PR TITLE
Generic Heater Support

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1176,6 +1176,33 @@
 #    Directly sets the default prefix. If present, this value will override
 #    the "default_type".
 
+# The heater_generic section is used to describe a custom/generic heater.
+# These behave the same as typical heaters (extruders, heated beds) and
+# can be configured as similarly.
+# However, a gcode_id must be supplied which is used for temperature reporting.
+# See notes on the SET_HEATER_TEMPERATURE command for setting the temperature.
+#[heater_generic my_generic_heater]
+#gcode_id: C
+#    A mandatory parameter that is required for reporting the temperature
+#    through the M105 command.
+#heater_pin:
+#max_power:
+#sensor_type:
+#sensor_pin:
+#pullup_resistor:
+#adc_voltage:
+#smooth_time:
+#control:
+#pid_Kp:
+#pid_Ki:
+#pid_Kd:
+#pid_integral_max:
+#pwm_cycle_time:
+#min_extrude_temp:
+#min_temp:
+#max_temp:
+#   See the example.cfg for the definition of the above parameters.
+
 # Pause/Resume functionality with support of position capture and restore
 #[pause_resume]
 #recover_velocity: 50.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -111,6 +111,9 @@ The following standard commands are supported:
   [ACCEL_TO_DECEL=<value>] [SQUARE_CORNER_VELOCITY=<value>]`: Modify
   the printer's velocity limits. Note that one may only set values
   less than or equal to the limits specified in the config file.
+- `SET_HEATER_TEMPERATURE HEATER=<heater_name> [TARGET=<target_temperature>]`:
+  Sets the target temperature for a heater. If a target temperature is
+  not supplied, the target is 0.
 - `SET_PRESSURE_ADVANCE [EXTRUDER=<config_name>] [ADVANCE=<pressure_advance>]
   [ADVANCE_LOOKAHEAD_TIME=<pressure_advance_lookahead_time>]`:
   Set pressure advance parameters. If EXTRUDER is not specified, it

--- a/klippy/extras/heater_generic.py
+++ b/klippy/extras/heater_generic.py
@@ -1,0 +1,16 @@
+# Support for a generic heater
+#
+# Copyright (C) 2019  John Jardine <john@gprime.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+
+class PrinterHeaterGeneric:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        gcode_id = config.get("gcode_id")
+        self.heater = self.printer.lookup_object('heater').setup_heater(config, gcode_id)
+
+def load_config_prefix(config):
+    return PrinterHeaterGeneric(config)

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -21,8 +21,9 @@ class error(Exception):
 class Heater:
     error = error
     def __init__(self, config, sensor, gcode_id):
-        printer = config.get_printer()
-        self.name = config.get_name()
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object("gcode")
+        self.name = config.get_name().split()[-1]
         self.gcode_id = gcode_id
         # Setup sensor
         self.sensor = sensor
@@ -34,7 +35,7 @@ class Heater:
         # Setup temperature checks
         self.min_extrude_temp = config.getfloat(
             'min_extrude_temp', 170., minval=self.min_temp, maxval=self.max_temp)
-        is_fileoutput = printer.get_start_args().get('debugoutput') is not None
+        is_fileoutput = self.printer.get_start_args().get('debugoutput') is not None
         self.can_extrude = self.min_extrude_temp <= 0. or is_fileoutput
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
         self.smooth_time = config.getfloat('smooth_time', 2., above=0.)
@@ -51,7 +52,7 @@ class Heater:
         self.control = algo(self, config)
         # Setup output heater pin
         heater_pin = config.get('heater_pin')
-        ppins = printer.lookup_object('pins')
+        ppins = self.printer.lookup_object('pins')
         if algo is ControlBangBang and self.max_power == 1.:
             self.mcu_pwm = ppins.setup_pin('digital_out', heater_pin)
         else:
@@ -61,8 +62,11 @@ class Heater:
             self.mcu_pwm.setup_cycle_time(pwm_cycle_time)
         self.mcu_pwm.setup_max_duration(MAX_HEAT_TIME)
         # Load additional modules
-        printer.try_load_module(config, "verify_heater %s" % (self.name,))
-        printer.try_load_module(config, "pid_calibrate")
+        self.printer.try_load_module(config, "verify_heater %s" % (self.name,))
+        self.printer.try_load_module(config, "pid_calibrate")
+        self.gcode.register_mux_command("SET_HEATER_TEMPERATURE", "HEATER", self.name,
+                                    self.cmd_SET_HEATER_TEMPERATURE,
+                                    desc=self.cmd_SET_HEATER_TEMPERATURE_help)
     def set_pwm(self, read_time, value):
         if self.target_temp <= 0.:
             value = 0.
@@ -134,6 +138,11 @@ class Heater:
             target_temp = self.target_temp
             smoothed_temp = self.smoothed_temp
         return {'temperature': smoothed_temp, 'target': target_temp}
+    cmd_SET_HEATER_TEMPERATURE_help = "Sets a heater temperature"
+    def cmd_SET_HEATER_TEMPERATURE(self, params):
+        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
+        temp = self.gcode.get_float('TARGET', params, 0.)
+        self.set_temp(print_time, temp)
 
 
 ######################################################################
@@ -229,7 +238,7 @@ class PrinterHeaters:
     def add_sensor(self, sensor_type, sensor_factory):
         self.sensors[sensor_type] = sensor_factory
     def setup_heater(self, config, gcode_id):
-        heater_name = config.get_name()
+        heater_name = config.get_name().split()[-1]
         if heater_name == 'extruder':
             heater_name = 'extruder0'
         if heater_name in self.heaters:


### PR DESCRIPTION
Adds the ability to register a custom/generic heater through a new extra called heater_generic.
This takes a gcode_id that is reported by M105. Adds a new command to set the temperature for any heater using the syntax:
SET_HEATER_TEMPERATURE HEATER=<heater_name> TARGET=<target_temp>

Signed-off-by: John Jardine <john@gprime.net>