### PR TITLE
z_tilt: bugfix for final correction of z-offset

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -266,9 +266,11 @@
 #[z_tilt]
 #z_positions:
 #   A list of X,Y coordinates (one per line; subsequent lines
-#   indented) describing the location of each Z stepper. The first
+#   indented) describing the location of each pivot point. The first
 #   entry corresponds to stepper_z, the second to stepper_z1, the
 #   third to stepper_z2, etc. This parameter must be provided.
+#   The positions are relative to the nozzle. Be sure to also configure
+#   the probe offset in the [probe] section.
 #points:
 #   A list of X,Y coordinates (one per line; subsequent lines
 #   indented) that should be probed during a Z_TILT_ADJUST command.

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -99,7 +99,7 @@ class ZTilt:
         # Z should now be level - do final cleanup
         last_stepper_offset, last_stepper = positions[-1]
         last_stepper.set_ignore_move(False)
-        curpos[2] -= z_adjust
+        curpos[2] -= z_adjust - first_stepper_offset
         toolhead.set_position(curpos)
         self.gcode.reset_last_position()
 


### PR DESCRIPTION
The z_adjust offset provided to adjust_steppers is calculated given the
steppers adjust exactly according to the given x_adjust/y_adjust. As the
algorithm eliminates an offset that is common to all steppers, this offset
must be taken into account in the final correction.

Signed-off-by: Arne Jansen <arne@die-jansens.de>