### PR TITLE
gcode_macro: dump all variables

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -34,6 +34,10 @@ class GetStatusWrapper:
         except KeyError as e:
             return False
         return True
+    def __iter__(self):
+        for name, obj in self.printer.lookup_objects():
+            if self.__contains__(name):
+                yield name
 
 # Wrapper around a Jinja2 template
 class TemplateWrapper:


### PR DESCRIPTION
This makes possible to dump all `printer` variables to the log and host.
It goes thru all the printer object variables and in case of a function, it tries to show the content of `__doc__` as a description.
The output shows variables as they can be used  in `gcode_macro`

_The `do` aka jinja2 expression-statement extension adds a simple do tag to the template engine that works like a variable expression but ignores the return value._

It can be used in `gcode_macro` as jinja2 statement by using `do` tag
```ini
[gcode_macro DUMP]
gcode:
    {% do printer.action_dump() %}
```
or like jinja2 expression, then it returns empty string for gcode
```ini
[gcode_macro DUMP]
gcode:
    {printer.action_dump()}
```

Signed-off-by: Janar Sööt <janar.soot@gmail.com>