### PR TITLE
bed_mesh: fix get_position() when fade is enabled

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -129,14 +129,14 @@
 # center of the print area.
 #
 #  Visual Examples:
-#   bed_shape = rectangular, probe_count = 3,3:
+#   rectangular bed, probe_count = 3,3:
 #               x---x---x (max_point)
 #               |
 #               x---x---x
 #                       |
 #   (min_point) x---x---x
 #
-#   bed_shape = round, probe_count = 5, radius = r:
+#   round bed, round_probe_count = 5, bed_radius = r:
 #                  x (0,r) end
 #                /
 #              x---x---x
@@ -160,34 +160,30 @@
 #sample_retract_dist: 2.0
 #   The distance (in mm) to retract between each sample if
 #   sampling more than once.  Default is 2mm.
-#bed_shape: rectangular
-#   Defines the shape of the bed for probing.  May be 'rectangular',
-#   as is common for cartesian printers, or 'round', as is common for
-#   delta printers.  Default is rectangular.
-#radius:
-#   Defines the radius to probe when the bed_shape is 'round'.  Note
-#   that the radius is relative to the nozzle's origin, if using a
-#   probe be sure to account for its offset. This parameter must be
-#   provided if the bed_shape is 'round'.
+#bed_radius:
+#   Defines the radius to probe for round beds.  Note that the radius
+#   is relative to the nozzle's origin, if using a probe be sure to
+#   account for its offset.  This parameter must be provided for round
+#   beds and omitted for rectangular beds.
 #min_point:
-#   Defines the minimum x,y position to probe when the bed_shape
-#   is 'rectangular'. Note that this refers to the nozzle position,
-#   take care that you do not define a point that will move the
-#   probe off of the bed. This parameter must be provided.
+#   Defines the minimum x,y position to probe when for rectangular
+#   beds. Note that this refers to the nozzle position, take care that
+#   you do not define a point that will move the probe off of the bed.
+#   This parameter must be provided for rectangular beds.
 #max_point:
-#   Defines the maximum x,y position to probe when the bed_shape
-#   is 'rectangular'. Follow the same precautions as listed in min_point.
-#   Also note that this does not necessarily define the last point
-#   probed, only the maximum coordinate. This parameter must be provided.
+#   Defines the maximum x,y position to probe when for rectangular
+#   beds. Follow the same precautions as listed in min_point. Also note
+#   that this does not necessarily define the last point probed, only
+#   the maximum coordinate. This parameter must be provided.
 #probe_count: 3,3
-## OR ##
-#probe_count: 5
-#   For 'rectangular' beds, this is a comma separate pair of integer
+#   For rectangular beds, this is a comma separate pair of integer
 #   values (X,Y) defining the number of points to probe along each axis.
 #   A single value is also valid, in which case that value will be applied
-#   to both axes. 'Round' beds only accept a single integer value that is
-#   applied to both axes.  The probe count must be odd for round beds.
-#   Default is 3,3 for 'rectangular' beds, and 5 for 'round' beds.
+#   to both axes.  Default is 3,3.
+#round_probe_count: 5
+#   For round beds, this is integer value defines the maximum number of
+#   points to probe along each axis. This value must be an odd number.
+#   Default is 5.
 #fade_start: 1.0
 #   The gcode z position in which to start phasing out z-adjustment
 #   when fade is enabled.  Default is 1.0.

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,10 @@ All dates in this document are approximate.
 
 # Changes
 
+20190224: The bed_shape option has been removed from bed_mesh.  The
+radius option has been renamed to bed_radius.  Users with round beds
+should supply the bed_radius and round_probe_count options.
+
 20190107: The i2c_address parameter in the mcp4451 config section
 changed. This is a common setting on Smoothieboards. The new value is
 half the old value (88 should be changed to 44, and 90 should be

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -10,8 +10,6 @@ import json
 import probe
 import collections
 
-BED_SHAPES = {'rectangular': 0, 'round': 1}
-
 class BedMeshError(Exception):
     pass
 
@@ -210,14 +208,13 @@ class BedMeshCalibrate:
             'BED_MESH_PROFILE', self.cmd_BED_MESH_PROFILE,
             desc=self.cmd_BED_MESH_PROFILE_help)
     def _generate_points(self, config):
-        shape = config.getchoice('bed_shape', BED_SHAPES, 'rectangular')
-        if shape == BED_SHAPES['round']:
-            x_cnt = y_cnt = config.getint('probe_count', 5)
+        self.radius = config.getfloat('bed_radius', None, above=0.)
+        if self.radius is not None:
+            x_cnt = y_cnt = config.getint('round_probe_count', 5, minval=3)
             # round beds must have an odd number of points along each axis
             if not x_cnt & 1:
                 raise config.error(
                     "bed_mesh: probe_count must be odd for round beds")
-            self.radius = config.getfloat('radius', above=0.)
             # radius may have precision to .1mm
             self.radius = math.floor(self.radius * 10) / 10
             min_x = min_y = -self.radius


### PR DESCRIPTION
This request is separated into 3 commits:

* The first commit refactors how the fade_target is applied.  Rather than apply it to each lookup, its applied to the entire mesh after generation.  This made the math more tolerable when applying the fix for get_position()

* The second commit applies the fix for #1234 and #1252.   The factor in get_position() is now correctly calculated when fade is enabled.    Also included is an additional check in set_mesh to make sure that the maximum z adjustment applied is smaller than the fade distance.  This prevents a potential divide by zero when calculating the factor in get_position().

* The last commit applies config changes previously recommended.  I did not update config_changes.md, however if necessary I will do so.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>