### PR TITLE
bed_mesh: enable relative offset bed meshes

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -220,6 +220,10 @@
 #   may be applied to change the amount of slope interpolated.
 #   Larger numbers will increase the amount of slope, which
 #   results in more curvature in the mesh. Default is .2.
+#relative_reference_index:
+#   A point index in the mesh to reference all z values to. Enabling
+#   this parameter produces a mesh relative to the probed z position
+#   at the provided index.
 
 
 # Tool to help adjust bed leveling screws. One may define a


### PR DESCRIPTION
Adds parameter for bed meshes to be adjusted relative to a probed point
during calibration. This allows the probe z offset to be ignored for
probes that are not stable over time (for example, the thermal drift of
inductive probes). An endstop other than the probe is then necessary to
determine the bed-nozzle offset.

Signed-off-by: Matt Baker <baker.matt.j@gmail.com>