### PR TITLE
Pressure advance testing tower

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -160,6 +160,14 @@ The following standard commands are supported:
   for calibrating a Z position_endstop config setting. See the
   MANUAL_PROBE command for details on the parameters and the
   additional commands available while the tool is active.
+- `TUNING_TOWER COMMAND=<command> PARAMETER=<name> START=<value>
+  FACTOR=<value> [BAND=<value>]`: A tool for tuning a parameter on
+  each Z height during a print. The tool will run the given COMMAND
+  with the given PARAMETER assigned to the value using the formula
+  `value = start + factor * z_height`. If BAND is provided then the
+  adjustment will only be made every BAND millimeters of z height - in
+  that case the formula used is `value = start + factor *
+  ((floor(z_height / band) + .5) * band)`.
 - `SET_IDLE_TIMEOUT [TIMEOUT=<timeout>]`:  Allows the user to set the
   idle timeout (in seconds).
 - `RESTART`: This will cause the host software to reload its config

--- a/docs/prints/square_tower.scad
+++ b/docs/prints/square_tower.scad
@@ -1,0 +1,63 @@
+// Calibration test tower
+//
+// Generate STL using OpenSCAD:
+//   openscad square_tower.scad -o square_tower.stl
+
+square_width = 5;
+square_size = 60;
+square_height = 50;
+antiwarp_height = .8;
+antiwarp_radius = 5;
+
+module square_with_anti_warp() {
+    module anti_warp_cylinder() {
+        cylinder(r=antiwarp_radius, h=antiwarp_height, $fs=.5);
+    }
+    cube([square_size, square_size, square_height]);
+    dist = antiwarp_radius / 2.5;
+    translate([dist, dist, 0])
+        anti_warp_cylinder();
+    translate([square_size-dist, dist, 0])
+        anti_warp_cylinder();
+    translate([dist, square_size-dist, 0])
+        anti_warp_cylinder();
+    translate([square_size-dist, square_size-dist, 0])
+        anti_warp_cylinder();
+}
+
+module hollow_square() {
+    difference() {
+        square_with_anti_warp();
+        translate([square_width, square_width, -1])
+            cube([square_size-2*square_width, square_size-2*square_width,
+                  square_height+2]);
+    }
+}
+
+module notch() {
+    CUT = 0.01;
+    depth = .5;
+    width = 1;
+    translate([-depth, -width, -CUT])
+        cube([2*depth, 2*width, square_height + 2*CUT]);
+}
+
+module square_with_notches() {
+    difference() {
+        // Start with initial square
+        hollow_square();
+        // Remove four notches on inside perimeter
+        translate([square_width, square_size/2 - 4, 0])
+            notch();
+        translate([square_size/2, square_size - square_width, 0])
+            rotate([0, 0, 90])
+                notch();
+        translate([square_size - square_width, square_size/2, 0])
+            notch();
+        translate([square_size/2, square_width, 0])
+            rotate([0, 0, 90])
+                notch();
+    }
+}
+
+square_with_notches();

--- a/docs/prints/square_tower.stl
+++ b/docs/prints/square_tower.stl
@@ -1,0 +1,3026 @@
+solid OpenSCAD_Model
+  facet normal 1 0 0
+    outer loop
+      vertex 60 60 50
+      vertex 60 53.4473 0.799999
+      vertex 60 60 0.799999
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 53.4473 0.799999
+      vertex 60 6.55274 0.799999
+      vertex 60 53.4473 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 60 50
+      vertex 60 6.55274 0.799999
+      vertex 60 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 60 0 50
+      vertex 60 6.55274 0.799999
+      vertex 60 60 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 6.55274 0.799999
+      vertex 60 0 50
+      vertex 60 0 0.799999
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 53.4473 0
+      vertex 60 6.55274 0.799999
+      vertex 60 6.55274 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 25 50
+      vertex 4.5 25 50
+      vertex 5 5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 50
+      vertex 5 5 50
+      vertex 29 4.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 50
+      vertex 55.5 31 50
+      vertex 60 0 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 50
+      vertex 55 55 50
+      vertex 55.5 31 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 50
+      vertex 31 55.5 50
+      vertex 55 55 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 50
+      vertex 29 55.5 50
+      vertex 31 55.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 55.5 50
+      vertex 5 55 50
+      vertex 29 55 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 60 50
+      vertex 29 55.5 50
+      vertex 60 60 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 55 50
+      vertex 4.5 27 50
+      vertex 5 27 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 50
+      vertex 4.5 27 50
+      vertex 0 60 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 55 50
+      vertex 0 60 50
+      vertex 4.5 27 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 55.5 50
+      vertex 0 60 50
+      vertex 5 55 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 55.5 29 50
+      vertex 60 0 50
+      vertex 55.5 31 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55 5 50
+      vertex 55.5 29 50
+      vertex 55 29 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 29 50
+      vertex 55 5 50
+      vertex 60 0 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31 4.5 50
+      vertex 55 5 50
+      vertex 31 5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55 5 50
+      vertex 31 4.5 50
+      vertex 60 0 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 29 4.5 50
+      vertex 60 0 50
+      vertex 31 4.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 50
+      vertex 29 4.5 50
+      vertex 5 5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 27 50
+      vertex 0 0 50
+      vertex 4.5 25 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 4.5 50
+      vertex 0 0 50
+      vertex 60 0 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 25 50
+      vertex 0 0 50
+      vertex 5 5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 31 50
+      vertex 55 55 50
+      vertex 55 31 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55 55 50
+      vertex 31 55.5 50
+      vertex 31 55 50
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 63 2 0
+      vertex 62.8907 0.960441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 62.8907 0.960441 0
+      vertex 62.5677 -0.0336828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63 2 0
+      vertex 55 5 0
+      vertex 62.8907 3.03956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 62.5677 -0.0336828 0
+      vertex 62.0451 -0.938926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.8907 3.03956 0
+      vertex 55 5 0
+      vertex 62.5677 4.03368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 62.0451 -0.938926 0
+      vertex 61.3457 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.5677 4.03368 0
+      vertex 55 5 0
+      vertex 62.0451 4.93893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 61.3457 -1.71572 0
+      vertex 60.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0451 4.93893 0
+      vertex 55 5 0
+      vertex 61.3457 5.71572 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60 6.55274 0
+      vertex 61.3457 5.71572 0
+      vertex 55 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.3457 5.71572 0
+      vertex 60 6.55274 0
+      vertex 60.5 6.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 60.5 -2.33013 0
+      vertex 59.5451 -2.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 63 58 0
+      vertex 62.8907 56.9604 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 62.8907 56.9604 0
+      vertex 62.5677 55.9663 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63 58 0
+      vertex 55 55 0
+      vertex 62.8907 59.0396 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 62.5677 55.9663 0
+      vertex 62.0451 55.0611 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.8907 59.0396 0
+      vertex 55 55 0
+      vertex 62.5677 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 62.0451 55.0611 0
+      vertex 61.3457 54.2843 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.5677 60.0337 0
+      vertex 55 55 0
+      vertex 62.0451 60.9389 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 53.4473 0
+      vertex 61.3457 54.2843 0
+      vertex 60.5 53.6699 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.0451 60.9389 0
+      vertex 55 55 0
+      vertex 61.3457 61.7157 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.3457 54.2843 0
+      vertex 60 53.4473 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.3457 61.7157 0
+      vertex 55 55 0
+      vertex 60.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 6.55274 0
+      vertex 55.5 29 0
+      vertex 60 53.4473 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 59.5451 -2.75528 0
+      vertex 58.5226 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.5 31 0
+      vertex 60 53.4473 0
+      vertex 55.5 29 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 58.5226 -2.97261 0
+      vertex 57.4774 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 31 0
+      vertex 60 53.4473 0
+      vertex 55.5 31 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 57.4774 -2.97261 0
+      vertex 56.4549 -2.75528 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.5 62.3301 0
+      vertex 55 55 0
+      vertex 59.5451 62.7553 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 56.4549 -2.75528 0
+      vertex 55.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.5451 62.7553 0
+      vertex 55 55 0
+      vertex 58.5226 62.9726 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 58.5226 62.9726 0
+      vertex 55 55 0
+      vertex 57.4774 62.9726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.4774 62.9726 0
+      vertex 55 55 0
+      vertex 56.4549 62.7553 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60 53.4473 0
+      vertex 55 31 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.4549 62.7553 0
+      vertex 55 55 0
+      vertex 55.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 54.6543 61.7157 0
+      vertex 55.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 53.9549 60.9389 0
+      vertex 54.6543 61.7157 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.4213 60 0
+      vertex 53.9549 60.9389 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.9549 60.9389 0
+      vertex 53.4213 60 0
+      vertex 53.4323 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31 55 0
+      vertex 53.4213 60 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31 55.5 0
+      vertex 53.4213 60 0
+      vertex 31 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29 55.5 0
+      vertex 53.4213 60 0
+      vertex 31 55.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 53.4213 60 0
+      vertex 29 55.5 0
+      vertex 6.57867 60 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 53.4473 0
+      vertex 5 27 0
+      vertex 4.5 27 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29 55 0
+      vertex 6.57867 60 0
+      vertex 29 55.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.57867 60 0
+      vertex 6.04508 60.9389 0
+      vertex 6.56773 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 6.04508 60.9389 0
+      vertex 6.57867 60 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 6.57867 60 0
+      vertex 29 55 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.04508 60.9389 0
+      vertex 5 55 0
+      vertex 5.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 4.5 62.3301 0
+      vertex 5.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 27 0
+      vertex 0 53.4473 0
+      vertex 5 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.4213 0 0
+      vertex 29 4.5 0
+      vertex 31 4.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.57867 0 0
+      vertex 29 4.5 0
+      vertex 53.4213 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.57867 0 0
+      vertex 29 5 0
+      vertex 29 4.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.04508 -0.938926 0
+      vertex 6.57867 0 0
+      vertex 6.56773 -0.0336828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex 6.04508 -0.938926 0
+      vertex 5.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.57867 0 0
+      vertex 5 5 0
+      vertex 29 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.04508 -0.938926 0
+      vertex 5 5 0
+      vertex 6.57867 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.5 -2.33013 0
+      vertex 5 5 0
+      vertex 5.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.54508 -2.75528 0
+      vertex 5 5 0
+      vertex 4.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex 0 6.55274 0
+      vertex 5 25 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 5 25 0
+      vertex 0 6.55274 0
+      vertex 4.5 25 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 4.5 25 0
+      vertex 0 6.55274 0
+      vertex 4.5 27 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.52264 -2.97261 0
+      vertex 5 5 0
+      vertex 3.54508 -2.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 53.4473 0
+      vertex 4.5 27 0
+      vertex 0 6.55274 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.47736 -2.97261 0
+      vertex 5 5 0
+      vertex 2.52264 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.34565 54.2843 0
+      vertex 5 55 0
+      vertex 0 53.4473 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.454914 -2.75528 0
+      vertex 5 5 0
+      vertex 1.47736 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 3.54508 62.7553 0
+      vertex 4.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.5 -2.33013 0
+      vertex 5 5 0
+      vertex 0.454914 -2.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 2.52264 62.9726 0
+      vertex 3.54508 62.7553 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 1.47736 62.9726 0
+      vertex 2.52264 62.9726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.34565 -1.71572 0
+      vertex 5 5 0
+      vertex -0.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.04508 -0.938926 0
+      vertex 5 5 0
+      vertex -1.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.56773 -0.0336828 0
+      vertex 5 5 0
+      vertex -2.04508 -0.938926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 6.55274 0
+      vertex -1.34565 5.71572 0
+      vertex -0.5 6.33013 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -1.34565 5.71572 0
+      vertex 5 5 0
+      vertex -2.04508 4.93893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex -1.34565 5.71572 0
+      vertex 0 6.55274 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.89074 0.960441 0
+      vertex 5 5 0
+      vertex -2.56773 -0.0336828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex -2.56773 4.03368 0
+      vertex -2.04508 4.93893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3 2 0
+      vertex 5 5 0
+      vertex -2.89074 0.960441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex -2.89074 3.03956 0
+      vertex -2.56773 4.03368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex -3 2 0
+      vertex -2.89074 3.03956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 29 0
+      vertex 60 6.55274 0
+      vertex 55 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.6543 -1.71572 0
+      vertex 55 5 0
+      vertex 55.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.9549 -0.938926 0
+      vertex 55 5 0
+      vertex 54.6543 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.4213 0 0
+      vertex 53.9549 -0.938926 0
+      vertex 53.4323 -0.0336828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.9549 -0.938926 0
+      vertex 53.4213 0 0
+      vertex 55 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31 5 0
+      vertex 53.4213 0 0
+      vertex 31 4.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.4213 0 0
+      vertex 31 5 0
+      vertex 55 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 6.55274 0
+      vertex 55 29 0
+      vertex 55.5 29 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 0.454914 62.7553 0
+      vertex 1.47736 62.9726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.34565 54.2843 0
+      vertex 0 53.4473 0
+      vertex -0.5 53.6699 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -0.5 62.3301 0
+      vertex 0.454914 62.7553 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -1.34565 54.2843 0
+      vertex -2.04508 55.0611 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -1.34565 61.7157 0
+      vertex -0.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.56773 55.9663 0
+      vertex 5 55 0
+      vertex -2.04508 55.0611 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -2.04508 60.9389 0
+      vertex -1.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.89074 56.9604 0
+      vertex 5 55 0
+      vertex -2.56773 55.9663 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -2.56773 60.0337 0
+      vertex -2.04508 60.9389 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3 58 0
+      vertex 5 55 0
+      vertex -2.89074 56.9604 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -2.89074 59.0396 0
+      vertex -2.56773 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -3 58 0
+      vertex -2.89074 59.0396 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 53.4473 0
+      vertex 0 6.55274 0
+      vertex 0 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 53.4473 0.799999
+      vertex 0 60 50
+      vertex 0 60 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 6.55274 0.799999
+      vertex 0 53.4473 0.799999
+      vertex 0 6.55274 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 53.4473 0.799999
+      vertex 0 6.55274 0.799999
+      vertex 0 60 50
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 50
+      vertex 0 6.55274 0.799999
+      vertex 0 0 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 6.55274 0.799999
+      vertex 0 0 50
+      vertex 0 60 50
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 53.4213 60 0
+      vertex 6.57867 60 0.799999
+      vertex 53.4213 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6.57867 60 0.799999
+      vertex 53.4213 60 0
+      vertex 6.57867 60 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 53.4213 60 0.799999
+      vertex 60 60 50
+      vertex 60 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 60 60 50
+      vertex 53.4213 60 0.799999
+      vertex 0 60 50
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 6.57867 60 0.799999
+      vertex 0 60 50
+      vertex 53.4213 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 60 50
+      vertex 6.57867 60 0.799999
+      vertex 0 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6.57867 0 0
+      vertex 53.4213 0 0.799999
+      vertex 6.57867 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 53.4213 0 0.799999
+      vertex 6.57867 0 0
+      vertex 53.4213 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6.57867 0 0.799999
+      vertex 0 0 50
+      vertex 0 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 50
+      vertex 6.57867 0 0.799999
+      vertex 60 0 50
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 53.4213 0 0.799999
+      vertex 60 0 50
+      vertex 6.57867 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 60 0 50
+      vertex 53.4213 0 0.799999
+      vertex 60 0 0.799999
+    endloop
+  endfacet
+  facet normal 0.40673 -0.913548 0
+    outer loop
+      vertex 3.54508 -2.75528 0
+      vertex 4.5 -2.33013 0.799999
+      vertex 3.54508 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0.40673 -0.913548 0
+    outer loop
+      vertex 4.5 -2.33013 0.799999
+      vertex 3.54508 -2.75528 0
+      vertex 4.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104527 0
+    outer loop
+      vertex -2.89074 0.960441 0
+      vertex -3 2 0.799999
+      vertex -3 2 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104527 0
+    outer loop
+      vertex -3 2 0.799999
+      vertex -2.89074 0.960441 0
+      vertex -2.89074 0.960441 0.799999
+    endloop
+  endfacet
+  facet normal -0.866022 -0.500005 0
+    outer loop
+      vertex -2.04508 -0.938926 0
+      vertex -2.56773 -0.0336828 0.799999
+      vertex -2.56773 -0.0336828 0
+    endloop
+  endfacet
+  facet normal -0.866022 -0.500005 0
+    outer loop
+      vertex -2.56773 -0.0336828 0.799999
+      vertex -2.04508 -0.938926 0
+      vertex -2.04508 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0.866022 -0.500005 0
+    outer loop
+      vertex 6.04508 -0.938926 0.799999
+      vertex 6.56773 -0.0336828 0
+      vertex 6.56773 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0.866022 -0.500005 0
+    outer loop
+      vertex 6.56773 -0.0336828 0
+      vertex 6.04508 -0.938926 0.799999
+      vertex 6.04508 -0.938926 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 6.55274 0.799999
+      vertex -0.5 6.33013 0.799999
+      vertex 0 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.57867 0 0.799999
+      vertex 6.04508 -0.938926 0.799999
+      vertex 6.56773 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex 6.04508 -0.938926 0.799999
+      vertex 6.57867 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.04508 -0.938926 0.799999
+      vertex 0 0 0.799999
+      vertex 5.34565 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.34565 -1.71572 0.799999
+      vertex 0 0 0.799999
+      vertex 4.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 -2.33013 0.799999
+      vertex 0 0 0.799999
+      vertex 3.54508 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.54508 -2.75528 0.799999
+      vertex 0 0 0.799999
+      vertex 2.52264 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.52264 -2.97261 0.799999
+      vertex 0 0 0.799999
+      vertex 1.47736 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.47736 -2.97261 0.799999
+      vertex 0 0 0.799999
+      vertex 0.454914 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -0.5 -2.33013 0.799999
+      vertex 0.454914 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.34565 5.71572 0.799999
+      vertex 0 0 0.799999
+      vertex -0.5 6.33013 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.04508 4.93893 0.799999
+      vertex 0 0 0.799999
+      vertex -1.34565 5.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -1.34565 -1.71572 0.799999
+      vertex -0.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.56773 4.03368 0.799999
+      vertex 0 0 0.799999
+      vertex -2.04508 4.93893 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -2.04508 -0.938926 0.799999
+      vertex -1.34565 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.89074 3.03956 0.799999
+      vertex 0 0 0.799999
+      vertex -2.56773 4.03368 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -2.56773 -0.0336828 0.799999
+      vertex -2.04508 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3 2 0.799999
+      vertex 0 0 0.799999
+      vertex -2.89074 3.03956 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -2.89074 0.960441 0.799999
+      vertex -2.56773 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -3 2 0.799999
+      vertex -2.89074 0.960441 0.799999
+    endloop
+  endfacet
+  facet normal -0.866024 0.500003 0
+    outer loop
+      vertex -2.56773 4.03368 0
+      vertex -2.04508 4.93893 0.799999
+      vertex -2.04508 4.93893 0
+    endloop
+  endfacet
+  facet normal -0.866024 0.500003 0
+    outer loop
+      vertex -2.04508 4.93893 0.799999
+      vertex -2.56773 4.03368 0
+      vertex -2.56773 4.03368 0.799999
+    endloop
+  endfacet
+  facet normal -0.743142 0.669133 0
+    outer loop
+      vertex -2.04508 4.93893 0
+      vertex -1.34565 5.71572 0.799999
+      vertex -1.34565 5.71572 0
+    endloop
+  endfacet
+  facet normal -0.743142 0.669133 0
+    outer loop
+      vertex -1.34565 5.71572 0.799999
+      vertex -2.04508 4.93893 0
+      vertex -2.04508 4.93893 0.799999
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex -3 2 0
+      vertex -2.89074 3.03956 0.799999
+      vertex -2.89074 3.03956 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex -2.89074 3.03956 0.799999
+      vertex -3 2 0
+      vertex -3 2 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.47736 -2.97261 0
+      vertex 2.52264 -2.97261 0.799999
+      vertex 1.47736 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 2.52264 -2.97261 0.799999
+      vertex 1.47736 -2.97261 0
+      vertex 2.52264 -2.97261 0
+    endloop
+  endfacet
+  facet normal -0.40673 0.913548 0
+    outer loop
+      vertex 0 6.55274 0
+      vertex -0.5 6.33013 0.799999
+      vertex 0 6.55274 0.799999
+    endloop
+  endfacet
+  facet normal -0.40673 0.913548 0
+    outer loop
+      vertex -0.5 6.33013 0.799999
+      vertex 0 6.55274 0
+      vertex -0.5 6.33013 0
+    endloop
+  endfacet
+  facet normal 0.207915 -0.978147 0
+    outer loop
+      vertex 2.52264 -2.97261 0
+      vertex 3.54508 -2.75528 0.799999
+      vertex 2.52264 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0.207915 -0.978147 0
+    outer loop
+      vertex 3.54508 -2.75528 0.799999
+      vertex 2.52264 -2.97261 0
+      vertex 3.54508 -2.75528 0
+    endloop
+  endfacet
+  facet normal -0.207914 -0.978147 0
+    outer loop
+      vertex 0.454914 -2.75528 0
+      vertex 1.47736 -2.97261 0.799999
+      vertex 0.454914 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal -0.207914 -0.978147 -0
+    outer loop
+      vertex 1.47736 -2.97261 0.799999
+      vertex 0.454914 -2.75528 0
+      vertex 1.47736 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0.587791 -0.809013 0
+    outer loop
+      vertex 4.5 -2.33013 0
+      vertex 5.34565 -1.71572 0.799999
+      vertex 4.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0.587791 -0.809013 0
+    outer loop
+      vertex 5.34565 -1.71572 0.799999
+      vertex 4.5 -2.33013 0
+      vertex 5.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal -0.406733 -0.913547 0
+    outer loop
+      vertex -0.5 -2.33013 0
+      vertex 0.454914 -2.75528 0.799999
+      vertex -0.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal -0.406733 -0.913547 -0
+    outer loop
+      vertex 0.454914 -2.75528 0.799999
+      vertex -0.5 -2.33013 0
+      vertex 0.454914 -2.75528 0
+    endloop
+  endfacet
+  facet normal -0.587791 0.809013 0
+    outer loop
+      vertex -0.5 6.33013 0
+      vertex -1.34565 5.71572 0.799999
+      vertex -0.5 6.33013 0.799999
+    endloop
+  endfacet
+  facet normal -0.587791 0.809013 0
+    outer loop
+      vertex -1.34565 5.71572 0.799999
+      vertex -0.5 6.33013 0
+      vertex -1.34565 5.71572 0
+    endloop
+  endfacet
+  facet normal 0.743144 -0.669131 0
+    outer loop
+      vertex 5.34565 -1.71572 0.799999
+      vertex 6.04508 -0.938926 0
+      vertex 6.04508 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0.743144 -0.669131 0
+    outer loop
+      vertex 6.04508 -0.938926 0
+      vertex 5.34565 -1.71572 0.799999
+      vertex 5.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309017 0
+    outer loop
+      vertex -2.56773 -0.0336828 0
+      vertex -2.89074 0.960441 0.799999
+      vertex -2.89074 0.960441 0
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309017 0
+    outer loop
+      vertex -2.89074 0.960441 0.799999
+      vertex -2.56773 -0.0336828 0
+      vertex -2.56773 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal -0.743144 -0.669131 0
+    outer loop
+      vertex -1.34565 -1.71572 0
+      vertex -2.04508 -0.938926 0.799999
+      vertex -2.04508 -0.938926 0
+    endloop
+  endfacet
+  facet normal -0.743144 -0.669131 0
+    outer loop
+      vertex -2.04508 -0.938926 0.799999
+      vertex -1.34565 -1.71572 0
+      vertex -1.34565 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0.587791 -0.809013 0
+    outer loop
+      vertex -1.34565 -1.71572 0
+      vertex -0.5 -2.33013 0.799999
+      vertex -1.34565 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0.587791 -0.809013 -0
+    outer loop
+      vertex -0.5 -2.33013 0.799999
+      vertex -1.34565 -1.71572 0
+      vertex -0.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0.951091 -0.30891 0
+    outer loop
+      vertex 6.56773 -0.0336828 0.799999
+      vertex 6.57867 0 0
+      vertex 6.57867 0 0.799999
+    endloop
+  endfacet
+  facet normal 0.951091 -0.30891 0
+    outer loop
+      vertex 6.57867 0 0
+      vertex 6.56773 -0.0336828 0.799999
+      vertex 6.56773 -0.0336828 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex -2.89074 3.03956 0
+      vertex -2.56773 4.03368 0.799999
+      vertex -2.56773 4.03368 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex -2.56773 4.03368 0.799999
+      vertex -2.89074 3.03956 0
+      vertex -2.89074 3.03956 0.799999
+    endloop
+  endfacet
+  facet normal -0.207903 -0.978149 0
+    outer loop
+      vertex 56.4549 -2.75528 0
+      vertex 57.4774 -2.97261 0.799999
+      vertex 56.4549 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal -0.207903 -0.978149 -0
+    outer loop
+      vertex 57.4774 -2.97261 0.799999
+      vertex 56.4549 -2.75528 0
+      vertex 57.4774 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0.951059 0.309009 0
+    outer loop
+      vertex 62.8907 3.03956 0.799999
+      vertex 62.5677 4.03368 0
+      vertex 62.5677 4.03368 0.799999
+    endloop
+  endfacet
+  facet normal 0.951059 0.309009 0
+    outer loop
+      vertex 62.5677 4.03368 0
+      vertex 62.8907 3.03956 0.799999
+      vertex 62.8907 3.03956 0
+    endloop
+  endfacet
+  facet normal 0.994518 0.104564 0
+    outer loop
+      vertex 63 2 0.799999
+      vertex 62.8907 3.03956 0
+      vertex 62.8907 3.03956 0.799999
+    endloop
+  endfacet
+  facet normal 0.994518 0.104564 0
+    outer loop
+      vertex 62.8907 3.03956 0
+      vertex 63 2 0.799999
+      vertex 63 2 0
+    endloop
+  endfacet
+  facet normal 0.866045 0.499967 0
+    outer loop
+      vertex 62.5677 4.03368 0.799999
+      vertex 62.0451 4.93893 0
+      vertex 62.0451 4.93893 0.799999
+    endloop
+  endfacet
+  facet normal 0.866045 0.499967 0
+    outer loop
+      vertex 62.0451 4.93893 0
+      vertex 62.5677 4.03368 0.799999
+      vertex 62.5677 4.03368 0
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex 59.5451 -2.75528 0
+      vertex 60.5 -2.33013 0.799999
+      vertex 59.5451 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex 60.5 -2.33013 0.799999
+      vertex 59.5451 -2.75528 0
+      vertex 60.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0.994518 -0.104564 0
+    outer loop
+      vertex 62.8907 0.960441 0.799999
+      vertex 63 2 0
+      vertex 63 2 0.799999
+    endloop
+  endfacet
+  facet normal 0.994518 -0.104564 0
+    outer loop
+      vertex 63 2 0
+      vertex 62.8907 0.960441 0.799999
+      vertex 62.8907 0.960441 0
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 0
+    outer loop
+      vertex 55.5 -2.33013 0
+      vertex 56.4549 -2.75528 0.799999
+      vertex 55.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 -0
+    outer loop
+      vertex 56.4549 -2.75528 0.799999
+      vertex 55.5 -2.33013 0
+      vertex 56.4549 -2.75528 0
+    endloop
+  endfacet
+  facet normal 0.866043 -0.49997 0
+    outer loop
+      vertex 62.0451 -0.938926 0.799999
+      vertex 62.5677 -0.0336828 0
+      vertex 62.5677 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0.866043 -0.49997 0
+    outer loop
+      vertex 62.5677 -0.0336828 0
+      vertex 62.0451 -0.938926 0.799999
+      vertex 62.0451 -0.938926 0
+    endloop
+  endfacet
+  facet normal 0.743158 -0.669116 0
+    outer loop
+      vertex 61.3457 -1.71572 0.799999
+      vertex 62.0451 -0.938926 0
+      vertex 62.0451 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0.743158 -0.669116 0
+    outer loop
+      vertex 62.0451 -0.938926 0
+      vertex 61.3457 -1.71572 0.799999
+      vertex 61.3457 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 57.4774 -2.97261 0
+      vertex 58.5226 -2.97261 0.799999
+      vertex 57.4774 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 58.5226 -2.97261 0.799999
+      vertex 57.4774 -2.97261 0
+      vertex 58.5226 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0.951059 -0.309008 0
+    outer loop
+      vertex 62.5677 -0.0336828 0.799999
+      vertex 62.8907 0.960441 0
+      vertex 62.8907 0.960441 0.799999
+    endloop
+  endfacet
+  facet normal 0.951059 -0.309008 0
+    outer loop
+      vertex 62.8907 0.960441 0
+      vertex 62.5677 -0.0336828 0.799999
+      vertex 62.5677 -0.0336828 0
+    endloop
+  endfacet
+  facet normal -0.950593 -0.310441 0
+    outer loop
+      vertex 53.4323 -0.0336828 0
+      vertex 53.4213 0 0.799999
+      vertex 53.4213 0 0
+    endloop
+  endfacet
+  facet normal -0.950593 -0.310441 0
+    outer loop
+      vertex 53.4213 0 0.799999
+      vertex 53.4323 -0.0336828 0
+      vertex 53.4323 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0.587768 -0.809029 0
+    outer loop
+      vertex 60.5 -2.33013 0
+      vertex 61.3457 -1.71572 0.799999
+      vertex 60.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0.587768 -0.809029 0
+    outer loop
+      vertex 61.3457 -1.71572 0.799999
+      vertex 60.5 -2.33013 0
+      vertex 61.3457 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0.743157 0.669117 0
+    outer loop
+      vertex 62.0451 4.93893 0.799999
+      vertex 61.3457 5.71572 0
+      vertex 61.3457 5.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0.743157 0.669117 0
+    outer loop
+      vertex 61.3457 5.71572 0
+      vertex 62.0451 4.93893 0.799999
+      vertex 62.0451 4.93893 0
+    endloop
+  endfacet
+  facet normal 0.587768 0.809029 -0
+    outer loop
+      vertex 61.3457 5.71572 0
+      vertex 60.5 6.33013 0.799999
+      vertex 61.3457 5.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0.587768 0.809029 0
+    outer loop
+      vertex 60.5 6.33013 0.799999
+      vertex 61.3457 5.71572 0
+      vertex 60.5 6.33013 0
+    endloop
+  endfacet
+  facet normal 0.40673 0.913548 -0
+    outer loop
+      vertex 60.5 6.33013 0
+      vertex 60 6.55274 0.799999
+      vertex 60.5 6.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0.40673 0.913548 0
+    outer loop
+      vertex 60 6.55274 0.799999
+      vertex 60.5 6.33013 0
+      vertex 60 6.55274 0
+    endloop
+  endfacet
+  facet normal -0.587768 -0.809029 0
+    outer loop
+      vertex 54.6543 -1.71572 0
+      vertex 55.5 -2.33013 0.799999
+      vertex 54.6543 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0.587768 -0.809029 -0
+    outer loop
+      vertex 55.5 -2.33013 0.799999
+      vertex 54.6543 -1.71572 0
+      vertex 55.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0.207903 -0.978149 0
+    outer loop
+      vertex 58.5226 -2.97261 0
+      vertex 59.5451 -2.75528 0.799999
+      vertex 58.5226 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0.207903 -0.978149 0
+    outer loop
+      vertex 59.5451 -2.75528 0.799999
+      vertex 58.5226 -2.97261 0
+      vertex 59.5451 -2.75528 0
+    endloop
+  endfacet
+  facet normal -0.743158 -0.669116 0
+    outer loop
+      vertex 54.6543 -1.71572 0
+      vertex 53.9549 -0.938926 0.799999
+      vertex 53.9549 -0.938926 0
+    endloop
+  endfacet
+  facet normal -0.743158 -0.669116 0
+    outer loop
+      vertex 53.9549 -0.938926 0.799999
+      vertex 54.6543 -1.71572 0
+      vertex 54.6543 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0.866043 -0.49997 0
+    outer loop
+      vertex 53.9549 -0.938926 0
+      vertex 53.4323 -0.0336828 0.799999
+      vertex 53.4323 -0.0336828 0
+    endloop
+  endfacet
+  facet normal -0.866043 -0.49997 0
+    outer loop
+      vertex 53.4323 -0.0336828 0.799999
+      vertex 53.9549 -0.938926 0
+      vertex 53.9549 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 63 2 0.799999
+      vertex 62.8907 3.03956 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 62.8907 3.03956 0.799999
+      vertex 62.5677 4.03368 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63 2 0.799999
+      vertex 60 0 0.799999
+      vertex 62.8907 0.960441 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 62.5677 4.03368 0.799999
+      vertex 62.0451 4.93893 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8907 0.960441 0.799999
+      vertex 60 0 0.799999
+      vertex 62.5677 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 62.0451 4.93893 0.799999
+      vertex 61.3457 5.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5677 -0.0336828 0.799999
+      vertex 60 0 0.799999
+      vertex 62.0451 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 61.3457 5.71572 0.799999
+      vertex 60.5 6.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0451 -0.938926 0.799999
+      vertex 60 0 0.799999
+      vertex 61.3457 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 60.5 6.33013 0.799999
+      vertex 60 6.55274 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3457 -1.71572 0.799999
+      vertex 60 0 0.799999
+      vertex 60.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 59.5451 -2.75528 0.799999
+      vertex 60.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 58.5226 -2.97261 0.799999
+      vertex 59.5451 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 57.4774 -2.97261 0.799999
+      vertex 58.5226 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 56.4549 -2.75528 0.799999
+      vertex 57.4774 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 55.5 -2.33013 0.799999
+      vertex 56.4549 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 54.6543 -1.71572 0.799999
+      vertex 55.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 53.9549 -0.938926 0.799999
+      vertex 54.6543 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 53.4213 0 0.799999
+      vertex 53.9549 -0.938926 0.799999
+      vertex 60 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.9549 -0.938926 0.799999
+      vertex 53.4213 0 0.799999
+      vertex 53.4323 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0.951138 0.308767 0
+    outer loop
+      vertex 6.57867 60 0.799999
+      vertex 6.56773 60.0337 0
+      vertex 6.56773 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0.951138 0.308767 0
+    outer loop
+      vertex 6.56773 60.0337 0
+      vertex 6.57867 60 0.799999
+      vertex 6.57867 60 0
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex 6.56773 60.0337 0.799999
+      vertex 6.04508 60.9389 0
+      vertex 6.04508 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex 6.04508 60.9389 0
+      vertex 6.56773 60.0337 0.799999
+      vertex 6.56773 60.0337 0
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex -0.5 62.3301 0
+      vertex -1.34565 61.7157 0.799999
+      vertex -0.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex -1.34565 61.7157 0.799999
+      vertex -0.5 62.3301 0
+      vertex -1.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal 0.207888 0.978153 -0
+    outer loop
+      vertex 3.54508 62.7553 0
+      vertex 2.52264 62.9726 0.799999
+      vertex 3.54508 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0.207888 0.978153 0
+    outer loop
+      vertex 2.52264 62.9726 0.799999
+      vertex 3.54508 62.7553 0
+      vertex 2.52264 62.9726 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669129 0
+    outer loop
+      vertex -2.04508 60.9389 0
+      vertex -1.34565 61.7157 0.799999
+      vertex -1.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669129 0
+    outer loop
+      vertex -1.34565 61.7157 0.799999
+      vertex -2.04508 60.9389 0
+      vertex -2.04508 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104522 0
+    outer loop
+      vertex -2.89074 56.9604 0
+      vertex -3 58 0.799999
+      vertex -3 58 0
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104522 0
+    outer loop
+      vertex -3 58 0.799999
+      vertex -2.89074 56.9604 0
+      vertex -2.89074 56.9604 0.799999
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex -2.04508 55.0611 0
+      vertex -2.56773 55.9663 0.799999
+      vertex -2.56773 55.9663 0
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex -2.56773 55.9663 0.799999
+      vertex -2.04508 55.0611 0
+      vertex -2.04508 55.0611 0.799999
+    endloop
+  endfacet
+  facet normal -0.951054 -0.309023 0
+    outer loop
+      vertex -2.56773 55.9663 0
+      vertex -2.89074 56.9604 0.799999
+      vertex -2.89074 56.9604 0
+    endloop
+  endfacet
+  facet normal -0.951054 -0.309023 0
+    outer loop
+      vertex -2.89074 56.9604 0.799999
+      vertex -2.56773 55.9663 0
+      vertex -2.56773 55.9663 0.799999
+    endloop
+  endfacet
+  facet normal 0.40677 0.91353 -0
+    outer loop
+      vertex 4.5 62.3301 0
+      vertex 3.54508 62.7553 0.799999
+      vertex 4.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0.40677 0.91353 0
+    outer loop
+      vertex 3.54508 62.7553 0.799999
+      vertex 4.5 62.3301 0
+      vertex 3.54508 62.7553 0
+    endloop
+  endfacet
+  facet normal -0.994523 0.104522 0
+    outer loop
+      vertex -3 58 0
+      vertex -2.89074 59.0396 0.799999
+      vertex -2.89074 59.0396 0
+    endloop
+  endfacet
+  facet normal -0.994523 0.104522 0
+    outer loop
+      vertex -2.89074 59.0396 0.799999
+      vertex -3 58 0
+      vertex -3 58 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.52264 62.9726 0
+      vertex 1.47736 62.9726 0.799999
+      vertex 2.52264 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.47736 62.9726 0.799999
+      vertex 2.52264 62.9726 0
+      vertex 1.47736 62.9726 0
+    endloop
+  endfacet
+  facet normal -0.406772 0.913529 0
+    outer loop
+      vertex 0.454914 62.7553 0
+      vertex -0.5 62.3301 0.799999
+      vertex 0.454914 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal -0.406772 0.913529 0
+    outer loop
+      vertex -0.5 62.3301 0.799999
+      vertex 0.454914 62.7553 0
+      vertex -0.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0.743147 0.669129 0
+    outer loop
+      vertex 6.04508 60.9389 0.799999
+      vertex 5.34565 61.7157 0
+      vertex 5.34565 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0.743147 0.669129 0
+    outer loop
+      vertex 5.34565 61.7157 0
+      vertex 6.04508 60.9389 0.799999
+      vertex 6.04508 60.9389 0
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 0
+    outer loop
+      vertex -0.5 53.6699 0
+      vertex 0 53.4473 0.799999
+      vertex -0.5 53.6699 0.799999
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 -0
+    outer loop
+      vertex 0 53.4473 0.799999
+      vertex -0.5 53.6699 0
+      vertex 0 53.4473 0
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 -0
+    outer loop
+      vertex 5.34565 61.7157 0
+      vertex 4.5 62.3301 0.799999
+      vertex 5.34565 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 0
+    outer loop
+      vertex 4.5 62.3301 0.799999
+      vertex 5.34565 61.7157 0
+      vertex 4.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.04508 60.9389 0.799999
+      vertex 6.57867 60 0.799999
+      vertex 6.56773 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex 6.04508 60.9389 0.799999
+      vertex 5.34565 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex 5.34565 61.7157 0.799999
+      vertex 4.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex 4.5 62.3301 0.799999
+      vertex 3.54508 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex 3.54508 62.7553 0.799999
+      vertex 2.52264 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex 2.52264 62.9726 0.799999
+      vertex 1.47736 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex 1.47736 62.9726 0.799999
+      vertex 0.454914 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.04508 60.9389 0.799999
+      vertex 0 60 0.799999
+      vertex 6.57867 60 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.5 62.3301 0.799999
+      vertex 0 60 0.799999
+      vertex 0.454914 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.34565 61.7157 0.799999
+      vertex 0 60 0.799999
+      vertex -0.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.04508 60.9389 0.799999
+      vertex 0 60 0.799999
+      vertex -1.34565 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.56773 60.0337 0.799999
+      vertex 0 60 0.799999
+      vertex -2.04508 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex -0.5 53.6699 0.799999
+      vertex 0 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -1.34565 54.2843 0.799999
+      vertex 0 60 0.799999
+      vertex -2.04508 55.0611 0.799999
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -0.5 53.6699 0.799999
+      vertex 0 60 0.799999
+      vertex -1.34565 54.2843 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89074 59.0396 0.799999
+      vertex 0 60 0.799999
+      vertex -2.56773 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex -2.56773 55.9663 0.799999
+      vertex -2.04508 55.0611 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3 58 0.799999
+      vertex 0 60 0.799999
+      vertex -2.89074 59.0396 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex -2.89074 56.9604 0.799999
+      vertex -2.56773 55.9663 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex -3 58 0.799999
+      vertex -2.89074 56.9604 0.799999
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex -2.56773 60.0337 0
+      vertex -2.04508 60.9389 0.799999
+      vertex -2.04508 60.9389 0
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex -2.04508 60.9389 0.799999
+      vertex -2.56773 60.0337 0
+      vertex -2.56773 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669129 0
+    outer loop
+      vertex -1.34565 54.2843 0
+      vertex -2.04508 55.0611 0.799999
+      vertex -2.04508 55.0611 0
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669129 0
+    outer loop
+      vertex -2.04508 55.0611 0.799999
+      vertex -1.34565 54.2843 0
+      vertex -1.34565 54.2843 0.799999
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809017 0
+    outer loop
+      vertex -1.34565 54.2843 0
+      vertex -0.5 53.6699 0.799999
+      vertex -1.34565 54.2843 0.799999
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809017 -0
+    outer loop
+      vertex -0.5 53.6699 0.799999
+      vertex -1.34565 54.2843 0
+      vertex -0.5 53.6699 0
+    endloop
+  endfacet
+  facet normal -0.207886 0.978153 0
+    outer loop
+      vertex 1.47736 62.9726 0
+      vertex 0.454914 62.7553 0.799999
+      vertex 1.47736 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal -0.207886 0.978153 0
+    outer loop
+      vertex 0.454914 62.7553 0.799999
+      vertex 1.47736 62.9726 0
+      vertex 0.454914 62.7553 0
+    endloop
+  endfacet
+  facet normal -0.951054 0.309023 0
+    outer loop
+      vertex -2.89074 59.0396 0
+      vertex -2.56773 60.0337 0.799999
+      vertex -2.56773 60.0337 0
+    endloop
+  endfacet
+  facet normal -0.951054 0.309023 0
+    outer loop
+      vertex -2.56773 60.0337 0.799999
+      vertex -2.89074 59.0396 0
+      vertex -2.89074 59.0396 0.799999
+    endloop
+  endfacet
+  facet normal 0.951057 0.309015 0
+    outer loop
+      vertex 62.8907 59.0396 0.799999
+      vertex 62.5677 60.0337 0
+      vertex 62.5677 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0.951057 0.309015 0
+    outer loop
+      vertex 62.5677 60.0337 0
+      vertex 62.8907 59.0396 0.799999
+      vertex 62.8907 59.0396 0
+    endloop
+  endfacet
+  facet normal 0.994519 0.10456 0
+    outer loop
+      vertex 63 58 0.799999
+      vertex 62.8907 59.0396 0
+      vertex 62.8907 59.0396 0.799999
+    endloop
+  endfacet
+  facet normal 0.994519 0.10456 0
+    outer loop
+      vertex 62.8907 59.0396 0
+      vertex 63 58 0.799999
+      vertex 63 58 0
+    endloop
+  endfacet
+  facet normal 0.866033 0.499987 0
+    outer loop
+      vertex 62.5677 60.0337 0.799999
+      vertex 62.0451 60.9389 0
+      vertex 62.0451 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0.866033 0.499987 0
+    outer loop
+      vertex 62.0451 60.9389 0
+      vertex 62.5677 60.0337 0.799999
+      vertex 62.5677 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 58.5226 62.9726 0
+      vertex 57.4774 62.9726 0.799999
+      vertex 58.5226 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 57.4774 62.9726 0.799999
+      vertex 58.5226 62.9726 0
+      vertex 57.4774 62.9726 0
+    endloop
+  endfacet
+  facet normal 0.743161 -0.669113 0
+    outer loop
+      vertex 61.3457 54.2843 0.799999
+      vertex 62.0451 55.0611 0
+      vertex 62.0451 55.0611 0.799999
+    endloop
+  endfacet
+  facet normal 0.743161 -0.669113 0
+    outer loop
+      vertex 62.0451 55.0611 0
+      vertex 61.3457 54.2843 0.799999
+      vertex 61.3457 54.2843 0
+    endloop
+  endfacet
+  facet normal 0.207876 0.978155 -0
+    outer loop
+      vertex 59.5451 62.7553 0
+      vertex 58.5226 62.9726 0.799999
+      vertex 59.5451 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0.207876 0.978155 0
+    outer loop
+      vertex 58.5226 62.9726 0.799999
+      vertex 59.5451 62.7553 0
+      vertex 58.5226 62.9726 0
+    endloop
+  endfacet
+  facet normal 0.743161 0.669113 0
+    outer loop
+      vertex 62.0451 60.9389 0.799999
+      vertex 61.3457 61.7157 0
+      vertex 61.3457 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0.743161 0.669113 0
+    outer loop
+      vertex 61.3457 61.7157 0
+      vertex 62.0451 60.9389 0.799999
+      vertex 62.0451 60.9389 0
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309015 0
+    outer loop
+      vertex 62.5677 55.9663 0.799999
+      vertex 62.8907 56.9604 0
+      vertex 62.8907 56.9604 0.799999
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309015 0
+    outer loop
+      vertex 62.8907 56.9604 0
+      vertex 62.5677 55.9663 0.799999
+      vertex 62.5677 55.9663 0
+    endloop
+  endfacet
+  facet normal -0.950639 0.310298 0
+    outer loop
+      vertex 53.4213 60 0
+      vertex 53.4323 60.0337 0.799999
+      vertex 53.4323 60.0337 0
+    endloop
+  endfacet
+  facet normal -0.950639 0.310298 0
+    outer loop
+      vertex 53.4323 60.0337 0.799999
+      vertex 53.4213 60 0
+      vertex 53.4213 60 0.799999
+    endloop
+  endfacet
+  facet normal -0.406777 0.913527 0
+    outer loop
+      vertex 56.4549 62.7553 0
+      vertex 55.5 62.3301 0.799999
+      vertex 56.4549 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal -0.406777 0.913527 0
+    outer loop
+      vertex 55.5 62.3301 0.799999
+      vertex 56.4549 62.7553 0
+      vertex 55.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex 60 53.4473 0
+      vertex 60.5 53.6699 0.799999
+      vertex 60 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex 60.5 53.6699 0.799999
+      vertex 60 53.4473 0
+      vertex 60.5 53.6699 0
+    endloop
+  endfacet
+  facet normal 0.866033 -0.499987 0
+    outer loop
+      vertex 62.0451 55.0611 0.799999
+      vertex 62.5677 55.9663 0
+      vertex 62.5677 55.9663 0.799999
+    endloop
+  endfacet
+  facet normal 0.866033 -0.499987 0
+    outer loop
+      vertex 62.5677 55.9663 0
+      vertex 62.0451 55.0611 0.799999
+      vertex 62.0451 55.0611 0
+    endloop
+  endfacet
+  facet normal -0.743161 0.669113 0
+    outer loop
+      vertex 53.9549 60.9389 0
+      vertex 54.6543 61.7157 0.799999
+      vertex 54.6543 61.7157 0
+    endloop
+  endfacet
+  facet normal -0.743161 0.669113 0
+    outer loop
+      vertex 54.6543 61.7157 0.799999
+      vertex 53.9549 60.9389 0
+      vertex 53.9549 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal -0.587762 0.809034 0
+    outer loop
+      vertex 55.5 62.3301 0
+      vertex 54.6543 61.7157 0.799999
+      vertex 55.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal -0.587762 0.809034 0
+    outer loop
+      vertex 54.6543 61.7157 0.799999
+      vertex 55.5 62.3301 0
+      vertex 54.6543 61.7157 0
+    endloop
+  endfacet
+  facet normal 0.994519 -0.10456 0
+    outer loop
+      vertex 62.8907 56.9604 0.799999
+      vertex 63 58 0
+      vertex 63 58 0.799999
+    endloop
+  endfacet
+  facet normal 0.994519 -0.10456 0
+    outer loop
+      vertex 63 58 0
+      vertex 62.8907 56.9604 0.799999
+      vertex 62.8907 56.9604 0
+    endloop
+  endfacet
+  facet normal 0.587762 0.809034 -0
+    outer loop
+      vertex 61.3457 61.7157 0
+      vertex 60.5 62.3301 0.799999
+      vertex 61.3457 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0.587762 0.809034 0
+    outer loop
+      vertex 60.5 62.3301 0.799999
+      vertex 61.3457 61.7157 0
+      vertex 60.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0.406777 0.913527 -0
+    outer loop
+      vertex 60.5 62.3301 0
+      vertex 59.5451 62.7553 0.799999
+      vertex 60.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0.406777 0.913527 0
+    outer loop
+      vertex 59.5451 62.7553 0.799999
+      vertex 60.5 62.3301 0
+      vertex 59.5451 62.7553 0
+    endloop
+  endfacet
+  facet normal -0.866033 0.499987 0
+    outer loop
+      vertex 53.4323 60.0337 0
+      vertex 53.9549 60.9389 0.799999
+      vertex 53.9549 60.9389 0
+    endloop
+  endfacet
+  facet normal -0.866033 0.499987 0
+    outer loop
+      vertex 53.9549 60.9389 0.799999
+      vertex 53.4323 60.0337 0
+      vertex 53.4323 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0.587762 -0.809034 0
+    outer loop
+      vertex 60.5 53.6699 0
+      vertex 61.3457 54.2843 0.799999
+      vertex 60.5 53.6699 0.799999
+    endloop
+  endfacet
+  facet normal 0.587762 -0.809034 0
+    outer loop
+      vertex 61.3457 54.2843 0.799999
+      vertex 60.5 53.6699 0
+      vertex 61.3457 54.2843 0
+    endloop
+  endfacet
+  facet normal -0.207876 0.978155 0
+    outer loop
+      vertex 57.4774 62.9726 0
+      vertex 56.4549 62.7553 0.799999
+      vertex 57.4774 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal -0.207876 0.978155 0
+    outer loop
+      vertex 56.4549 62.7553 0.799999
+      vertex 57.4774 62.9726 0
+      vertex 56.4549 62.7553 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 63 58 0.799999
+      vertex 62.8907 59.0396 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 62.8907 59.0396 0.799999
+      vertex 62.5677 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63 58 0.799999
+      vertex 60 60 0.799999
+      vertex 62.8907 56.9604 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 62.5677 60.0337 0.799999
+      vertex 62.0451 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8907 56.9604 0.799999
+      vertex 60 60 0.799999
+      vertex 62.5677 55.9663 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 62.0451 60.9389 0.799999
+      vertex 61.3457 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5677 55.9663 0.799999
+      vertex 60 60 0.799999
+      vertex 62.0451 55.0611 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 61.3457 61.7157 0.799999
+      vertex 60.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0451 55.0611 0.799999
+      vertex 60 60 0.799999
+      vertex 61.3457 54.2843 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3457 54.2843 0.799999
+      vertex 60 60 0.799999
+      vertex 60.5 53.6699 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5451 62.7553 0.799999
+      vertex 60 60 0.799999
+      vertex 60.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5226 62.9726 0.799999
+      vertex 60 60 0.799999
+      vertex 59.5451 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 57.4774 62.9726 0.799999
+      vertex 60 60 0.799999
+      vertex 58.5226 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 56.4549 62.7553 0.799999
+      vertex 60 60 0.799999
+      vertex 57.4774 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 55.5 62.3301 0.799999
+      vertex 60 60 0.799999
+      vertex 56.4549 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 54.6543 61.7157 0.799999
+      vertex 60 60 0.799999
+      vertex 55.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 53.9549 60.9389 0.799999
+      vertex 60 60 0.799999
+      vertex 54.6543 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.4213 60 0.799999
+      vertex 53.9549 60.9389 0.799999
+      vertex 53.4323 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.9549 60.9389 0.799999
+      vertex 53.4213 60 0.799999
+      vertex 60 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5 53.6699 0.799999
+      vertex 60 60 0.799999
+      vertex 60 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 55 31 0
+      vertex 55 55 50
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 55 55 50
+      vertex 55 31 0
+      vertex 55 31 50
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 55 5 0
+      vertex 55 29 50
+      vertex 55 29 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 55 29 50
+      vertex 55 5 0
+      vertex 55 5 50
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 5 27 50
+      vertex 5 55 0
+      vertex 5 55 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 55 0
+      vertex 5 27 50
+      vertex 5 27 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 5 5 50
+      vertex 5 25 0
+      vertex 5 25 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 25 0
+      vertex 5 5 50
+      vertex 5 5 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 55 0
+      vertex 29 55 50
+      vertex 5 55 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 29 55 50
+      vertex 5 55 0
+      vertex 29 55 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 31 55 0
+      vertex 55 55 50
+      vertex 31 55 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 55 55 50
+      vertex 31 55 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 29 5 0
+      vertex 5 5 50
+      vertex 29 5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 5 50
+      vertex 29 5 0
+      vertex 5 5 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 55 5 0
+      vertex 31 5 50
+      vertex 55 5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 31 5 50
+      vertex 55 5 0
+      vertex 31 5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 4.5 25 50
+      vertex 4.5 27 0
+      vertex 4.5 27 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 4.5 27 0
+      vertex 4.5 25 50
+      vertex 4.5 25 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 4.5 27 0
+      vertex 5 27 50
+      vertex 4.5 27 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 5 27 50
+      vertex 4.5 27 0
+      vertex 5 27 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5 25 0
+      vertex 4.5 25 50
+      vertex 5 25 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.5 25 50
+      vertex 5 25 0
+      vertex 4.5 25 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 29 55 50
+      vertex 29 55.5 0
+      vertex 29 55.5 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 29 55.5 0
+      vertex 29 55 50
+      vertex 29 55 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 31 55 0
+      vertex 31 55.5 50
+      vertex 31 55.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 31 55.5 50
+      vertex 31 55 0
+      vertex 31 55 50
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 29 55.5 0
+      vertex 31 55.5 50
+      vertex 29 55.5 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 31 55.5 50
+      vertex 29 55.5 0
+      vertex 31 55.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 55.5 29 0
+      vertex 55.5 31 50
+      vertex 55.5 31 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 55.5 31 50
+      vertex 55.5 29 0
+      vertex 55.5 29 50
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 55 31 0
+      vertex 55.5 31 50
+      vertex 55 31 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 55.5 31 50
+      vertex 55 31 0
+      vertex 55.5 31 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 55.5 29 0
+      vertex 55 29 50
+      vertex 55.5 29 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 55 29 50
+      vertex 55.5 29 0
+      vertex 55 29 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 31 4.5 0
+      vertex 29 4.5 50
+      vertex 31 4.5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 29 4.5 50
+      vertex 31 4.5 0
+      vertex 29 4.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 29 4.5 50
+      vertex 29 5 0
+      vertex 29 5 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 29 5 0
+      vertex 29 4.5 50
+      vertex 29 4.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 31 4.5 0
+      vertex 31 5 50
+      vertex 31 5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 31 5 50
+      vertex 31 4.5 0
+      vertex 31 4.5 50
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/klippy/extras/tuning_tower.py
+++ b/klippy/extras/tuning_tower.py
@@ -1,0 +1,72 @@
+# Helper script to adjust parameters based on Z level
+#
+# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import math, logging
+
+class TuningTower:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.normal_transform = None
+        self.last_position = [0., 0., 0., 0.]
+        self.last_z = self.start = self.factor = self.band = 0.
+        self.command = self.parameter = ""
+        # Register command
+        gcode = self.printer.lookup_object("gcode")
+        gcode.register_command("TUNING_TOWER", self.cmd_TUNING_TOWER,
+                               desc=self.cmd_TUNING_TOWER_help)
+    cmd_TUNING_TOWER_help = "Tool to adjust a parameter at each Z height"
+    def cmd_TUNING_TOWER(self, params):
+        if self.normal_transform is not None:
+            self.end_test()
+        # Get parameters
+        gcode = self.printer.lookup_object("gcode")
+        self.command = gcode.get_str('COMMAND', params)
+        self.parameter = gcode.get_str('PARAMETER', params)
+        self.start = gcode.get_float('START', params, 0.)
+        self.factor = gcode.get_float('FACTOR', params)
+        self.band = gcode.get_float('BAND', params, 0., minval=0.)
+        # Enable test mode
+        logging.info("Starting tuning test (start=%.6f factor=%.6f)",
+                     self.start, self.factor)
+        self.normal_transform = gcode.set_move_transform(self, force=True)
+        self.last_z = -99999999.9
+        gcode.reset_last_position()
+        self.get_position()
+    def get_position(self):
+        pos = self.normal_transform.get_position()
+        self.last_postition = list(pos)
+        return pos
+    def calc_value(self, z):
+        if self.band:
+            z = (math.floor(z / self.band) + .5) * self.band
+        return self.start + z * self.factor
+    def move(self, newpos, speed):
+        normal_transform = self.normal_transform
+        if (newpos[3] > self.last_position[3] and newpos[2] != self.last_z
+            and newpos[:3] != self.last_position[:3]):
+            # Extrusion move at new z height
+            z = newpos[2]
+            if z > self.last_z:
+                # Process update
+                oldval = self.calc_value(self.last_z)
+                newval = self.calc_value(z)
+                self.last_z = z
+                if newval != oldval:
+                    gcode = self.printer.lookup_object("gcode")
+                    gcode.run_script_from_command("%s %s=%.9f" % (
+                        self.command, self.parameter, newval))
+            else:
+                self.end_test()
+        # Forward move to actual handler
+        self.last_position[:] = newpos
+        normal_transform.move(newpos, speed)
+    def end_test(self):
+        gcode = self.printer.lookup_object("gcode")
+        gcode.respond_info("Ending tuning test mode")
+        gcode.set_move_transform(self.normal_transform, force=True)
+        self.normal_transform = None
+
+def load_config(config):
+    return TuningTower(config)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -274,6 +274,7 @@ class ToolHead:
         self.printer.try_load_module(config, "idle_timeout")
         self.printer.try_load_module(config, "statistics")
         self.printer.try_load_module(config, "manual_probe")
+        self.printer.try_load_module(config, "tuning_tower")
     # Print time tracking
     def update_move_time(self, movetime):
         self.print_time += movetime


### PR DESCRIPTION
FYI, just something I've been looking at recently.  This series introduces a TEST_PRESSURE_ADVANCE command.  This command will setup the basic requirements for testing pressure advance (`SET_VELOCITY_LIMIT ACCEL=500 SQUARE_CORNER_VELOCITY=1` and `SET_PRESSURE_ADVANCE ADVANCE_LOOKAHEAD_TIME=0`) and then arrange to set a new pressure advance value for each Z layer.  So, one could issue a `TEST_PRESSURE_ADVANCE INCREMENT=0.05` command, print an object, and the resulting object would have the pressure advance setting changed such that every 1mm of the print had .05 additional pressure advance.  Thus a "pressure advance testing tower".

I've also added a docs/prints/square_tower.stl file to test with.

My opinion of this testing method is a little mixed.  It's certainly easier to run the test, and it is dramatically faster to test many pressure advance values.  However, I think it may be harder for new users to inspect the resulting tower and accurately find the correct pressure advance value.  (Specifically, the impact of pressure advance when looking at the sides of a corner aren't as obvious as they are when looking down on a corner.)

-Kevin
