### PR TITLE
BL-Touch v3 improvements

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -62,12 +62,12 @@
 #   Set if the BLTouch consistently reports the probe in a "not
 #   triggered" state after a successful "pin_up" command. This should
 #   be True for a genuine BLTouch; some BLTouch clones may require
-#   False.  The default is True.
+#   False. The default is True.
 #pin_up_touch_mode_reports_triggered: True
 #   Set if the BLTouch consistently reports a "triggered" state after
 #   the commands "pin_up" followed by "touch_mode". This should be
-#   True for a genuine BLTouch; some BLTouch clones may require
-#   False. The default is True.
+#   True for a genuine BLTouch v2 and earlier; the BLTouch v3 and some
+#   BLTouch clones require False. The default is True.
 #x_offset:
 #y_offset:
 #z_offset:

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -108,3 +108,27 @@ position. Carefully readjust the headless screw into place. You need
 to find the right position so it is able to lower and raise the pin
 and the red light turns on and of. Use the `reset`, `pin_up` and
 `pin_down` commands to achieve this.
+
+Troubleshooting
+===============
+
+* If you are sure the wiring of the BL-Touch is correct and every
+  attempt to probe with the BL-Touch reports "BLTouch failed to verify
+  sensor state" then it may be necessary to add
+  `pin_up_touch_mode_reports_triggered: False` to the bltouch config
+  section. The BL-Touch v3 and many clones require this setting.
+
+* A BL-Touch v3 may not work correctly when its signal wire is
+  connected to the Z end-stop pin on some printer boards. The symptoms
+  of this problem are: the BL-Touch probe deploys, the printer
+  descends, the probe contacts a surface, the BL-Touch raises the
+  probe, the BL-Touch does not successfully notify the
+  micro-controller, and the printer continues to descend. The Z
+  end-stop pin on some printer boards have a capacitor to filter the
+  signal which the BL-Touch v3 may not support. The simplest solution
+  is to connect the BL-Touch v3 sensor wire to an available pin on the
+  printer board that is not associated with an end-stop (and thus is
+  unlikely to have a capacitor). An alternative solution is to
+  physically alter the printer board to disable the given end-stop
+  capacitor or to add a hardware "pull up resistor" to the BL-Touch v3
+  sensor wire.

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -1,13 +1,13 @@
 # BLTouch support
 #
-# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
 import homing, probe
 
-SIGNAL_PERIOD = 0.025600
-MIN_CMD_TIME = 4 * SIGNAL_PERIOD
+SIGNAL_PERIOD = 0.020
+MIN_CMD_TIME = 5 * SIGNAL_PERIOD
 
 TEST_TIME = 5 * 60.
 RETRY_RESET_TIME = 1.
@@ -16,8 +16,8 @@ ENDSTOP_SAMPLE_TIME = .000015
 ENDSTOP_SAMPLE_COUNT = 4
 
 Commands = {
-    None: 0.0, 'pin_down': 0.000700, 'touch_mode': 0.001200,
-    'pin_up': 0.001500, 'self_test': 0.001800, 'reset': 0.002200,
+    None: 0.0, 'pin_down': 0.000650, 'touch_mode': 0.001165,
+    'pin_up': 0.001475, 'self_test': 0.001780, 'reset': 0.002190,
 }
 
 # BLTouch "endstop" wrapper

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -341,7 +341,7 @@ class MCU_pwm:
                 or self._shutdown_value not in [0., 1.]):
                 raise pins.error(
                     "start and shutdown values must be 0.0 or 1.0 on soft pwm")
-            self._pwm_max = self._mcu.get_constant_float("SOFT_PWM_MAX")
+            self._pwm_max = float(cycle_ticks)
             if self._is_static:
                 self._mcu.add_config_cmd("set_digital_out pin=%s value=%d" % (
                     self._pin, self._start_value >= 0.5))
@@ -354,7 +354,8 @@ class MCU_pwm:
                     self._start_value >= 0.5, self._shutdown_value >= 0.5,
                     self._mcu.seconds_to_clock(self._max_duration)))
             self._set_cmd = self._mcu.lookup_command(
-                "schedule_soft_pwm_out oid=%c clock=%u value=%hu", cq=cmd_queue)
+                "schedule_soft_pwm_out oid=%c clock=%u on_ticks=%u",
+                cq=cmd_queue)
     def set_pwm(self, print_time, value):
         clock = self._mcu.print_time_to_clock(print_time)
         if self._invert:

--- a/src/gpiocmds.c
+++ b/src/gpiocmds.c
@@ -106,9 +106,6 @@ DECL_COMMAND(command_set_digital_out, "set_digital_out pin=%u value=%c");
  * Soft PWM output pins
  ****************************************************************/
 
-#define MAX_SOFT_PWM 256
-DECL_CONSTANT("SOFT_PWM_MAX", MAX_SOFT_PWM);
-
 struct soft_pwm_s {
     struct timer timer;
     uint32_t on_duration, off_duration, end_time;
@@ -192,17 +189,14 @@ void
 command_schedule_soft_pwm_out(uint32_t *args)
 {
     struct soft_pwm_s *s = oid_lookup(args[0], command_config_soft_pwm_out);
-    uint32_t time = args[1];
-    uint16_t value = args[2];
+    uint32_t time = args[1], next_on_duration = args[2], next_off_duration;
     uint8_t next_flags = SPF_CHECK_END | SPF_HAVE_NEXT;
-    uint32_t next_on_duration, next_off_duration;
-    if (value == 0 || value >= MAX_SOFT_PWM) {
-        next_on_duration = next_off_duration = 0;
-        next_flags |= value ? SPF_NEXT_ON : 0;
-        if (!!value != s->default_value && s->max_duration)
+    if (next_on_duration == 0 || next_on_duration >= s->cycle_time) {
+        next_flags |= next_on_duration ? SPF_NEXT_ON : 0;
+        if (!!next_on_duration != s->default_value && s->max_duration)
             next_flags |= SPF_NEXT_CHECK_END;
+        next_on_duration = next_off_duration = 0;
     } else {
-        next_on_duration = (s->cycle_time / MAX_SOFT_PWM) * value;
         next_off_duration = s->cycle_time - next_on_duration;
         next_flags |= SPF_NEXT_ON | SPF_NEXT_TOGGLING;
         if (s->max_duration)
@@ -227,7 +221,7 @@ command_schedule_soft_pwm_out(uint32_t *args)
     irq_enable();
 }
 DECL_COMMAND(command_schedule_soft_pwm_out,
-             "schedule_soft_pwm_out oid=%c clock=%u value=%hu");
+             "schedule_soft_pwm_out oid=%c clock=%u on_ticks=%u");
 
 void
 soft_pwm_shutdown(void)


### PR DESCRIPTION
It looks like the BL-Touch v3 has several incompatibilities with the BL-Touch v2.  This series attempts to address issue #1483 (via documentation), #1515 (via documentation), #1649 (via timing changes), #1651 (via documentation).

I do not own a BL-Touch (neither a v2 nor a v3) so I cannot test this.  Feedback welcome.

-Kevin