### PR TITLE
quad_gantry_level: Limit maximum adjustment

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -371,6 +371,9 @@
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5
+#max_adjust: 4
+#   Saftey limit if an ajustment greater than this value is requested
+#   quad_gantry_level will abort.
 #samples: 1
 #   Number of probe samples per point. The defaut is 1
 #samples_result: average

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -9,6 +9,7 @@ import probe
 class QuadGantryLevel:
     def __init__(self, config):
         self.printer = config.get_printer()
+        self.max_adjust = config.getfloat("max_adjust", 4, above=0)
         self.horizontal_move_z = config.getfloat("horizontal_move_z", 5.0)
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
@@ -81,6 +82,15 @@ class QuadGantryLevel:
         z_adjust = []
         for z in z_height:
             z_adjust.append(z_ave - z)
+
+        adjust_max = max(z_adjust)
+        if adjust_max > self.max_adjust:
+            self.gcode.respond_error(
+                "Aborting quad_gantry_level " +
+                "required adjustment %0.6f " % ( adjust_max ) +
+                "is greater than max_adjust %0.6f" % (self.max_adjust))
+            return
+
         try:
             self.adjust_steppers(z_adjust)
         except:


### PR DESCRIPTION
Idea from @doowrednu: 

safety feature that prevents quad_gantry_level from trying to do a
correction that might break things - if your probe fires early for
whatever reason and tries to do an 8mm correction in one corner instead
we abort if a correction is over a configurable limit by default 4mm

configurable via `max_adjust` parameter in the config