### PR TITLE
skew_correction:  move configuration to gcode

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -377,28 +377,15 @@
 #   if retries are enabled then retry if largest and smallest probed points
 #   differ more than retry_tolerance
 
+
 # Printer Skew Correction.  It is possible to use software to correct
 # printer skew across 3 planes, xy, xz, yz.  This is done by printing
-# a calibration model along a plane and measuring three lengths.  See
-# skew_correction.md in the docs directory for more details.
+# a calibration model along a plane and measuring three lengths.  Due
+# to the nature of skew correction these lengths are set via gcode. See
+# skew_correction.md and G-Codes.md in the docs directory for details.
 #
 #[skew_correction]
-#xy_ac_length:
-#xy_bd_length:
-#xy_ad_length:
-#   The measured lengths (in mm) on the xy plane skew calibration print.
-#   If one length is provided all three lengths must be provided.  The default
-#   is no measurement, which results in no skew correction along the xy plane.
-#xz_ac_length:
-#xz_bd_length:
-#xz_ad_length:
-#   The same as above, on the xz plane.  The default is no skew correction
-#   on the xz plane.
-#yz_ac_length:
-#yz_bd_length:
-#yz_ad_length:
-#   The same as above on the yz plane.  The default is no skew correction
-#   on the yz plane.
+
 
 # In a multi-extruder printer add an additional extruder section for
 # each additional extruder. The additional extruder sections should be

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,11 @@ All dates in this document are approximate.
 
 # Changes
 
+20190628: All configuration options have been removed from the
+[skew_correction] section.  Configuration for skew_correction
+is now done via the SET_SKEW gcode.  See skew_correction.md
+for recommended usage.
+
 20190607: The "variable_X" parameters of gcode_macro (along with the
 VALUE parameter of SET_GCODE_VARIABLE) are now parsed as Python
 literals. If a value needs to be assigned a string then wrap the value

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -477,12 +477,26 @@ of retraction required.
 
 The following commands are available when the "skew_correction" config
 section is enabled.
+  - `SET_SKEW [XY=<ac_length,bd_length,ad_length>] [XZ=<ac,bd,ad>]
+    [YZ=<ac,bd,ad>] [CLEAR=<0|1>]`:  Configures the [skew_correction] module
+    with measurements (in mm) taken from a calibration print.  One may
+    enter measurements for any combination of planes, planes not entered will
+    retain their current value.  If `CLEAR=1` is entered then all skew
+    correction will be disabled.
   - `GET_CURRENT_SKEW`: Reports the current printer skew for each plane in
     both radians and degrees.  The skew is calculated based on parameters
-    provided to the [skew_correction] section of printer.cfg.
+    provided via the `SET_SKEW` gcode.
   - `CALC_MEASURED_SKEW [AC=<ac_length>] [BD=<bd_length>] [AD=<ad_length>]`:
     Calculates and reports the skew (in radians and degrees) based on a
     measured print.  This can be useful for determining the printer's current
     skew after correction has been applied.  It may also be useful before
     correction is applied to determine if skew correction is necessary.   See
-    skew_correction.md for details on skew calibration objects and measurements.
+    skew_correction.md for details on skew calibration objects and
+    measurements.
+  - `SKEW_PROFILE [LOAD=<name>] [SAVE=<name>] [REMOVE=<name>]`: Profile
+    management for skew_correction.  LOAD will restore skew state from the
+    profile matching the supplied name. SAVE will save the current skew state
+    to a profile matching the supplied name.  Remove will delete the profile
+    matching the supplied name from persistent memory.  Note that after SAVE
+    or REMOVE operations have been run the SAVE_CONFIG gcode must be run
+    to make the changes to peristent memory permanent.

--- a/docs/skew_correction.md
+++ b/docs/skew_correction.md
@@ -1,6 +1,6 @@
 Software based skew correction can help resolve dimensional inaccuracies
 resulting from a printer assembly that is not perfectly square.  Note
-that if your printer is significantly skewed it is strongy recommended to
+that if your printer is significantly skewed it is strongly recommended to
 first use mechanical means to get your printer as square as possible prior
 to applying software based correction.
 
@@ -12,8 +12,9 @@ along the plane you want to correct.  There is also a
 that includes all planes in one model.  You want the object oriented
 so that corner A is toward the origin of the plane.
 
-Make sure that the [skew_correction] module is not enabled in printer.cfg
-prior to printing the calibration part.
+Make sure that no skew correction is applied during this print.  You may
+do this by either removing the [skew_correction] module from printer.cfg
+or by issuing a `SET_SKEW CLEAR=1` gcode.
 
 # Take your measurements
 The [skew_correcton] module requires 3 measurements for each plane you want
@@ -23,18 +24,56 @@ AD do not include the flats on the corners that some test objects provide.
 
 ![skew_lengths](img/skew_lengths.png)
 
-# Update printer.cfg
-Enter your lengths for the calibration print corresponding to the correct
-plane under the [skew_correction] section in printer.cfg, for example:
+# Configure your skew
+Make sure [skew_correction] is in printer.cfg.  You may now use the `SET_SKEW`
+gcode to configure skew_correcton.  For example, if your measured lengths
+along XY are as follows:
 ```
-[skew_correction]
-xy_ac_length: 140.4
-xy_bd_length: 142.8
-xy_ad_length: 99.8
+Length AC = 140.4
+Length BD = 142.8
+Length AD = 99.8
 ```
-Restart your printer.  If desired, you can reprint the calibration part
-with skew correction enabled. The following gcode can be used to calculate
-skew of a single plane and output the results:
+
+`SET_SKEW` can be used to configure skew correction for the XY plane.
+
+```
+SET_SKEW XY=140.4,142.8,99.8
+```
+You may also add measurements for XZ and YZ to the gcode:
+
+```
+SET_SKEW XY=140.4,142.8,99.8 XZ=141.6,141.4,99.8 YZ=142.4,140.5,99.5
+```
+
+The [skew_correction] module also supports profile management in a manner
+similar to [bed_mesh].  After setting skew using the `SET_SKEW` gcode,
+you may use the `SKEW_PROFILE` gcode to save it:
+
+```
+SKEW_PROFILE SAVE=my_skew_profile
+```
+After this command you will be prompted to issue a `SAVE_CONFIG` gcode to
+save the profile to persistent storage.  If no profile is named
+`my_skew_profile` then a new profile will be created.  If the named profile
+exists it will be overwritten.
+
+Once you have a saved profile, you may load it:
+```
+SKEW_PROFILE LOAD=my_skew_profile
+```
+
+It is also possible to remove an old or out of date profile:
+```
+SKEW_PROFILE REMOVE=my_skew_profile
+```
+After removing a profile you will be prompted to issue a `SAVE_CONFIG` to
+make this change persist.
+
+# Verifying your correction
+After skew_correction has been configured you may reprint the calibration
+part with correction enabled.  Use the following gcode to check your
+skew on each plane.  The results should be lower than those reported via
+`GET_CURRENT_SKEW`.
 
 ```
 CALC_MEASURED_SKEW AC=<ac_length> BD=<bd_length> AD=<ad_length>
@@ -42,11 +81,13 @@ CALC_MEASURED_SKEW AC=<ac_length> BD=<bd_length> AD=<ad_length>
 
 # Caveats
 
-When using the [skew_correction] module it is suggested to home all axes
-before attempting a move.  Homing a single axis to move could result in a
-correction along the x and/or y axis, potentially leading to a homing error.
+Due to the nature of skew correction it is recommended to configure skew
+in your start gcode, after homing and any kind of movement that travels
+near the edge of the print area such as a purge or nozzle wipe.   You may
+use use the `SET_SKEW` or `SKEW_PROFILE` gcodes to accomplish this.  It is
+also recommended to issue a `SET_SKEW CLEAR=1` in your end gcode.
 
-It is also important to keep in mind that it is possible for [skew_correction]
-to generate a correction that moves the tool beyond the printer's boundries
-on the X and/or Y axes.  It is recommended to arrange parts away from the
-edges when using [skew_correction].
+Keep in mind that it is possible for [skew_correction] to generate a correction
+that moves the tool beyond the printer's boundries on the X and/or Y axes.  It
+is recommended to arrange parts away from the edges when using
+[skew_correction].


### PR DESCRIPTION
As previously discussed, all configuration options have been removed from printer.cfg and are now available via a SET_SKEW gcode:
```
SET_SKEW XY=ac,bd,ad XZ=ac,bd,ad YZ=ac,bd,ad CLEAR=0|1
```
I added the CLEAR parameter to make zeroing the skew settings easier and more forthright.

I also added profile management similar to [bed_mesh]:
```
SKEW_PROFILE LOAD=name SAVE=name REMOVE=name
```
My thought was that it would be easier for users to load a saved profile their start gcode. 

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>