### PR TITLE
chelper: Switch cffi from ABI mode to API mode

### DIFF
--- a/klippy/chelper/.gitignore
+++ b/klippy/chelper/.gitignore
@@ -1,0 +1,3 @@
+*.o
+*.so
+_chelper.c

--- a/klippy/chelper/kin_corexy.c
+++ b/klippy/chelper/kin_corexy.c
@@ -8,6 +8,7 @@
 #include <string.h> // memset
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
+#include "kinematics.h"
 
 static double
 corexy_stepper_plus_calc_position(struct stepper_kinematics *sk, struct move *m

--- a/klippy/chelper/kin_delta.c
+++ b/klippy/chelper/kin_delta.c
@@ -10,6 +10,7 @@
 #include <string.h> // memset
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
+#include "kinematics.h"
 
 struct delta_stepper {
     struct stepper_kinematics sk;

--- a/klippy/chelper/kin_extruder.c
+++ b/klippy/chelper/kin_extruder.c
@@ -9,6 +9,7 @@
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
 #include "pyhelper.h" // errorf
+#include "kinematics.h"
 
 static double
 extruder_calc_position(struct stepper_kinematics *sk, struct move *m

--- a/klippy/chelper/kin_polar.c
+++ b/klippy/chelper/kin_polar.c
@@ -9,6 +9,7 @@
 #include <string.h> // memset
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
+#include "kinematics.h"
 
 static double
 polar_stepper_radius_calc_position(struct stepper_kinematics *sk, struct move *m

--- a/klippy/chelper/kin_winch.c
+++ b/klippy/chelper/kin_winch.c
@@ -10,6 +10,7 @@
 #include <string.h> // memset
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
+#include "kinematics.h"
 
 struct winch_stepper {
     struct stepper_kinematics sk;

--- a/klippy/chelper/kinematics.h
+++ b/klippy/chelper/kinematics.h
@@ -1,0 +1,18 @@
+#ifndef __KINEMATICS_H
+#define __KINEMATICS_H
+
+struct stepper_kinematics *cartesian_stepper_alloc(char axis);
+struct stepper_kinematics *corexy_stepper_alloc(char type);
+struct stepper_kinematics *delta_stepper_alloc(double arm2
+    , double tower_x, double tower_y);
+struct stepper_kinematics *polar_stepper_alloc(char type);
+struct stepper_kinematics *winch_stepper_alloc(double anchor_x
+    , double anchor_y, double anchor_z);
+struct stepper_kinematics *extruder_stepper_alloc(void);
+void extruder_move_fill(struct move *m, double print_time
+    , double accel_t, double cruise_t, double decel_t, double start_pos
+    , double start_v, double cruise_v, double accel
+    , double extra_accel_v, double extra_decel_v);
+
+
+#endif

--- a/klippy/chelper/pyhelper.c
+++ b/klippy/chelper/pyhelper.c
@@ -34,20 +34,6 @@ fill_time(double time)
     return (struct timespec) {t, (time - t)*1000000000. };
 }
 
-static void
-default_logger(const char *msg)
-{
-    fprintf(stderr, "%s\n", msg);
-}
-
-static void (*python_logging_callback)(const char *msg) = default_logger;
-
-void __visible
-set_python_logging_callback(void (*func)(const char *))
-{
-    python_logging_callback = func;
-}
-
 // Log an error message
 void
 errorf(const char *fmt, ...)

--- a/klippy/chelper/pyhelper.h
+++ b/klippy/chelper/pyhelper.h
@@ -1,6 +1,9 @@
 #ifndef PYHELPER_H
 #define PYHELPER_H
 
+// Defined in Python
+void python_logging_callback(const char *msg);
+
 double get_monotonic(void);
 struct timespec fill_time(double time);
 void set_python_logging_callback(void (*func)(const char *));

--- a/klippy/chelper/serialqueue.h
+++ b/klippy/chelper/serialqueue.h
@@ -60,6 +60,8 @@ void serialqueue_encode_and_send(
     , uint32_t *data, int len, uint64_t min_clock, uint64_t req_clock);
 void serialqueue_pull(struct serialqueue *sq, struct pull_queue_message *pqm);
 void serialqueue_set_baud_adjust(struct serialqueue *sq, double baud_adjust);
+void serialqueue_set_receive_window(struct serialqueue *sq
+    , int receive_window);
 void serialqueue_set_clock_est(struct serialqueue *sq, double est_freq
                                , double last_clock_time, uint64_t last_clock);
 void serialqueue_get_stats(struct serialqueue *sq, char *buf, int len);

--- a/scripts/check_whitespace.py
+++ b/scripts/check_whitespace.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import sys, os.path, unicodedata
+import sys, os.path, unicodedata, re
 
 HaveError = False
 
@@ -16,6 +16,12 @@ def report_error(filename, lineno, msg):
     sys.stderr.write("%s:%d: %s\n" % (filename, lineno + 1, msg))
 
 def check_file(filename):
+    # These are generated
+    if re.match('.*.generated.c\Z', filename):
+        return
+    if re.match('.*/_chelper.c\Z', filename):
+        return
+
     # Open and read file
     try:
         f = open(filename, 'rb')


### PR DESCRIPTION
I made these changes when I was prototyping expression evaluation, but it's probably worthwhile hygiene on its own.

In this mode, CFFI handles compilation of our .c files via distutils.extension.Extension.

To interface with the extension, CFFI generates a .c file and compiles with GCC.  This gives us additional static type checking so cdefs in __init__.py that conflict with .h files will cause compiler warnings at startup rather than runtime core dumps.

The generated code reduces Python <-> C overhead although I doubt there will be much real-world advantage in the current code.  It also allows us to use "new" style statically typed callbacks using @ffi.def_extern().