### PR TITLE
virtual_sdcard: consistent sorting, further filtering to workable types.

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1197,15 +1197,6 @@
 #   are not supported). One may point this to OctoPrint's upload
 #   directory (generally ~/.octoprint/uploads/ ). This parameter must
 #   be provided.
-#sort_by: name
-#   The sort order of files in virtual sdcard. Can be one of:
-#     "name" alphabetical
-#     "date" newest to oldest
-#     "size" large to small
-#   This parameter is optional and defaults to "name"
-#sort_reverse: false
-#   Reverse the sort order of the files in the virtual sdcard. This
-#   parameter is optional and defaults to false.
 
 
 # Support for a display attached to the micro-controller.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1197,6 +1197,15 @@
 #   are not supported). One may point this to OctoPrint's upload
 #   directory (generally ~/.octoprint/uploads/ ). This parameter must
 #   be provided.
+#sort_by: name
+#   The sort order of files in virtual sdcard. Can be one of:
+#     "name" alphabetical
+#     "date" newest to oldest
+#     "size" large to small
+#   This parameter is optional and defaults to "name"
+#sort_reverse: false
+#   Reverse the sort order of the files in the virtual sdcard. This
+#   parameter is optional and defaults to false.
 
 
 # Support for a display attached to the micro-controller.

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -15,12 +15,6 @@ class VirtualSD:
         self.sdcard_dirname = os.path.normpath(os.path.expanduser(sd))
         self.current_file = None
         self.file_position = self.file_size = 0
-        # file sort config
-        sort_choices = {'name': self._sort_by_name,
-                        'date': self._sort_by_date,
-                        'size': self._sort_by_size}
-        self.sort = config.getchoice('sort_by', sort_choices, 'name')
-        self.sort_reverse = config.getboolean('sort_reverse', False)
         # Work timer
         self.reactor = printer.get_reactor()
         self.must_pause_work = False
@@ -59,22 +53,12 @@ class VirtualSD:
                               and fname.endswith('.gcode')
                               and os.path.isfile(os.path.join(dname, fname)),
                 raw_dir_list)
-            sorted_files = sorted(filtered,
-                               key=lambda fname: self.sort(dname, fname),
-                               reverse=self.sort_reverse)
+            sorted_files = sorted(filtered)
             return [(fname, os.path.getsize(os.path.join(dname, fname)))
                     for fname in sorted_files]
         except:
             logging.exception("virtual_sdcard get_file_list")
             raise self.gcode.error("Unable to get file list")
-    def _sort_by_name(self, dname, fname):
-        return fname
-    def _sort_by_date(self, dname, fname):
-        #negate mtime so that default is descending
-        return os.path.getmtime(os.path.join(dname, fname)) * -1
-    def _sort_by_size(self, dname, fname):
-        #negate size so that default is descending
-        return os.path.getsize(os.path.join(dname, fname)) * -1
     def get_status(self, eventtime):
         progress = 0.
         if self.work_timer is not None and self.file_size:

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -47,14 +47,11 @@ class VirtualSD:
     def get_file_list(self):
         dname = self.sdcard_dirname
         try:
-            raw_dir_list = os.listdir(self.sdcard_dirname)
-            filtered = filter(
-                lambda fname: not fname.startswith('.')
-                              and os.path.isfile(os.path.join(dname, fname)),
-                raw_dir_list)
-            sorted_files = sorted(filtered)
+            filenames = os.listdir(self.sdcard_dirname)
             return [(fname, os.path.getsize(os.path.join(dname, fname)))
-                    for fname in sorted_files]
+                    for fname in sorted(filenames, key=str.lower)
+                    if not fname.startswith('.')
+                    and os.path.isfile((os.path.join(dname, fname)))]
         except:
             logging.exception("virtual_sdcard get_file_list")
             raise self.gcode.error("Unable to get file list")

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -6,6 +6,7 @@
 import os, logging
 
 class VirtualSD:
+
     def __init__(self, config):
         printer = config.get_printer()
         printer.register_event_handler("klippy:shutdown", self.handle_shutdown)
@@ -14,6 +15,12 @@ class VirtualSD:
         self.sdcard_dirname = os.path.normpath(os.path.expanduser(sd))
         self.current_file = None
         self.file_position = self.file_size = 0
+        # file sort config
+        sort_choices = {'name': self._sort_by_name,
+                        'date': self._sort_by_date,
+                        'size': self._sort_by_size}
+        self.sort = config.getchoice('sort_by', sort_choices, 'name')
+        self.sort_reverse = config.getboolean('sort_reverse', False)
         # Work timer
         self.reactor = printer.get_reactor()
         self.must_pause_work = False
@@ -46,13 +53,26 @@ class VirtualSD:
     def get_file_list(self):
         dname = self.sdcard_dirname
         try:
-            filenames = os.listdir(self.sdcard_dirname)
+            raw_dir_list = os.listdir(self.sdcard_dirname)
+            filtered = filter(lambda fname: not fname.startswith('.')
+                                            and fname.endswith('.gcode'),
+                              raw_dir_list)
+            sorted_files = sorted(filtered,
+                               key=lambda fname: self.sort(dname, fname),
+                               reverse=self.sort_reverse)
             return [(fname, os.path.getsize(os.path.join(dname, fname)))
-                    for fname in filenames
-                    if not fname.startswith('.')]
+                    for fname in sorted_files]
         except:
             logging.exception("virtual_sdcard get_file_list")
             raise self.gcode.error("Unable to get file list")
+    def _sort_by_name(self, dname, fname):
+        return fname
+    def _sort_by_date(self, dname, fname):
+        #negate mtime so that default is descending
+        return os.path.getmtime(os.path.join(dname, fname)) * -1
+    def _sort_by_size(self, dname, fname):
+        #negate size so that default is descending
+        return os.path.getsize(os.path.join(dname, fname)) * -1
     def get_status(self, eventtime):
         progress = 0.
         if self.work_timer is not None and self.file_size:

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -50,7 +50,6 @@ class VirtualSD:
             raw_dir_list = os.listdir(self.sdcard_dirname)
             filtered = filter(
                 lambda fname: not fname.startswith('.')
-                              and fname.endswith('.gcode')
                               and os.path.isfile(os.path.join(dname, fname)),
                 raw_dir_list)
             sorted_files = sorted(filtered)

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -54,10 +54,11 @@ class VirtualSD:
         dname = self.sdcard_dirname
         try:
             raw_dir_list = os.listdir(self.sdcard_dirname)
-            filtered = filter(lambda fname: not fname.startswith('.')
-                                            and fname.endswith('.gcode')
-                                            and os.path.isfile(os.path.join(dname, fname)),
-                              raw_dir_list)
+            filtered = filter(
+                lambda fname: not fname.startswith('.')
+                              and fname.endswith('.gcode')
+                              and os.path.isfile(os.path.join(dname, fname)),
+                raw_dir_list)
             sorted_files = sorted(filtered,
                                key=lambda fname: self.sort(dname, fname),
                                reverse=self.sort_reverse)

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -55,7 +55,8 @@ class VirtualSD:
         try:
             raw_dir_list = os.listdir(self.sdcard_dirname)
             filtered = filter(lambda fname: not fname.startswith('.')
-                                            and fname.endswith('.gcode'),
+                                            and fname.endswith('.gcode')
+                                            and os.path.isfile(os.path.join(dname, fname)),
                               raw_dir_list)
             sorted_files = sorted(filtered,
                                key=lambda fname: self.sort(dname, fname),


### PR DESCRIPTION
more virtual sd options as requested in #1304 
also added some further filtering to ensure only `.gcode` files are listed somewhat in response to discussion of gcode not really handling directories in #1303 