### PR TITLE
tsl1401cl_filament_width_sensor: Fix incorrect flow adjustment calculation

### DIFF
--- a/klippy/extras/tsl1401cl_filament_width_sensor.py
+++ b/klippy/extras/tsl1401cl_filament_width_sensor.py
@@ -93,8 +93,8 @@ class FilamentWidthSensor:
                     filament_width = item[1]
                     if ((filament_width <= self.max_diameter)
                         and (filament_width >= self.min_diameter)):
-                        percentage = round(self.nominal_filament_dia
-                                           / filament_width * 100)
+                        percentage = round(self.nominal_filament_dia**2
+                                           / filament_width**2 * 100)
                         self.gcode.run_script("M221 S" + str(percentage))
                     else:
                         self.gcode.run_script("M221 S100")


### PR DESCRIPTION
The parameter to the M221 command should be the ratio of the nominal to
measured filament *area*, rather than the ratio of the *diameter*. Since we
are taking the ratio, most of the area calculation cancels out. Fixes #1535.

(Note: I don't actually have one of these sensors, I just noticed it was wrong)

Signed-off-by: Len Trigg <lenbok@gmail.com>