### PR TITLE
Don't apply the SET_GCODE_OFFSET to the next g-code command

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,11 @@ All dates in this document are approximate.
 
 # Changes
 
+20190520: The SET_GCODE_OFFSET command has changed; update any g-code
+macros accordingly. The command will no longer apply the requested
+offset to the next G1 command. The old behavior may be approximated by
+using the new "MOVE=1" parameter.
+
 20190404: The Python host software packages were updated. Users will
 need to rerun the ~/klipper/scripts/install-octopi.sh script (or
 otherwise upgrade the python dependencies if not using a standard

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -90,15 +90,21 @@ The following standard commands are supported:
 - `GET_POSITION`: Return information on the current location of the
   toolhead.
 - `SET_GCODE_OFFSET [X=<pos>|X_ADJUST=<adjust>]
-  [Y=<pos>|Y_ADJUST=<adjust>] [Z=<pos>|Z_ADJUST=<adjust>]`: Set a
-  positional offset to apply to future G-Code commands. This is
-  commonly used to virtually change the Z bed offset or to set nozzle
-  XY offsets when switching extruders. For example, if
-  "SET_GCODE_OFFSET Z=0.2" is sent, then future G-Code moves will
-  have 0.2mm added to their Z height. If the X_ADJUST style parameters
-  are used, then the adjustment will be added to any existing offset
-  (eg, "SET_GCODE_OFFSET Z=-0.2" followed by "SET_GCODE_OFFSET
-  Z_ADJUST=0.3" would result in a total Z offset of 0.1).
+  [Y=<pos>|Y_ADJUST=<adjust>] [Z=<pos>|Z_ADJUST=<adjust>]
+  [MOVE=1 [MOVE_SPEED=<speed>]]`: Set a positional offset to apply to
+  future G-Code commands. This is commonly used to virtually change
+  the Z bed offset or to set nozzle XY offsets when switching
+  extruders. For example, if "SET_GCODE_OFFSET Z=0.2" is sent, then
+  future G-Code moves will have 0.2mm added to their Z height. If the
+  X_ADJUST style parameters are used, then the adjustment will be
+  added to any existing offset (eg, "SET_GCODE_OFFSET Z=-0.2" followed
+  by "SET_GCODE_OFFSET Z_ADJUST=0.3" would result in a total Z offset
+  of 0.1). If "MOVE=1" is specified then a toolhead move will be
+  issued to apply the given offset (otherwise the offset will take
+  effect on the next absolute G-Code move that specifies the given
+  axis). If "MOVE_SPEED" is specified then the toolhead move will be
+  performed with the given speed (in mm/s); otherwise the toolhead
+  move will use the last specified G-Code speed.
 - `PID_CALIBRATE HEATER=<config_name> TARGET=<temperature>
   [WRITE_FILE=1]`: Perform a PID calibration test. The specified
   heater will be enabled until the specified target temperature is

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -1,6 +1,6 @@
 # Parse gcode commands
 #
-# Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, re, logging, collections, shlex
@@ -597,6 +597,7 @@ class GCodeParser:
         self.extrude_factor = new_extrude_factor
     cmd_SET_GCODE_OFFSET_help = "Set a virtual offset to g-code positions"
     def cmd_SET_GCODE_OFFSET(self, params):
+        move_delta = [0., 0., 0., 0.]
         for axis, pos in self.axis2pos.items():
             if axis in params:
                 offset = self.get_float(axis, params)
@@ -606,9 +607,19 @@ class GCodeParser:
             else:
                 continue
             delta = offset - self.homing_position[pos]
-            self.last_position[pos] += delta
+            move_delta[pos] = delta
             self.base_position[pos] += delta
             self.homing_position[pos] = offset
+        # Move the toolhead the given offset if requested
+        if self.get_int('MOVE', params, 0):
+            speed = self.get_float('MOVE_SPEED', params,
+                                   self.speed * self.speed_factor, above=0.)
+            for pos, delta in enumerate(move_delta):
+                self.last_position[pos] += delta
+            try:
+                self.move_with_transform(self.last_position, speed)
+            except homing.EndstopError as e:
+                raise error(str(e))
     def cmd_M206(self, params):
         # Offset axes
         offsets = { self.axis2pos[a]: self.get_float(a, params)


### PR DESCRIPTION
The SET_GCODE_OFFSET command could cause unwanted behaviour when an offset is applied to the following g-code command.  (In particular, when the following command is an extrude only move - as in issue #1289.)

Don't apply the offset immediately.  Instead, add support for a MOVE=1 parameter which will schedule a move to apply the given offset.

-Kevin