### PR TITLE
configfile: Add "include" support

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -171,7 +171,7 @@ class PrinterConfig:
             self._parse_config(include_data, include_filename, fileconfig,
                                visited)
         return include_filenames
-    def _parse_config(self, data, filename, fileconfig, visited = set()):
+    def _parse_config(self, data, filename, fileconfig, visited):
         path = os.path.abspath(filename)
         if path in visited:
             raise error("Recursive include of config file '%s'" % (filename))
@@ -199,7 +199,7 @@ class PrinterConfig:
         visited.remove(path)
     def _build_config_wrapper(self, data, filename):
         fileconfig = ConfigParser.RawConfigParser()
-        self._parse_config(data, filename, fileconfig)
+        self._parse_config(data, filename, fileconfig, set())
         return ConfigWrapper(self.printer, fileconfig, {}, 'printer')
     def _build_config_string(self, config):
         sfile = StringIO.StringIO()
@@ -258,8 +258,7 @@ class PrinterConfig:
             for option in self.autosave.fileconfig.options(section):
                 if config.fileconfig.has_option(section, option):
                     msg = "SAVE_CONFIG section '%s' option '%s' conflicts " \
-                          " with included value" % (section, option)
-                    logging.exception(msg)
+                          "with included value" % (section, option)
                     raise gcode.error(msg)
     cmd_SAVE_CONFIG_help = "Overwrite config file and restart"
     def cmd_SAVE_CONFIG(self, params):


### PR DESCRIPTION
Allows configuration files to include other configuration files using `[include filename.cfg]` syntax.  Klippy loads include files in the position of the include header; subsequent definitions override included values.

Supports wildcards (e.g. `[include macros/*.cfg]`).  Allows included files to include other files but blocks recursion.

Resolves #1145

Example `printer.cfg`:

```ini
# Load standard simulator config
[include klipper/config/avrsim.cfg]

# Make it faster
[printer]
max_velocity: 750
max_accel: 4500

# Add our macros
[include macros/*.cfg]
```

Signed-off-by: Greg Lauckhart <greg@lauckhart.com>