### PR TITLE
Suggest setting position mode when using homing_override

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1152,7 +1152,10 @@
 #   g-code input. If a G28 is contained in this list of commands then
 #   it will invoke the normal homing procedure for the printer. The
 #   commands listed here must home all axes. This parameter must be
-#   provided.
+#   provided. Note that this gcode runs in place of the original G28
+#   with whatever gcode position mode was last set. It is recommended
+#   to specify absolute positioning mode with G90 or relative
+#   positioning with G91 before commanding any moves.
 #axes: xyz
 #   The axes to override. For example, if this is set to "z" then the
 #   override script will only be run when the z axis is homed (eg, via

--- a/config/kit-voron2-250mm.cfg
+++ b/config/kit-voron2-250mm.cfg
@@ -208,7 +208,7 @@ max_temp: 110
 axes: z
 set_position_z: 0
 gcode:
-   G90
+   G90  ; Force the gcode parser into absolute position mode
    G0 Z5 F600
    G28 X Y
    G0 X179 Y249.5 F3600

--- a/config/printer-tevo-flash-2018.cfg
+++ b/config/printer-tevo-flash-2018.cfg
@@ -109,7 +109,7 @@ z_offset: 1.64
 set_position_z: 0
 axes: z
 gcode:
-    G90
+    G90  ; Force the gcode parser into absolute position mode
     G1 Z5 F600
     G28 X0 Y0
     G1 X118 Y118 F3600

--- a/config/sample-probe-as-z-endstop.cfg
+++ b/config/sample-probe-as-z-endstop.cfg
@@ -25,8 +25,8 @@ position_min: -2 # The Z carriage may need to travel below the Z=0
 set_position_z: 0
 axes: z
 gcode:
-    ; G90   ; Uncomment these 2 lines to blindly lift the Z 2mm at start
-    ; G1 Z2 F600
+    G90  ; Force the gcode parser into absolute position mode
+    ; G1 Z2 F600  ; Uncomment this line to blindly lift the Z 2mm at start
     G28 X0 Y0
     G1 X100 Y100 F3600
     G28 Z0

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -25,6 +25,7 @@ and y-axis, and finally move to the center and home the z-axis. Like this:
 ```
     [homing_override]
     gcode:
+        G90  ; Force the gcode parser into absolute position mode
         G1 Z10 ; Move up 10mm
         G28 X Y
         G1 X166 Y120 F6000 ; Change the X and Y coordinates to the center of your print bed


### PR DESCRIPTION
The homing_override gcode section runs with whatever position mode the
gcode parser happens to be in. This makes move commands unpredictable
unless the gcode section forces the gcode parser into a particular mode.
This change improves the documenation and examples to point that out.

Signed-off-by: Jeff Rogers <sgtnoodle@gmail.com>