### PR TITLE
Set the default stepper current lower

### DIFF
--- a/config/generic-printrboard.cfg
+++ b/config/generic-printrboard.cfg
@@ -78,7 +78,7 @@ max_z_accel: 100
 # Use the following on a Printrboard RevF to control stepper current.
 #[mcp4728 stepper_current_dac]
 #scale: 2.327
-#channel_a: 1.3 # Extruder
-#channel_b: 1.1 # stepper_z
-#channel_c: 1.1 # stepper_y
-#channel_d: 1.1 # stepper_x
+#channel_a: 0.5 # Extruder
+#channel_b: 0.5 # stepper_z
+#channel_c: 0.5 # stepper_y
+#channel_d: 0.5 # stepper_x


### PR DESCRIPTION
To keep n00bs from burning out their stepper drivers, set the stepper current to 0.5 instead of 1.0 and 1.3