### PR TITLE
Update install-octopi.sh

### DIFF
--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -52,7 +52,6 @@ install_script()
 install_config()
 {
     DEFAULTS_FILE=/etc/default/klipper
-    [ -f $DEFAULTS_FILE ] && return
 
     report_status "Installing system start configuration..."
     sudo /bin/sh -c "cat > $DEFAULTS_FILE" <<EOF


### PR DESCRIPTION
Better overwrite this config file. For example, if someone will reinstall klipper from different install location.