### PR TITLE
Added M300 G-Code support in printer-anycubic-4max-2018.cfg

### DIFF
--- a/config/printer-anycubic-4max-2018.cfg
+++ b/config/printer-anycubic-4max-2018.cfg
@@ -125,3 +125,28 @@ gcode:
     M140 S0 ; turn bed heating off
     M107 ; turn fan off
     M84 ; steppers off
+
+[output_pin BEEPER_pin]
+pin: ar37
+#   Beeper pin. This parameter must be provided.
+#   ar37 is the default RAMPS/MKS pin.
+pwm: True
+#   A piezo beeper needs a PWM signal, a DC buzzer doesn't.
+value: 0
+#   Silent at power on, set to 1 if active low.
+shutdown_value: 0
+#   Disable at emergency shutdown (no PWM would be available anyway).
+cycle_time: 0.001
+#   PWM frequency : 0.001 = 1ms will give a base tone of 1kHz
+scale: 1000
+#   PWM parameter will be in the range of (0-1000 Hz).
+#   Although not pitch perfect.
+
+[gcode_macro M300]
+default_parameter_S=1000
+#   Allows for a default 1kHz tone if S is omitted
+default_parameter_P=100
+#   Allows for a default 10ms duration is P is omitted
+gcode:  SET_PIN PIN=BEEPER_pin VALUE={S}
+        G4 P{P}
+        SET_PIN PIN=BEEPER_pin VALUE=0


### PR DESCRIPTION
Added a M300 macro G-Code for Anycubic 4Max 2018 default config file.

Signed-off-by: Christian Toulon christian@bouncy-studio.com