### PR TITLE
Adjust some minimum points assertions for ProbePointsHelper 

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -195,6 +195,7 @@ class BedMeshCalibrate:
         self._init_probe_params(config, points)
         self.probe_helper = probe.ProbePointsHelper(
             config, self.probe_finalize, points)
+        self.probe_helper.minimum_points(3)
         # setup persistent storage
         self.profiles = {}
         self._load_storage(config)

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -44,6 +44,7 @@ class BedTiltCalibrate:
         self.printer = config.get_printer()
         self.bedtilt = bedtilt
         self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
+        self.probe_helper.minimum_points(3)
         # Register BED_TILT_CALIBRATE command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -143,6 +143,7 @@ class DeltaCalibrate:
             points.append((math.cos(r) * dist, math.sin(r) * dist))
         self.probe_helper = probe.ProbePointsHelper(
             config, self.probe_finalize, default_points=points)
+        self.probe_helper.minimum_points(3)
         # Restore probe stable positions
         self.last_probe_positions = []
         for i in range(999):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -226,6 +226,7 @@ class ProbePointsHelper:
         self.printer = config.get_printer()
         self.finalize_callback = finalize_callback
         self.probe_points = default_points
+        self.name = config.get_name()
         # Read config settings
         if default_points is None or config.get('points', None) is not None:
             points = config.get('points').split('\n')
@@ -235,10 +236,7 @@ class ProbePointsHelper:
                                      for p in points]
             except:
                 raise config.error("Unable to parse probe points in %s" % (
-                    config.get_name()))
-        if len(self.probe_points) < 3:
-            raise config.error("Need at least 3 probe points for %s" % (
-                config.get_name()))
+                    self.name))
         self.horizontal_move_z = config.getfloat('horizontal_move_z', 5.)
         self.speed = self.lift_speed = config.getfloat('speed', 50., above=0.)
         self.probe_offsets = (0., 0., 0.)
@@ -252,6 +250,10 @@ class ProbePointsHelper:
         self.results = []
         self.busy = self.manual_probe = False
         self.gcode = self.toolhead = None
+    def minimum_points(self,n):
+        if len(self.probe_points) < n:
+            raise self.printer.config_error(
+                "Need at least %d probe points for %s" % (n, self.name))
     def get_lift_speed(self):
         return self.lift_speed
     def _lift_z(self, z_pos, add=False, speed=None):

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -14,6 +14,7 @@ class QuadGantryLevel:
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
         self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
+        self.probe_helper.minimum_points(3)
         gantry_corners = config.get('gantry_corners').split('\n')
         try:
             gantry_corners = [line.split(',', 1)

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -14,7 +14,9 @@ class QuadGantryLevel:
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
         self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
-        self.probe_helper.minimum_points(3)
+        if len(self.probe_helper.probe_points) != 4:
+            raise config.error(
+                "Need exactly 4 probe points for quad_gantry_level")
         gantry_corners = config.get('gantry_corners').split('\n')
         try:
             gantry_corners = [line.split(',', 1)

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -46,6 +46,7 @@ class ScrewsTiltAdjust:
         self.probe_helper = probe.ProbePointsHelper(self.config,
                                                     self.probe_finalize,
                                                     default_points=points)
+        self.probe_helper.minimum_points(3)
         # Register command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("SCREWS_TILT_CALCULATE",

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -23,6 +23,7 @@ class ZTilt:
         if len(z_positions) < 2:
             raise config.error("z_tilt requires at least two z_positions")
         self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
+        self.probe_helper.minimum_points(3)
         self.z_steppers = []
         # Register Z_TILT_ADJUST command
         self.gcode = self.printer.lookup_object('gcode')

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -23,7 +23,7 @@ class ZTilt:
         if len(z_positions) < 2:
             raise config.error("z_tilt requires at least two z_positions")
         self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
-        self.probe_helper.minimum_points(3)
+        self.probe_helper.minimum_points(2)
         self.z_steppers = []
         # Register Z_TILT_ADJUST command
         self.gcode = self.printer.lookup_object('gcode')


### PR DESCRIPTION
- quad-gantry level require 4 probe points exactly instead of minimum of 3. 
- z-tilt minimum points set to 2 instead of 3. 

"The z_tilt_adjust was coded to require 3 points because the original
intent was for railcore-xl and voron.  Since then, a number of users
have started using z_tilt_adjust for prusa i3 style printers with dual z
steppers.  That's fine, but we just haven't gotten around to removing
the superfluous check in the code." -- Kevin O'Connor

Quad Gantry level, the code expects 4. 
