### PR TITLE
quad_gantry_level: Support retries

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -378,6 +378,11 @@
 #   The default is average.
 #sample_retract_dist: 2.0
 #   Distance in mm to retract the probe between samples. Default is 2.
+#retries: 0
+#   number of times to retry if the probed points aren't within tolerance
+#retry_tolerance: 0
+#   if retries are enabled then retry if probed points
+#   differ more than retry_tolerance
 
 
 # In a multi-extruder printer add an additional extruder section for

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -45,7 +45,7 @@ class QuadGantryLevel:
     def cmd_QUAD_GANTRY_LEVEL(self, params):
         self.retries = self.gcode.get_int(
             'RETRIES', params, default=self.default_retries,
-            minval=1, maxval=30)
+            minval=0, maxval=30)
         self.retry_tolerance = self.gcode.get_float(
             'RETRY_TOLERANCE', params, default=self.default_retry_tolerance,
             minval=0, maxval=1.0)

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -50,6 +50,7 @@ class QuadGantryLevel:
             'RETRY_TOLERANCE', params, default=self.default_retry_tolerance,
             minval=0, maxval=1.0)
         self.params = params
+        self.previous_delta = None
         self.probe_helper.start_probe(params)
     def probe_finalize(self, offsets, positions):
         # Mirror our perspective so the adjustments make sense
@@ -99,6 +100,15 @@ class QuadGantryLevel:
             raise
 
         delta = max(z_positions) - min(z_positions)
+
+        if self.previous_delta and delta > self.previous_delta:
+            self.gcode.respond_error(
+                  "Probe points delta of %0.6f is worse than previous %0.6f " %
+                  (delta, self.previous_delta) +
+                  "Possibly Z motor numbering is wrong")
+
+        self.previous_delta = delta
+
         if self.retries > 0 and delta > self.retry_tolerance:
             self.gcode.respond_info(
                 "retries %d delta: %0.6f retry_tolerance: %0.6f" %

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -101,7 +101,7 @@ class QuadGantryLevel:
 
         delta = max(z_positions) - min(z_positions)
 
-        if self.previous_delta and delta > self.previous_delta:
+        if self.previous_delta and delta > self.previous_delta + 0.0000001:
             self.gcode.respond_error(
                   "Probe points delta of %0.6f is worse than previous %0.6f " %
                   (delta, self.previous_delta) +


### PR DESCRIPTION
first pass, open to any feedback.  cc @mzbotreprap  

support retrying QUAD_GANTRY_LEVEL a configurable number of times
to a configurable tolerance both in the config or as parameters.

by default keeps original behavior of no retries.

adds parameters RETRIES and RETRY_TOLERANCE
adds config options retries and retry_tolerance
