### PR TITLE
Automatic retry for QUAD_GANTRY_LEVEL and Z_TILT_ADJUST

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -350,6 +350,11 @@
 #max_adjust: 4
 #   Saftey limit if an ajustment greater than this value is requested
 #   quad_gantry_level will abort.
+#retries: 0
+#   number of times to retry if the probed points aren't within tolerance
+#retry_tolerance: 0
+#   if retries are enabled then retry if largest and smallest probed points
+#   differ more than retry_tolerance
 
 
 # In a multi-extruder printer add an additional extruder section for

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -310,6 +310,15 @@
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#retries: 0
+#   Number of times to retry if the probed points aren't within tolerance
+#retry_tolerance: 0
+# if retries are enabled then retry if largest and smallest probed points
+# differ more than retry_tolerance.
+# Note the smallest unit of change here would be a single step. However if you
+# are probing more points than steppers then you will likely have a fixed
+# minimum value for the range of probed points which you can learn by observing
+# command output.
 
 
 # Moving gantry leveling using 4 independently controlled Z motors.

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -285,8 +285,10 @@ class ProbePointsHelper:
         if len(self.results) >= len(self.probe_points):
             self.gcode.reset_last_position()
             toolhead.get_last_move_time()
-            self.finalize_callback(self.probe_offsets, self.results)
-            return True
+            res = self.finalize_callback(self.probe_offsets, self.results)
+            if res != "retry":
+                return True
+            self.results = []
         # Move to next XY probe point
         curpos[:2] = self.probe_points[len(self.results)]
         toolhead.move(curpos, self.speed)

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -117,6 +117,7 @@ class ZTilt:
         except:
             raise config.error("Unable to parse z_positions in %s" % (
                 config.get_name()))
+        self.retry_helper = RetryHelper(config)
         self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
         self.probe_helper.minimum_points(2)
         self.z_helper = ZAdjustHelper(config, len(self.z_positions))
@@ -126,6 +127,7 @@ class ZTilt:
                                     desc=self.cmd_Z_TILT_ADJUST_help)
     cmd_Z_TILT_ADJUST_help = "Adjust the Z tilt"
     def cmd_Z_TILT_ADJUST(self, params):
+        self.retry_helper.start(params)
         self.probe_helper.start_probe(params)
     def probe_finalize(self, offsets, positions):
         # Setup for coordinate descent analysis
@@ -154,6 +156,7 @@ class ZTilt:
         adjustments = [x*x_adjust + y*y_adjust + z_adjust
                        for x, y in self.z_positions]
         self.z_helper.adjust_steppers(adjustments, speed)
+        return self.retry_helper.check_retry([p[2] for p in positions])
 
 def load_config(config):
     return ZTilt(config)

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -61,6 +61,50 @@ class ZAdjustHelper:
         toolhead.set_position(curpos)
         gcode.reset_last_position()
 
+class RetryHelper:
+    def __init__(self, config, error_msg_extra = ""):
+        self.gcode = config.get_printer().lookup_object('gcode')
+        self.default_max_retries = config.getint("retries", 0, minval=0)
+        self.default_retry_tolerance = \
+            config.getfloat("retry_tolerance", 0., above=0.)
+        self.value_label = "Probed points range"
+        self.error_msg_extra = error_msg_extra
+    def start(self, params):
+        self.max_retries = self.gcode.get_int('RETRIES', params,
+            default=self.default_max_retries, minval=0, maxval=30)
+        self.retry_tolerance = self.gcode.get_float('RETRY_TOLERANCE', params,
+            default=self.default_retry_tolerance, minval=0, maxval=1.0)
+        self.current_retry = 0
+        self.previous = None
+        self.increasing = 0
+    def check_increase(self,error):
+        if self.previous and error > self.previous + 0.0000001:
+            self.increasing += 1
+        elif self.increasing > 0:
+            self.increasing -= 1
+        self.previous = error
+        return self.increasing > 1
+    def check_retry(self,z_positions):
+        if self.max_retries == 0:
+            return
+        error = max(z_positions) - min(z_positions)
+        if self.check_increase(error):
+            self.gcode.respond_error(
+                "Retries aborting: %s is increasing. %s" % (
+                    self.value_label, self.error_msg_extra))
+            return
+        self.gcode.respond_info(
+            "Retries: %d/%d %s: %0.6f tolerance: %0.6f" % (
+                self.current_retry, self.max_retries, self.value_label,
+                error, self.retry_tolerance))
+        if error <= self.retry_tolerance:
+            return "done"
+        self.current_retry += 1
+        if self.current_retry > self.max_retries:
+            self.gcode.respond_error("Too many retries")
+            return
+        return "retry"
+
 class ZTilt:
     def __init__(self, config):
         self.printer = config.get_printer()


### PR DESCRIPTION
Support retrying QUAD_GANTRY_LEVEL and Z_TILT_ADJUST a configurable number of times to a configurable tolerance both in the config or as parameters. 

By default keeps original behavior of no retries.

Adds parameters RETRIES and RETRY_TOLERANCE to Z_TILT_ADJUST and QUAD_GANTRY_LEVEL gcode. 
Adds config options retries and retry_tolerance to `[z_tilt]` and `[quad_gantry_level]`
Issues an error if we are getting worse intead of approaching tolerance
Issues an error if retries were requested but we did not reach the tolerance in the specified number of retries

