### PR TITLE
[verify_heater] add option to disable heater/sensor verification

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -439,6 +439,12 @@
 #   The minimum temperature (in Celsius) that the heater must increase
 #   by during the check_gain_time check. It is rare to customize this
 #   value. The default is 2.
+#disabled: False
+#   Disable heater and temperature sensor verification for this specific
+#   heater. Useful eg. for chamber heaters where the temperature sensor
+#   is decoupled from the heating element by design - and therefore
+#   temperature might be stagnant while the chamber doors are open. The
+#   default is False.
 
 
 # Idle timeout. An idle timeout is automatically enabled - add an

--- a/klippy/extras/verify_heater.py
+++ b/klippy/extras/verify_heater.py
@@ -19,6 +19,7 @@ class HeaterCheck:
                                             self.handle_shutdown)
         self.heater_name = config.get_name().split()[1]
         self.heater = None
+        self.disabled = config.getboolean('disabled', False)
         self.hysteresis = config.getfloat('hysteresis', 5., minval=0.)
         self.max_error = config.getfloat('max_error', 120., minval=0.)
         self.heating_gain = config.getfloat('heating_gain', 2., above=0.)
@@ -34,6 +35,9 @@ class HeaterCheck:
     def handle_connect(self):
         if self.printer.get_start_args().get('debugoutput') is not None:
             # Disable verify_heater if outputting to a debug file
+            return
+        if self.disabled:
+            # Disable verify_heater if configuration says so
             return
         pheater = self.printer.lookup_object('heater')
         self.heater = pheater.lookup_heater(self.heater_name)


### PR DESCRIPTION
module: verify_heater.py, add option to disable heater/sensor verification

In some setups like recirculating chamber heaters, the temperature sensor is
decoupled from the heating element by design. In this case the use of the
verification checks would trigger when eg. the chamber doors are opened
during operation. This option introduces an overwrite to disable the checks
for a specific heater.

Signed-off-by: Simon Kühling <mail@simonkuehling.de>