### PR TITLE
Add generic sensors

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1331,3 +1331,19 @@
 #recover_velocity: 50.
 #  When capture/restore is enabled, the speed at which to return to
 #  the captured position (in mm/s).  Default is 50.0 mm/s.
+
+# Generic sensor setup
+# Can be used to monitor temperature sensors and shutdown mcu if out of range
+#[sensor_generic my_generic_sensor]
+#sensor_type:
+#sensor_pin:
+#min_temp:
+#  If not above mcu will shutdown
+#max_temp:
+#  If not below mcu will shutdown
+#target_temp:
+#   This can be set for reference only.  For example if gcode_id is set to T3 octoprint
+#   will show the current temperature and the target temperature defined here.
+#gcode_id:
+#   Set the gcode_id used for temperature reports. For example set to T3
+#   to see the reported temperature in octoprint.  The default is None.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -587,7 +587,9 @@
 #pid_integral_max:
 #   The maximum "windup" the integral term may accumulate. The default
 #   is to use the same value as max_power.
-
+#gcode_id:
+#   Set the gcode_id used for temperature reports. For example set to T3
+#   to see the reported temperature in octoprint.  The default is None.
 
 # Additional micro-controllers (one may define any number of sections
 # with an "mcu" prefix). Additional micro-controllers introduce

--- a/klippy/extras/sensor_generic.py
+++ b/klippy/extras/sensor_generic.py
@@ -1,0 +1,24 @@
+# Support for a generic sensor
+
+KELVIN_TO_CELCIUS = -273.15
+
+class PrinterSensorGeneric:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.sensor = self.printer.lookup_object('heater').setup_sensor(config)
+        self.min_temp = config.getfloat('min_temp', minval=KELVIN_TO_CELCIUS)
+        self.max_temp = config.getfloat('max_temp', above=self.min_temp)
+        self.target_temp = config.getfloat('target_temp', 0., minval=self.min_temp, maxval=self.max_temp)
+        self.sensor.setup_minmax(self.min_temp, self.max_temp)
+        self.sensor.setup_callback(self.temperature_callback)
+        gcode_id = config.get("gcode_id", None)
+        if gcode_id is not None:
+            self.printer.lookup_object('heater').register_gcode_sensor(self, gcode_id)
+        self.last_temp = 0.
+    def temperature_callback(self, read_time, temp):
+        self.last_temp = temp
+    def get_temp(self, eventtime):
+         return self.last_temp, self.target_temp
+
+def load_config_prefix(config):
+    return PrinterSensorGeneric(config)

--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -52,9 +52,6 @@ class TemperatureFan:
     def temperature_callback(self, read_time, temp):
         self.last_temp = temp
         self.control.temperature_callback(read_time, temp)
-    def stats(self, eventtime):
-        return False, '%s: temp=%.1f fan_speed=%.3f' % (
-            self.name, self.last_temp, self.last_speed_value)
     def get_temp(self, eventtime):
         return self.last_temp, self.target_temp
 

--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -21,6 +21,9 @@ class TemperatureFan:
         self.sensor = self.printer.lookup_object('heater').setup_sensor(config)
         self.sensor.setup_minmax(self.min_temp, self.max_temp)
         self.sensor.setup_callback(self.temperature_callback)
+        gcode_id = config.get('gcode_id', None)
+        if gcode_id is not None:
+            self.printer.lookup_object('heater').register_gcode_sensor(self, gcode_id)
         self.speed_delay = self.sensor.get_report_time_delta()
         self.max_speed = config.getfloat('max_speed', 1., above=0., maxval=1.)
         self.min_speed = config.getfloat('min_speed', 0.3, above=0., maxval=1.)
@@ -52,6 +55,8 @@ class TemperatureFan:
     def stats(self, eventtime):
         return False, '%s: temp=%.1f fan_speed=%.3f' % (
             self.name, self.last_temp, self.last_speed_value)
+    def get_temp(self, eventtime):
+        return self.last_temp, self.target_temp
 
 ######################################################################
 # Bang-bang control algo

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -249,7 +249,7 @@ class PrinterHeaters:
         # Create heater
         self.heaters[heater_name] = heater = Heater(config, sensor)
         if gcode_id is not None:
-            self.gcode_id_to_sensor[gcode_id] = heater
+            self.register_gcode_sensor(heater, gcode_id)
         return heater
     def lookup_heater(self, heater_name):
         if heater_name == 'extruder':
@@ -269,6 +269,10 @@ class PrinterHeaters:
         return self.sensor_factories[sensor_type](config)
     def get_gcode_sensors(self):
         return self.gcode_id_to_sensor.items()
+    def register_gcode_sensor(self, sensor, gcode_id):
+        if gcode_id in self.gcode_id_to_sensor:
+            raise error("Sensor %s already registered for" % (gcode_id,))
+        self.gcode_id_to_sensor[gcode_id] = sensor
     def turn_off_all_heaters(self, print_time):
         for heater in self.heaters.values():
             heater.set_temp(print_time, 0.)


### PR DESCRIPTION
This allows setting up sensor for monitor only.  min and max temps are respected and will mcu will go into shutdown if out of range.  This is part of the ADC code.

```
[sensor_generic mosfet_sensor]
# using T2 here so octoprint graphs it as a tool
gcode_id: T2
sensor_type: NTC 100K beta 3950
sensor_pin: analog15
min_temp: 0
max_temp: 80
# setting a target temp will show the desired temp for example in octoprint
target_temp: 60

```

Signed-off-by: Douglas Hammond [wizhippo@gmail.com](mailto:wizhippo@gmail.com)