### PR TITLE
Update printer-tevo-flash-2018.cfg

### DIFF
--- a/config/printer-tevo-flash-2018.cfg
+++ b/config/printer-tevo-flash-2018.cfg
@@ -1,5 +1,9 @@
-# Support for Tevo Flash using a Bondtech BMG extruder.  To use this
-# config, the firmware should be compiled for the AVR atmega2560.
+# Support for a fully upgraded Tevo Flash using a Bondtech BMG extruder.
+# If you're using a 0.6mm nozzle add max_extrude_cross_section: 2.16
+# to the extruder section. More info about this function can be found
+# in the example-extras.cfg file.
+# To use this config, the firmware should be compiled for
+# the AVR atmega2560.
 
 [stepper_x]
 step_pin: ar54
@@ -43,7 +47,7 @@ step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
 step_distance: .002401
-nozzle_diameter: 0.600
+nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10
 sensor_type: EPCOS 100K B57560G104F

--- a/config/printer-tevo-flash-2018.cfg
+++ b/config/printer-tevo-flash-2018.cfg
@@ -1,9 +1,15 @@
-# Support for a fully upgraded Tevo Flash using a Bondtech BMG extruder.
-# If you're using a 0.6mm nozzle add max_extrude_cross_section: 2.16
-# to the extruder section. More info about this function can be found
-# in the example-extras.cfg file.
+# Support for the Tevo Flash with all options.
+# Dual Z axis, genuine BLTouch and TCM2100 drivers.
 # To use this config, the firmware should be compiled for
 # the AVR atmega2560.
+
+# Note,this config has only been tested on a Tevo Flash with a
+# Bondtech BMG extruder. If using a stock printer it may be 
+# necessary to update the extruder step_distance parameter.
+# I also found when using a 0.6mm nozzle max_extrude_cross_section
+# should be set to 2.16 in the extruder section to prevent 
+# MCU timer to close error. (6.0 * nozzle_diameter^2)
+# See example.cfg for more information.
 
 [stepper_x]
 step_pin: ar54


### PR DESCRIPTION
By default the printer comes installed with a 0.4mm nozzle so changed that in the configuration file.
Aditionally I've added some more information about the setup I'm using.

Signed-off-by: Jeroen van der Does <twistit@gmail.com>