### PR TITLE
Rework homing code to use new host based "drip feed" system

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -31,7 +31,6 @@ defs_stepcompress = """
         , uint32_t set_next_step_dir_msgid);
     void stepcompress_free(struct stepcompress *sc);
     int stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock);
-    int stepcompress_set_homing(struct stepcompress *sc, uint64_t homing_clock);
     int stepcompress_queue_msg(struct stepcompress *sc
         , uint32_t *data, int len);
 

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -11,7 +11,6 @@ void stepcompress_fill(struct stepcompress *sc, uint32_t max_error
                        , uint32_t set_next_step_dir_msgid);
 void stepcompress_free(struct stepcompress *sc);
 int stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock);
-int stepcompress_set_homing(struct stepcompress *sc, uint64_t homing_clock);
 int stepcompress_queue_msg(struct stepcompress *sc, uint32_t *data, int len);
 double stepcompress_get_mcu_freq(struct stepcompress *sc);
 uint32_t stepcompress_get_oid(struct stepcompress *sc);

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -55,7 +55,6 @@ class BLTouchEndstopWrapper:
         self.get_steppers = self.mcu_endstop.get_steppers
         self.home_wait = self.mcu_endstop.home_wait
         self.query_endstop = self.mcu_endstop.query_endstop
-        self.query_endstop_wait = self.mcu_endstop.query_endstop_wait
         self.TimeoutError = self.mcu_endstop.TimeoutError
         # Register BLTOUCH_DEBUG command
         self.gcode = self.printer.lookup_object('gcode')

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -157,10 +157,11 @@ class BLTouchEndstopWrapper:
             if s.get_mcu_position() == mcu_pos:
                 raise homing.EndstopError("BLTouch failed to deploy")
         self.mcu_endstop.home_finalize()
-    def home_start(self, print_time, sample_time, sample_count, rest_time):
+    def home_start(self, print_time, sample_time, sample_count, rest_time,
+                   notify=None):
         rest_time = min(rest_time, ENDSTOP_REST_TIME)
-        self.mcu_endstop.home_start(
-            print_time, sample_time, sample_count, rest_time)
+        self.mcu_endstop.home_start(print_time, sample_time, sample_count,
+                                    rest_time, notify=notify)
     def get_position_endstop(self):
         return self.position_endstop
     cmd_BLTOUCH_DEBUG_help = "Send a command to the bltouch for debugging"

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -145,8 +145,7 @@ class PrinterProbe:
     def cmd_QUERY_PROBE(self, params):
         toolhead = self.printer.lookup_object('toolhead')
         print_time = toolhead.get_last_move_time()
-        self.mcu_probe.query_endstop(print_time)
-        res = self.mcu_probe.query_endstop_wait()
+        res = self.mcu_probe.query_endstop(print_time)
         self.gcode.respond_info(
             "probe: %s" % (["open", "TRIGGERED"][not not res],))
     cmd_PROBE_ACCURACY_help = "Probe Z-height accuracy at current XY position"
@@ -244,7 +243,6 @@ class ProbeEndstopWrapper:
         self.home_start = self.mcu_endstop.home_start
         self.home_wait = self.mcu_endstop.home_wait
         self.query_endstop = self.mcu_endstop.query_endstop
-        self.query_endstop_wait = self.mcu_endstop.query_endstop_wait
         self.TimeoutError = self.mcu_endstop.TimeoutError
     def _build_config(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()

--- a/klippy/extras/query_endstops.py
+++ b/klippy/extras/query_endstops.py
@@ -1,6 +1,6 @@
 # Utility for querying the current state of all endstops
 #
-# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -16,14 +16,10 @@ class QueryEndstops:
         self.endstops.append((mcu_endstop, name))
     cmd_QUERY_ENDSTOPS_help = "Report on the status of each endstop"
     def cmd_QUERY_ENDSTOPS(self, params):
-        toolhead = self.printer.lookup_object('toolhead')
-        print_time = toolhead.get_last_move_time()
         # Query the endstops
-        for mcu_endstop, name in self.endstops:
-            mcu_endstop.query_endstop(print_time)
-        out = []
-        for mcu_endstop, name in self.endstops:
-            out.append((name, mcu_endstop.query_endstop_wait()))
+        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
+        out = [(name, mcu_endstop.query_endstop(print_time))
+               for mcu_endstop, name in self.endstops]
         # Report results
         msg = " ".join(["%s:%s" % (name, ["open", "TRIGGERED"][not not t])
                         for name, t in out])

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -171,7 +171,6 @@ class TMCVirtualEndstop:
         self.home_start = self.mcu_endstop.home_start
         self.home_wait = self.mcu_endstop.home_wait
         self.query_endstop = self.mcu_endstop.query_endstop
-        self.query_endstop_wait = self.mcu_endstop.query_endstop_wait
         self.TimeoutError = self.mcu_endstop.TimeoutError
     def home_prepare(self):
         self.fields.set_field("en_pwm_mode", 0)

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -5,7 +5,6 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math, collections
 
-HOMING_STEP_DELAY = 0.00000025
 HOMING_START_DELAY = 0.001
 ENDSTOP_SAMPLE_TIME = .000015
 ENDSTOP_SAMPLE_COUNT = 4
@@ -32,25 +31,15 @@ class Homing:
         return thcoord
     def set_homed_position(self, pos):
         self.toolhead.set_position(self._fill_coord(pos))
-    def _get_homing_speed(self, speed, endstops):
-        # Round the requested homing speed so that it is an even
-        # number of ticks per step.
-        mcu_stepper = endstops[0][0].get_steppers()[0]
-        adjusted_freq = mcu_stepper.get_mcu().get_adjusted_freq()
-        dist_ticks = adjusted_freq * mcu_stepper.get_step_dist()
-        ticks_per_step = math.ceil(dist_ticks / speed)
-        return dist_ticks / ticks_per_step
     def _endstop_notify(self):
         self.endstops_pending -= 1
         if not self.endstops_pending:
             self.toolhead.signal_drip_mode_end()
-    def homing_move(self, movepos, endstops, speed, dwell_t=0.,
+    def homing_move(self, movepos, endstops, speed,
                     probe_pos=False, verify_movement=False):
         # Notify endstops of upcoming home
         for mcu_endstop, name in endstops:
             mcu_endstop.home_prepare()
-        if dwell_t:
-            self.toolhead.dwell(dwell_t, check_stall=False)
         # Start endstop checking
         print_time = self.toolhead.get_last_move_time()
         start_mcu_pos = [(s, name, s.get_mcu_position())
@@ -98,42 +87,30 @@ class Homing:
                         raise EndstopError("Probe triggered prior to movement")
                     raise EndstopError(
                         "Endstop %s still triggered after retract" % (name,))
-    def home_rails(self, rails, forcepos, movepos, limit_speed=None):
+    def home_rails(self, rails, forcepos, movepos):
         # Alter kinematics class to think printer is at forcepos
         homing_axes = [axis for axis in range(3) if forcepos[axis] is not None]
         forcepos = self._fill_coord(forcepos)
         movepos = self._fill_coord(movepos)
         self.toolhead.set_position(forcepos, homing_axes=homing_axes)
-        # Determine homing speed
+        # Perform first home
         endstops = [es for rail in rails for es in rail.get_endstops()]
         hi = rails[0].get_homing_info()
-        max_velocity = self.toolhead.get_max_velocity()[0]
-        if limit_speed is not None and limit_speed < max_velocity:
-            max_velocity = limit_speed
-        homing_speed = min(hi.speed, max_velocity)
-        homing_speed = self._get_homing_speed(homing_speed, endstops)
-        second_homing_speed = min(hi.second_homing_speed, max_velocity)
-        # Calculate a CPU delay when homing a large axis
-        axes_d = [mp - fp for mp, fp in zip(movepos, forcepos)]
-        est_move_d = abs(axes_d[0]) + abs(axes_d[1]) + abs(axes_d[2])
-        est_steps = sum([est_move_d / s.get_step_dist()
-                         for es, n in endstops for s in es.get_steppers()])
-        dwell_t = est_steps * HOMING_STEP_DELAY
-        # Perform first home
-        self.homing_move(movepos, endstops, homing_speed, dwell_t=dwell_t)
+        self.homing_move(movepos, endstops, hi.speed)
         # Perform second home
         if hi.retract_dist:
             # Retract
+            axes_d = [mp - fp for mp, fp in zip(movepos, forcepos)]
             move_d = math.sqrt(sum([d*d for d in axes_d[:3]]))
             retract_r = min(1., hi.retract_dist / move_d)
             retractpos = [mp - ad * retract_r
                           for mp, ad in zip(movepos, axes_d)]
-            self.toolhead.move(retractpos, homing_speed)
+            self.toolhead.move(retractpos, hi.speed)
             # Home again
             forcepos = [rp - ad * retract_r
                         for rp, ad in zip(retractpos, axes_d)]
             self.toolhead.set_position(forcepos)
-            self.homing_move(movepos, endstops, second_homing_speed,
+            self.homing_move(movepos, endstops, hi.second_homing_speed,
                              verify_movement=self.verify_retract)
         # Signal home operation complete
         ret = self.printer.send_event("homing:homed_rails", self, rails)

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -66,10 +66,7 @@ class CartKinematics:
         else:
             forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
         # Perform homing
-        limit_speed = None
-        if axis == 2:
-            limit_speed = self.max_z_velocity
-        homing_state.home_rails([rail], forcepos, homepos, limit_speed)
+        homing_state.home_rails([rail], forcepos, homepos)
     def home(self, homing_state):
         # Each axis is homed independently and in order
         for axis in homing_state.get_axes():

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -60,10 +60,7 @@ class CoreXYKinematics:
             else:
                 forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
             # Perform homing
-            limit_speed = None
-            if axis == 2:
-                limit_speed = self.max_z_velocity
-            homing_state.home_rails([rail], forcepos, homepos, limit_speed)
+            homing_state.home_rails([rail], forcepos, homepos)
     def motor_off(self, print_time):
         self.limits = [(1.0, -1.0)] * 3
         for rail in self.rails:

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -101,8 +101,7 @@ class DeltaKinematics:
         homing_state.set_axes([0, 1, 2])
         forcepos = list(self.home_position)
         forcepos[2] = -1.5 * math.sqrt(max(self.arm2)-self.max_xy2)
-        homing_state.home_rails(self.rails, forcepos, self.home_position,
-                                limit_speed=self.max_z_velocity)
+        homing_state.home_rails(self.rails, forcepos, self.home_position)
     def motor_off(self, print_time):
         self.limit_xy2 = -1.
         for rail in self.rails:

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -63,10 +63,7 @@ class PolarKinematics:
         else:
             forcepos[axis] += position_max - hi.position_endstop
         # Perform homing
-        limit_speed = None
-        if axis == 2:
-            limit_speed = self.max_z_velocity
-        homing_state.home_rails([rail], forcepos, homepos, limit_speed)
+        homing_state.home_rails([rail], forcepos, homepos)
     def home(self, homing_state):
         # Always home XY together
         homing_axes = homing_state.get_axes()

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -234,10 +234,8 @@ class MCU_endstop:
         return True
     def query_endstop(self, print_time):
         self._homing = False
-        self._min_query_time = self._mcu.monotonic()
+        self._min_query_time = eventtime = self._mcu.monotonic()
         self._next_query_print_time = print_time
-    def query_endstop_wait(self):
-        eventtime = self._mcu.monotonic()
         while self._check_busy(eventtime):
             eventtime = self._mcu.pause(eventtime + 0.1)
         return self._last_state.get('pin_value', self._invert) ^ self._invert

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -438,11 +438,10 @@ class CommandWrapper:
         if minclock:
             minsystime = self._clocksync.estimate_clock_systime(minclock)
         cmd = self._cmd.encode(data)
+        src = serialhdl.SerialRetryCommand(self._serial, response, response_oid)
         try:
-            src = serialhdl.SerialRetryCommand(
-                self._serial, [cmd], self._cmd_queue, response, response_oid,
-                minclock=minclock, minsystime=minsystime)
-            return src.get_response()
+            return src.get_response([cmd], self._cmd_queue,
+                                    minclock=minclock, minsystime=minsystime)
         except serialhdl.error as e:
             raise error(str(e))
 

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -9,8 +9,6 @@ import serialhdl, pins, chelper, clocksync
 class error(Exception):
     pass
 
-STEPCOMPRESS_ERROR_RET = -989898989
-
 class MCU_stepper:
     def __init__(self, mcu, pin_params):
         self._mcu = mcu
@@ -104,15 +102,7 @@ class MCU_stepper:
         else:
             self._itersolve_gen_steps = self._ffi_lib.itersolve_gen_steps
         return was_ignore
-    def note_homing_start(self, homing_clock):
-        ret = self._ffi_lib.stepcompress_set_homing(
-            self._stepqueue, homing_clock)
-        if ret:
-            raise error("Internal error in stepcompress")
     def note_homing_end(self, did_trigger=False):
-        ret = self._ffi_lib.stepcompress_set_homing(self._stepqueue, 0)
-        if ret:
-            raise error("Internal error in stepcompress")
         ret = self._ffi_lib.stepcompress_reset(self._stepqueue, 0)
         if ret:
             raise error("Internal error in stepcompress")

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -1,6 +1,6 @@
 # Serial port management for firmware communication
 #
-# Copyright (C) 2016,2017  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, threading
@@ -152,8 +152,8 @@ class SerialReader:
         self.raw_send(cmd, minclock, reqclock, self.default_cmd_queue)
     def send_with_response(self, msg, response):
         cmd = self.msgparser.create_command(msg)
-        src = SerialRetryCommand(self, [cmd], self.default_cmd_queue, response)
-        return src.get_response()
+        src = SerialRetryCommand(self, response)
+        return src.get_response([cmd], self.default_cmd_queue)
     def alloc_command_queue(self):
         return self.ffi_main.gc(self.ffi_lib.serialqueue_alloc_commandqueue(),
                                 self.ffi_lib.serialqueue_free_commandqueue)
@@ -199,52 +199,30 @@ class SerialReader:
 class SerialRetryCommand:
     TIMEOUT_TIME = 5.0
     RETRY_TIME = 0.500
-    def __init__(self, serial, cmds, cmd_queue, name, oid=None,
-                 minclock=0, minsystime=0.):
+    def __init__(self, serial, name, oid=None):
         self.serial = serial
-        self.cmds = cmds
-        self.cmd_queue = cmd_queue
         self.name = name
         self.oid = oid
-        self.minclock = minclock
-        self.response = None
-        reactor = self.serial.reactor
-        self.mutex = reactor.mutex(is_locked=True)
-        self.min_query_time = self.serial.reactor.monotonic()
-        self.first_query_time = max(self.min_query_time, minsystime)
-        self.serial.register_response(self.handle_callback, self.name, self.oid)
-        self.send_event(self.min_query_time)
-        retry_time = self.first_query_time + self.RETRY_TIME
-        self.send_timer = reactor.register_timer(self.send_event, retry_time)
-    def unregister(self):
-        self.serial.register_response(None, self.name, self.oid)
-        self.serial.reactor.unregister_timer(self.send_timer)
-    def send_event(self, eventtime):
-        if self.response is not None:
-            return self.serial.reactor.NEVER
-        if eventtime > self.first_query_time + self.TIMEOUT_TIME:
-            self.unregister()
-            if self.response is None:
-                self.mutex.unlock()
-            return self.serial.reactor.NEVER
-        for cmd in self.cmds:
-            self.serial.raw_send(cmd, self.minclock, self.minclock,
-                                 self.cmd_queue)
-        return eventtime + self.RETRY_TIME
+        self.completion = serial.reactor.completion()
+        self.min_query_time = serial.reactor.monotonic()
+        self.serial.register_response(self.handle_callback, name, oid)
     def handle_callback(self, params):
-        last_sent_time = params['#sent_time']
-        if last_sent_time >= self.min_query_time and self.response is None:
-            self.response = params
-            self.serial.reactor.register_async_callback(self.do_wake)
-    def do_wake(self, eventtime):
-        self.mutex.unlock()
-    def get_response(self):
-        with self.mutex:
-            pass
-        if self.response is None:
-            raise error("Timeout on wait for '%s' response" % (self.name,))
-        self.unregister()
-        return self.response
+        if params['#sent_time'] >= self.min_query_time:
+            self.min_query_time = self.serial.reactor.NEVER
+            self.serial.reactor.async_complete(self.completion, params)
+    def get_response(self, cmds, cmd_queue, minclock=0, minsystime=0.):
+        first_query_time = query_time = max(self.min_query_time, minsystime)
+        while 1:
+            for cmd in cmds:
+                self.serial.raw_send(cmd, minclock, minclock, cmd_queue)
+            params = self.completion.wait(query_time + self.RETRY_TIME)
+            if params is not None:
+                self.serial.register_response(None, self.name, self.oid)
+                return params
+            query_time = self.serial.reactor.monotonic()
+            if query_time > first_query_time + self.TIMEOUT_TIME:
+                self.serial.register_response(None, self.name, self.oid)
+                raise error("Timeout on wait for '%s' response" % (self.name,))
 
 # Attempt to place an AVR stk500v2 style programmer into normal mode
 def stk500v2_leave(ser, reactor):

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -139,10 +139,10 @@ class SerialReader:
     # Serial response callbacks
     def register_response(self, callback, name, oid=None):
         with self.lock:
-            self.handlers[name, oid] = callback
-    def unregister_response(self, name, oid=None):
-        with self.lock:
-            del self.handlers[name, oid]
+            if callback is None:
+                del self.handlers[name, oid]
+            else:
+                self.handlers[name, oid] = callback
     # Command sending
     def raw_send(self, cmd, minclock, reqclock, cmd_queue):
         self.ffi_lib.serialqueue_send(
@@ -217,7 +217,7 @@ class SerialRetryCommand:
         retry_time = self.first_query_time + self.RETRY_TIME
         self.send_timer = reactor.register_timer(self.send_event, retry_time)
     def unregister(self):
-        self.serial.unregister_response(self.name, self.oid)
+        self.serial.register_response(None, self.name, self.oid)
         self.serial.reactor.unregister_timer(self.send_timer)
     def send_event(self, eventtime):
         if self.response is not None:

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -326,10 +326,6 @@ class ToolHead:
         if self.special_queuing_state:
             self._calc_print_time()
         return self.print_time
-    def reset_print_time(self, min_print_time=0.):
-        self._full_flush()
-        est_print_time = self.mcu.estimated_print_time(self.reactor.monotonic())
-        self.print_time = max(min_print_time, est_print_time)
     def _check_stall(self):
         eventtime = self.reactor.monotonic()
         if self.special_queuing_state:
@@ -392,11 +388,10 @@ class ToolHead:
         self.move_queue.add_move(move)
         if self.print_time > self.need_check_stall:
             self._check_stall()
-    def dwell(self, delay, check_stall=True):
+    def dwell(self, delay):
         self.get_last_move_time()
         self.update_move_time(delay)
-        if check_stall:
-            self._check_stall()
+        self._check_stall()
     def motor_off(self):
         self.dwell(STALL_TIME)
         last_move_time = self.get_last_move_time()
@@ -488,7 +483,6 @@ class ToolHead:
         self.motor_off()
     def _handle_shutdown(self):
         self.move_queue.reset()
-        self.reset_print_time()
     def get_kinematics(self):
         return self.kin
     def get_max_velocity(self):


### PR DESCRIPTION
This series implements a new internal mechanism for homing and probing.

Currently, the Klipper code implements "homing moves" via a four step system: enable endstop checking, buffer the entire movement into the micro-controllers, start the movement, clear the mcu movement buffer on each endstop trigger.  This system is not particularly flexible - it causes problems when a movement exceeds the buffer space in the micro-controller and it causes problems on slower host machines (where the host may not be able to generate and compress all the steps for the movement before the movement is scheduled to start).

This pull request changes the homing system to use a new system: enable endstop checking, buffer the entire movement in the host look-ahead buffer, drip feed the moves to the micro-controllers, clear the look-ahead buffer after all endstops trigger.  This system should be more flexible - in particular it is no longer necessary to generate a large number of steps in advance.  It is also no longer necessary for the internal code to manipulate the internal "print_time" tracking during a homing operation.

This is a fairly substantial change, so additional testers would be great.

cd ~/klipper ; git fetch ; git checkout origin/work-homing-20190625 ; sudo service klipper restart

-Kevin