### PR TITLE
Avoid to allocate 'struct gpio_out' on initial pin state change

### DIFF
--- a/src/gpiocmds.c
+++ b/src/gpiocmds.c
@@ -94,7 +94,7 @@ digital_out_shutdown(void)
 }
 DECL_SHUTDOWN(digital_out_shutdown);
 
-void
+__attribute__((weak)) void
 command_set_digital_out(uint32_t *args)
 {
     gpio_out_setup(args[0], args[1]);


### PR DESCRIPTION
Fix for #1436.
In target code this function implemented as

```
void
command_set_digital_out(uint32_t *args)
{
    struct gpio_out g = { .pin=args[0] };
    gpio_out_reset(g, args[1]);
}
```

to avoid errors on pin allocation checker