### PR TITLE
idle_timeout: Add SET_IDLE_TIMEOUT gcode

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -160,6 +160,8 @@ The following standard commands are supported:
   for calibrating a Z position_endstop config setting. See the
   MANUAL_PROBE command for details on the parameters and the
   additional commands available while the tool is active.
+- `SET_IDLE_TIMEOUT [TIMEOUT=<timeout>]`:  Allows the user to set the
+  idle timeout (in seconds).
 - `RESTART`: This will cause the host software to reload its config
   and perform an internal reset. This command will not clear error
   state from the micro-controller (see FIRMWARE_RESTART) nor will it

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -23,6 +23,8 @@ class IdleTimeout:
         self.state = "Idle"
         self.idle_timeout = config.getfloat('timeout', 600., above=0.)
         self.idle_gcode = config.get('gcode', DEFAULT_IDLE_GCODE).split('\n')
+        self.gcode.register_command(
+            'SET_IDLE_TIMEOUT', self.cmd_SET_IDLE_TIMEOUT)
     def handle_ready(self):
         self.toolhead = self.printer.lookup_object('toolhead')
         self.timeout_timer = self.reactor.register_timer(self.timeout_handler)
@@ -88,6 +90,16 @@ class IdleTimeout:
         self.reactor.update_timer(self.timeout_timer, curtime + check_time)
         self.printer.send_event("idle_timeout:printing",
                                 est_print_time + PIN_MIN_TIME)
+    def cmd_SET_IDLE_TIMEOUT(self, params):
+        timeout = self.gcode.get_float(
+            'TIMEOUT', params, self.idle_timeout, above=0.)
+        self.idle_timeout = timeout
+        self.gcode.respond_info(
+            "idle_timeout: Timeout set to %.2f s" % timeout)
+        if self.state == "Ready":
+            checktime = self.reactor.monotonic() + timeout
+            self.reactor.update_timer(
+                self.timeout_timer, checktime)
 
 def load_config(config):
     return IdleTimeout(config)


### PR DESCRIPTION
This helps resolve issues where the idle timeout turns off heater/motors during a long PAUSE or while a chamber is heating.  The user can temporarily increase the idle_timeout in a macro then restore the original idle timeout when ready.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>