### PR TITLE
Add Safe Z Homing extra

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1223,6 +1223,21 @@
 #   head must move prior to invoking the normal G28 mechanism for an
 #   axis. The default is to not force a position for an axis.
 
+# Safe Z homing. One may use this mechanism to home the Z axis at a
+# specific XY coordinate. This is useful if the toolhead, for example
+# has to move to the center of the bed before Z can be homed.
+#[safe_z_home]
+#home_xy_position:
+#   A X,Y coordinate (e.g. 100,100) where the Z homing should be
+#   performed. This parameter must be provided.
+#speed: 50.0
+#   Speed at which the toolhead is moved to the safe Z home coordinate.
+#   The default is 50 mm/s
+#z_hop: 0.0
+#   Lift the Z axis prior to homing. This is applied to any homing command,
+#   even if it doesn't home the Z axis. The default is 0.0mm.
+#z_hop_speed: 20.0
+#   Speed at which the Z axis is lifted prior to homing. The default is 20mm/s.
 
 # Support manually moving stepper motors for diagnostic purposes.
 # Note, using this feature may place the printer in an invalid state -

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1196,6 +1196,22 @@
 #driver_seimin: 0
 #driver_sfilt: 0
 
+# Safe Z homing. One may use this mechanism to home the Z axis at a
+# specific XY coordinate. This is useful if the toolhead, for example
+# has to move to the center of the bed before Z can be homed.
+#[safe_z_home]
+#home_xy_position:
+#   A X,Y coordinate (e.g. 100,100) where the Z homing should be
+#   performed. This parameter must be provided.
+#speed: 50.0
+#   Speed at which the toolhead is moved to the safe Z home coordinate.
+#   The default is 50 mm/s
+#z_hop: 0.0
+#   Lift the Z axis prior to homing. This is applied to any homing command,
+#   even if it doesn't home the Z axis. The default is 0.0mm.
+#z_hop_speed: 20.0
+#   Speed at which the Z axis is lifted prior to homing. The default is 20mm/s.
+
 # Homing override. One may use this mechanism to run a series of
 # g-code commands in place of a G28 found in the normal g-code input.
 # This may be useful on printers that require a specific procedure to
@@ -1222,22 +1238,6 @@
 #   disables homing checks for that axis. This may be useful if the
 #   head must move prior to invoking the normal G28 mechanism for an
 #   axis. The default is to not force a position for an axis.
-
-# Safe Z homing. One may use this mechanism to home the Z axis at a
-# specific XY coordinate. This is useful if the toolhead, for example
-# has to move to the center of the bed before Z can be homed.
-#[safe_z_home]
-#home_xy_position:
-#   A X,Y coordinate (e.g. 100,100) where the Z homing should be
-#   performed. This parameter must be provided.
-#speed: 50.0
-#   Speed at which the toolhead is moved to the safe Z home coordinate.
-#   The default is 50 mm/s
-#z_hop: 0.0
-#   Lift the Z axis prior to homing. This is applied to any homing command,
-#   even if it doesn't home the Z axis. The default is 0.0mm.
-#z_hop_speed: 20.0
-#   Speed at which the Z axis is lifted prior to homing. The default is 20mm/s.
 
 # Support manually moving stepper motors for diagnostic purposes.
 # Note, using this feature may place the printer in an invalid state -

--- a/klippy/extras/homing_override.py
+++ b/klippy/extras/homing_override.py
@@ -16,6 +16,10 @@ class HomingOverride:
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("G28", None)
         self.gcode.register_command("G28", self.cmd_G28)
+
+        if self.printer.lookup_object("safe_z_homing", default=None):
+            raise config.error("homing_override and safe_z_homing cannot"
+                                    +" be used simultaneously")
     def cmd_G28(self, params):
         if self.in_script:
             # Was called recursively - invoke the real G28 command

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -1,0 +1,60 @@
+# Execute Z Homing at specific XY coordinates. Also allows to lift Z prior to
+# probing
+#
+# Copyright (C) 2019 Florian Heilmann <Florian.Heilmann@gmx.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import probe
+
+class SafeZHoming:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        (self.home_x_pos,
+          self.home_y_pos) = config.get("home_xy_position").split(',')
+        self.z_hop = config.getfloat("z_hop", default=0.0)
+        self.z_hop_speed = config.getfloat('z_hop_speed', 15., above=0.)
+        self.speed = config.getfloat('speed', 50.0, above=0.)
+        self.gcode = self.printer.lookup_object('gcode')
+        self.gcode.register_command("G28", None)
+        self.gcode.register_command("G28", self.cmd_G28)
+
+    def cmd_G28(self, params):
+        need_x, need_y, need_z = [False] * 3
+
+        # Perform Z Hop if necessary
+        if self.z_hop != 0.0:
+            toolhead = self.printer.lookup_object('toolhead')
+            pos = toolhead.get_position()
+            toolhead.set_position(pos, homing_axes=[2])
+            pos[2] = pos[2] + self.z_hop
+            toolhead.move(pos, self.z_hop_speed)
+            self.gcode.reset_last_position()
+
+        # Determine which axes we need to home
+        if not any([axis in params.keys() for axis in ['X', 'Y', 'Z']]):
+            need_x, need_y, need_z = [True] * 3
+        else:
+            need_z = 'Z' in params
+            need_x = 'X' in params
+            need_y = 'Y' in params
+
+        # Home XY axes if necessary
+        new_params = {}
+        if need_x:
+            new_params['X'] = '0'
+        if need_y:
+            new_params['Y'] = '0'
+        if new_params:
+            self.gcode.cmd_G28(new_params)
+        # Home Z axis if necessary
+        if need_z:
+            # Move to safe XY homing position
+            self.gcode.cmd_G1({'X': self.home_x_pos,
+                               'Y': self.home_y_pos,
+                               'F': self.speed*60.0})
+            # Home Z
+            self.gcode.cmd_G28({'Z': '0'})
+
+def load_config(config):
+    return SafeZHoming(config)


### PR DESCRIPTION
As discussed, here is a simple extra that allows to specify a safe z homing location. This is meant to easily replicate safe z homing features in other firmwares, by allowing the user to specify a coordinate at which the Z homing should be performed, as well a ZHop to lift the Z axis prior to homing.

This is a first draft, comments are welcome. Especially the zhop is something that can warrant discussion. As of now, the zhop is performed regardless of which axis is supposed to be homed. This is useful if you want to avoid dragging your nozzle through the bed whilst homing the X and Y axis, but I could also make this configurable to either zhop everytime, or only if the Z axis is involved in the homing procedure.

Also I'm not sure how this interacts with kinematics such as delta, polar etc. that have special axis setups. Maybe the comments should be extended to reflect that. 

Bests,
Florian