### PR TITLE
Add buttons to anet config

### DIFF
--- a/config/printer-anet-a8-2017.cfg
+++ b/config/printer-anet-a8-2017.cfg
@@ -86,3 +86,11 @@ d4_pin: PD2
 d5_pin: PD3
 d6_pin: PC0
 d7_pin: PC1
+up_pin: PA1
+analog_range_up_pin: 470000,600000 
+down_pin: PA1 
+analog_range_down_pin: 3900,4100 
+click_pin: PA1 
+analog_range_click_pin: 9000,11000 
+analog_pullup_resistor: 4700
+analog_pin_debug:false

--- a/config/printer-anet-a8-2017.cfg
+++ b/config/printer-anet-a8-2017.cfg
@@ -87,10 +87,16 @@ d5_pin: PD3
 d6_pin: PC0
 d7_pin: PC1
 up_pin: PA1
-analog_range_up_pin: 470000,600000 
+analog_range_up_pin: 9000,13000
 down_pin: PA1 
-analog_range_down_pin: 3900,4100 
+analog_range_down_pin:  800,1300 
 click_pin: PA1 
-analog_range_click_pin: 9000,11000 
+analog_range_click_pin: 2000,2500
+back_pin: PA1
+analog_range_back_pin: 4500, 5000 
+#kill_pin: PA1
+#analog_range_kill_pin: 400, 600
 analog_pullup_resistor: 4700
-analog_pin_debug:false
+analog_pin_debug: false
+
+ 


### PR DESCRIPTION
As requested by @KevinOConnor , the anet-a8 config with analog-button config.
I commented out the kill_pin because the default firmware, doesn't use one.

Signed-off-by: Arnoud Thörig