### PR TITLE
probe: Add support for probe slow down

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -147,6 +147,10 @@
 #speed: 50
 #   The speed (in mm/s) of non-probing moves during the
 #   calibration. The default is 50.
+#lift_speed:
+#   The speed (in mm/s) of probe raising moves during the
+#   calibration. The default is the minimum of non-probing moves
+#   speed and probing moves speed.
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -261,8 +261,8 @@ class ProbePointsHelper:
                     self.name))
         self.horizontal_move_z = config.getfloat('horizontal_move_z', 5.)
         self.speed = config.getfloat('speed', 50., above=0.)
+        self.lift_speed = config.getfloat('lift_speed', 0., above=0.)
         # Internal probing state
-        self.lift_speed = self.speed
         self.probe_offsets = (0., 0., 0.)
         self.results = []
     def minimum_points(self,n):
@@ -302,12 +302,14 @@ class ProbePointsHelper:
         self.results = []
         if probe is None or method != 'automatic':
             # Manual probe
-            self.lift_speed = self.speed
+            if self.lift_speed is None:
+                self.lift_speed = self.speed
             self.probe_offsets = (0., 0., 0.)
             self._manual_probe_start()
             return
         # Perform automatic probing
-        self.lift_speed = min(self.speed, probe.speed)
+        if self.lift_speed is None:
+            self.lift_speed = min(self.speed, probe.speed)
         self.probe_offsets = probe.get_offsets()
         if self.horizontal_move_z < self.probe_offsets[2]:
             raise self.gcode.error("horizontal_move_z can't be less than"

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -261,8 +261,9 @@ class ProbePointsHelper:
                     self.name))
         self.horizontal_move_z = config.getfloat('horizontal_move_z', 5.)
         self.speed = config.getfloat('speed', 50., above=0.)
-        self.lift_speed = config.getfloat('lift_speed', None, above=0.)
+        self.config_lift_speed = config.getfloat('lift_speed', None, above=0.)
         # Internal probing state
+        self.lift_speed = self.config_lift_speed
         self.probe_offsets = (0., 0., 0.)
         self.results = []
     def minimum_points(self,n):
@@ -300,6 +301,7 @@ class ProbePointsHelper:
         probe = self.printer.lookup_object('probe', None)
         method = self.gcode.get_str('METHOD', params, 'automatic').lower()
         self.results = []
+        self.lift_speed = self.config_lift_speed
         if probe is None or method != 'automatic':
             # Manual probe
             if self.lift_speed is None:

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -261,7 +261,7 @@ class ProbePointsHelper:
                     self.name))
         self.horizontal_move_z = config.getfloat('horizontal_move_z', 5.)
         self.speed = config.getfloat('speed', 50., above=0.)
-        self.lift_speed = config.getfloat('lift_speed', 0., above=0.)
+        self.lift_speed = config.getfloat('lift_speed', None, above=0.)
         # Internal probing state
         self.probe_offsets = (0., 0., 0.)
         self.results = []


### PR DESCRIPTION
Added an option to increase probing accuracy by first doing a fast
probe, backing off, and then performing a slow probe. This allows
to set a reasonable probe speed for bed leveling while retaining
the accuracy of a slow probe speed.

This a solution for #1297 and a partial solution for #1249.