### PR TITLE
Changed Menu item "Feed Filament" name

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -565,7 +565,7 @@ gcode:
 
 [menu __filament __feed]
 type: input
-name: Feed Filament: {0:.1f}
+name: Feed: {0:.1f}
 parameter: 0
 input_step: 0.1
 gcode:


### PR DESCRIPTION
"Feed Filament" menu item value was off-screen that made this item useless. So I changed its name to just "Feed". Users shall easily guess that this item is for filament feeding because this item is located in "Filament" menu.

Signed-off-by: Alexander Fadeev <alfsoft@gmail.com>