### PR TITLE
auto_init option for tmc_2208 stepper driver

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1039,6 +1039,15 @@
 #   chip. This may be used to set custom motor parameters. The
 #   defaults for each parameter are next to the parameter name in the
 #   above list.
+#auto_init: True
+#   Controls automatic stepper driver register initialization on
+#   klipper start.
+#   Useful in case drivers are powered by external power supply
+#   and are off at the klipper start phase.
+#   The default is 'True'.
+#   WARNING: Don't forget to initialize it manually,
+#            i.e. issuing the following command:
+#            INIT_TMC stepper=stepper_x
 
 
 # Configure a TMC2660 stepper motor driver via SPI bus. To use this

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -248,7 +248,8 @@ class TMC2208:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[-1]
-        self.printer.register_event_handler("klippy:connect",
+        if config.getboolean('auto_init', True):
+          self.printer.register_event_handler("klippy:connect",
                                             self._init_registers)
         # pin setup
         ppins = self.printer.lookup_object("pins")


### PR DESCRIPTION
- auto_init option for tmc_2208 stepper driver added.
  Allows klipper to start in case drivers are not powered up yet.
- example-extras config updated with a description.

Issue #1702