### PR TITLE
menu: set input ranges for moving toolhead to same value

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -252,8 +252,8 @@ type: input
 enable: !toolhead.is_printing
 name: "Move E:{0:+06.1f}"
 parameter: 0
-input_min: -250.0
-input_max: 250.0
+input_min: -50.0
+input_max: 50.0
 input_step: 10.0
 gcode: G1 E{0:.1f} F240
 
@@ -272,7 +272,7 @@ type: input
 name: "X:{0:05.1f} "
 parameter: toolhead.xpos
 input_min: 0
-input_max: 100.0
+input_max: 200.0
 input_step: 1.0
 gcode: G1 X{0:.1f}
 
@@ -281,7 +281,7 @@ type: input
 name: "Y:{0:05.1f} "
 parameter: toolhead.ypos
 input_min: 0
-input_max: 100.0
+input_max: 200.0
 input_step: 1.0
 gcode: G1 Y{0:.1f}
 
@@ -291,7 +291,7 @@ enable: !toolhead.is_printing
 name: "Move Z:{0:05.1f}"
 parameter: toolhead.zpos
 input_min: 0
-input_max: 100.0
+input_max: 200.0
 input_step: 1.0
 gcode: G1 Z{0:.1f}
 
@@ -300,8 +300,8 @@ type: input
 enable: !toolhead.is_printing
 name: "Move E:{0:+06.1f}"
 parameter: 0
-input_min: -100.0
-input_max: 100.0
+input_min: -50.0
+input_max: 50.0
 input_step: 1.0
 gcode: G1 E{0:.1f} F240
 
@@ -320,7 +320,7 @@ type: input
 name: "X:{0:05.1f} "
 parameter: toolhead.xpos
 input_min: 0
-input_max: 50.0
+input_max: 200.0
 input_step: 0.1
 gcode: G1 X{0:.1f}
 
@@ -329,7 +329,7 @@ type: input
 name: "Y:{0:05.1f} "
 parameter: toolhead.ypos
 input_min: 0
-input_max: 50.0
+input_max: 200.0
 input_step: 0.1
 gcode: G1 Y{0:.1f}
 
@@ -339,7 +339,7 @@ enable: !toolhead.is_printing
 name: "Move Z:{0:05.1f}"
 parameter: toolhead.zpos
 input_min: 0
-input_max: 50.0
+input_max: 200.0
 input_step: 0.1
 gcode: G1 Z{0:.1f}
 


### PR DESCRIPTION
Currently, `input_min`/`input_max` settings in menu for moving toolhead are different for 10mm, 1mm and 0.1mm moves. Propose change to same 200.0 `input_max` value of the 10mm XYZ move option. Also update extruder move `input_min` and `input_max` settings to -250 to 250 of 10mm setting.

One should be able to access the same range regardless of the step value. Also current settings can cause unexpected toolhead movement. For example, you can move x to 200 via the 10mm step menu, then if you decide to adjust position via 1mm menu, previous `input_max` setting will move head at least 100mm down to 100.

Reported in issue: https://github.com/KevinOConnor/klipper/issues/1334

Signed-off-by: Frank Kang <amblidex@outlook.com>