### PR TITLE
[WIP] Allow heaters to be negative heaters such as fan.

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1262,6 +1262,7 @@
 #min_extrude_temp:
 #min_temp:
 #max_temp:
+#target_temp:
 #   See the example.cfg for the definition of the above parameters.
 
 # Pause/Resume functionality with support of position capture and restore

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -22,7 +22,7 @@ class ConfigWrapper:
     def get_name(self):
         return self.section
     def _get_wrapper(self, parser, option, default,
-                     minval=None, maxval=None, above=None, below=None):
+                     minval=None, maxval=None, above=None, below=None, notzero=False):
         if (default is not sentinel
             and not self.fileconfig.has_option(self.section, option)):
             return default
@@ -48,6 +48,9 @@ class ConfigWrapper:
         if below is not None and v >= below:
             raise self.error("Option '%s' in section '%s' must be below %s" % (
                 option, self.section, below))
+        if notzero is not False and v == 0.:
+            raise self.error("Option '%s' in section '%s' must not be 0" % (
+                option, self.section))
         return v
     def get(self, option, default=sentinel):
         return self._get_wrapper(self.fileconfig.get, option, default)
@@ -55,9 +58,9 @@ class ConfigWrapper:
         return self._get_wrapper(
             self.fileconfig.getint, option, default, minval, maxval)
     def getfloat(self, option, default=sentinel,
-                 minval=None, maxval=None, above=None, below=None):
+                 minval=None, maxval=None, above=None, below=None, notzero=False):
         return self._get_wrapper(self.fileconfig.getfloat, option, default,
-                                 minval, maxval, above, below)
+                                 minval, maxval, above, below, notzero)
     def getboolean(self, option, default=sentinel):
         return self._get_wrapper(self.fileconfig.getboolean, option, default)
     def getchoice(self, option, choices, default=sentinel):

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -29,6 +29,7 @@ class Heater:
         self.sensor = sensor
         self.min_temp = config.getfloat('min_temp', minval=KELVIN_TO_CELCIUS)
         self.max_temp = config.getfloat('max_temp', above=self.min_temp)
+        self.target_temp = config.getfloat('target_temp', 0, above=self.min_temp, below=self.max_temp)
         self.sensor.setup_minmax(self.min_temp, self.max_temp)
         self.sensor.setup_callback(self.temperature_callback)
         self.pwm_delay = self.sensor.get_report_time_delta()
@@ -41,7 +42,7 @@ class Heater:
         self.smooth_time = config.getfloat('smooth_time', 2., above=0.)
         self.inv_smooth_time = 1. / self.smooth_time
         self.lock = threading.Lock()
-        self.last_temp = self.smoothed_temp = self.target_temp = 0.
+        self.last_temp = self.smoothed_temp = 0.
         self.last_temp_time = 0.
         # pwm caching
         self.next_pwm_time = 0.


### PR DESCRIPTION
This would replace temperature_fan as they really are just a heater in reverse.

kick_start_time not implemented as in fan.  could add?

thoughts/comments?

Related to https://github.com/KevinOConnor/klipper/issues/1189

Example use
--------------
```
[heater_generic case_fan]
# using T2 here so octoprint graphs it as a tool
gcode_id: T2
# note heater_pin is inverted as we want the fan to be inverted vs a heater
heater_pin: !ar7
max_power: 1.0
pwm_cycle_time: 0.010
sensor_type: NTC 100K beta 3950
sensor_pin: analog15
control: pid
pid_Kp: 40
pid_Ki: 0.2
pid_Kd: 0.1
min_temp: 0
max_temp: 80
# allow to set initial target for devices like fans that should be set by default
target_temp: 60

[verify_heater case_fan]
check_gain_time: 10
# we expect cooling not heating
heating_gain: -2
```