### PR TITLE
menu: Show current positions based on gcode positions

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -222,30 +222,36 @@ items:
 [menu __control __move_10mm __axis_x]
 type: input
 name: "X:{0:05.1f} "
-parameter: gcode.last_xpos
+parameter: gcode.move_xpos
 input_min: 0
 input_max: 200.0
 input_step: 10.0
-gcode: G1 X{0:.1f}
+gcode:
+    G90
+    G1 X{0:.1f}
 
 [menu __control __move_10mm __axis_y]
 type: input
 name: "Y:{0:05.1f} "
-parameter: gcode.last_ypos
+parameter: gcode.move_ypos
 input_min: 0
 input_max: 200.0
 input_step: 10.0
-gcode: G1 Y{0:.1f}
+gcode:
+    G90
+    G1 Y{0:.1f}
 
 [menu __control __move_10mm __axis_z]
 type: input
 enable: !toolhead.is_printing
 name: "Move Z:{0:05.1f}"
-parameter: gcode.last_zpos
+parameter: gcode.move_zpos
 input_min: 0
 input_max: 200.0
 input_step: 10.0
-gcode: G1 Z{0:.1f}
+gcode:
+    G90
+    G1 Z{0:.1f}
 
 [menu __control __move_10mm __axis_e]
 type: input
@@ -255,7 +261,9 @@ parameter: 0
 input_min: -50.0
 input_max: 50.0
 input_step: 10.0
-gcode: G1 E{0:.1f} F240
+gcode:
+    M83
+    G1 E{0:.1f} F240
 
 ### menu move 1mm ###
 [menu __control __move_1mm]
@@ -270,30 +278,36 @@ items:
 [menu __control __move_1mm __axis_x]
 type: input
 name: "X:{0:05.1f} "
-parameter: gcode.last_xpos
+parameter: gcode.move_xpos
 input_min: 0
 input_max: 200.0
 input_step: 1.0
-gcode: G1 X{0:.1f}
+gcode:
+    G90
+    G1 X{0:.1f}
 
 [menu __control __move_1mm __axis_y]
 type: input
 name: "Y:{0:05.1f} "
-parameter: gcode.last_ypos
+parameter: gcode.move_ypos
 input_min: 0
 input_max: 200.0
 input_step: 1.0
-gcode: G1 Y{0:.1f}
+gcode:
+    G90
+    G1 Y{0:.1f}
 
 [menu __control __move_1mm __axis_z]
 type: input
 enable: !toolhead.is_printing
 name: "Move Z:{0:05.1f}"
-parameter: gcode.last_zpos
+parameter: gcode.move_zpos
 input_min: 0
 input_max: 200.0
 input_step: 1.0
-gcode: G1 Z{0:.1f}
+gcode:
+    G90
+    G1 Z{0:.1f}
 
 [menu __control __move_1mm __axis_e]
 type: input
@@ -303,7 +317,9 @@ parameter: 0
 input_min: -50.0
 input_max: 50.0
 input_step: 1.0
-gcode: G1 E{0:.1f} F240
+gcode:
+    M83
+    G1 E{0:.1f} F240
 
 ### menu move 0.1mm ###
 [menu __control __move_01mm]
@@ -318,30 +334,36 @@ items:
 [menu __control __move_01mm __axis_x]
 type: input
 name: "X:{0:05.1f} "
-parameter: gcode.last_xpos
+parameter: gcode.move_xpos
 input_min: 0
 input_max: 200.0
 input_step: 0.1
-gcode: G1 X{0:.1f}
+gcode:
+    G90
+    G1 X{0:.1f}
 
 [menu __control __move_01mm __axis_y]
 type: input
 name: "Y:{0:05.1f} "
-parameter: gcode.last_ypos
+parameter: gcode.move_ypos
 input_min: 0
 input_max: 200.0
 input_step: 0.1
-gcode: G1 Y{0:.1f}
+gcode:
+    G90
+    G1 Y{0:.1f}
 
 [menu __control __move_01mm __axis_z]
 type: input
 enable: !toolhead.is_printing
 name: "Move Z:{0:05.1f}"
-parameter: gcode.last_zpos
+parameter: gcode.move_zpos
 input_min: 0
 input_max: 200.0
 input_step: 0.1
-gcode: G1 Z{0:.1f}
+gcode:
+    G90
+    G1 Z{0:.1f}
 
 [menu __control __move_01mm __axis_e]
 type: input
@@ -351,7 +373,9 @@ parameter: 0
 input_min: -50.0
 input_max: 50.0
 input_step: 0.1
-gcode: G1 E{0:.1f} F240
+gcode:
+    M83
+    G1 E{0:.1f} F240
 
 ### menu temperature ###
 [menu __temp]
@@ -542,9 +566,11 @@ gcode:
 [menu __filament __feed]
 type: input
 name: Feed Filament: {0:.1f}
-parameter: gcode.last_epos
+parameter: 0
 input_step: 0.1
-gcode: G1 E{0:.1f} F30
+gcode:
+    M83
+    G1 E{0:.1f} F30
 
 ### menu prepare ###
 [menu __prepare]

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -222,7 +222,7 @@ items:
 [menu __control __move_10mm __axis_x]
 type: input
 name: "X:{0:05.1f} "
-parameter: toolhead.xpos
+parameter: gcode.last_xpos
 input_min: 0
 input_max: 200.0
 input_step: 10.0
@@ -231,7 +231,7 @@ gcode: G1 X{0:.1f}
 [menu __control __move_10mm __axis_y]
 type: input
 name: "Y:{0:05.1f} "
-parameter: toolhead.ypos
+parameter: gcode.last_ypos
 input_min: 0
 input_max: 200.0
 input_step: 10.0
@@ -241,7 +241,7 @@ gcode: G1 Y{0:.1f}
 type: input
 enable: !toolhead.is_printing
 name: "Move Z:{0:05.1f}"
-parameter: toolhead.zpos
+parameter: gcode.last_zpos
 input_min: 0
 input_max: 200.0
 input_step: 10.0
@@ -270,7 +270,7 @@ items:
 [menu __control __move_1mm __axis_x]
 type: input
 name: "X:{0:05.1f} "
-parameter: toolhead.xpos
+parameter: gcode.last_xpos
 input_min: 0
 input_max: 200.0
 input_step: 1.0
@@ -279,7 +279,7 @@ gcode: G1 X{0:.1f}
 [menu __control __move_1mm __axis_y]
 type: input
 name: "Y:{0:05.1f} "
-parameter: toolhead.ypos
+parameter: gcode.last_ypos
 input_min: 0
 input_max: 200.0
 input_step: 1.0
@@ -289,7 +289,7 @@ gcode: G1 Y{0:.1f}
 type: input
 enable: !toolhead.is_printing
 name: "Move Z:{0:05.1f}"
-parameter: toolhead.zpos
+parameter: gcode.last_zpos
 input_min: 0
 input_max: 200.0
 input_step: 1.0
@@ -318,7 +318,7 @@ items:
 [menu __control __move_01mm __axis_x]
 type: input
 name: "X:{0:05.1f} "
-parameter: toolhead.xpos
+parameter: gcode.last_xpos
 input_min: 0
 input_max: 200.0
 input_step: 0.1
@@ -327,7 +327,7 @@ gcode: G1 X{0:.1f}
 [menu __control __move_01mm __axis_y]
 type: input
 name: "Y:{0:05.1f} "
-parameter: toolhead.ypos
+parameter: gcode.last_ypos
 input_min: 0
 input_max: 200.0
 input_step: 0.1
@@ -337,7 +337,7 @@ gcode: G1 Y{0:.1f}
 type: input
 enable: !toolhead.is_printing
 name: "Move Z:{0:05.1f}"
-parameter: toolhead.zpos
+parameter: gcode.last_zpos
 input_min: 0
 input_max: 200.0
 input_step: 0.1
@@ -542,7 +542,7 @@ gcode:
 [menu __filament __feed]
 type: input
 name: Feed Filament: {0:.1f}
-parameter: toolhead.epos
+parameter: gcode.last_epos
 input_step: 0.1
 gcode: G1 E{0:.1f} F30
 


### PR DESCRIPTION
Changes the move menus to show current position based on gcode
position. This allows gcode offsets and bed leveling offsets
to be taken into account, and prevents unexpected toolhead
movements when moving it using the menu.

Signed-off-by: Robert Konklewski <nythil@gmail.com>