### PR TITLE
Support for enumerations in the low-level mcu<->host protocol

### DIFF
--- a/docs/Protocol.md
+++ b/docs/Protocol.md
@@ -115,7 +115,7 @@ Declaring constants
 Constants can also be exported. For example, the following:
 
 ```
-DECL_CONSTANT(SERIAL_BAUD, 250000);
+DECL_CONSTANT("SERIAL_BAUD", 250000);
 ```
 
 would export a constant named "SERIAL_BAUD" with a value of 250000

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -7,12 +7,6 @@
 import math
 import bus
 
-# Sensor types defined in the micro-controller code (thermocouple.c)
-TS_CHIP_MAX31855 = 1 << 0
-TS_CHIP_MAX31856 = 1 << 1
-TS_CHIP_MAX31865 = 1 << 2
-TS_CHIP_MAX6675  = 1 << 3
-
 
 ######################################################################
 # SensorBase
@@ -46,7 +40,7 @@ class SensorBase:
         return REPORT_TIME
     def _build_config(self):
         self.mcu.add_config_cmd(
-            "config_thermocouple oid=%u spi_oid=%u chip_type=%u" % (
+            "config_thermocouple oid=%u spi_oid=%u thermocouple_type=%s" % (
                 self.oid, self.spi.get_oid(), self.chip_type))
         clock = self.mcu.get_query_slot(self.oid)
         self._report_clock = self.mcu.seconds_to_clock(REPORT_TIME)
@@ -123,7 +117,7 @@ MAX31856_MULT = 0.0078125
 
 class MAX31856(SensorBase):
     def __init__(self, config):
-        SensorBase.__init__(self, config, TS_CHIP_MAX31856,
+        SensorBase.__init__(self, config, "MAX31856",
                             self.build_spi_init(config))
     def calc_temp(self, adc, fault):
         if fault & MAX31856_FAULT_CJRANGE:
@@ -198,7 +192,7 @@ MAX31855_MULT = 0.25
 
 class MAX31855(SensorBase):
     def __init__(self, config):
-        SensorBase.__init__(self, config, TS_CHIP_MAX31855)
+        SensorBase.__init__(self, config, "MAX31855")
     def calc_temp(self, adc, fault):
         if adc & 0x1:
             self.fault("MAX31855 : Open Circuit")
@@ -227,7 +221,7 @@ MAX6675_MULT = 0.25
 
 class MAX6675(SensorBase):
     def __init__(self, config):
-        SensorBase.__init__(self, config, TS_CHIP_MAX6675)
+        SensorBase.__init__(self, config, "MAX6675")
     def calc_temp(self, adc, fault):
         if adc & 0x02:
             self.fault("Max6675 : Device ID error")
@@ -281,7 +275,7 @@ class MAX31865(SensorBase):
     def __init__(self, config):
         self.rtd_nominal_r = config.getint('rtd_nominal_r', 100)
         self.reference_r = config.getfloat('rtd_reference_r', 430., above=0.)
-        SensorBase.__init__(self, config, TS_CHIP_MAX31865,
+        SensorBase.__init__(self, config, "MAX31865",
                             self.build_spi_init(config))
     def calc_temp(self, adc, fault):
         if fault & 0x80:

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -483,7 +483,7 @@ class MCU:
         if self._is_shutdown:
             return
         self._is_shutdown = True
-        self._shutdown_msg = msg = params['#msg']
+        self._shutdown_msg = msg = params['static_string_id']
         logging.info("MCU '%s' %s: %s\n%s\n%s", self._name, params['#name'],
                      self._shutdown_msg, self._clocksync.dump_debug(),
                      self._serial.dump_debug())

--- a/klippy/msgproto.py
+++ b/klippy/msgproto.py
@@ -1,6 +1,6 @@
 # Protocol definitions for firmware communication
 #
-# Copyright (C) 2016,2017  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import json, zlib, logging
@@ -37,9 +37,10 @@ def crc16_ccitt(buf):
     return crc
 
 class PT_uint32:
-    is_int = 1
+    is_int = True
+    is_dynamic_string = False
     max_length = 5
-    signed = 0
+    signed = False
     def encode(self, out, v):
         if v >= 0xc000000 or v < -0x4000000: out.append((v>>28) & 0x7f | 0x80)
         if v >= 0x180000 or v < -0x80000:    out.append((v>>21) & 0x7f | 0x80)
@@ -61,17 +62,18 @@ class PT_uint32:
         return v, pos
 
 class PT_int32(PT_uint32):
-    signed = 1
+    signed = True
 class PT_uint16(PT_uint32):
     max_length = 3
 class PT_int16(PT_int32):
-    signed = 1
+    signed = True
     max_length = 3
 class PT_byte(PT_uint32):
     max_length = 2
 
 class PT_string:
-    is_int = 0
+    is_int = False
+    is_dynamic_string = True
     max_length = 64
     def encode(self, out, v):
         out.append(len(v))
@@ -91,22 +93,55 @@ MessageTypes = {
     '%s': PT_string(), '%.*s': PT_progmem_buffer(), '%*s': PT_buffer(),
 }
 
+class Enumeration:
+    is_int = False
+    is_dynamic_string = False
+    def __init__(self, pt, enum_name, enums):
+        self.pt = pt
+        self.max_length = pt.max_length
+        self.enum_name = enum_name
+        self.enums = enums
+        self.reverse_enums = {v: k for k, v in enums.items()}
+    def encode(self, out, v):
+        tv = self.enums.get(v)
+        if tv is None:
+            raise error("Unknown value '%s' in enumeration '%s'" % (
+                v, self.enum_name))
+        self.pt.encode(out, tv)
+    def parse(self, s, pos):
+        v, pos = self.pt.parse(s, pos)
+        tv = self.reverse_enums.get(v)
+        if tv is None:
+            tv = "?%d" % (v,)
+        return tv, pos
+
+# Lookup the message types for a format string
+def lookup_params(msgformat, enumerations={}):
+    out = []
+    argparts = [arg.split('=') for arg in msgformat.split()[1:]]
+    for name, fmt in argparts:
+        pt = MessageTypes[fmt]
+        for enum_name, enums in enumerations.items():
+            if name == enum_name or name.endswith('_' + enum_name):
+                pt = Enumeration(pt, enum_name, enums)
+                break
+        out.append((name, pt))
+    return out
+
 # Update the message format to be compatible with python's % operator
 def convert_msg_format(msgformat):
-    mf = msgformat.replace('%c', '%u')
-    mf = mf.replace('%.*s', '%s').replace('%*s', '%s')
-    return mf
+    for c in ['%u', '%i', '%hu', '%hi', '%c', '%.*s', '%*s']:
+        msgformat = msgformat.replace(c, '%s')
+    return msgformat
 
 class MessageFormat:
-    def __init__(self, msgid, msgformat):
+    def __init__(self, msgid, msgformat, enumerations={}):
         self.msgid = msgid
         self.msgformat = msgformat
         self.debugformat = convert_msg_format(msgformat)
-        parts = msgformat.split()
-        self.name = parts[0]
-        argparts = [arg.split('=') for arg in parts[1:]]
-        self.param_types = [MessageTypes[fmt] for name, fmt in argparts]
-        self.param_names = [(name, MessageTypes[fmt]) for name, fmt in argparts]
+        self.name = msgformat.split()[0]
+        self.param_names = lookup_params(msgformat, enumerations)
+        self.param_types = [t for name, t in self.param_names]
         self.name_to_type = dict(self.param_names)
     def encode(self, params):
         out = []
@@ -131,7 +166,7 @@ class MessageFormat:
         out = []
         for name, t in self.param_names:
             v = params[name]
-            if not t.is_int:
+            if t.is_dynamic_string:
                 v = repr(v)
             out.append(v)
         return self.debugformat % tuple(out)
@@ -162,7 +197,7 @@ class OutputFormat:
         out = []
         for t in self.param_types:
             v, pos = t.parse(s, pos)
-            if not t.is_int:
+            if t.is_dynamic_string:
                 v = repr(v)
             out.append(v)
         outmsg = self.debugformat % tuple(out)
@@ -183,10 +218,10 @@ class MessageParser:
     error = error
     def __init__(self):
         self.unknown = UnknownFormat()
+        self.enumerations = {}
         self.command_ids = []
         self.messages_by_id = {}
         self.messages_by_name = {}
-        self.static_strings = {}
         self.config = {}
         self.version = self.build_versions = ""
         self.raw_identify_data = ""
@@ -239,9 +274,6 @@ class MessageParser:
         if pos != len(s)-MESSAGE_TRAILER_SIZE:
             raise error("Extra data at end of message")
         params['#name'] = mid.name
-        static_string_id = params.get('static_string_id')
-        if static_string_id is not None:
-            params['#msg'] = self.static_strings.get(static_string_id, "?")
         return params
     def encode(self, seq, cmd):
         msglen = MESSAGE_MIN + len(cmd)
@@ -282,27 +314,47 @@ class MessageParser:
             argparts = dict(arg.split('=', 1) for arg in parts[1:])
             for name, value in argparts.items():
                 t = mp.name_to_type[name]
-                if t.is_int:
+                if t.is_dynamic_string:
+                    tval = self._parse_buffer(value)
+                elif t.is_int:
                     tval = int(value, 0)
                 else:
-                    tval = self._parse_buffer(value)
+                    tval = value
                 argparts[name] = tval
         except:
-            #traceback.print_exc()
+            #logging.exception("Unable to extract params")
             raise error("Unable to extract params from: %s" % (msgname,))
         try:
             cmd = mp.encode_by_name(**argparts)
         except:
-            #traceback.print_exc()
+            #logging.exception("Unable to encode")
             raise error("Unable to encode: %s" % (msgname,))
         return cmd
+    def _fill_enumerations(self, enumerations):
+        for add_name, add_enums in enumerations.items():
+            enums = self.enumerations.setdefault(add_name, {})
+            for enum, value in add_enums.items():
+                if type(value) == type(0):
+                    # Simple enumeration
+                    enums[str(enum)] = value
+                    continue
+                # Enumeration range
+                enum = enum_root = str(enum)
+                while enum_root and enum_root[-1].isdigit():
+                    enum_root = enum_root[:-1]
+                start_enum = 0
+                if len(enum_root) != len(enum):
+                    start_enum = int(enum[len(enum_root):])
+                start_value, count = value
+                for i in range(count):
+                    enums[enum_root + str(start_enum + i)] = start_value + i
     def _init_messages(self, messages, output_ids=[]):
         for msgformat, msgid in messages.items():
             msgid = int(msgid)
             if msgid in output_ids:
                 self.messages_by_id[msgid] = OutputFormat(msgid, msgformat)
                 continue
-            msg = MessageFormat(msgid, msgformat)
+            msg = MessageFormat(msgid, msgformat, self.enumerations)
             self.messages_by_id[msgid] = msg
             self.messages_by_name[msg.name] = msg
     def process_identify(self, data, decompress=True):
@@ -311,6 +363,7 @@ class MessageParser:
                 data = zlib.decompress(data)
             self.raw_identify_data = data
             data = json.loads(data)
+            self._fill_enumerations(data.get('enumerations', {}))
             commands = data.get('commands')
             responses = data.get('responses')
             output = data.get('output', {})
@@ -319,8 +372,6 @@ class MessageParser:
             all_messages.update(output)
             self.command_ids = sorted(commands.values())
             self._init_messages(all_messages, output.values())
-            static_strings = data.get('static_strings', {})
-            self.static_strings = {int(k): v for k, v in static_strings.items()}
             self.config.update(data.get('config', {}))
             self.version = data.get('version', '')
             self.build_versions = data.get('build_versions', '')

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -38,8 +38,6 @@ def beaglebone_pins():
     return gpios
 
 MCU_PINS = {
-    "sam3x8e": port_pins(4, 32), "sam3x8c": port_pins(2, 32),
-    "sam4s8c": port_pins(3, 32), "sam4e8e" : port_pins(5, 32),
     "samd21g18a": port_pins(2, 32), "samd21e18a": port_pins(2, 32),
     "samd51g19a": port_pins(2, 32), "samd51j19a": port_pins(3, 32),
     "samd51n19a": port_pins(3, 32), "samd51p20a": port_pins(4, 32),

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -38,9 +38,6 @@ def beaglebone_pins():
     return gpios
 
 MCU_PINS = {
-    "samd21g18a": port_pins(2, 32), "samd21e18a": port_pins(2, 32),
-    "samd51g19a": port_pins(2, 32), "samd51j19a": port_pins(3, 32),
-    "samd51n19a": port_pins(3, 32), "samd51p20a": port_pins(4, 32),
     "stm32f103": port_pins(5, 16),
     "lpc176x": lpc_pins(),
     "pru": beaglebone_pins(),

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -28,10 +28,6 @@ def named_pins(fmt, port_count, bit_count=32):
              for port in range(port_count)
              for portbit in range(bit_count) }
 
-def lpc_pins():
-    return { 'P%d.%d' % (port, pin) : port * 32 + pin
-             for port in range(5) for pin in range(32) }
-
 def beaglebone_pins():
     gpios = named_pins("gpio%d_%d", 4)
     gpios.update({"AIN%d" % i: i+4*32 for i in range(8)})
@@ -39,7 +35,6 @@ def beaglebone_pins():
 
 MCU_PINS = {
     "stm32f103": port_pins(5, 16),
-    "lpc176x": lpc_pins(),
     "pru": beaglebone_pins(),
     "linux": {"analog%d" % i: i for i in range(8)}, # XXX
 }

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -13,16 +13,6 @@ class error(Exception):
 # Hardware pin names
 ######################################################################
 
-def port_pins(port_count, bit_count=8):
-    pins = {}
-    for port in range(port_count):
-        portchr = chr(65 + port)
-        if portchr == 'I':
-            continue
-        for portbit in range(bit_count):
-            pins['P%c%d' % (portchr, portbit)] = port * bit_count + portbit
-    return pins
-
 def named_pins(fmt, port_count, bit_count=32):
     return { fmt % (port, portbit) : port * bit_count + portbit
              for port in range(port_count)
@@ -34,7 +24,6 @@ def beaglebone_pins():
     return gpios
 
 MCU_PINS = {
-    "stm32f103": port_pins(5, 16),
     "pru": beaglebone_pins(),
     "linux": {"analog%d" % i: i for i in range(8)}, # XXX
 }

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -14,7 +14,6 @@ class error(Exception):
 ######################################################################
 
 MCU_PINS = {
-    "linux": {"analog%d" % i: i for i in range(8)}, # XXX
 }
 
 

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -13,18 +13,7 @@ class error(Exception):
 # Hardware pin names
 ######################################################################
 
-def named_pins(fmt, port_count, bit_count=32):
-    return { fmt % (port, portbit) : port * bit_count + portbit
-             for port in range(port_count)
-             for portbit in range(bit_count) }
-
-def beaglebone_pins():
-    gpios = named_pins("gpio%d_%d", 4)
-    gpios.update({"AIN%d" % i: i+4*32 for i in range(8)})
-    return gpios
-
 MCU_PINS = {
-    "pru": beaglebone_pins(),
     "linux": {"analog%d" % i: i for i in range(8)}, # XXX
 }
 
@@ -141,8 +130,7 @@ beagleboneblack_mappings = {
 def update_map_beaglebone(pins, mcu):
     if mcu != 'pru':
         raise error("Beaglebone aliases not supported on mcu '%s'" % (mcu,))
-    for pin, gpio in beagleboneblack_mappings.items():
-        pins[pin] = pins[gpio]
+    pins.update(beagleboneblack_mappings)
 
 
 ######################################################################

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -31,7 +31,6 @@ class SerialReader:
         # Message handlers
         handlers = {
             '#unknown': self.handle_unknown, '#output': self.handle_output,
-            'shutdown': self.handle_output, 'is_shutdown': self.handle_output
         }
         self.handlers = { (k, None): v for k, v in handlers.items() }
     def _bg_thread(self):

--- a/src/atsam/adc.c
+++ b/src/atsam/adc.c
@@ -27,7 +27,7 @@ static const uint8_t adc_pins[] = {
 };
 
 #define ADC_FREQ_MAX 20000000
-DECL_CONSTANT(ADC_MAX, 4095);
+DECL_CONSTANT("ADC_MAX", 4095);
 
 struct gpio_adc
 gpio_adc_setup(uint8_t pin)

--- a/src/atsam/gpio.c
+++ b/src/atsam/gpio.c
@@ -11,15 +11,28 @@
 #include "internal.h" // gpio_peripheral
 #include "sched.h" // sched_shutdown
 
+DECL_ENUMERATION_RANGE("pin", "PA0", GPIO('A', 0), 32);
+DECL_ENUMERATION_RANGE("pin", "PB0", GPIO('B', 0), 32);
+#ifdef PIOC
+DECL_ENUMERATION_RANGE("pin", "PC0", GPIO('C', 0), 32);
+#endif
+#ifdef PIOD
+DECL_ENUMERATION_RANGE("pin", "PD0", GPIO('D', 0), 32);
+#endif
+#ifdef PIOE
+DECL_ENUMERATION_RANGE("pin", "PE0", GPIO('E', 0), 32);
+#endif
+
 static Pio * const digital_regs[] = {
-#if CONFIG_MACH_SAM3X8E
-    PIOA, PIOB, PIOC, PIOD
-#elif CONFIG_MACH_SAM3X8C
-    PIOA, PIOB
-#elif CONFIG_MACH_SAM4S8C
-    PIOA, PIOB, PIOC
-#elif CONFIG_MACH_SAM4E8E
-    PIOA, PIOB, PIOC, PIOD, PIOE
+    PIOA, PIOB,
+#ifdef PIOC
+    PIOC,
+#endif
+#ifdef PIOD
+    PIOD,
+#endif
+#ifdef PIOE
+    PIOE,
 #endif
 };
 

--- a/src/atsam/hard_pwm.c
+++ b/src/atsam/hard_pwm.c
@@ -54,7 +54,7 @@ static const struct gpio_pwm_info pwm_regs[] = {
 
 #define MAX_PWM 255
 
-DECL_CONSTANT(PWM_MAX, MAX_PWM);
+DECL_CONSTANT("PWM_MAX", MAX_PWM);
 
 struct gpio_pwm
 gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint8_t val)

--- a/src/atsam/main.c
+++ b/src/atsam/main.c
@@ -10,7 +10,7 @@
 #include "internal.h" // WDT
 #include "sched.h" // sched_main
 
-DECL_CONSTANT(MCU, CONFIG_MCU);
+DECL_CONSTANT_STR("MCU", CONFIG_MCU);
 
 
 /****************************************************************

--- a/src/atsam/sam4e_afec.c
+++ b/src/atsam/sam4e_afec.c
@@ -51,7 +51,7 @@ gpio_adc_to_afec_chan(struct gpio_adc g)
 }
 
 #define ADC_FREQ_MAX 6000000UL
-DECL_CONSTANT(ADC_MAX, 4095);
+DECL_CONSTANT("ADC_MAX", 4095);
 
 static int
 init_afec(Afec* afec) {

--- a/src/atsamd/adc.c
+++ b/src/atsamd/adc.c
@@ -37,7 +37,7 @@ static const uint8_t adc_pins[] = {
 };
 #endif
 
-DECL_CONSTANT(ADC_MAX, 4095);
+DECL_CONSTANT("ADC_MAX", 4095);
 
 static struct gpio_adc gpio_adc_pin_to_struct(uint8_t pin)
 {

--- a/src/atsamd/gpio.c
+++ b/src/atsamd/gpio.c
@@ -44,8 +44,14 @@ gpio_peripheral(uint32_t gpio, char ptype, int32_t pull_up)
 
 #if CONFIG_MACH_SAMD21
 #define NUM_PORT 2
+DECL_ENUMERATION_RANGE("pin", "PA0", GPIO('A', 0), 32);
+DECL_ENUMERATION_RANGE("pin", "PB0", GPIO('B', 0), 32);
 #elif CONFIG_MACH_SAMD51
 #define NUM_PORT 4
+DECL_ENUMERATION_RANGE("pin", "PA0", GPIO('A', 0), 32);
+DECL_ENUMERATION_RANGE("pin", "PB0", GPIO('B', 0), 32);
+DECL_ENUMERATION_RANGE("pin", "PC0", GPIO('C', 0), 32);
+DECL_ENUMERATION_RANGE("pin", "PD0", GPIO('D', 0), 32);
 #endif
 
 struct gpio_out

--- a/src/atsamd/hard_pwm.c
+++ b/src/atsamd/hard_pwm.c
@@ -41,7 +41,7 @@ static const struct gpio_pwm_info pwm_regs[] = {
 
 #define MAX_PWM 255
 
-DECL_CONSTANT(PWM_MAX, MAX_PWM);
+DECL_CONSTANT("PWM_MAX", MAX_PWM);
 
 struct gpio_pwm
 gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint8_t val)

--- a/src/atsamd/main.c
+++ b/src/atsamd/main.c
@@ -8,7 +8,7 @@
 #include "internal.h" // NVIC_SystemReset
 #include "sched.h" // sched_main
 
-DECL_CONSTANT(MCU, CONFIG_MCU);
+DECL_CONSTANT_STR("MCU", CONFIG_MCU);
 
 // Return the start of memory available for dynamic allocations
 void *

--- a/src/avr/adc.c
+++ b/src/avr/adc.c
@@ -36,7 +36,7 @@ static const uint8_t adc_pins[] PROGMEM = {
 enum { ADMUX_DEFAULT = 0x40 };
 enum { ADC_ENABLE = (1<<ADPS0)|(1<<ADPS1)|(1<<ADPS2)|(1<<ADEN)|(1<<ADIF) };
 
-DECL_CONSTANT(ADC_MAX, 1023);
+DECL_CONSTANT("ADC_MAX", 1023);
 
 struct gpio_adc
 gpio_adc_setup(uint8_t pin)

--- a/src/avr/gpio.c
+++ b/src/avr/gpio.c
@@ -12,6 +12,24 @@
 #include "pgm.h" // PROGMEM
 #include "sched.h" // sched_shutdown
 
+#ifdef PINA
+DECL_ENUMERATION_RANGE("pin", "PA0", GPIO('A', 0), 8);
+#endif
+DECL_ENUMERATION_RANGE("pin", "PB0", GPIO('B', 0), 8);
+DECL_ENUMERATION_RANGE("pin", "PC0", GPIO('C', 0), 8);
+DECL_ENUMERATION_RANGE("pin", "PD0", GPIO('D', 0), 8);
+#ifdef PINE
+DECL_ENUMERATION_RANGE("pin", "PE0", GPIO('E', 0), 8);
+DECL_ENUMERATION_RANGE("pin", "PF0", GPIO('F', 0), 8);
+#endif
+#ifdef PING
+DECL_ENUMERATION_RANGE("pin", "PG0", GPIO('G', 0), 8);
+DECL_ENUMERATION_RANGE("pin", "PH0", GPIO('H', 0), 8);
+DECL_ENUMERATION_RANGE("pin", "PJ0", GPIO('J', 0), 8);
+DECL_ENUMERATION_RANGE("pin", "PK0", GPIO('K', 0), 8);
+DECL_ENUMERATION_RANGE("pin", "PL0", GPIO('L', 0), 8);
+#endif
+
 volatile uint8_t * const digital_regs[] PROGMEM = {
 #ifdef PINA
     &PINA,

--- a/src/avr/hard_pwm.c
+++ b/src/avr/hard_pwm.c
@@ -74,7 +74,7 @@ static const struct gpio_pwm_info pwm_regs[] PROGMEM = {
 #endif
 };
 
-DECL_CONSTANT(PWM_MAX, 255);
+DECL_CONSTANT("PWM_MAX", 255);
 
 struct gpio_pwm
 gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint8_t val)

--- a/src/avr/main.c
+++ b/src/avr/main.c
@@ -12,7 +12,7 @@
 #include "irq.h" // irq_enable
 #include "sched.h" // sched_main
 
-DECL_CONSTANT(MCU, CONFIG_MCU);
+DECL_CONSTANT_STR("MCU", CONFIG_MCU);
 
 
 /****************************************************************

--- a/src/avr/timer.c
+++ b/src/avr/timer.c
@@ -16,7 +16,7 @@
  * Low level timer code
  ****************************************************************/
 
-DECL_CONSTANT(CLOCK_FREQ, CONFIG_CLOCK_FREQ);
+DECL_CONSTANT("CLOCK_FREQ", CONFIG_CLOCK_FREQ);
 
 // Return the number of clock ticks for a given number of microseconds
 uint32_t

--- a/src/basecmd.c
+++ b/src/basecmd.c
@@ -258,7 +258,7 @@ command_get_uptime(uint32_t *args)
 DECL_COMMAND_FLAGS(command_get_uptime, HF_IN_SHUTDOWN, "get_uptime");
 
 #define SUMSQ_BASE 256
-DECL_CONSTANT(STATS_SUMSQ_BASE, SUMSQ_BASE);
+DECL_CONSTANT("STATS_SUMSQ_BASE", SUMSQ_BASE);
 
 void
 stats_update(uint32_t start, uint32_t cur)

--- a/src/command.h
+++ b/src/command.h
@@ -16,8 +16,8 @@
 #define HF_IN_SHUTDOWN   0x01   // Handler can run even when in emergency stop
 
 // Declare a constant exported to the host
-#define DECL_CONSTANT(NAME, VALUE)              \
-    _DECL_CONSTANT(NAME, VALUE)
+#define DECL_CONSTANT(NAME, VALUE) _DECL_CONSTANT(NAME, __stringify(VALUE))
+#define DECL_CONSTANT_STR(NAME, VALUE) _DECL_CONSTANT(NAME, VALUE)
 
 // Send an output message (and declare a static message type for it)
 #define output(FMT, args...)                    \
@@ -88,8 +88,8 @@ uint8_t ctr_lookup_static_string(const char *str);
 #define _DECL_COMMAND(FUNC, FLAGS, MSG)                                 \
     DECL_CTR("_DECL_COMMAND " __stringify(FUNC) " " __stringify(FLAGS) " " MSG)
 
-#define _DECL_CONSTANT(NAME, VALUE)                                     \
-    DECL_CTR("_DECL_CONSTANT " __stringify(NAME) " " __stringify(VALUE))
+#define _DECL_CONSTANT(NAME, VALUE)             \
+    DECL_CTR("_DECL_CONSTANT " NAME " " VALUE)
 
 #define _DECL_ENCODER(FMT) ({                   \
     DECL_CTR("_DECL_ENCODER " FMT);             \

--- a/src/command.h
+++ b/src/command.h
@@ -7,17 +7,19 @@
 #include "ctr.h" // DECL_CTR
 
 // Declare a function to run when the specified command is received
+#define DECL_COMMAND_FLAGS(FUNC, FLAGS, MSG)                            \
+    DECL_CTR("_DECL_COMMAND " __stringify(FUNC) " " __stringify(FLAGS) " " MSG)
 #define DECL_COMMAND(FUNC, MSG)                 \
-    _DECL_COMMAND(FUNC, 0, MSG)
-#define DECL_COMMAND_FLAGS(FUNC, FLAGS, MSG)    \
-    _DECL_COMMAND(FUNC, FLAGS, MSG)
+    DECL_COMMAND_FLAGS(FUNC, 0, MSG)
 
 // Flags for command handler declarations.
 #define HF_IN_SHUTDOWN   0x01   // Handler can run even when in emergency stop
 
 // Declare a constant exported to the host
-#define DECL_CONSTANT(NAME, VALUE) _DECL_CONSTANT(NAME, __stringify(VALUE))
-#define DECL_CONSTANT_STR(NAME, VALUE) _DECL_CONSTANT(NAME, VALUE)
+#define DECL_CONSTANT(NAME, VALUE)                      \
+    DECL_CTR_INT("_DECL_CONSTANT " NAME, (VALUE))
+#define DECL_CONSTANT_STR(NAME, VALUE)                  \
+    DECL_CTR("_DECL_CONSTANT_STR " NAME " " VALUE)
 
 // Send an output message (and declare a static message type for it)
 #define output(FMT, args...)                    \
@@ -84,12 +86,6 @@ extern const uint32_t command_identify_size;
 const struct command_encoder *ctr_lookup_encoder(const char *str);
 const struct command_encoder *ctr_lookup_output(const char *str);
 uint8_t ctr_lookup_static_string(const char *str);
-
-#define _DECL_COMMAND(FUNC, FLAGS, MSG)                                 \
-    DECL_CTR("_DECL_COMMAND " __stringify(FUNC) " " __stringify(FLAGS) " " MSG)
-
-#define _DECL_CONSTANT(NAME, VALUE)             \
-    DECL_CTR("_DECL_CONSTANT " NAME " " VALUE)
 
 #define _DECL_ENCODER(FMT) ({                   \
     DECL_CTR("_DECL_ENCODER " FMT);             \

--- a/src/command.h
+++ b/src/command.h
@@ -21,6 +21,13 @@
 #define DECL_CONSTANT_STR(NAME, VALUE)                  \
     DECL_CTR("_DECL_CONSTANT_STR " NAME " " VALUE)
 
+// Declare an enumeration
+#define DECL_ENUMERATION(ENUM, NAME, VALUE)                     \
+    DECL_CTR_INT("_DECL_ENUMERATION " ENUM " " NAME, (VALUE))
+#define DECL_ENUMERATION_RANGE(ENUM, NAME, VALUE, COUNT)        \
+    DECL_CTR_INT("_DECL_ENUMERATION_RANGE " ENUM " " NAME       \
+                 " " __stringify(COUNT), (VALUE))
+
 // Send an output message (and declare a static message type for it)
 #define output(FMT, args...)                    \
     command_sendf(_DECL_OUTPUT(FMT) , ##args )

--- a/src/ctr.h
+++ b/src/ctr.h
@@ -14,4 +14,17 @@
     static char __PASTE(_DECLS_, __LINE__)[] __attribute__((used))      \
         __section(".compile_time_request") = (REQUEST)
 
+#define CTR_INT(V, S) ((((uint32_t)(V) >> S) & 0x3f) + 48)
+
+// Declare a compile time request with an integer expression
+#define DECL_CTR_INT(REQUEST, VALUE)                            \
+    static struct { char _r[sizeof(REQUEST)]; char _v[8]; }     \
+        __PASTE(_DECLI_, __LINE__) __attribute__((used))        \
+            __section(".compile_time_request") = {              \
+            REQUEST " ", {                                      \
+                (VALUE) < 0 ? '-' : '+',                        \
+                CTR_INT((VALUE),0), CTR_INT((VALUE),6),         \
+                CTR_INT((VALUE),12), CTR_INT((VALUE),18),       \
+                CTR_INT((VALUE),24), CTR_INT((VALUE),30), 0 } }
+
 #endif // ctr.h

--- a/src/generic/armcm_timer.c
+++ b/src/generic/armcm_timer.c
@@ -11,7 +11,7 @@
 #include "command.h" // shutdown
 #include "sched.h" // sched_timer_dispatch
 
-DECL_CONSTANT(CLOCK_FREQ, CONFIG_CLOCK_FREQ);
+DECL_CONSTANT("CLOCK_FREQ", CONFIG_CLOCK_FREQ);
 
 // Return the number of clock ticks for a given number of microseconds
 uint32_t

--- a/src/generic/serial_irq.c
+++ b/src/generic/serial_irq.c
@@ -19,8 +19,8 @@
 static uint8_t receive_buf[RX_BUFFER_SIZE], receive_pos;
 static uint8_t transmit_buf[96], transmit_pos, transmit_max;
 
-DECL_CONSTANT(SERIAL_BAUD, CONFIG_SERIAL_BAUD);
-DECL_CONSTANT(RECEIVE_WINDOW, RX_BUFFER_SIZE);
+DECL_CONSTANT("SERIAL_BAUD", CONFIG_SERIAL_BAUD);
+DECL_CONSTANT("RECEIVE_WINDOW", RX_BUFFER_SIZE);
 
 // Rx interrupt - store read data
 void

--- a/src/generic/timer_irq.c
+++ b/src/generic/timer_irq.c
@@ -11,7 +11,7 @@
 #include "command.h" // shutdown
 #include "sched.h" // sched_timer_dispatch
 
-DECL_CONSTANT(CLOCK_FREQ, CONFIG_CLOCK_FREQ);
+DECL_CONSTANT("CLOCK_FREQ", CONFIG_CLOCK_FREQ);
 
 // Return the number of clock ticks for a given number of microseconds
 uint32_t

--- a/src/gpiocmds.c
+++ b/src/gpiocmds.c
@@ -107,7 +107,7 @@ DECL_COMMAND(command_set_digital_out, "set_digital_out pin=%u value=%c");
  ****************************************************************/
 
 #define MAX_SOFT_PWM 256
-DECL_CONSTANT(SOFT_PWM_MAX, MAX_SOFT_PWM);
+DECL_CONSTANT("SOFT_PWM_MAX", MAX_SOFT_PWM);
 
 struct soft_pwm_s {
     struct timer timer;

--- a/src/linux/analog.c
+++ b/src/linux/analog.c
@@ -13,7 +13,7 @@
 #include "internal.h" // report_errno
 #include "sched.h" // sched_shutdown
 
-DECL_CONSTANT(ADC_MAX, 4095); // Assume 12bit adc
+DECL_CONSTANT("ADC_MAX", 4095); // Assume 12bit adc
 
 #define IIO_PATH "/sys/bus/iio/devices/iio:device0/in_voltage%d_raw"
 

--- a/src/linux/analog.c
+++ b/src/linux/analog.c
@@ -15,6 +15,8 @@
 
 DECL_CONSTANT("ADC_MAX", 4095); // Assume 12bit adc
 
+DECL_ENUMERATION_RANGE("pin", "analog0", 0, 8);
+
 #define IIO_PATH "/sys/bus/iio/devices/iio:device0/in_voltage%d_raw"
 
 struct gpio_adc

--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -13,7 +13,7 @@
 #include "internal.h" // console_setup
 #include "sched.h" // sched_main
 
-DECL_CONSTANT(MCU, "linux");
+DECL_CONSTANT_STR("MCU", "linux");
 
 
 /****************************************************************

--- a/src/linux/pca9685.c
+++ b/src/linux/pca9685.c
@@ -136,7 +136,7 @@ struct i2cpwm_s {
     uint32_t max_duration;
 };
 
-DECL_CONSTANT(PCA9685_MAX, VALUE_MAX);
+DECL_CONSTANT("PCA9685_MAX", VALUE_MAX);
 
 static uint_fast8_t
 pca9685_end_event(struct timer *timer)

--- a/src/linux/timer.c
+++ b/src/linux/timer.c
@@ -106,7 +106,7 @@ timer_check_periodic(struct timespec *ts)
  * Timers
  ****************************************************************/
 
-DECL_CONSTANT(CLOCK_FREQ, CONFIG_CLOCK_FREQ);
+DECL_CONSTANT("CLOCK_FREQ", CONFIG_CLOCK_FREQ);
 
 // Return the number of clock ticks for a given number of microseconds
 uint32_t

--- a/src/lpc176x/adc.c
+++ b/src/lpc176x/adc.c
@@ -23,7 +23,7 @@ static const uint8_t adc_pin_funcs[] = {
 };
 
 #define ADC_FREQ_MAX 13000000
-DECL_CONSTANT(ADC_MAX, 4095);
+DECL_CONSTANT("ADC_MAX", 4095);
 
 // The lpc176x adc is extremely noisy. Implement a 5 entry median
 // filter to weed out obviously incorrect readings.

--- a/src/lpc176x/gpio.c
+++ b/src/lpc176x/gpio.c
@@ -17,6 +17,12 @@
  * Pin mappings
  ****************************************************************/
 
+DECL_ENUMERATION_RANGE("pin", "P0.0", GPIO(0, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "P1.0", GPIO(1, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "P2.0", GPIO(2, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "P3.0", GPIO(3, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "P4.0", GPIO(4, 0), 32);
+
 static LPC_GPIO_TypeDef * const digital_regs[] = {
     LPC_GPIO0, LPC_GPIO1, LPC_GPIO2, LPC_GPIO3, LPC_GPIO4
 };

--- a/src/lpc176x/main.c
+++ b/src/lpc176x/main.c
@@ -8,7 +8,7 @@
 #include "command.h" // DECL_CONSTANT
 #include "sched.h" // sched_main
 
-DECL_CONSTANT(MCU, "lpc176x");
+DECL_CONSTANT_STR("MCU", "lpc176x");
 
 
 /****************************************************************

--- a/src/pru/adc.c
+++ b/src/pru/adc.c
@@ -16,7 +16,7 @@
  * Analog to Digital Converter (ADC) pins
  ****************************************************************/
 
-DECL_CONSTANT(ADC_MAX, 4095);
+DECL_CONSTANT("ADC_MAX", 4095);
 
 static void
 adc_full_reset(void)

--- a/src/pru/adc.c
+++ b/src/pru/adc.c
@@ -51,6 +51,8 @@ adc_full_reset(void)
     have_done_reset = 1;
 }
 
+DECL_ENUMERATION_RANGE("pin", "AIN0", 4 * 32, 8);
+
 struct gpio_adc
 gpio_adc_setup(uint8_t pin)
 {

--- a/src/pru/gpio.c
+++ b/src/pru/gpio.c
@@ -29,6 +29,11 @@ struct gpio_regs {
     volatile uint32_t setdataout;
 };
 
+DECL_ENUMERATION_RANGE("pin", "gpio0_0", GPIO(0, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "gpio1_0", GPIO(1, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "gpio2_0", GPIO(2, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "gpio3_0", GPIO(3, 0), 32);
+
 static struct gpio_regs *digital_regs[] = {
     (void*)0x44e07000, (void*)0x4804c000, (void*)0x481ac000, (void*)0x481ae000
 };

--- a/src/pru/main.c
+++ b/src/pru/main.c
@@ -17,7 +17,7 @@
 #include "internal.h" // SHARED_MEM
 #include "sched.h" // sched_main
 
-DECL_CONSTANT(MCU, "pru");
+DECL_CONSTANT_STR("MCU", "pru");
 
 
 /****************************************************************

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -1,6 +1,6 @@
 // Handling of stepper drivers.
 //
-// Copyright (C) 2016  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -51,8 +51,10 @@ struct stepper {
 
 enum { POSITION_BIAS=0x40000000 };
 
-enum { SF_LAST_DIR=1<<0, SF_NEXT_DIR=1<<1, SF_INVERT_STEP=1<<2,
-       SF_HAVE_ADD=1<<3, SF_LAST_RESET=1<<4, SF_NO_NEXT_CHECK=1<<5 };
+enum {
+    SF_LAST_DIR=1<<0, SF_NEXT_DIR=1<<1, SF_INVERT_STEP=1<<2, SF_HAVE_ADD=1<<3,
+    SF_LAST_RESET=1<<4, SF_NO_NEXT_CHECK=1<<5, SF_NEED_RESET=1<<6
+};
 
 // Setup a stepper for the next move in its queue
 static uint_fast8_t
@@ -226,6 +228,8 @@ command_queue_step(uint32_t *args)
         else
             s->first = m;
         s->plast = &m->next;
+    } else if (flags & SF_NEED_RESET) {
+        move_free(m);
     } else {
         s->first = m;
         stepper_load_next(s, s->next_step_time + m->interval);
@@ -258,7 +262,7 @@ command_reset_step_clock(uint32_t *args)
     if (s->count)
         shutdown("Can't reset time when stepper active");
     s->next_step_time = waketime;
-    s->flags |= SF_LAST_RESET;
+    s->flags = (s->flags & !SF_NEED_RESET) | SF_LAST_RESET;
     irq_enable();
 }
 DECL_COMMAND(command_reset_step_clock, "reset_step_clock oid=%c clock=%u");
@@ -299,7 +303,7 @@ stepper_stop(struct stepper *s)
     s->next_step_time = 0;
     s->position = -stepper_get_position(s);
     s->count = 0;
-    s->flags &= SF_INVERT_STEP;
+    s->flags = (s->flags & SF_INVERT_STEP) | SF_NEED_RESET;
     gpio_out_write(s->dir_pin, 0);
     gpio_out_write(s->step_pin, s->flags & SF_INVERT_STEP);
     while (s->first) {

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -13,7 +13,7 @@
 #include "sched.h" // struct timer
 #include "stepper.h" // command_config_stepper
 
-DECL_CONSTANT(STEP_DELAY, CONFIG_STEP_DELAY);
+DECL_CONSTANT("STEP_DELAY", CONFIG_STEP_DELAY);
 
 
 /****************************************************************

--- a/src/stm32f1/adc.c
+++ b/src/stm32f1/adc.c
@@ -14,7 +14,7 @@
 #include "stm32f1xx_ll_gpio.h" // LL_GPIO_SetPinMode
 #include "sched.h" // sched_shutdown
 
-DECL_CONSTANT(ADC_MAX, 4095);
+DECL_CONSTANT("ADC_MAX", 4095);
 
 #define ADC_DELAY (240 * 8)
 

--- a/src/stm32f1/gpio.c
+++ b/src/stm32f1/gpio.c
@@ -17,6 +17,12 @@
  * Pin mappings
  ****************************************************************/
 
+DECL_ENUMERATION_RANGE("pin", "PA0", GPIO('A', 0), 16);
+DECL_ENUMERATION_RANGE("pin", "PB0", GPIO('B', 0), 16);
+DECL_ENUMERATION_RANGE("pin", "PC0", GPIO('C', 0), 16);
+DECL_ENUMERATION_RANGE("pin", "PD0", GPIO('D', 0), 16);
+DECL_ENUMERATION_RANGE("pin", "PE0", GPIO('E', 0), 16);
+
 GPIO_TypeDef *const digital_regs[] = {
     GPIOA, GPIOB, GPIOC, GPIOD, GPIOE
 };

--- a/src/stm32f1/main.c
+++ b/src/stm32f1/main.c
@@ -19,7 +19,7 @@
 #include "stm32f1xx_ll_spi.h"
 #include "sched.h" // sched_main
 
-DECL_CONSTANT(MCU, "stm32f103");
+DECL_CONSTANT_STR("MCU", "stm32f103");
 
 
 /****************************************************************

--- a/src/thermocouple.c
+++ b/src/thermocouple.c
@@ -14,11 +14,13 @@
 #include "spicmds.h" // spidev_transfer
 
 enum {
-    TS_CHIP_MAX31855 = 1 << 0,
-    TS_CHIP_MAX31856 = 1 << 1,
-    TS_CHIP_MAX31865 = 1 << 2,
-    TS_CHIP_MAX6675  = 1 << 3
+    TS_CHIP_MAX31855, TS_CHIP_MAX31856, TS_CHIP_MAX31865, TS_CHIP_MAX6675
 };
+
+DECL_ENUMERATION("thermocouple_type", "MAX31855", TS_CHIP_MAX31855);
+DECL_ENUMERATION("thermocouple_type", "MAX31856", TS_CHIP_MAX31856);
+DECL_ENUMERATION("thermocouple_type", "MAX31865", TS_CHIP_MAX31865);
+DECL_ENUMERATION("thermocouple_type", "MAX6675", TS_CHIP_MAX6675);
 
 struct thermocouple_spi {
     struct timer timer;
@@ -49,7 +51,7 @@ void
 command_config_thermocouple(uint32_t *args)
 {
     uint8_t chip_type = args[2];
-    if (chip_type > TS_CHIP_MAX6675 || !chip_type)
+    if (chip_type > TS_CHIP_MAX6675)
         shutdown("Invalid thermocouple chip type");
     struct thermocouple_spi *spi = oid_alloc(
         args[0], command_config_thermocouple, sizeof(*spi));
@@ -58,7 +60,7 @@ command_config_thermocouple(uint32_t *args)
     spi->chip_type = chip_type;
 }
 DECL_COMMAND(command_config_thermocouple,
-             "config_thermocouple oid=%c spi_oid=%c chip_type=%c");
+             "config_thermocouple oid=%c spi_oid=%c thermocouple_type=%c");
 
 void
 command_query_thermocouple(uint32_t *args)


### PR DESCRIPTION
This series adds support for enumerations to the binary communication protocol.  It also converts the micro-controller pin names to use enumerations.  At a high-level, this allows the pin names to be determined solely by the micro-controller code (so, no updates to pins.py are required for a new architecture).

-Kevin