### PR TITLE
Upgrade pyserial version, set exclusive access when opening serial ports on POSIX systems.

### DIFF
--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -59,7 +59,7 @@ class SerialReader:
             try:
                 if self.baud:
                     self.ser = serial.Serial(
-                        self.serialport, self.baud, timeout=0)
+                        self.serialport, self.baud, timeout=0, exclusive=True)
                 else:
                     self.ser = open(self.serialport, 'rb+')
             except (OSError, IOError, serial.SerialException) as e:
@@ -285,7 +285,7 @@ def stk500v2_leave(ser, reactor):
 # Attempt an arduino style reset on a serial port
 def arduino_reset(serialport, reactor):
     # First try opening the port at a different baud
-    ser = serial.Serial(serialport, 2400, timeout=0)
+    ser = serial.Serial(serialport, 2400, timeout=0, exclusive=True)
     ser.read(1)
     reactor.pause(reactor.monotonic() + 0.100)
     # Then toggle DTR

--- a/scripts/install-centos.sh
+++ b/scripts/install-centos.sh
@@ -34,7 +34,7 @@ create_virtualenv()
     [ ! -d ${PYTHONDIR} ] && virtualenv ${PYTHONDIR}
 
     # Install/update dependencies
-    ${PYTHONDIR}/bin/pip install cffi==1.6.0 pyserial==3.2.1 greenlet==0.4.10
+    ${PYTHONDIR}/bin/pip install cffi==1.6.0 pyserial==3.4 greenlet==0.4.10
 }
 
 # Step 3: Install startup script

--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -37,7 +37,7 @@ create_virtualenv()
     [ ! -d ${PYTHONDIR} ] && virtualenv ${PYTHONDIR}
 
     # Install/update dependencies
-    ${PYTHONDIR}/bin/pip install cffi==1.6.0 pyserial==3.2.1 greenlet==0.4.10
+    ${PYTHONDIR}/bin/pip install cffi==1.6.0 pyserial==3.4 greenlet==0.4.10
 }
 
 # Step 3: Install startup script

--- a/scripts/install-ubuntu-18.04.sh
+++ b/scripts/install-ubuntu-18.04.sh
@@ -40,7 +40,7 @@ create_virtualenv()
     [ ! -d ${PYTHONDIR} ] && virtualenv ${PYTHONDIR}
 
     # Install/update dependencies
-    ${PYTHONDIR}/bin/pip install cffi==1.6.0 pyserial==3.2.1 greenlet==0.4.10
+    ${PYTHONDIR}/bin/pip install cffi==1.6.0 pyserial==3.4 greenlet==0.4.10
 }
 
 # Step 3: Install startup script

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -62,4 +62,4 @@ fi
 echo "=============== Install python virtualenv"
 cd ${MAIN_DIR}
 virtualenv ${BUILD_DIR}/python-env
-${BUILD_DIR}/python-env/bin/pip install cffi==1.6.0 pyserial==3.2.1 greenlet==0.4.10
+${BUILD_DIR}/python-env/bin/pip install cffi==1.6.0 pyserial==3.4 greenlet==0.4.10


### PR DESCRIPTION
Latest PySerial version is 3.4. Upgrading to this will allow us to exclusively access serial ports on POSIX systems.