### PR TITLE
module: STM32F1 - ADC

### DIFF
--- a/src/stm32f1/adc.c
+++ b/src/stm32f1/adc.c
@@ -76,7 +76,7 @@ gpio_adc_sample(struct gpio_adc g)
     if (!readb(&adc_busy)) {
         LL_ADC_REG_SetSequencerRanks(ADC1, LL_ADC_REG_RANK_1, g.bit);
         LL_ADC_SetChannelSamplingTime(ADC1, g.bit
-                                      , LL_ADC_SAMPLINGTIME_239CYCLES_5);
+                                      , LL_ADC_SAMPLINGTIME_41CYCLES_5);
         LL_ADC_REG_StartConversionSWStart(ADC1);
         adc_busy = true;
         adc_current_channel = g.bit;


### PR DESCRIPTION
The sampling time of the ADC was too slow (239 ADC clock cycles), causing the reading of the next ADC channel to have cross talk as per issue #1261. Sampling time updated to 41 ADC clock cycles.

Signed-off-by: Marco D'Alessio <marco@wrecklab.com>