### PR TITLE
P.I.N.D.A. 2 support

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -193,7 +193,8 @@ class BedMeshCalibrate:
         self.probe_params = collections.OrderedDict()
         points = self._generate_points(config)
         self._init_probe_params(config, points)
-        self.probe_helper = probe.ProbePointsHelper(
+        self.probe = self.printer.lookup_object('probe')
+        self.probe_helper = self.probe.getProbePointsHelper(
             config, self.probe_finalize, points)
         # setup persistent storage
         self.profiles = {}

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -43,7 +43,8 @@ class BedTiltCalibrate:
     def __init__(self, config, bedtilt):
         self.printer = config.get_printer()
         self.bedtilt = bedtilt
-        self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
+        self.probe = self.printer.lookup_object('probe')
+        self.probe_helper = self.probe.getProbePointsHelper(config, self.probe_finalize)
         # Register BED_TILT_CALIBRATE command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -45,6 +45,7 @@ class BedTiltCalibrate:
         self.bedtilt = bedtilt
         self.probe = self.printer.lookup_object('probe')
         self.probe_helper = self.probe.getProbePointsHelper(config, self.probe_finalize)
+        self.probe_helper.minimum_points(3)
         # Register BED_TILT_CALIBRATE command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -141,7 +141,8 @@ class DeltaCalibrate:
             r = math.radians(90. + 60. * i)
             dist = radius * scatter[i]
             points.append((math.cos(r) * dist, math.sin(r) * dist))
-        self.probe_helper = probe.ProbePointsHelper(
+        self.probe = self.printer.lookup_object('probe')
+        self.probe_helper = self.probe.getProbePointsHelper(
             config, self.probe_finalize, default_points=points)
         # Restore probe stable positions
         self.last_probe_positions = []

--- a/klippy/extras/pinda2.py
+++ b/klippy/extras/pinda2.py
@@ -16,7 +16,8 @@
 ## min and max temp define safe operating range, like other thermistors
 #min_temp:5
 #max_temp:60
-## Autoadjust correction after home - if you want to do that manually add PROBE_ADJUST in start code
+## Autoadjust correction after home 
+## if you want to do that manually add PROBE_ADJUST in start code
 #auto_adjust: True
 #z_offset_calibration:
 #    0, 0.00
@@ -60,7 +61,8 @@ class Pinda2Probe (probe.PrinterProbe):
     cmd_PROBE_ADJUST_help = "Adjust P.I.N.D.A 2 offset"
     def cmd_PROBE_ADJUST(self, params):
         self.mcu_probe.apply_corection()
-        self.gcode.respond_info( "pinda2_temp: %s , temp correction: %s" % (self.mcu_probe.last_temp, self.mcu_probe.last_e) )
+        self.gcode.respond_info( "pinda2_temp: %s , temp correction: %s" 
+                                % (self.mcu_probe.last_temp, self.mcu_probe.last_e) )
 
     def _probe(self, speed):
         self.mcu_probe.in_probe = True
@@ -88,13 +90,15 @@ class Pinda2EndstopWrapper(probe.ProbeEndstopWrapper):
         z_offset_calibration_samples = s.split('\n')
         try:
             offset_map = [line.split(',', 1)
-                              for line in z_offset_calibration_samples if line.strip()]
+                for line in z_offset_calibration_samples if line.strip()]
             self.z_offset_calibration_samples = []
             for zp in offset_map :
-                self.z_offset_calibration_samples += [(float(zp[0].strip()), float(zp[1].strip()))]
+                self.z_offset_calibration_samples += [(float(zp[0].strip()), 
+                                                       float(zp[1].strip()))]
         except:
             raise config.error(
-                "Unable to parse date %s, %s. A newline separated list of temperature, correction" % (
+                "Unable to parse date %s, %s. A newline separated list of "
+                "temperature, correction" % (
                     config.get_name(), s))
         if len(self.z_offset_calibration_samples) < 2:
             raise config.error(
@@ -149,7 +153,8 @@ class Pinda2EndstopWrapper(probe.ProbeEndstopWrapper):
 
 class ProbePointsHelper(probe.ProbePointsHelper):
     def __init__(self, config, finalize_callback, default_points=None):
-        probe.ProbePointsHelper.__init__(self, config, finalize_callback, default_points)
+        probe.ProbePointsHelper.__init__(self, config, 
+                                         finalize_callback, default_points)
         self.probe = self.printer.lookup_object('probe')
 
     def _automatic_probe_point(self):

--- a/klippy/extras/pinda2.py
+++ b/klippy/extras/pinda2.py
@@ -15,7 +15,6 @@
 #additionl command:
 #PROBE_TEMP
 # gives temperature of P.I.N.D.A. sensor
-
 import pins, homing, manual_probe, adc_temperature, probe
 
 class Pinda2Probe (probe.PrinterProbe):
@@ -49,10 +48,12 @@ class Pinda2EndstopWrapper(probe.ProbeEndstopWrapper):
             self.z_offset_calibration_samples= eval(s)
         except SyntaxError:
             raise config.error(
-                "Syntax error in z_offset_calibration. Should be [(t1, e1), (t2, e2),...(tn, en)] "
-                "where t is temperature, e is offset correction. There is z_offset_calibration: " + s)
+                "Syntax error in z_offset_calibration. Should be [(t1, e1), (t"
+                "2, e2),...(tn, en)] where t is temperature, e is offset corre"
+                "ction. There is z_offset_calibration: " + s)
         try:
-            li = adc_temperature.LinearInterpolate(self.z_offset_calibration_samples)
+            li = adc_temperature.LinearInterpolate(
+                self.z_offset_calibration_samples)
         except ValueError as e:
             raise config.error("Error in z_offset_calibration %s, %s" % (
                 str(e), config.get_name()))

--- a/klippy/extras/pinda2.py
+++ b/klippy/extras/pinda2.py
@@ -13,13 +13,34 @@
 #speed: 10.0
 #sensor_pin: PF3
 #sensor_type: EPCOS 100K B57560G104F
-#min_temp:0
-#max_temp:100
-#z_offset_calibration:[(0, 0.00),(40, 0.00),(50, -0.25), (100, -0.50)]
+## min and max temp define safe operating range, like other thermistors
+#min_temp:5
+#max_temp:60
+## Autoadjust correction after home - if you want to do that manually add PROBE_ADJUST in start code
+#auto_adjust: True
+#z_offset_calibration:
+#    0, 0.00
+#    30, -0.00
+#    35, -0.05
+#    40, -0.15
+#    45, -0.4
+#    50, -0.8
+#    55, -1.7
+#    60, -2.6
+#    100, -2.00
 
 #additionl command:
 #PROBE_TEMP
 # gives temperature of P.I.N.D.A. sensor
+
+#PROBE_ADJUST
+# moves Z down a little if probe is hot
+# use when auto_adjust=False
+
+# You have to use
+# homing_retract_dist: 5
+# for stepper_z
+
 import pins, homing, manual_probe, adc_temperature, probe
 
 class Pinda2Probe (probe.PrinterProbe):
@@ -28,34 +49,56 @@ class Pinda2Probe (probe.PrinterProbe):
         self.gcode.register_command('PROBE_TEMP', self.cmd_PROBE_TEMP,
                                     desc=self.cmd_PROBE_TEMP_help)
 
+        self.gcode.register_command('PROBE_ADJUST', self.cmd_PROBE_ADJUST,
+                                desc=self.cmd_PROBE_ADJUST_help)
+
     cmd_PROBE_TEMP_help = "Return the temperature of P.I.N.D.A 2 sensor"
     def cmd_PROBE_TEMP(self, params):
         temp = self.mcu_probe.last_temp
         self.gcode.respond_info( "pinda2_temp: %s" % temp)
 
+    cmd_PROBE_ADJUST_help = "Adjust P.I.N.D.A 2 offset"
+    def cmd_PROBE_ADJUST(self, params):
+        self.mcu_probe.apply_corection()
+        self.gcode.respond_info( "pinda2_temp: %s , temp correction: %s" % (self.mcu_probe.last_temp, self.mcu_probe.last_e) )
+
+    def _probe(self, speed):
+        self.mcu_probe.in_probe = True
+        probe.PrinterProbe._probe(self, speed)
+        self.mcu_probe.in_probe = False
+
+    def getProbePointsHelper(self, config, finalize_callback, default_points=None) :
+        return ProbePointsHelper(config, finalize_callback, default_points)
+
 class Pinda2EndstopWrapper(probe.ProbeEndstopWrapper):
     def __init__(self, config):
         probe.ProbeEndstopWrapper.__init__(self, config)
         self.init_sensor(config)
+        self.in_probe = False
+        self.home_e = 0
 
     def init_sensor(self, config):
         self.speed = config.getfloat('speed', 5.0)
-        self.min_temp = config.getfloat('min_temp', minval=-273)
-        self.max_temp = config.getfloat('max_temp', above=self.min_temp)
+        self.auto_adjust = config.getboolean('auto_adjust', True)
         self.sensor = self.printer.lookup_object('heater').setup_sensor(config)
-        self.sensor.setup_minmax(self.min_temp, self.max_temp)
         self.sensor.setup_callback(self.temperature_callback)
         self.printer.lookup_object('heater').register_sensor(config, self)
 
         s = config.get('z_offset_calibration')
-
+        z_offset_calibration_samples = s.split('\n')
         try:
-            self.z_offset_calibration_samples= eval(s)
-        except SyntaxError:
+            offset_map = [line.split(',', 1)
+                              for line in z_offset_calibration_samples if line.strip()]
+            self.z_offset_calibration_samples = []
+            for zp in offset_map :
+                self.z_offset_calibration_samples += [(float(zp[0].strip()), float(zp[1].strip()))]
+        except:
             raise config.error(
-                "Syntax error in z_offset_calibration. Should be [(t1, e1), (t"
-                "2, e2),...(tn, en)] where t is temperature, e is offset corre"
-                "ction. There is z_offset_calibration: " + s)
+                "Unable to parse date %s, %s. A newline separated list of temperature, correction" % (
+                    config.get_name(), s))
+        if len(self.z_offset_calibration_samples) < 2:
+            raise config.error(
+                "Calibration map requires at least two lines")
         try:
             li = adc_temperature.LinearInterpolate(
                 self.z_offset_calibration_samples)
@@ -70,32 +113,51 @@ class Pinda2EndstopWrapper(probe.ProbeEndstopWrapper):
     def get_temp(self, eventtime):
         return self.last_temp, self.target_temp
 
-    def correct_pos(self, pos_z):
+    def get_e(self):
         temp = self.last_temp
-        e = self.z_offset_calibration_li.interpolate(temp)
-        return pos_z + e
+        self.last_e = self.z_offset_calibration_li.interpolate(temp)
+        return self.last_e
 
     def apply_corection(self):
         toolhead = self.printer.lookup_object('toolhead')
         pos = toolhead.get_position()
         pos_z = pos[2]
-        pos[2] = self.correct_pos(pos_z)
-        try:
-            toolhead.move(pos, self.speed)
-            pos[2] = pos_z
-            toolhead.set_position(pos)
-        except homing.EndstopError as e:
-            self._finalize(False)
-            raise self.gcode.error(str(e))
+        self.home_e = self.get_e()
+        new_z = pos_z + self.home_e
+        if new_z != pos_z :
+            pos[2] = new_z
+            try:
+                toolhead.move(pos, self.speed)
+                pos[2] = pos_z
+                toolhead.set_position(pos)
+            except homing.EndstopError as e:
+                self._finalize(False)
+                raise self.gcode.error(str(e))
 
 
     def home_finalize(self):
         try:
             self.deactivate_gcode.run_gcode_from_command()
-            self.apply_corection()
+            if self.auto_adjust and not self.in_probe:
+                self.apply_corection()
+
         except self.gcode.error as e:
             raise homing.EndstopError(str(e))
         self.mcu_endstop.home_finalize()
+    def get_position_endstop(self):
+        return self.position_endstop
+
+class ProbePointsHelper(probe.ProbePointsHelper):
+    def __init__(self, config, finalize_callback, default_points=None):
+        probe.ProbePointsHelper.__init__(self, config, finalize_callback, default_points)
+        self.probe = self.printer.lookup_object('probe')
+
+    def _automatic_probe_point(self):
+        probe.ProbePointsHelper._automatic_probe_point(self)
+        r = self.results[-1]
+        e = self.probe.mcu_probe.get_e() - self.probe.mcu_probe.home_e
+        r[2] = r[2] + e
+        self.results[-1] = r
 
 def load_config(config):
     p2 = Pinda2Probe(config, Pinda2EndstopWrapper(config))

--- a/klippy/extras/pinda2.py
+++ b/klippy/extras/pinda2.py
@@ -1,0 +1,97 @@
+# P.I.N.D.A. 2 support
+# configuration example:
+#[pinda2]
+#pin: PB4
+#x_offset: 24
+#y_offset: 5
+#z_offset: 0.25
+#speed: 10.0
+#sensor_pin: PF3
+#sensor_type: EPCOS 100K B57560G104F
+#min_temp:0
+#max_temp:100
+#z_offset_calibration:[(0, 0.00),(40, 0.00),(50, -0.25), (100, -0.50)]
+
+#additionl command:
+#PROBE_TEMP
+# gives temperature of P.I.N.D.A. sensor
+
+import pins, homing, manual_probe, adc_temperature, probe
+
+class Pinda2Probe (probe.PrinterProbe):
+    def __init__(self, config, mcu_probe):
+        probe.PrinterProbe.__init__(self, config, mcu_probe)
+        self.gcode.register_command('PROBE_TEMP', self.cmd_PROBE_TEMP,
+                                    desc=self.cmd_PROBE_TEMP_help)
+
+    cmd_PROBE_TEMP_help = "Return the temperature of P.I.N.D.A 2 sensor"
+    def cmd_PROBE_TEMP(self, params):
+        temp = self.mcu_probe.last_temp
+        self.gcode.respond_info( "pinda2_temp: %s" % temp)
+
+class Pinda2EndstopWrapper(probe.ProbeEndstopWrapper):
+    def __init__(self, config):
+        probe.ProbeEndstopWrapper.__init__(self, config)
+        self.init_sensor(config)
+
+    def init_sensor(self, config):
+        self.speed = config.getfloat('speed', 5.0)
+        self.min_temp = config.getfloat('min_temp', minval=-273)
+        self.max_temp = config.getfloat('max_temp', above=self.min_temp)
+        self.sensor = self.printer.lookup_object('heater').setup_sensor(config)
+        self.sensor.setup_minmax(self.min_temp, self.max_temp)
+        self.sensor.setup_callback(self.temperature_callback)
+        self.printer.lookup_object('heater').register_sensor(config, self)
+
+        s = config.get('z_offset_calibration')
+
+        try:
+            self.z_offset_calibration_samples= eval(s)
+        except SyntaxError:
+            raise config.error(
+                "Syntax error in z_offset_calibration. Should be [(t1, e1), (t2, e2),...(tn, en)] "
+                "where t is temperature, e is offset correction. There is z_offset_calibration: " + s)
+        try:
+            li = adc_temperature.LinearInterpolate(self.z_offset_calibration_samples)
+        except ValueError as e:
+            raise config.error("Error in z_offset_calibration %s, %s" % (
+                str(e), config.get_name()))
+        self.z_offset_calibration_li = li
+
+    def temperature_callback(self, read_time, temp):
+        self.last_temp = temp
+
+    def get_temp(self, eventtime):
+        return self.last_temp, self.target_temp
+
+    def correct_pos(self, pos_z):
+        temp = self.last_temp
+        e = self.z_offset_calibration_li.interpolate(temp)
+        return pos_z + e
+
+    def apply_corection(self):
+        toolhead = self.printer.lookup_object('toolhead')
+        pos = toolhead.get_position()
+        pos_z = pos[2]
+        pos[2] = self.correct_pos(pos_z)
+        try:
+            toolhead.move(pos, self.speed)
+            pos[2] = pos_z
+            toolhead.set_position(pos)
+        except homing.EndstopError as e:
+            self._finalize(False)
+            raise self.gcode.error(str(e))
+
+
+    def home_finalize(self):
+        try:
+            self.deactivate_gcode.run_gcode_from_command()
+            self.apply_corection()
+        except self.gcode.error as e:
+            raise homing.EndstopError(str(e))
+        self.mcu_endstop.home_finalize()
+
+def load_config(config):
+    p2 = Pinda2Probe(config, Pinda2EndstopWrapper(config))
+    config.get_printer().add_object('probe', p2)
+    return p2

--- a/klippy/extras/pinda2.py
+++ b/klippy/extras/pinda2.py
@@ -1,4 +1,9 @@
 # P.I.N.D.A. 2 support
+#
+# Copyright (C) 2019  Rafal Jastrzebski <r2@jastrzebscy.org>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
 # configuration example:
 #[pinda2]
 #pin: PB4

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -172,6 +172,8 @@ class PrinterProbe:
         # Start manual probe
         manual_probe.ManualProbeHelper(self.printer, params,
                                        self.probe_calibrate_finalize)
+    def getProbePointsHelper(self, config, finalize_callback, default_points=None) :
+        return ProbePointsHelper(self, config, finalize_callback, default_points)
 
 # Endstop wrapper that enables probe specific features
 class ProbeEndstopWrapper:

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -4,17 +4,21 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import probe
+import probe, z_tilt
 
 class QuadGantryLevel:
     def __init__(self, config):
         self.printer = config.get_printer()
+        self.retry_helper = z_tilt.RetryHelper(config,
+            "Possibly Z motor numbering is wrong")
         self.max_adjust = config.getfloat("max_adjust", 4, above=0)
         self.horizontal_move_z = config.getfloat("horizontal_move_z", 5.0)
-        self.printer.register_event_handler("klippy:connect",
-                                            self.handle_connect)
         self.probe = self.printer.lookup_object('probe')
         self.probe_helper = self.probe.getProbePointsHelper(config, self.probe_finalize)
+        if len(self.probe_helper.probe_points) != 4:
+            raise config.error(
+                "Need exactly 4 probe points for quad_gantry_level")
+        self.z_helper = z_tilt.ZAdjustHelper(config, 4)
         gantry_corners = config.get('gantry_corners').split('\n')
         try:
             gantry_corners = [line.split(',', 1)
@@ -27,22 +31,15 @@ class QuadGantryLevel:
         if len(self.gantry_corners) < 2:
             raise config.error(
                 "quad_gantry_level requires at least two gantry_corners")
-        self.z_steppers = []
         # Register QUAD_GANTRY_LEVEL command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(
             'QUAD_GANTRY_LEVEL', self.cmd_QUAD_GANTRY_LEVEL,
             desc=self.cmd_QUAD_GANTRY_LEVEL_help)
-    def handle_connect(self):
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        z_steppers = kin.get_steppers('Z')
-        if len(z_steppers) != 4:
-            raise self.printer.config_error(
-                "quad_gantry_level needs exactly 4 z steppers")
-        self.z_steppers = z_steppers
     cmd_QUAD_GANTRY_LEVEL_help = (
         "Conform a moving, twistable gantry to the shape of a stationary bed")
     def cmd_QUAD_GANTRY_LEVEL(self, params):
+        self.retry_helper.start(params)
         self.probe_helper.start_probe(params)
     def probe_finalize(self, offsets, positions):
         # Mirror our perspective so the adjustments make sense
@@ -94,13 +91,9 @@ class QuadGantryLevel:
                 "is greater than max_adjust %0.6f" % (self.max_adjust))
             return
 
-        try:
-            self.adjust_steppers(z_adjust)
-        except:
-            logging.exception("quad_gantry_level adjust_steppers")
-            for s in self.z_steppers:
-                s.set_ignore_move(False)
-            raise
+        speed = self.probe_helper.get_lift_speed()
+        self.z_helper.adjust_steppers(z_adjust, speed)
+        return self.retry_helper.check_retry(z_positions)
     def linefit(self,p1,p2):
         if p1[1] == p2[1]:
             # Straight line
@@ -110,29 +103,6 @@ class QuadGantryLevel:
         return m,b
     def plot(self,f,x):
         return f[0]*x + f[1]
-    def adjust_steppers(self, z_adjust):
-        msg = "Making the following gantry adjustments:\n%s\n" % (
-            "\n".join(["%s = %.6f" % (
-                self.z_steppers[z_id].get_name(), z_adjust[z_id]
-                ) for z_id in range(4)]))
-        self.gcode.respond_info(msg)
-        toolhead = self.printer.lookup_object('toolhead')
-        cur_pos = toolhead.get_position()
-        speed = self.probe_helper.get_lift_speed()
-        # Disable moves on all Z steppers
-        for s in self.z_steppers:
-            s.set_ignore_move(True)
-        for z_id in range(len(z_adjust)):
-            stepper = self.z_steppers[z_id]
-            stepper.set_ignore_move(False)
-            cur_pos[2] = cur_pos[2] + z_adjust[z_id]
-            toolhead.move(cur_pos, speed)
-            toolhead.set_position(cur_pos)
-            stepper.set_ignore_move(True)
-        # Re-enable moves on all Z steppers
-        for s in self.z_steppers:
-            s.set_ignore_move(False)
-        self.gcode.reset_last_position()
 
 def load_config(config):
     return QuadGantryLevel(config)

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -13,7 +13,8 @@ class QuadGantryLevel:
         self.horizontal_move_z = config.getfloat("horizontal_move_z", 5.0)
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
-        self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
+        self.probe = self.printer.lookup_object('probe')
+        self.probe_helper = self.probe.getProbePointsHelper(config, self.probe_finalize)
         gantry_corners = config.get('gantry_corners').split('\n')
         try:
             gantry_corners = [line.split(',', 1)

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -43,7 +43,8 @@ class ScrewsTiltAdjust:
                                        default='CW-M3')
         # Initialize ProbePointsHelper
         points = [coord for coord, name in self.screws]
-        self.probe_helper = probe.ProbePointsHelper(self.config,
+        self.probe = self.printer.lookup_object('probe')
+        self.probe_helper = self.probe.getProbePointsHelper(self.config,
                                                     self.probe_finalize,
                                                     default_points=points)
         # Register command


### PR DESCRIPTION
module: PINDA2, P.I.N.D.A. 2 support

The 8mm sensor that is used in Prusa mk3s has a built-in thermistor.
In my setup - Prusa Mk3s bear upgrade with 0.9' steppers It is accurate in the temperature range of 20-40 degrees. The sensor heats up to 40 degrees when the table heats up to 70 and 50 when when the table heats up to 100. So it needs correction over 40.
In example below correction is interpolated between 40'C and 50'C from 0mm to -0.25mm
this is example of my configuration, I defined [pinda2] section instead of [probe] :
[pinda2]
pin: PB4
x_offset: 24
y_offset: 5
z_offset: 0.25
speed: 10.0
sensor_pin: PF3
sensor_type: EPCOS 100K B57560G104F
min_temp:0
max_temp:100
z_offset_calibration:[(0, 0.00),(40, 0.00),(50, -0.25), (100, -0.50)]

PROBE_TEMP command provides you current temperature

Signed-off-by: Rafal Jastrzebski <r2@jastrzebscy.org>