### PR TITLE
SET_TMC_FIELD: Check field name validity.

### DIFF
--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -354,7 +354,9 @@ class TMC2130:
             'VALUE' not in params):
             raise gcode.error("Invalid command format")
         field = gcode.get_str('FIELD', params)
-        reg = self.fields.field_to_register[field]
+        reg = self.fields.field_to_register.get(field)
+        if reg is None:
+            raise gcode.error("Unknown field name '%s'" % field)
         value = gcode.get_int('VALUE', params)
         self.fields.set_field(field, value)
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -427,7 +427,9 @@ class TMC2208:
             'VALUE' not in params):
             raise gcode.error("Invalid command format")
         field = gcode.get_str('FIELD', params)
-        reg = self.fields.field_to_register[field]
+        reg = self.fields.field_to_register.get(field)
+        if reg is None:
+            raise gcode.error("Unknown field name '%s'" % field)
         value = gcode.get_int('VALUE', params)
         self.fields.set_field(field, value)
         self.printer.lookup_object('toolhead').wait_moves()

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -294,7 +294,9 @@ class TMC2660:
             'VALUE' not in params):
             raise gcode.error("Invalid command format")
         field = gcode.get_str('FIELD', params)
-        reg = self.fields.field_to_register[field]
+        reg = self.fields.field_to_register.get(field)
+        if reg is None:
+            raise gcode.error("Unknown field name '%s'" % field)
         value = gcode.get_int('VALUE', params)
         self.fields.set_field(field, value)
         pt = self.printer.lookup_object('toolhead').get_last_move_time()

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -428,7 +428,9 @@ class TMC5160:
             'VALUE' not in params):
             raise gcode.error("Invalid command format")
         field = gcode.get_str('FIELD', params)
-        reg = self.fields.field_to_register[field]
+        reg = self.fields.field_to_register.get(field)
+        if reg is None:
+            raise gcode.error("Unknown field name '%s'" % field)
         value = gcode.get_int('VALUE', params)
         self.fields.set_field(field, value)
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()


### PR DESCRIPTION
This avoids crashing clipper if user entered invalid field name.

Signed-off-by: Artem Belevich <artemb@gmail.com>