### PR TITLE
uc1701:  make contrast configurable

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1217,6 +1217,9 @@
 #a0_pin:
 #   The pins connected to an uc1701 type lcd. These parameters must be
 #   provided when using an uc1701 display.
+#contrast: 40
+#   The contrast to set when using a uc1701 type display.  The value may
+#   range from 0 to 63.  Default is 40.
 #cs_pin:
 #dc_pin:
 #spi_bus:

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -153,6 +153,7 @@ class I2C:
 class UC1701(DisplayBase):
     def __init__(self, config):
         DisplayBase.__init__(self, SPI4wire(config, "a0_pin"))
+        self.contrast = config.getint('contrast', 40, minval=0, maxval=63)
     def init(self):
         init_cmds = [0xE2, # System reset
                      0x40, # Set display to start at line 0
@@ -166,7 +167,7 @@ class UC1701(DisplayBase):
                      0x00, # Booster ratio value (4x)
                      0x23, # Set resistor ratio (3)
                      0x81, # Set Electronic Volume
-                     0x28, # Electronic volume value (40)
+                     self.contrast, # Electronic Volume value
                      0xAC, # Set static indicator off
                      0x00, # NOP
                      0xA6, # Disable Inverse


### PR DESCRIPTION
Some users report UC1701 displays that are barely visible using the default initialization sequence.  This pull request makes the electronic volume (contrast) register configurable.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>