### PR TITLE
tmc2130: add spi daisy chaining

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -970,6 +970,13 @@
 #spi_software_miso_pin:
 #   These optional parameters allow one to customize the SPI settings
 #   used to communicate with the chip.
+#spi_chain:
+#   With this parameter it is possible to configure spi daisy chaining.
+#   For all drivers in the chain the same cs_pin has to be configured. This
+#   parameter in the form of <position>/<length> determines the position in
+#   the chain. Position 1 corresponds to the chip which connects to the mosi
+#   signal.
+#   Example: spi_chain: 2/3
 #microsteps:
 #   The number of microsteps to configure the driver to use. Valid
 #   values are 1, 2, 4, 8, 16, 32, 64, 128, 256. This parameter must

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -70,11 +70,12 @@ class MCU_SPI:
 
 # Helper to setup an spi bus from settings in a config section
 def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
-                        default_speed=100000, shutdown_seq=()):
+                        default_speed=100000, shutdown_seq=(),
+                        share_type=None):
     # Determine pin from config
     ppins = config.get_printer().lookup_object("pins")
     cs_pin = config.get(pin_option)
-    cs_pin_params = ppins.lookup_pin(cs_pin)
+    cs_pin_params = ppins.lookup_pin(cs_pin, share_type=share_type)
     pin = cs_pin_params['pin']
     if pin == 'None':
         ppins.reset_pin_sharing(cs_pin_params)
@@ -97,7 +98,7 @@ def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
         bus = config.getint('spi_bus', 0, minval=0)
         sw_pins = None
     # Create MCU_SPI object
-    return MCU_SPI(mcu, bus, pin, mode, speed, shutdown_seq, sw_pins)
+    return (MCU_SPI(mcu, bus, pin, mode, speed, shutdown_seq, sw_pins), cs_pin)
 
 
 ######################################################################


### PR DESCRIPTION
This patch adds the ability to daisy-chain multiple tmc2130 drivers. The
implementation is currently specific to tmc2130, mixing different drivers
in a chain is not possible and would require a higher-level code change.

This is a preliminary version as I'm unsure if my solution fits the overall
code structure and style.

Signed-off-by: Arne Jansen <arne@die-jansens.de>