### PR TITLE
delayed_gcode: Support for non-blocking delayed gcode execution

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1693,3 +1693,16 @@
 #release_gcode:
 #   A list of G-Code commands to execute when the button is released.
 #   G-Code templates are supported.
+
+# Execute a gcode on a set delay.
+#[delayed_gcode my_delayed_gcode]
+#initial_duration: 0.
+#   The duration of the initial delay (in seconds).  If set to a non-zero
+#   value the delayed_gcode will execute the specified number of seconds
+#   after the printer enters the "ready" state.  This can be useful for
+#   initialization procedures or a repeating delayed_gcode.  If set to 0
+#   the delayed_gcode will not execute on startup.  Default is 0.
+#gcode:
+#   A list of G-Code commands to execute when the delay duration has
+#   elapsed.  G-Code templates are supported.  This parameter must be
+#   provided.

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -186,3 +186,64 @@ gcode:
 
 Be sure to take the timing of macro evaluation and command execution
 into account when using SET_GCODE_VARIABLE.
+
+### Delayed Gcodes
+
+The [delayed_gcode] configuration option can be used to execute a delayed
+gcode sequence:
+
+```
+[delayed_gcode clear_display]
+gcode:
+  M117
+
+[gcode_macro load_filament]
+gcode:
+ G91
+ G1 E50
+ G90
+ M400
+ M117 Load Complete!
+ UPDATE_DELAYED_GCODE ID=clear_display DURATION=10
+```
+
+When the `load_filament` macro above executes, it will display a
+"Load Complete!" message after the extrusion is finished.  The
+last line of gcode enables the "clear_display" delayed_gcode, set
+to execute in 10 seconds.
+
+The `initial_duration` config option can be set to execute the
+delayed_gcode on printer startup.  The countdown begins when the
+printer enters the "ready" state.  For example, the below delayed_gcode
+will execute 5 seconds after the printer is ready, initializing
+the display with a "Welcome!" message:
+
+```
+[delayed_gcode welcome]
+initial_duration: 5.
+gcode:
+  M117 Welcome!
+```
+
+Its possible for a delayed gcode to repeat by updating itself in
+the gcode option:
+
+```
+[delayed_gcode report_temp]
+initial_duration: 2.
+gcode:
+  {printer.gcode.action_respond_info(
+    "Extruder Temp: %.1f" %
+    (printer.extruder0.temperature))}
+  UPDATE_DELAYED_GCODE ID=report_temp DURATION=2
+
+```
+
+The above delayed_gcode will send "// Extruder Temp: [ex0_temp]" to
+Octoprint every 2 seconds.  This can be canceled with the following
+gcode:
+
+
+```
+UPDATE_DELAYED_GCODE ID=report_temp DURATION=0
+```

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -500,3 +500,12 @@ section is enabled.
     matching the supplied name from persistent memory.  Note that after SAVE
     or REMOVE operations have been run the SAVE_CONFIG gcode must be run
     to make the changes to peristent memory permanent.
+
+## Delayed GCode
+
+The following command is enabled if a [delayed_gcode] config section has
+been enabled:
+  - `UPDATE_DELAYED_GCODE [ID=<name>] [DURATION=<seconds>]`:  Updates the
+    delay duration for the identified [delayed_gcode] and starts the timer
+    for gcode execution.  A value of 0 will cancel a pending delayed gcode
+    from executing.

--- a/klippy/extras/delayed_gcode.py
+++ b/klippy/extras/delayed_gcode.py
@@ -1,0 +1,54 @@
+# A simple timer for executing gcode templates
+#
+# Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+
+class DelayedGcode:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.name = config.get_name().split()[1]
+        self.gcode = self.printer.lookup_object('gcode')
+        gcode_macro = self.printer.try_load_module(config, 'gcode_macro')
+        self.timer_gcode = gcode_macro.load_template(config, 'gcode')
+        self.duration = config.getfloat('initial_duration', 0., minval=0.)
+        self.timer_handler = None
+        self.inside_timer = self.repeat = False
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
+        self.gcode.register_mux_command(
+            "UPDATE_DELAYED_GCODE", "ID", self.name,
+            self.cmd_UPDATE_DELAYED_GCODE,
+            desc=self.cmd_UPDATE_DELAYED_GCODE)
+    def _handle_ready(self):
+        waketime = self.reactor.NEVER
+        if self.duration:
+            waketime = self.reactor.monotonic() + self.duration
+        self.timer_handler = self.reactor.register_timer(
+            self._gcode_timer_event, waketime)
+    def _gcode_timer_event(self, eventtime):
+        self.inside_timer = True
+        try:
+            self.gcode.run_script(self.timer_gcode.render())
+        except Exception:
+            logging.exception("Script running error")
+        nextwake = self.reactor.NEVER
+        if self.repeat:
+            nextwake = eventtime + self.duration
+        self.inside_timer = self.repeat = False
+        return nextwake
+    cmd_UPDATE_DELAYED_GCODE_help = "Update the duration of a delayed_gcode"
+    def cmd_UPDATE_DELAYED_GCODE(self, params):
+        self.duration = self.gcode.get_float('DURATION', params, minval=0.)
+        if self.inside_timer:
+            self.repeat = (self.duration != 0.)
+        else:
+            waketime = self.reactor.NEVER
+            if self.duration:
+                waketime = self.reactor.monotonic() + self.duration
+            self.reactor.update_timer(self.timer_handler, waketime)
+
+def load_config_prefix(config):
+    return DelayedGcode(config)


### PR DESCRIPTION
This PR adds the aforementioned [delayed_gcode] module.  Apart from the standard docs, I added detailed documentation to Command_Templates.md.  I thought that this would be a better location for it rather than creating a new markdown file.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>