### PR TITLE
filament_sensor: advanced filament detection

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1347,3 +1347,24 @@
 #recover_velocity: 50.
 #  When capture/restore is enabled, the speed at which to return to
 #  the captured position (in mm/s).  Default is 50.0 mm/s.
+
+# Filament Switch Sensor.  Support for filament insert and runout detection
+# using a switch sensor, such as an endstop switch.
+#[filament_switch_sensor my_sensor]
+#pause_on_runout: True
+#  When set to True, a PAUSE will execute immediately after a runout is
+#  detected. Note that if pause_on_runout is False and the runout_gcode is
+#  omitted then runout detection is disabled. Default is True.
+#runout_gcode:
+#  The gcode to run after a filament runout is detected.  If pause_on_runout
+#  is set to True this gcode will run after the PAUSE is complete.  The default
+#  is not to run any gcode commands.
+#insert_gcode:
+#  The gcode to run after a filament insert is detected.  The default is not to
+#  run any gcode commands, which disables insert detection.
+#event_delay: 3.0
+#  The minimum amount of time in seconds to delay between events. Events
+#  triggered during this time period will be silently ignored. The default
+#  is 3 seconds.
+#switch_pin:
+#  The pin on which the switch is connected.  This parameter must be provided.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -354,3 +354,11 @@ is enabled:
   - `RESUME [VELOCITY=<value>]`: Resumes the print from a pause, first restoring
   the previously captured position.  The VELOCITY parameter determines the speed
   at which the tool should return to the original captured position.
+
+## Filament Sensor
+
+The following command is available when the "filament_switch_sensor" config
+section is enabled.
+ - `QUERY_FILAMENT_SENSOR SENSOR=<sensor_name>`: Queries the current status of
+  the filament sensor.  The data displayed on the terminal will depend on the
+  sensor type defined in the confguration.

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,0 +1,124 @@
+# Generic Filament Sensor Module
+#
+# Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+
+class BaseSensor(object):
+    def __init__(self, config):
+        self.name = config.get_name().split()[1]
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.runout_gcode = config.get('runout_gcode', None)
+        self.insert_gcode = config.get('insert_gcode', None)
+        self.runout_pause = config.getboolean('pause_on_runout', True)
+        if self.runout_pause:
+            if self.runout_gcode is None:
+                self.runout_gcode = "PAUSE"
+            else:
+                self.runout_gcode = "PAUSE\n" + self.runout_gcode
+        self.runout_enabled = False
+        self.insert_enabled = self.insert_gcode is not None
+        self.event_running = False
+        self.print_status = "idle"
+        self.printer.register_event_handler(
+            "idle_timeout:idle",
+            (lambda e, s=self, st="idle": s._update_print_status(e, st)))
+        self.printer.register_event_handler(
+            "idle_timeout:ready",
+            (lambda e, s=self, st="ready": s._update_print_status(e, st)))
+        self.printer.register_event_handler(
+            "idle_timeout:printing",
+            (lambda e, s=self, st="printing": s._update_print_status(e, st)))
+    def _handle_ready(self):
+        self.toolhead = self.printer.lookup_object('toolhead')
+    def _update_print_status(self, eventtime, status):
+        if status == "printing":
+            runout_en = self.runout_gcode is not None
+            self.set_enable(runout_en, False)
+        else:
+            insert_en = self.insert_gcode is not None
+            self.set_enable(False, insert_en)
+    def _runout_event_handler(self, eventtime):
+        if self.event_running:
+            return
+        self.event_running = True
+        # Pausing from inside an event requires that the pause portion
+        # of pause_resume execute immediately.
+        pause_resume = self.printer.lookup_object('pause_resume', None)
+        if self.runout_pause and pause_resume is not None:
+            pause_resume.send_pause_command()
+        self._exec_gcode(self.runout_gcode)
+        self.event_running = False
+    def _insert_event_handler(self, eventtime):
+        if self.event_running:
+            return
+        self.event_running = True
+        self._exec_gcode(self.insert_gcode)
+        self.event_running = False
+    def _exec_gcode(self, script):
+        try:
+            self.gcode.run_script(script)
+        except Exception:
+            logging.exception("Script running error")
+    def set_enable(self, runout, insert):
+        if runout and insert:
+            # both cannot be enabled
+            insert = False
+        self.runout_enabled = runout
+        self.insert_enabled = insert
+    cmd_QUERY_FILAMENT_SENSOR_help = "Query the status of the Filament Sensor"
+    def cmd_QUERY_FILAMENT_SENSOR(self, params):
+        raise NotImplementedError(
+            "Sensor must implement cmd_QUERY_FILAMENT_SENSOR")
+
+class SwitchSensor(BaseSensor):
+    def __init__(self, config):
+        super(SwitchSensor, self).__init__(config)
+        self.reactor = self.printer.get_reactor()
+        self.buttons = self.printer.try_load_module(config, 'buttons')
+        switch_pin = config.get('switch_pin')
+        self.buttons.register_buttons([switch_pin], self._button_handler)
+        self.event_delay = config.getfloat('event_delay', 3., above=0.)
+        self.start_time = self.reactor.NEVER
+        self.last_button_state = False
+        self.last_cb_event_time = 0.
+        self.gcode.register_mux_command(
+            "QUERY_FILAMENT_SENSOR", "SENSOR", self.name,
+            self.cmd_QUERY_FILAMENT_SENSOR,
+            desc=self.cmd_QUERY_FILAMENT_SENSOR_help)
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
+    def _handle_ready(self):
+        super(SwitchSensor, self)._handle_ready()
+        self.start_time = self.reactor.monotonic() + 2.
+    def _button_handler(self, eventtime, state):
+        if eventtime < self.start_time or state == self.last_button_state:
+            self.last_button_state = state
+            return
+        if state:
+            # button pushed, check if insert callback should happen
+            if (self.insert_enabled and
+                    (eventtime - self.last_cb_event_time) > self.event_delay):
+                self.last_cb_event_time = eventtime
+                logging.info(
+                    "switch_sensor: insert event detected, Time %.2f",
+                    eventtime)
+                self.reactor.register_callback(self._insert_event_handler)
+        elif (self.runout_enabled and
+                (eventtime - self.last_cb_event_time) > self.event_delay):
+            # Filament runout detected
+            self.last_cb_event_time = eventtime
+            logging.info(
+                "switch_sensor: runout event detected, Time %.2f", eventtime)
+            self.reactor.register_callback(self._runout_event_handler)
+        self.last_button_state = state
+    def cmd_QUERY_FILAMENT_SENSOR(self, params):
+        if self.last_button_state:
+            msg = "Switch Sensor: filament detected"
+        else:
+            msg = "Switch Sensor: filament not detected"
+        self.gcode.respond_info(msg)
+
+def load_config_prefix(config):
+    return SwitchSensor(config)

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -60,6 +60,9 @@ class VirtualSD:
         return {'progress': progress}
     def is_active(self):
         return self.work_timer is not None
+    def do_pause(self):
+        if self.work_timer is not None:
+            self.must_pause_work = True
     # G-Code commands
     def cmd_error(self, params):
         raise self.gcode.error("SD write not supported")
@@ -116,8 +119,7 @@ class VirtualSD:
             self.work_handler, self.reactor.NOW)
     def cmd_M25(self, params):
         # Pause SD print
-        if self.work_timer is not None:
-            self.must_pause_work = True
+        self.do_pause()
     def cmd_M26(self, params):
         # Set SD position
         if self.work_timer is not None:


### PR DESCRIPTION
This PR contains an advanced implementation for filament detection.  Features include:

* Runout and insert detection.  By default the sensor module monitors the current print status and enables the correct detection mechanism based on the status (runout while printing, otherwise insert).
* Executes a user configured gcode script when an event is detected.  If the gcode is not configured the event is disabled.
* Allows for multiple underlying sensor implementations.  Includes a default switch based implementation.
* Will not allow multiple events to execute concurrently.
* Does not call a gcode handler from inside a reactor callback or button event.
* Allows the user to specify a minimum event delay time.  This is desirable to keep multiple events from executing too close together.
* Exposes filament sensor API for other Klipper modules to monitor filament events and set their own event handlers.
* Switch sensor ignores false positives.  A change in button state must hold for 100ms before the event triggers.

There are a couple of things in here that may require explanation.  First, when pausing Octoprint, I have to send the action command from inside the runout event handler before the current move is acknowledged.  Otherwise Octoprint will queue up the next move after acknowledgement, which will be executed after the PAUSE gcode.   To make PAUSE optional on runout I do a nested search on the runout_gcode for the PAUSE command.  This is why I added the contains() function to gcode_macro.

Second, changes to gcode.py are necessary in order for the SD card to pause immediately, as mentioned in proposal outlined in #1236.   Alternatively I could directly call cmd_M25 inside the runout event handler as PR #1098 does.  I don't think this would have any negative consequences as it just sets must_pause_work to True, but it probably isn't good practice.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>

