### PR TITLE
config: Fixed reversed heater/fan output pins

### DIFF
--- a/config/generic-duet2.cfg
+++ b/config/generic-duet2.cfg
@@ -183,7 +183,7 @@ enable_pin: !PC6
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PA20
+heater_pin: !PA20
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC15
 control: pid
@@ -208,7 +208,7 @@ enable_pin: !PC6
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PA16
+heater_pin: !PA16
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC12
 control: pid
@@ -233,7 +233,7 @@ enable_pin: !PC6
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PC3
+heater_pin: !PC3
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC29
 control: pid
@@ -258,7 +258,7 @@ enable_pin: !PC6
 step_distance: .002
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PC5
+heater_pin: !PC5
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC30
 control: pid
@@ -276,7 +276,7 @@ interpolate: True
 run_current: 1.000
 
 [heater_bed]
-heater_pin: PA19
+heater_pin: !PA19
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC13
 control: watermark
@@ -327,32 +327,32 @@ max_z_accel: 100
 pins: !PC2
 
 [output_pin FAN3]
-pin: !sx1509_duex:PIN_12
+pin: sx1509_duex:PIN_12
 pwm: True
 hardware_pwm: True # Only hardware PWM fans are supported
 
 [output_pin FAN4]
-pin: !sx1509_duex:PIN_7
+pin: sx1509_duex:PIN_7
 pwm: True
 hardware_pwm: True
 
 [output_pin FAN5]
-pin: !sx1509_duex:PIN_6
+pin: sx1509_duex:PIN_6
 pwm: True
 hardware_pwm: True
 
 [output_pin FAN6]
-pin: !sx1509_duex:PIN_5
+pin: sx1509_duex:PIN_5
 pwm: True
 hardware_pwm: True
 
 [output_pin FAN7]
-pin: !sx1509_duex:PIN_4
+pin: sx1509_duex:PIN_4
 pwm: True
 hardware_pwm: True
 
 [output_pin FAN8]
-pin: !sx1509_duex:PIN_15
+pin: sx1509_duex:PIN_15
 pwm: True
 hardware_pwm: True
 


### PR DESCRIPTION
Using the Duet2 config as a base for your own config will no longer turn
on all heaters and fans at full power during the (almost inevitable) MCU
shutdown that will occur during initial Klipper setup.

Signed-off-by: Benoit Miller <github@benoitmiller.ca>