### PR TITLE
 lpc176x: force minimum usb disconnect time

### DIFF
--- a/src/lpc176x/internal.h
+++ b/src/lpc176x/internal.h
@@ -18,4 +18,6 @@ int is_enabled_pclock(uint32_t pclk);
 void enable_pclock(uint32_t pclk);
 void gpio_peripheral(uint32_t gpio, int func, int pullup);
 
+void udelay(uint32_t usecs);
+
 #endif // internal.h

--- a/src/lpc176x/main.c
+++ b/src/lpc176x/main.c
@@ -7,6 +7,7 @@
 #include "LPC17xx.h" // NVIC_SystemReset
 #include "command.h" // DECL_CONSTANT
 #include "sched.h" // sched_main
+#include "board/misc.h" // timer_read_time
 
 DECL_CONSTANT_STR("MCU", "lpc176x");
 
@@ -65,6 +66,20 @@ command_reset(uint32_t *args)
     NVIC_SystemReset();
 }
 DECL_COMMAND_FLAGS(command_reset, HF_IN_SHUTDOWN, "reset");
+
+// Implement simple early-boot delay mechanism
+void
+udelay(uint32_t usecs)
+{
+    if (!(CoreDebug->DEMCR & CoreDebug_DEMCR_TRCENA_Msk)) {
+        CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+        DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+    }
+
+    uint32_t end = timer_read_time() + timer_from_us(usecs);
+    while (timer_is_before(timer_read_time(), end))
+        ;
+}
 
 // Main entry point
 int

--- a/src/lpc176x/usbserial.c
+++ b/src/lpc176x/usbserial.c
@@ -277,6 +277,8 @@ usbserial_init(void)
     gpio_peripheral(GPIO(0, 30), 1, 0);
     gpio_peripheral(GPIO(0, 29), 1, 0);
     gpio_peripheral(GPIO(2, 9), 1, 0);
+    // enforce a minimum time bus is disconnected before connecting
+    udelay(5000);
     // setup endpoints
     realize_endpoint(EP0OUT, USB_CDC_EP0_SIZE);
     realize_endpoint(EP0IN, USB_CDC_EP0_SIZE);

--- a/src/lpc176x/usbserial.c
+++ b/src/lpc176x/usbserial.c
@@ -252,9 +252,7 @@ usb_request_bootloader(void)
     // Disable USB and pause for 5ms so host recognizes a disconnect
     irq_disable();
     sie_cmd_write(SIE_CMD_SET_DEVICE_STATUS, 0);
-    uint32_t end = timer_read_time() + timer_from_us(5000);
-    while (timer_is_before(timer_read_time(), end))
-        ;
+    udelay(5000);
     // The "LPC17xx-DFU-Bootloader" will enter the bootloader if the
     // watchdog timeout flag is set.
     LPC_WDT->WDMOD = 0x07;


### PR DESCRIPTION
Fixes GitHub Issue #1499. Resolves USB hang by forcing a minimum
USB disconnection time at boot.

Signed-off-by: Matt Baker <baker.matt.j@gmail.com>

lpc176x: refactor usbserial to use udelay helper.

Signed-off-by: Matt Baker <baker.matt.j@gmail.com>