### PR TITLE
Move probe multi-sampling capability into main PROBE handling

### DIFF
--- a/config/example-delta.cfg
+++ b/config/example-delta.cfg
@@ -123,12 +123,3 @@ radius: 50
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-#samples: 1
-#   The number of times to probe each point.  The probed z-values will
-#   be averaged. The default is to probe 1 time.
-#samples_result: average
-#   One can choose median or average between probes samples
-#   The default is average.
-#sample_retract_dist: 2.0
-#   The distance (in mm) to retract between each sample if sampling
-#   more than once. The default is 2mm.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -30,6 +30,15 @@
 #   triggers. This parameter must be provided.
 #speed: 5.0
 #   Speed (in mm/s) of the Z axis when probing. The default is 5mm/s.
+#samples: 1
+#   The number of times to probe each point. The probed z-values will
+#   be averaged. The default is to probe 1 time.
+#sample_retract_dist: 2.0
+#   The distance (in mm) to lift the toolhead between each sample (if
+#   sampling more than once). The default is 2mm.
+#samples_result: average
+#   The calculation method when sampling more than once - either
+#   "median" or "average". The default is average.
 #activate_gcode:
 #   A list of G-Code commands (one per line; subsequent lines
 #   indented) to execute prior to each probe attempt. This may be
@@ -72,6 +81,9 @@
 #y_offset:
 #z_offset:
 #speed:
+#samples:
+#sample_retract_dist:
+#samples_result:
 #   See the "probe" section for information on these parameters.
 
 
@@ -102,15 +114,6 @@
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-#samples: 1
-#   The number of times to probe each point.  The probed z-values
-#   will be averaged.  The default is to probe 1 time.
-#samples_result: average
-#   One can choose median or average between probes samples
-#   The default is average.
-#sample_retract_dist: 2.0
-#   The distance (in mm) to retract between each sample if
-#   sampling more than once.  Default is 2mm.
 
 
 # Mesh Bed Leveling. One may define a [bed_mesh] config section
@@ -147,15 +150,6 @@
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-#samples: 1
-#   The number of times to probe each point.  The probed z-values
-#   will be averaged.  The default is to probe 1 time.
-#samples_result: average
-#   One can choose median or average between probes samples
-#   The default is average.
-#sample_retract_dist: 2.0
-#   The distance (in mm) to retract between each sample if
-#   sampling more than once.  Default is 2mm.
 #bed_radius:
 #   Defines the radius to probe for round beds.  Note that the radius
 #   is relative to the nozzle's origin, if using a probe be sure to
@@ -283,15 +277,6 @@
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-#samples: 1
-#   The number of times to probe each point.  The probed z-values
-#   will be averaged.  The default is to probe 1 time.
-#sample_retract_dist: 2.0
-#   The distance (in mm) to retract between each sample if
-#   sampling more than once.  Default is 2mm.
-#samples_result: median
-#   One can choose median or average between screw probes
-#   The default is average.
 #screw_thread: CW-M3
 #   The type of screw used for bed level, M3, M4 or M5 and the
 #   direction of the knob used to level the bed, clockwise decrease
@@ -325,15 +310,6 @@
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-#samples: 1
-#   The number of times to probe each point.  The probed z-values
-#   will be averaged.  The default is to probe 1 time.
-#samples_result: average
-#   One can choose median or average between probes samples
-#   The default is average.
-#sample_retract_dist: 2.0
-#   The distance (in mm) to retract between each sample if
-#   sampling more than once.  Default is 2mm.
 
 
 # Moving gantry leveling using 4 independently controlled Z motors.
@@ -374,13 +350,6 @@
 #max_adjust: 4
 #   Saftey limit if an ajustment greater than this value is requested
 #   quad_gantry_level will abort.
-#samples: 1
-#   Number of probe samples per point. The defaut is 1
-#samples_result: average
-#   One can choose median or average between probes samples
-#   The default is average.
-#sample_retract_dist: 2.0
-#   Distance in mm to retract the probe between samples. Default is 2.
 
 
 # In a multi-extruder printer add an additional extruder section for

--- a/config/kit-voron2-250mm.cfg
+++ b/config/kit-voron2-250mm.cfg
@@ -158,6 +158,10 @@ x_offset: 0.0
 y_offset: 25.0
 z_offset: 0.00
 speed: 2.0
+samples: 4
+#   Number of times to probe a point
+sample_retract_dist: 6.0
+#   How far to retract (in mm) from the probe point for multi-probe samples
 
 [fan]
 # Print cooling fan
@@ -231,10 +235,6 @@ points:
 #   Probe points
 speed: 200
 horizontal_move_z: 6
-samples: 4
-#   Number of times to probe a point
-sample_retract_dist: 6.0
-#   How far to retract (in mm) from the probe point for multi-probe samples
 
 [display]
 # RepRapDiscount 128x64 Full Graphic Smart Controller

--- a/config/kit-zav3d-2019.cfg
+++ b/config/kit-zav3d-2019.cfg
@@ -123,12 +123,12 @@ x_offset: 39
 y_offset: 11
 z_offset: 0.9
 pin_up_touch_mode_reports_triggered: false
+samples: 2
+sample_retract_dist: 3.0
 
 [bed_mesh]
 speed: 100
 horizontal_move_z: 5
-samples: 2
-sample_retract_dist: 3.0
 min_point: 30,30
 max_point: 150,150
 probe_count: 3,3

--- a/config/printer-tevo-flash-2018.cfg
+++ b/config/printer-tevo-flash-2018.cfg
@@ -103,6 +103,8 @@ control_pin: ar11
 x_offset: 0
 y_offset: 18
 z_offset: 1.64
+samples: 3
+sample_retract_dist: 5
 
 # The homing_override section modifies the default G28 behavior
 [homing_override]
@@ -117,8 +119,6 @@ gcode:
 
 # Mesh Bed Leveling.
 [bed_mesh]
-samples: 3
-sample_retract_dist: 5
 min_point: 5,0
 max_point: 230,210
 probe_count: 9,9

--- a/docs/Delta_Calibrate.md
+++ b/docs/Delta_Calibrate.md
@@ -14,6 +14,22 @@ tower endstop switches. If one is using Trinamic stepper motor drivers
 then consider enabling [endstop phase](Endstop_Phase.md) detection to
 improve the accuracy of those switches.
 
+Automatic vs manual probing
+===========================
+
+Klipper supports calibrating the delta parameters via a manual probing
+method or via an automatic Z probe.
+
+A number of delta printer kits come with automatic Z probes that are
+not sufficiently accurate (specifically, small differences in arm
+length can cause effector tilt which can skew an automatic probe). If
+using an automatic probe then first
+[calibrate the probe](Probe_Calibrate.md) and then check for a
+[probe location bias](Probe_Calibrate.md#location-bias-check). If the
+automatic probe has a bias of more than 25 microns (.025mm) then use
+manual probing instead. Manual probing only takes a few minutes and it
+eliminates error introduced by the probe.
+
 Basic delta calibration
 =======================
 
@@ -39,20 +55,13 @@ calibration completes, one can remove this setting from the config.)
 
 There are two ways to perform the probing - manual probing
 (`DELTA_CALIBRATE METHOD=manual`) and automatic probing
-(`DELTA_CALIBRATE`). Automatic probing utilizes a hardware device
-capable of triggering when the toolhead is at a set distance from the
-bed. The manual probing method will move the head near the bed and
-then wait for the user to follow the steps described at
+(`DELTA_CALIBRATE`). The manual probing method will move the head near
+the bed and then wait for the user to follow the steps described at
 ["the paper test"](Bed_Level.md#the-paper-test) to determine the
-actual distance between the nozzle and bed at the given location. It
-is recommended to use manual probing for delta calibration. A number
-of common printer kits come with probes that are not sufficiently
-accurate (specifically, small differences in arm length can cause
-effector tilt which can skew an automatic probe). Manual probing only
-takes a few minutes and it eliminates error introduced by the probe.
+actual distance between the nozzle and bed at the given location.
 
 To perform the basic probe, make sure the config has a
-[delta_calibrate] section defined and run:
+[delta_calibrate] section defined and then run the tool:
 ```
 G28
 DELTA_CALIBRATE METHOD=manual

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -43,13 +43,17 @@ the new values take effect.
 
 # Calibrating probe Z offset
 
-Providing an accurate probe Z offset is critical to obtaining high
-quality prints.
+Providing an accurate probe z_offset is critical to obtaining high
+quality prints. The z_offset is the distance between the nozzle and
+bed when the probe triggers. The Klipper `PROBE_CALIBRATE` tool can be
+used to obtain this value - it will run an automatic probe to measure
+the probe's Z trigger position and then start a manual probe to obtain
+the nozzle Z height. The probe z_offset will then be calculated from
+these measurements.
 
 Start by homing the printer and then move the head to a position near
 the center of the bed. Navigate to the OctoPrint terminal tab and run
-the `PROBE_CALIBRATE` command to start Klipper's probe calibration
-tool.
+the `PROBE_CALIBRATE` command to start the tool.
 
 This tool will perform an automatic probe, then lift the head, move
 the nozzle over the location of the probe point, and start the manual
@@ -65,3 +69,116 @@ results to the config file with:
 ```
 SAVE_CONFIG
 ```
+
+# Repeatability check
+
+After calibrating the probe X, Y, and Z offsets it is a good idea to
+verify that the probe provides repeatable results. Start by homing the
+printer and then move the head to a position near the center of the
+bed. Navigate to the OctoPrint terminal tab and run the
+`PROBE_ACCURACY` command.
+
+This command will run the probe ten times and produce output similar
+to the following:
+```
+Recv: // probe accuracy: at X:0.000 Y:0.000 Z:10.000
+Recv: // and read 10 times with speed of 5 mm/s
+Recv: // probe at -0.003,0.005 is z=2.506948
+Recv: // probe at -0.003,0.005 is z=2.519448
+Recv: // probe at -0.003,0.005 is z=2.519448
+Recv: // probe at -0.003,0.005 is z=2.506948
+Recv: // probe at -0.003,0.005 is z=2.519448
+Recv: // probe at -0.003,0.005 is z=2.519448
+Recv: // probe at -0.003,0.005 is z=2.506948
+Recv: // probe at -0.003,0.005 is z=2.506948
+Recv: // probe at -0.003,0.005 is z=2.519448
+Recv: // probe at -0.003,0.005 is z=2.506948
+Recv: // probe accuracy results: maximum 2.506948, minimum 2.519448, average 2.513198, median 2.513198, standard deviation 0.006250
+```
+
+Ideally the tool will report an identical maximum and minimum value.
+(That is, ideally the probe obtains an identical result on all ten
+probes.) However, it's normal for the minimum/maximum distance to
+differ by one Z step_distance or up to 5 microns (.005mm). So, in the
+above example, since the printer uses a Z step_distance of .0125, the
+results would be considered normal.
+
+If the results of the test show a minimum and maximum distance that
+differs by more than 25 microns (.025mm) then the probe does not have
+sufficient accuracy for typical bed leveling procedures. It may be
+possible to tune the probe speed and/or probe start height to improve
+the repeatability of the probe. The `PROBE_ACCURACY` command allows
+one to run tests with different parameters to see their impact - see
+the [G-Codes document](G-Codes.md) for further details. If the probe
+generally obtains repeatable results but has an occasional outlier,
+then it may be possible to account for that by using multiple samples
+on each probe - read the description of the probe `samples` config
+parameters in the
+[example-extras.cfg](https://github.com/KevinOConnor/klipper/tree/master/config/example-extras.cfg)
+file for more details.
+
+If new probe speed, samples count, or other settings are needed, then
+update the printer.cfg file and issue a `RESTART` command. If so, it
+is a good idea to
+[calibrate the z_offset](#calibrating-probe-z-offset) again. If
+repeatable results can not be obtained then don't use the probe for
+bed leveling. Klipper has several manual probing tools that can be
+used instead - see the [Bed Level document](Bed_Level.md) for further
+details.
+
+# Location Bias Check
+
+Some probes can have a systemic bias that corrupts the results of the
+probe at certain toolhead locations. For example, if the probe mount
+tilts slightly when moving along the Y axis then it could result in
+the probe reporting biased results at different Y positions.
+
+This is a common issue with probes on delta printers, however it can
+occur on all printers.
+
+One can check for a location bias by using the `PROBE_CALIBRATE`
+command to measuring the probe z_offset at various X and Y
+locations. Ideally, the probe z_offset would be a constant value at
+every printer location.
+
+For delta printers, try measuring the z_offset at a position near the
+A tower, at a position near the B tower, and at a position near the C
+tower. For cartesian, corexy, and similar printers, try measuring the
+z_offset at positions near the four corners of the bed.
+
+Before starting this test, first calibrate the probe X, Y, and Z
+offsets as described at the beginning of this document. Then home the
+printer and navigate to the first XY position. Follow the steps at
+[calibrating probe Z offset](#calibrating-probe-z-offset) to run the
+`PROBE_CALIBRATE` command, `TESTZ` commands, and `ACCEPT` command, but
+do not run `SAVE_CONFIG`. Note the reported z_offset found. Then
+navigate to the other XY positions, repeat these `PROBE_CALIBRATE`
+steps, and note the reported z_offset.
+
+If the difference between the minimum reported z_offset and the
+maximum reported z_offset is greater than 25 microns (.025mm) then the
+probe is not suitable for typical bed leveling procedures. See the
+[Bed Level document](Bed_Level.md) for manual probe alternatives.
+
+# Temperature Bias
+
+Many probes have a systemic bias when probing at different
+temperatures. For example, the probe may consistently trigger at a
+lower height when the probe is at a higher temperature.
+
+It is recommended to run the bed leveling tools at a consistent
+temperature to account for this bias. For example, either always run
+the tools when the printer is at room temperature, or always run the
+tools after the printer has obtained a consistent print temperature.
+In either case, it is a good idea to wait several minutes after the
+desired temperature is reached, so that the printer apparatus is
+consistently at the desired temperature.
+
+To check for a temperature bias, start with the printer at room
+temperature and then home the printer, move the head to a position
+near the center of the bed, and run the `PROBE_ACCURACY` command. Note
+the results. Then, without homing or disabling the stepper motors,
+heat the printer nozzle and bed to printing temperature, and run the
+`PROBE_ACCURACY` command again. Ideally, the command will report
+identical results. As above, if the probe does have a temperature bias
+then be careful to always use the probe at a consistent temperature.

--- a/klippy/extras/bed_screws.py
+++ b/klippy/extras/bed_screws.py
@@ -51,10 +51,7 @@ class BedScrews:
         for i in range(len(coord)):
             if coord[i] is not None:
                 curpos[i] = coord[i]
-        try:
-            toolhead.move(curpos, speed)
-        except homing.EndstopError as e:
-            raise self.gcode.error(str(e))
+        toolhead.move(curpos, speed)
         self.gcode.reset_last_position()
     def move_to_screw(self, state, screw):
         # Move up, over, and then down

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -68,7 +68,7 @@ class BLTouchEndstopWrapper:
     def handle_connect(self):
         try:
             self.raise_probe()
-        except homing.EndstopError as e:
+        except homing.CommandError as e:
             logging.warning("BLTouch raise probe error: %s", str(e))
     def sync_mcu_print_time(self):
         curtime = self.printer.get_reactor().monotonic()
@@ -114,7 +114,7 @@ class BLTouchEndstopWrapper:
                 try:
                     self.verify_state(check_start_time, check_end_time,
                                       False, "raise probe")
-                except homing.EndstopError as e:
+                except homing.CommandError as e:
                     if retry >= 2:
                         raise
                     msg = "Failed to verify BLTouch probe is raised; retrying."

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -90,9 +90,9 @@ class ManualProbeHelper:
                 self.toolhead.move(curpos, self.speed)
             curpos[2] = z_pos
             self.toolhead.move(curpos, self.speed)
-        except homing.EndstopError as e:
+        except homing.CommandError as e:
             self.finalize(False)
-            raise self.gcode.error(str(e))
+            raise
     def report_z_status(self, warn_no_change=False, prev_pos=None):
         # Get position
         kin_pos = self.get_kinematics_pos()

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -89,12 +89,12 @@ class ManualStepper:
         for mcu_endstop, name in endstops:
             try:
                 mcu_endstop.home_finalize()
-            except homing.EndstopError as e:
+            except homing.CommandError as e:
                 if error is None:
                     error = str(e)
         self.sync_print_time()
         if error is not None:
-            raise self.gcode.error(error)
+            raise homing.CommandError(error)
     cmd_MANUAL_STEPPER_help = "Command a manually configured stepper"
     def cmd_MANUAL_STEPPER(self, params):
         if 'ENABLE' in params:

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -221,10 +221,20 @@ class ProbeEndstopWrapper:
         for stepper in kin.get_steppers('Z'):
             stepper.add_to_endstop(self)
     def home_prepare(self):
+        toolhead = self.printer.lookup_object('toolhead')
+        start_pos = toolhead.get_position()
         self.activate_gcode.run_gcode_from_command()
+        if toolhead.get_position()[:3] != start_pos[:3]:
+            raise homing.CommandError(
+                "Toolhead moved during probe activate_gcode script")
         self.mcu_endstop.home_prepare()
     def home_finalize(self):
+        toolhead = self.printer.lookup_object('toolhead')
+        start_pos = toolhead.get_position()
         self.deactivate_gcode.run_gcode_from_command()
+        if toolhead.get_position()[:3] != start_pos[:3]:
+            raise homing.CommandError(
+                "Toolhead moved during probe deactivate_gcode script")
         self.mcu_endstop.home_finalize()
     def get_position_endstop(self):
         return self.position_endstop

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -175,6 +175,7 @@ class PrinterProbe:
         configfile.set(self.name, 'z_offset', "%.3f" % (z_offset,))
     cmd_PROBE_CALIBRATE_help = "Calibrate the probe's z_offset"
     def cmd_PROBE_CALIBRATE(self, params):
+        manual_probe.verify_no_manual_probe(self.printer)
         # Perform initial probe
         curpos = self.run_probe()
         # Move away from the bed
@@ -292,6 +293,7 @@ class ProbePointsHelper:
         self.gcode.reset_last_position()
         return False
     def start_probe(self, params):
+        manual_probe.verify_no_manual_probe(self.printer)
         # Lookup objects
         probe = self.printer.lookup_object('probe', None)
         method = self.gcode.get_str('METHOD', params, 'automatic').lower()

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -86,6 +86,7 @@ class PrinterProbe:
             toolhead.move(curpos, speed)
         except homing.EndstopError as e:
             raise self.gcode.error(str(e))
+        self.gcode.reset_last_position()
     def _calc_mean(self, positions):
         count = float(len(positions))
         return [sum([pos[i] for pos in positions]) / count
@@ -277,6 +278,7 @@ class ProbePointsHelper:
         except homing.EndstopError as e:
             self._finalize(False)
             raise self.gcode.error(str(e))
+        self.gcode.reset_last_position()
     def _move_next(self):
         # Lift toolhead
         self._lift_z(self.horizontal_move_z, self.lift_speed)
@@ -340,7 +342,6 @@ class ProbePointsHelper:
         self._move_next()
     def _finalize(self, success):
         self.busy = False
-        self.gcode.reset_last_position()
         if success:
             self.finalize_callback(self.probe_offsets, self.results)
 

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -475,10 +475,7 @@ class GCodeParser:
         if self.extruder is e:
             return
         self.run_script_from_command(self.extruder.get_activate_gcode(False))
-        try:
-            self.toolhead.set_extruder(e)
-        except homing.EndstopError as e:
-            raise self.error(str(e))
+        self.toolhead.set_extruder(e)
         self.extruder = e
         self.reset_last_position()
         self.extrude_factor = 1.
@@ -533,10 +530,7 @@ class GCodeParser:
         except ValueError as e:
             raise self.error("Unable to parse move '%s'" % (
                 params['#original'],))
-        try:
-            self.move_with_transform(self.last_position, self.speed)
-        except homing.EndstopError as e:
-            raise self.error(str(e))
+        self.move_with_transform(self.last_position, self.speed)
     def cmd_G4(self, params):
         # Dwell
         if 'S' in params:
@@ -555,10 +549,7 @@ class GCodeParser:
         homing_state = homing.Homing(self.printer)
         if self.is_fileinput:
             homing_state.set_no_verify_retract()
-        try:
-            homing_state.home_axes(axes)
-        except homing.EndstopError as e:
-            raise self.error(str(e))
+        homing_state.home_axes(axes)
         for axis in homing_state.get_axes():
             self.base_position[axis] = self.homing_position[axis]
         self.reset_last_position()
@@ -632,10 +623,7 @@ class GCodeParser:
             speed = self.get_float('MOVE_SPEED', params, self.speed, above=0.)
             for pos, delta in enumerate(move_delta):
                 self.last_position[pos] += delta
-            try:
-                self.move_with_transform(self.last_position, speed)
-            except homing.EndstopError as e:
-                raise self.error(str(e))
+            self.move_with_transform(self.last_position, speed)
     def cmd_M206(self, params):
         # Offset axes
         offsets = { self.axis2pos[a]: -self.get_float(a, params)
@@ -677,10 +665,7 @@ class GCodeParser:
         if self.get_int('MOVE', params, 0):
             speed = self.get_float('MOVE_SPEED', params, self.speed, above=0.)
             self.last_position[:3] = state['last_position'][:3]
-            try:
-                self.move_with_transform(self.last_position, speed)
-            except homing.EndstopError as e:
-                raise self.error(str(e))
+            self.move_with_transform(self.last_position, speed)
     # G-Code temperature and fan commands
     cmd_M105_when_not_ready = True
     def cmd_M105(self, params):

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -146,7 +146,10 @@ class Homing:
             self.toolhead.motor_off()
             raise
 
-class EndstopError(Exception):
+class CommandError(Exception):
+    pass
+
+class EndstopError(CommandError):
     pass
 
 def EndstopMoveError(pos, msg="Move out of range"):

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -61,7 +61,7 @@ class Homing:
         error = None
         try:
             self.toolhead.move(movepos, speed)
-        except EndstopError as e:
+        except CommandError as e:
             error = "Error during homing move: %s" % (str(e),)
         # Wait for endstops to trigger
         move_end_print_time = self.toolhead.get_last_move_time()
@@ -80,11 +80,11 @@ class Homing:
         for mcu_endstop, name in endstops:
             try:
                 mcu_endstop.home_finalize()
-            except EndstopError as e:
+            except CommandError as e:
                 if error is None:
                     error = str(e)
         if error is not None:
-            raise EndstopError(error)
+            raise CommandError(error)
         # Check if some movement occurred
         if verify_movement:
             for s, name, pos in start_mcu_pos:
@@ -142,7 +142,7 @@ class Homing:
         self.changed_axes = axes
         try:
             self.toolhead.get_kinematics().home(self)
-        except EndstopError:
+        except CommandError:
             self.toolhead.motor_off()
             raise
 

--- a/test/klippy/screws_tilt_adjust.cfg
+++ b/test/klippy/screws_tilt_adjust.cfg
@@ -56,6 +56,9 @@ max_temp: 130
 sensor_pin: ar30
 control_pin: ar32
 z_offset: 1.15
+samples: 3
+sample_retract_dist: 2.
+samples_result: median
 
 [bed_mesh]
 min_point: 10,10
@@ -83,7 +86,4 @@ screw4: 10,190
 screw4_name: read left screw
 horizontal_move_z: 10.
 speed: 50.
-samples: 3
-sample_retract_dist: 2.
-samples_result: median
 screw_thread: CW-M3


### PR DESCRIPTION
This series moves the "samples" config option (and similar) from the DELTA_CALIBRATE, BED_MESH_CALIBRATE, etc. commands into the main Probe class.  Thus, all probe commands (eg, PROBE and PROBE_CALIBRATE) gain the ability to perform multi-sampling.

Unfortunately, this changes the config file layout, so anyone that was using the multi-sampling capability will need to modify their config files on an upgrade.

@rmcbc, @arksine, @sprk-nl - FYI.

-Kevin
