### PR TITLE
Refactor tmc drivers

### DIFF
--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -279,6 +279,8 @@ class TMC2130:
     def get_register(self, reg_name):
         reg = Registers[reg_name]
         self.spi.spi_send([reg, 0x00, 0x00, 0x00, 0x00])
+        if self.printer.get_start_args().get('debugoutput') is not None:
+            return 0
         params = self.spi.spi_transfer([reg, 0x00, 0x00, 0x00, 0x00])
         pr = bytearray(params['response'])
         return (pr[1] << 24) | (pr[2] << 16) | (pr[3] << 8) | pr[4]

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -309,8 +309,6 @@ class TMC2208:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[-1]
-        self.printer.register_event_handler("klippy:connect",
-                                            self._handle_connect)
         # Setup mcu communication
         self.regs = collections.OrderedDict()
         self.fields = tmc2130.FieldHelper(Fields, SignedFields, FieldFormatters,
@@ -354,15 +352,6 @@ class TMC2208:
         set_config_field(config, "pwm_autograd", True)
         set_config_field(config, "PWM_REG", 8)
         set_config_field(config, "PWM_LIM", 12)
-    def _init_registers(self):
-        # Send registers
-        for reg_name, val in self.regs.items():
-            self.set_register(reg_name, val)
-    def _handle_connect(self):
-        try:
-            self._init_registers()
-        except self.printer.command_error as e:
-            raise self.printer.config_error(str(e))
     def query_registers(self, print_time=0.):
         out = []
         for reg_name in ReadRegisters:

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -1,6 +1,6 @@
 # TMC2208 UART communication and configuration
 #
-# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, collections
@@ -179,77 +179,17 @@ FieldFormatters.update({
 
 
 ######################################################################
-# TMC2208 communication
+# TMC2208 uart communication
 ######################################################################
 
-# Generate a CRC8-ATM value for a bytearray
-def calc_crc8(data):
-    crc = 0
-    for b in data:
-        for i in range(8):
-            if (crc >> 7) ^ (b & 0x01):
-                crc = (crc << 1) ^ 0x07
-            else:
-                crc = (crc << 1)
-            crc &= 0xff
-            b >>= 1
-    return crc
-
-# Add serial start and stop bits to a message in a bytearray
-def add_serial_bits(data):
-    out = 0
-    pos = 0
-    for d in data:
-        b = (d << 1) | 0x200
-        out |= (b << pos)
-        pos += 10
-    res = bytearray()
-    for i in range((pos+7)//8):
-        res.append((out >> (i*8)) & 0xff)
-    return res
-
-# Generate a tmc2208 read register message
-def encode_tmc2208_read(sync, addr, reg):
-    msg = bytearray([sync, addr, reg])
-    msg.append(calc_crc8(msg))
-    return add_serial_bits(msg)
-
-# Generate a tmc2208 write register message
-def encode_tmc2208_write(sync, addr, reg, val):
-    msg = bytearray([sync, addr, reg, (val >> 24) & 0xff, (val >> 16) & 0xff,
-                     (val >> 8) & 0xff, val & 0xff])
-    msg.append(calc_crc8(msg))
-    return add_serial_bits(msg)
-
-# Extract a tmc2208 read response message
-def decode_tmc2208_read(reg, data):
-    # Convert data into a long integer for easy manipulation
-    if len(data) != 10:
-        return None
-    mval = pos = 0
-    for d in bytearray(data):
-        mval |= d << pos
-        pos += 8
-    # Extract register value
-    val = ((((mval >> 31) & 0xff) << 24) | (((mval >> 41) & 0xff) << 16)
-           | (((mval >> 51) & 0xff) << 8) | ((mval >> 61) & 0xff))
-    # Verify start/stop bits and crc
-    encoded_data = encode_tmc2208_write(0x05, 0xff, reg, val)
-    if data != encoded_data:
-        return None
-    return val
-
-
-######################################################################
-# TMC2208 printer object
-######################################################################
-
-class TMC2208:
-    def __init__(self, config):
+# Helper code for communicating via TMC uart
+class MCU_TMC_uart:
+    def __init__(self, config, name_to_reg, fields):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[-1]
-        self.printer.register_event_handler("klippy:connect",
-                                            self._init_registers)
+        self.name_to_reg = name_to_reg
+        self.fields = fields
+        self.ifcnt = None
         # pin setup
         ppins = self.printer.lookup_object("pins")
         rx_pin_params = ppins.lookup_pin(
@@ -268,6 +208,116 @@ class TMC2208:
         self.oid = self.mcu.create_oid()
         self.tmcuart_send_cmd = None
         self.mcu.register_config_callback(self.build_config)
+    def build_config(self):
+        bit_ticks = int(self.mcu.get_adjusted_freq() / 9000.)
+        self.mcu.add_config_cmd(
+            "config_tmcuart oid=%d rx_pin=%s pull_up=%d tx_pin=%s bit_time=%d"
+            % (self.oid, self.rx_pin, self.pullup, self.tx_pin, bit_ticks))
+        cmd_queue = self.mcu.alloc_command_queue()
+        self.tmcuart_send_cmd = self.mcu.lookup_command(
+            "tmcuart_send oid=%c write=%*s read=%c", cq=cmd_queue)
+    def get_fields(self):
+        return self.fields
+    def _calc_crc8(self, data):
+        # Generate a CRC8-ATM value for a bytearray
+        crc = 0
+        for b in data:
+            for i in range(8):
+                if (crc >> 7) ^ (b & 0x01):
+                    crc = (crc << 1) ^ 0x07
+                else:
+                    crc = (crc << 1)
+                crc &= 0xff
+                b >>= 1
+        return crc
+    def _add_serial_bits(self, data):
+        # Add serial start and stop bits to a message in a bytearray
+        out = 0
+        pos = 0
+        for d in data:
+            b = (d << 1) | 0x200
+            out |= (b << pos)
+            pos += 10
+        res = bytearray()
+        for i in range((pos+7)//8):
+            res.append((out >> (i*8)) & 0xff)
+        return res
+    def _encode_read(self, sync, addr, reg):
+        # Generate a tmc2208 read register message
+        msg = bytearray([sync, addr, reg])
+        msg.append(self._calc_crc8(msg))
+        return self._add_serial_bits(msg)
+    def _encode_write(self, sync, addr, reg, val):
+        # Generate a tmc2208 write register message
+        msg = bytearray([sync, addr, reg, (val >> 24) & 0xff,
+                         (val >> 16) & 0xff, (val >> 8) & 0xff, val & 0xff])
+        msg.append(self._calc_crc8(msg))
+        return self._add_serial_bits(msg)
+    def _decode_read(self, reg, data):
+        # Extract a tmc2208 read response message
+        if len(data) != 10:
+            return None
+        # Convert data into a long integer for easy manipulation
+        mval = pos = 0
+        for d in bytearray(data):
+            mval |= d << pos
+            pos += 8
+        # Extract register value
+        val = ((((mval >> 31) & 0xff) << 24) | (((mval >> 41) & 0xff) << 16)
+               | (((mval >> 51) & 0xff) << 8) | ((mval >> 61) & 0xff))
+        # Verify start/stop bits and crc
+        encoded_data = self._encode_write(0x05, 0xff, reg, val)
+        if data != encoded_data:
+            return None
+        return val
+    def get_register(self, reg_name):
+        reg = self.name_to_reg[reg_name]
+        msg = self._encode_read(0xf5, 0x00, reg)
+        if self.printer.get_start_args().get('debugoutput') is not None:
+            return 0
+        for retry in range(5):
+            params = self.tmcuart_send_cmd.send_with_response(
+                [self.oid, msg, 10], 'tmcuart_response', self.oid)
+            val = self._decode_read(reg, params['read'])
+            if val is not None:
+                return val
+        raise self.printer.command_error(
+            "Unable to read tmc2208 '%s' register %s" % (self.name, reg_name))
+    def set_register(self, reg_name, val, print_time=0.):
+        msg = self._encode_write(0xf5, 0x00,
+                                 self.name_to_reg[reg_name] | 0x80, val)
+        if self.printer.get_start_args().get('debugoutput') is not None:
+            return
+        for retry in range(5):
+            ifcnt = self.ifcnt
+            if ifcnt is None:
+                self.ifcnt = ifcnt = self.get_register("IFCNT")
+            params = self.tmcuart_send_cmd.send_with_response(
+                [self.oid, msg, 0], 'tmcuart_response', self.oid)
+            self.ifcnt = self.get_register("IFCNT")
+            if self.ifcnt == (ifcnt + 1) & 0xff:
+                return
+        raise self.printer.command_error(
+            "Unable to write tmc2208 '%s' register %s" % (self.name, reg_name))
+
+
+######################################################################
+# TMC2208 printer object
+######################################################################
+
+class TMC2208:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.printer.register_event_handler("klippy:connect",
+                                            self._handle_connect)
+        # Setup mcu communication
+        self.regs = collections.OrderedDict()
+        self.fields = tmc2130.FieldHelper(Fields, SignedFields, FieldFormatters,
+                                          self.regs)
+        self.mcu_tmc = MCU_TMC_uart(config, Registers, self.fields)
+        self.get_register = self.mcu_tmc.get_register
+        self.set_register = self.mcu_tmc.set_register
         # Add DUMP_TMC, INIT_TMC command
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command(
@@ -283,10 +333,6 @@ class TMC2208:
             "INIT_TMC", "STEPPER", self.name,
             self.cmd_INIT_TMC, desc=self.cmd_INIT_TMC_help)
         # Setup basic register values
-        self.ifcnt = None
-        self.regs = collections.OrderedDict()
-        self.fields = tmc2130.FieldHelper(Fields, SignedFields, FieldFormatters,
-                                          self.regs)
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
@@ -315,46 +361,15 @@ class TMC2208:
         set_config_field(config, "pwm_autograd", True)
         set_config_field(config, "PWM_REG", 8)
         set_config_field(config, "PWM_LIM", 12)
-    def build_config(self):
-        bit_ticks = int(self.mcu.get_adjusted_freq() / 9000.)
-        self.mcu.add_config_cmd(
-            "config_tmcuart oid=%d rx_pin=%s pull_up=%d tx_pin=%s bit_time=%d"
-            % (self.oid, self.rx_pin, self.pullup, self.tx_pin, bit_ticks))
-        cmd_queue = self.mcu.alloc_command_queue()
-        self.tmcuart_send_cmd = self.mcu.lookup_command(
-            "tmcuart_send oid=%c write=%*s read=%c", cq=cmd_queue)
     def _init_registers(self):
         # Send registers
         for reg_name, val in self.regs.items():
             self.set_register(reg_name, val)
-    def get_register(self, reg_name):
-        reg = Registers[reg_name]
-        msg = encode_tmc2208_read(0xf5, 0x00, reg)
-        if self.printer.get_start_args().get('debugoutput') is not None:
-            return 0
-        for retry in range(5):
-            params = self.tmcuart_send_cmd.send_with_response(
-                [self.oid, msg, 10], 'tmcuart_response', self.oid)
-            val = decode_tmc2208_read(reg, params['read'])
-            if val is not None:
-                return val
-        raise self.printer.config_error(
-            "Unable to read tmc2208 '%s' register %s" % (self.name, reg_name))
-    def set_register(self, reg_name, val):
-        msg = encode_tmc2208_write(0xf5, 0x00, Registers[reg_name] | 0x80, val)
-        if self.printer.get_start_args().get('debugoutput') is not None:
-            return
-        for retry in range(5):
-            ifcnt = self.ifcnt
-            if ifcnt is None:
-                self.ifcnt = ifcnt = self.get_register("IFCNT")
-            params = self.tmcuart_send_cmd.send_with_response(
-                [self.oid, msg, 0], 'tmcuart_response', self.oid)
-            self.ifcnt = self.get_register("IFCNT")
-            if self.ifcnt == (ifcnt + 1) & 0xff:
-                return
-        raise self.printer.config_error(
-            "Unable to write tmc2208 '%s' register %s" % (self.name, reg_name))
+    def _handle_connect(self):
+        try:
+            self._init_registers()
+        except self.printer.command_error as e:
+            raise self.printer.config_error(str(e))
     def get_microsteps(self):
         return 256 >> self.fields.get_field("MRES")
     def get_phase(self):
@@ -405,10 +420,7 @@ class TMC2208:
                 gcode.respond_info(self.fields.pretty_format(reg_name, val))
         gcode.respond_info("========== Queried registers ==========")
         for reg_name in ReadRegisters:
-            try:
-                val = self.get_register(reg_name)
-            except self.printer.config_error as e:
-                raise gcode.error(str(e))
+            val = self.get_register(reg_name)
             # IOIN has different mappings depending on the driver type
             # (SEL_A field of IOIN reg)
             if reg_name == "IOIN":

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -231,9 +231,6 @@ class TMC2660:
         self.fields.set_field("RDSEL", 0) # needed for phase calculations
         self.fields.set_field("SDOFF", 0) # only step/dir mode supported
 
-        # Init Registers
-        cmdhelper.init_registers()
-
         # Register ready/printing handlers
         self.idle_current_percentage = config.getint(
             'idle_current_percent', default=100, minval=0, maxval=100)

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -225,6 +225,8 @@ class TMC2660:
     def get_response(self):
         reg = Registers["DRVCTRL"]
         val = self.regs["DRVCTRL"]
+        if self.printer.get_start_args().get('debugoutput') is not None:
+            return 0
         params = self.spi.spi_transfer([((val >> 16) | reg) & 0xff,
                             (val >> 8) & 0xff, val & 0xff])
         pr = bytearray(params['response'])

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -230,20 +230,17 @@ class MCU_TMC2660_SPI:
 
 class TMC2660:
     def __init__(self, config):
-        self.printer = config.get_printer()
-        self.name = config.get_name().split()[1]
         # Setup mcu communication
         self.fields = tmc2130.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = MCU_TMC2660_SPI(config, Registers, self.fields)
-        self.get_register = self.mcu_tmc.get_register
-        self.set_register = self.mcu_tmc.set_register
         # Register commands
         cmdhelper = tmc2130.TMCCommandHelper(config, self.mcu_tmc)
         cmdhelper.setup_register_dump(self.query_registers)
 
         # DRVCTRL
-        mres = tmc2130.get_config_microsteps(config)
-        self.fields.set_field("MRES", mres)
+        mh = tmc2130.TMCMicrostepHelper(config, self.mcu_tmc)
+        self.get_microsteps = mh.get_microsteps
+        self.get_phase = mh.get_phase
         set_config_field = self.fields.set_config_field
         set_config_field(config, "DEDGE", 0)
         set_config_field(config, "INTPOL", True, 'interpolate')
@@ -280,16 +277,8 @@ class TMC2660:
         self.fields.set_field("SDOFF", 0) # only step/dir mode supported
 
     def query_registers(self, print_time=0.):
-        return [(reg_name, self.get_register(reg_name))
+        return [(reg_name, self.mcu_tmc.get_register(reg_name))
                 for reg_name in ReadRegisters]
-
-    def get_microsteps(self):
-        return 256 >> self.fields.get_field("MRES")
-
-    def get_phase(self):
-        reg = self.get_register("READRSP@RDSEL0")
-        mscnt = self.fields.get_field("MSTEP", reg)
-        return mscnt >> self.fields.get_field("MRES")
 
 def load_config_prefix(config):
     return TMC2660(config)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -10,68 +10,68 @@ vsense = 0.325
 GLOBAL_SCALER = 256
 TMC_FREQUENCY=12000000.
 
-registers = {
-    "GCONF":            0x00 ,
-    "GSTAT":            0x01 ,
-    "IFCNT":            0x02 ,
-    "SLAVECONF":        0x03 ,
-    "IOIN":             0x04 ,
-    "X_COMPARE":        0x05 ,
-    "OTP_READ":         0x07 ,
-    "FACTORY_CONF":     0x08 ,
-    "SHORT_CONF":       0x09 ,
-    "DRV_CONF":         0x0A ,
-    "GLOBAL_SCALER":    0x0B ,
-    "OFFSET_READ":      0x0C ,
-    "IHOLD_IRUN":       0x10 ,
-    "TPOWERDOWN":       0x11 ,
-    "TSTEP":            0x12 ,
-    "TPWMTHRS":         0x13 ,
-    "TCOOLTHRS":        0x14 ,
-    "THIGH":            0x15 ,
-    "RAMPMODE":         0x20 ,
-    "XACTUAL":          0x21 ,
-    "VACTUAL":          0x22 ,
-    "VSTART":           0x23 ,
-    "A1":               0x24 ,
-    "V1":               0x25 ,
-    "AMAX":             0x26 ,
-    "VMAX":             0x27 ,
-    "DMAX":             0x28 ,
-    "D1":               0x2A ,
-    "VSTOP":            0x2B ,
-    "TZEROWAIT":        0x2C ,
-    "XTARGET":          0x2D ,
-    "VDCMIN":           0x33 ,
-    "SW_MODE":          0x34 ,
-    "RAMP_STAT":        0x35 ,
-    "XLATCH":           0x36 ,
-    "ENCMODE":          0x38 ,
-    "X_ENC":            0x39 ,
-    "ENC_CONST":        0x3A ,
-    "ENC_STATUS":       0x3B ,
-    "ENC_LATCH":        0x3C ,
-    "ENC_DEVIATION":    0x3D ,
-    "MSLUT0":           0x60 ,
-    "MSLUT1":           0x61 ,
-    "MSLUT2":           0x62 ,
-    "MSLUT3":           0x63 ,
-    "MSLUT4":           0x64 ,
-    "MSLUT5":           0x65 ,
-    "MSLUT6":           0x66 ,
-    "MSLUT7":           0x67 ,
-    "MSLUTSEL":         0x68 ,
-    "MSLUTSTART":       0x69 ,
-    "MSCNT":            0x6A ,
-    "MSCURACT":         0x6B ,
-    "CHOPCONF":         0x6C ,
-    "COOLCONF":         0x6D ,
-    "DCCTRL":           0x6E ,
-    "DRV_STATUS":       0x6F ,
-    "PWMCONF":          0x70 ,
-    "PWM_SCALE":        0x71 ,
-    "PWM_AUTO":         0x72 ,
-    "LOST_STEPS":       0x73
+Registers = {
+    "GCONF":            0x00,
+    "GSTAT":            0x01,
+    "IFCNT":            0x02,
+    "SLAVECONF":        0x03,
+    "IOIN":             0x04,
+    "X_COMPARE":        0x05,
+    "OTP_READ":         0x07,
+    "FACTORY_CONF":     0x08,
+    "SHORT_CONF":       0x09,
+    "DRV_CONF":         0x0A,
+    "GLOBAL_SCALER":    0x0B,
+    "OFFSET_READ":      0x0C,
+    "IHOLD_IRUN":       0x10,
+    "TPOWERDOWN":       0x11,
+    "TSTEP":            0x12,
+    "TPWMTHRS":         0x13,
+    "TCOOLTHRS":        0x14,
+    "THIGH":            0x15,
+    "RAMPMODE":         0x20,
+    "XACTUAL":          0x21,
+    "VACTUAL":          0x22,
+    "VSTART":           0x23,
+    "A1":               0x24,
+    "V1":               0x25,
+    "AMAX":             0x26,
+    "VMAX":             0x27,
+    "DMAX":             0x28,
+    "D1":               0x2A,
+    "VSTOP":            0x2B,
+    "TZEROWAIT":        0x2C,
+    "XTARGET":          0x2D,
+    "VDCMIN":           0x33,
+    "SW_MODE":          0x34,
+    "RAMP_STAT":        0x35,
+    "XLATCH":           0x36,
+    "ENCMODE":          0x38,
+    "X_ENC":            0x39,
+    "ENC_CONST":        0x3A,
+    "ENC_STATUS":       0x3B,
+    "ENC_LATCH":        0x3C,
+    "ENC_DEVIATION":    0x3D,
+    "MSLUT0":           0x60,
+    "MSLUT1":           0x61,
+    "MSLUT2":           0x62,
+    "MSLUT3":           0x63,
+    "MSLUT4":           0x64,
+    "MSLUT5":           0x65,
+    "MSLUT6":           0x66,
+    "MSLUT7":           0x67,
+    "MSLUTSEL":         0x68,
+    "MSLUTSTART":       0x69,
+    "MSCNT":            0x6A,
+    "MSCURACT":         0x6B,
+    "CHOPCONF":         0x6C,
+    "COOLCONF":         0x6D,
+    "DCCTRL":           0x6E,
+    "DRV_STATUS":       0x6F,
+    "PWMCONF":          0x70,
+    "PWM_SCALE":        0x71,
+    "PWM_AUTO":         0x72,
+    "LOST_STEPS":       0x73,
 }
 
 ReadRegisters = [
@@ -80,8 +80,8 @@ ReadRegisters = [
     "PWM_AUTO", "TSTEP"
 ]
 
-fields = {}
-fields["COOLCONF"] = {
+Fields = {}
+Fields["COOLCONF"] = {
     "semin":                    0x0F << 0,
     "seup":                     0x03 << 5,
     "semax":                    0x0F << 8,
@@ -90,7 +90,7 @@ fields["COOLCONF"] = {
     "sgt":                      0x7F << 16,
     "sfilt":                    0x01 << 24
 }
-fields["CHOPCONF"] = {
+Fields["CHOPCONF"] = {
     "toff":                     0x0F << 0,
     "hstrt":                    0x07 << 4,
     "hend":                     0x0F << 7,
@@ -107,7 +107,7 @@ fields["CHOPCONF"] = {
     "diss2g":                   0x01 << 30,
     "diss2vs":                  0x01 << 31
 }
-fields["DRV_STATUS"] = {
+Fields["DRV_STATUS"] = {
     "SG_RESULT":                0x3FF << 0,
     "s2vsa":                    0x01 << 12,
     "s2vsb":                    0x01 << 13,
@@ -123,10 +123,10 @@ fields["DRV_STATUS"] = {
     "olb":                      0x01 << 30,
     "stst":                     0x01 << 31
 }
-fields["FACTORY_CONF"] = {
+Fields["FACTORY_CONF"] = {
     "FACTORY_CONF":             0x1F << 0
 }
-fields["GCONF"] = {
+Fields["GCONF"] = {
     "recalibrate":              0x01 << 0,
     "faststandstill":           0x01 << 1,
     "en_pwm_mode":              0x01 << 2,
@@ -146,17 +146,17 @@ fields["GCONF"] = {
     "direct_mode":              0x01 << 16,
     "test_mode":                0x01 << 17
 }
-fields["GSTAT"] = {
+Fields["GSTAT"] = {
     "reset":                    0x01 << 0,
     "drv_err":                  0x01 << 1,
     "uv_cp":                    0x01 << 2
 }
-fields["IHOLD_IRUN"] = {
+Fields["IHOLD_IRUN"] = {
     "IHOLD":                    0x1F << 0,
     "IRUN":                     0x1F << 8,
     "IHOLDDELAY":               0x0F << 16
 }
-fields["IOIN"] = {
+Fields["IOIN"] = {
     "REFL_STEP":                0x01 << 0,
     "REFR_DIR":                 0x01 << 1,
     "ENCB_DCEN_CFG4":           0x01 << 2,
@@ -167,27 +167,27 @@ fields["IOIN"] = {
     "SWCOMP_IN":                0x01 << 7,
     "VERSION":                  0xFF << 24
 }
-fields["LOST_STEPS"] = {
+Fields["LOST_STEPS"] = {
     "LOST_STEPS":               0xfffff << 0
 }
-fields["MSCNT"] = {
+Fields["MSCNT"] = {
     "MSCNT":                    0x3ff << 0
 }
-fields["MSCURACT"] = {
+Fields["MSCURACT"] = {
     "CUR_A":                    0x1ff << 0,
     "CUR_B":                    0x1ff << 16
 }
-fields["OTP_READ"] = {
+Fields["OTP_READ"] = {
     "OTP_FCLKTRIM":             0x1f << 0,
     "otp_S2_LEVEL":             0x01 << 5,
     "otp_BBM":                  0x01 << 6,
     "otp_TBL":                  0x01 << 7
 }
-fields["PWM_AUTO"] = {
+Fields["PWM_AUTO"] = {
     "PWM_OFS_AUTO":             0xff << 0,
     "PWM_GRAD_AUTO":            0xff << 16
 }
-fields["PWMCONF"] = {
+Fields["PWMCONF"] = {
     "PWM_OFS":                  0xFF << 0,
     "PWM_GRAD":                 0xFF << 8,
     "pwm_freq":                 0x03 << 16,
@@ -197,17 +197,17 @@ fields["PWMCONF"] = {
     "PWM_REG":                  0x0F << 24,
     "PWM_LIM":                  0x0F << 28
 }
-fields["PWM_SCALE"] = {
+Fields["PWM_SCALE"] = {
     "PWM_SCALE_SUM":            0xff << 0,
     "PWM_SCALE_AUTO":           0x1ff << 16
 }
-fields["TPOWERDOWN"] = {
+Fields["TPOWERDOWN"] = {
     "TPOWERDOWN":               0xff << 0
 }
-fields["TPWMTHRS"] = {
+Fields["TPWMTHRS"] = {
     "TPWMTHRS":                 0xfffff << 0
 }
-fields["TSTEP"] = {
+Fields["TSTEP"] = {
     "TSTEP":                    0xfffff << 0
 }
 
@@ -275,7 +275,7 @@ class TMC5160:
             self.cmd_INIT_TMC, desc=self.cmd_INIT_TMC_help)
         # Setup basic register values
         self.regs = collections.OrderedDict()
-        self.fields = tmc2130.FieldHelper(fields, SignedFields, FieldFormatters,
+        self.fields = tmc2130.FieldHelper(Fields, SignedFields, FieldFormatters,
                                           self.regs)
         irun, ihold, self.sense_resistor = get_config_current(config)
         msteps, en_pwm, thresh = \
@@ -328,12 +328,12 @@ class TMC5160:
         self._init_registers()
     def decode_hex(self, hex_, reg_name=False):
         reg = int( (hex_ >> 32) & 0xff - long(0x80) )
-        if reg not in registers.values():
+        if reg not in Registers.values():
             reg = int( (hex_ >> 32) & 0xff )
-            if reg not in registers.values():
+            if reg not in Registers.values():
                 reg_name = "UFO"
         if not reg_name:
-            for name, adr_ in registers.items():
+            for name, adr_ in Registers.items():
                 if adr_ == reg:
                     reg_name = name
         val = hex_ & 0xFFFFFFFF
@@ -348,7 +348,7 @@ class TMC5160:
             raise pins.error("Can not pullup/invert tmc5160 virtual endstop")
         return tmc2130.TMC2130VirtualEndstop(self)
     def get_register(self, reg_name):
-        reg = registers[reg_name]
+        reg = Registers[reg_name]
         self.spi.spi_send([reg, 0x00, 0x00, 0x00, 0x00])
         if self.printer.get_start_args().get('debugoutput') is not None:
             return 0
@@ -356,7 +356,7 @@ class TMC5160:
         pr = bytearray(params['response'])
         return (pr[1] << 24) | (pr[2] << 16) | (pr[3] << 8) | pr[4]
     def set_register(self, reg_name, val, min_clock = 0):
-        reg = registers[reg_name]
+        reg = Registers[reg_name]
         data = [(reg | 0x80) & 0xff, (val >> 24) & 0xff, (val >> 16) & 0xff,
             (val >> 8) & 0xff, val & 0xff]
         self.decode_hex( val, reg_name=reg_name )

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -320,8 +320,6 @@ class TMC5160:
         self.fields.set_field("TPWMTHRS", thresh)
         #   TPOWERDOWN
         set_config_field(config, "TPOWERDOWN", 10)
-
-        cmdhelper.init_registers()
     def setup_pin(self, pin_type, pin_params):
         if pin_type != 'endstop' or pin_params['pin'] != 'virtual_endstop':
             raise pins.error("tmc5160 virtual endstop only useful as endstop")

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -350,6 +350,8 @@ class TMC5160:
     def get_register(self, reg_name):
         reg = registers[reg_name]
         self.spi.spi_send([reg, 0x00, 0x00, 0x00, 0x00])
+        if self.printer.get_start_args().get('debugoutput') is not None:
+            return 0
         params = self.spi.spi_transfer([reg, 0x00, 0x00, 0x00, 0x00])
         pr = bytearray(params['response'])
         return (pr[1] << 24) | (pr[2] << 16) | (pr[3] << 8) | pr[4]

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -296,9 +296,8 @@ class TMC5160:
         self.get_register = self.mcu_tmc.get_register
         self.set_register = self.mcu_tmc.set_register
         # Allow virtual endstop to be created
-        self.diag1_pin = config.get('diag1_pin', None)
-        ppins = self.printer.lookup_object("pins")
-        ppins.register_chip("tmc5160_" + self.name, self)
+        diag1_pin = config.get('diag1_pin', None)
+        tmc2130.TMCEndstopHelper(config, self.mcu_tmc, diag1_pin)
         # Register commands
         cmdhelper = tmc2130.TMCCommandHelper(config, self.mcu_tmc)
         cmdhelper.setup_register_dump(self.query_registers)
@@ -348,12 +347,6 @@ class TMC5160:
         self.fields.set_field("TPWMTHRS", thresh)
         #   TPOWERDOWN
         set_config_field(config, "TPOWERDOWN", 10)
-    def setup_pin(self, pin_type, pin_params):
-        if pin_type != 'endstop' or pin_params['pin'] != 'virtual_endstop':
-            raise pins.error("tmc5160 virtual endstop only useful as endstop")
-        if pin_params['invert'] or pin_params['pullup']:
-            raise pins.error("Can not pullup/invert tmc5160 virtual endstop")
-        return tmc2130.TMC2130VirtualEndstop(self)
     def query_registers(self, print_time=0.):
         return [(reg_name, self.get_register(reg_name))
                 for reg_name in ReadRegisters]

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -265,20 +265,13 @@ class TMC5160:
         self.diag1_pin = config.get('diag1_pin', None)
         ppins = self.printer.lookup_object("pins")
         ppins.register_chip("tmc5160_" + self.name, self)
-        # Add DUMP_TMC, INIT_TMC command
+        # Register commands
+        cmdhelper = tmc2130.TMCCommandHelper(config, self.mcu_tmc)
+        cmdhelper.setup_register_dump(self.query_registers)
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command(
             "SET_TMC_CURRENT", "STEPPER", self.name,
             self.cmd_SET_TMC_CURRENT, desc=self.cmd_SET_TMC_CURRENT_help)
-        gcode.register_mux_command(
-            "DUMP_TMC", "STEPPER", self.name,
-            self.cmd_DUMP_TMC, desc=self.cmd_DUMP_TMC_help)
-        gcode.register_mux_command(
-            "SET_TMC_FIELD", "STEPPER", self.name,
-            self.cmd_SET_TMC_FIELD, desc=self.cmd_SET_TMC_FIELD_help)
-        gcode.register_mux_command(
-            "INIT_TMC", "STEPPER", self.name,
-            self.cmd_INIT_TMC, desc=self.cmd_INIT_TMC_help)
         # Setup basic register values
         irun, ihold, self.sense_resistor = get_config_current(config)
         msteps, en_pwm, thresh = \
@@ -328,16 +321,16 @@ class TMC5160:
         #   TPOWERDOWN
         set_config_field(config, "TPOWERDOWN", 10)
 
-        self._init_registers()
-    def _init_registers(self, print_time=0.):
-        for reg_name, val in self.regs.items():
-            self.set_register(reg_name, val, print_time)
+        cmdhelper.init_registers()
     def setup_pin(self, pin_type, pin_params):
         if pin_type != 'endstop' or pin_params['pin'] != 'virtual_endstop':
             raise pins.error("tmc5160 virtual endstop only useful as endstop")
         if pin_params['invert'] or pin_params['pullup']:
             raise pins.error("Can not pullup/invert tmc5160 virtual endstop")
         return tmc2130.TMC2130VirtualEndstop(self)
+    def query_registers(self, print_time=0.):
+        return [(reg_name, self.get_register(reg_name))
+                for reg_name in ReadRegisters]
     def get_microsteps(self):
         return 256 >> self.fields.get_field("MRES")
     def get_phase(self):
@@ -376,38 +369,6 @@ class TMC5160:
             gcode.respond_info(
                 "Run Current: %0.2fA Hold Current: %0.2fA"
                 % (run_current, hold_current))
-    cmd_DUMP_TMC_help = "Read and display TMC stepper driver registers"
-    def cmd_DUMP_TMC(self, params):
-        self.printer.lookup_object('toolhead').get_last_move_time()
-        gcode = self.printer.lookup_object('gcode')
-        logging.info("DUMP_TMC %s", self.name)
-        gcode.respond_info("========== Write-only registers ==========")
-        for reg_name, val in self.regs.items():
-            if reg_name not in ReadRegisters:
-                gcode.respond_info(self.fields.pretty_format(reg_name, val))
-        gcode.respond_info("========== Queried registers ==========")
-        for reg_name in ReadRegisters:
-            val = self.get_register(reg_name)
-            gcode.respond_info(self.fields.pretty_format(reg_name, val))
-    cmd_INIT_TMC_help = "Initialize TMC stepper driver registers"
-    def cmd_INIT_TMC(self, params):
-        logging.info("INIT_TMC 5160 %s", self.name)
-        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
-        self._init_registers(print_time)
-    cmd_SET_TMC_FIELD_help = "Set a register field of a TMC5160 driver"
-    def cmd_SET_TMC_FIELD(self, params):
-        gcode = self.printer.lookup_object('gcode')
-        if ('FIELD' not in params or
-            'VALUE' not in params):
-            raise gcode.error("Invalid command format")
-        field = gcode.get_str('FIELD', params)
-        reg = self.fields.field_to_register.get(field)
-        if reg is None:
-            raise gcode.error("Unknown field name '%s'" % field)
-        value = gcode.get_int('VALUE', params)
-        self.fields.set_field(field, value)
-        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
-        self.set_register(reg, self.regs[reg], print_time)
 
 def load_config_prefix(config):
     return TMC5160(config)

--- a/test/klippy/tmc.cfg
+++ b/test/klippy/tmc.cfg
@@ -1,0 +1,85 @@
+# Test config for tmc drivers
+
+[stepper_x]
+step_pin: PC0
+dir_pin: PL0
+enable_pin: !PA7
+step_distance: .005
+endstop_pin: tmc2130_stepper_x:virtual_endstop
+position_endstop: 0
+position_max: 250
+
+[tmc2130 stepper_x]
+cs_pin: PG0
+microsteps: 16
+run_current: .5
+sense_resistor: 0.220
+diag1_pin: !PK2
+
+[stepper_x1]
+step_pin: PC3
+dir_pin: PL6
+enable_pin: !PA4
+step_distance: .005
+endstop_pin: ^PB6
+
+[tmc2130 stepper_x1]
+cs_pin: PG1
+microsteps: 16
+run_current: .5
+sense_resistor: 0.220
+diag1_pin: !PK2
+
+[stepper_y]
+step_pin: PC1
+dir_pin: !PL1
+enable_pin: !PA6
+step_distance: .005
+endstop_pin: tmc5160_stepper_y:virtual_endstop
+position_endstop: 0
+position_max: 210
+
+[tmc5160 stepper_y]
+cs_pin: PG2
+microsteps: 16
+run_current: .5
+sense_resistor: 0.220
+diag1_pin: !PK7
+
+[stepper_z]
+step_pin: PC2
+dir_pin: PL2
+enable_pin: !PA5
+step_distance: .0025
+endstop_pin: ^PB4
+position_endstop: 0.5
+position_max: 200
+
+[tmc2208 stepper_z]
+uart_pin: PK5
+microsteps: 16
+run_current: .5
+sense_resistor: 0.220
+
+[stepper_z1]
+step_pin: PB5
+dir_pin: PK6
+enable_pin: !PH5
+step_distance: .0025
+endstop_pin: ^PH3
+
+[tmc2660 stepper_z1]
+cs_pin: PK1
+microsteps: 16
+run_current: .5
+sense_resistor: 0.220
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/tmc.test
+++ b/test/klippy/tmc.test
@@ -1,0 +1,41 @@
+# Tests for the tmc drivers
+CONFIG tmc.cfg
+DICTIONARY atmega2560.dict
+
+; Start by homing the printer.
+G28
+G90
+G1 F6000
+
+; Z / X / Y moves
+G1 Z1
+G1 X1
+G1 Y1
+
+; Test DUMP_TMC commands
+DUMP_TMC STEPPER=stepper_x
+DUMP_TMC STEPPER=stepper_x1
+DUMP_TMC STEPPER=stepper_y
+DUMP_TMC STEPPER=stepper_z
+DUMP_TMC STEPPER=stepper_z1
+
+; Test INIT_TMC commands
+INIT_TMC STEPPER=stepper_x
+INIT_TMC STEPPER=stepper_x1
+INIT_TMC STEPPER=stepper_y
+INIT_TMC STEPPER=stepper_z
+INIT_TMC STEPPER=stepper_z1
+
+; Test SET_TMC_CURRENT commands
+SET_TMC_CURRENT STEPPER=stepper_x CURRENT=.7
+SET_TMC_CURRENT STEPPER=stepper_x1 CURRENT=.7
+SET_TMC_CURRENT STEPPER=stepper_y CURRENT=.7
+SET_TMC_CURRENT STEPPER=stepper_z CURRENT=.7
+SET_TMC_CURRENT STEPPER=stepper_z1 CURRENT=.7
+
+; Test SET_TMC_FIELD commands
+SET_TMC_CURRENT STEPPER=stepper_x FIELD=intpol VALUE=0
+SET_TMC_CURRENT STEPPER=stepper_x1 FIELD=intpol VALUE=0
+SET_TMC_CURRENT STEPPER=stepper_y FIELD=intpol VALUE=0
+SET_TMC_CURRENT STEPPER=stepper_z FIELD=intpol VALUE=0
+SET_TMC_CURRENT STEPPER=stepper_z1 FIELD=intpol VALUE=0


### PR DESCRIPTION
This is a large series intended to refactor the code in tmc2130.py, tmc2208.py, tmc2660.py, and tmc5160.py.  The goal is to make it easier to support future drivers (such as the tmc2209) and to make it easier to support other types of communication methods (such as tmc5160 uart mode, tmc2208 via analog mux).

@FHeilmann , @Stephan3 - would you be able to verify that the tmc5160, tmc2660, and tmc2130 continue to work properly?

Thanks.
-Kevin