### PR TITLE
pause_resume:  Add CLEAR_PAUSE gcode

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -430,6 +430,10 @@ is enabled:
   - `RESUME [VELOCITY=<value>]`: Resumes the print from a pause, first restoring
   the previously captured position.  The VELOCITY parameter determines the speed
   at which the tool should return to the original captured position.
+  - `CLEAR_PAUSE`:  Clears the current paused state without resuming the print.
+  This is useful if one decides to cancel a print after a PAUSE.  It is recommended
+  to add this to your start gcode to make sure the paused state is fresh for each
+  print.
 
 ## Filament Sensor
 

--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -16,6 +16,7 @@ class PauseResume:
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.gcode.register_command("PAUSE", self.cmd_PAUSE)
         self.gcode.register_command("RESUME", self.cmd_RESUME)
+        self.gcode.register_command("CLEAR_PAUSE", self.cmd_CLEAR_PAUSE)
     def handle_ready(self):
         self.v_sd = self.printer.lookup_object('virtual_sdcard', None)
     def get_status(self, eventtime):
@@ -59,6 +60,8 @@ class PauseResume:
             self.v_sd.cmd_M24({})
         else:
             self.gcode.respond_info("action:resumed")
+    def cmd_CLEAR_PAUSE(self, params):
+        self.is_paused = self.pause_command_sent = False
 
 def load_config(config):
     return PauseResume(config)


### PR DESCRIPTION
This pull request adds  a `CLEAR_PAUSE` gcode which clears the paused state without restoring the saved gcode state.  This is useful in the event that a user decides to cancel a print after a PAUSE.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>