### PR TITLE
Add support for s-curve acceleration

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -306,6 +306,11 @@ max_velocity: 500
 max_accel: 3000
 #   Maximum acceleration (in mm/s^2) of the toolhead (relative to the
 #   print). This parameter must be specified.
+acceleration_order: 2
+#   This parameter determines the acceleration method. Use 2 for
+#   constant acceleration, 4 for a 4th order position s-curve
+#   acceleration, or 6 for 6th order position s-curve acceleration.
+#   The default is 2.
 #max_accel_to_decel:
 #   A pseudo acceleration (in mm/s^2) controlling how fast the
 #   toolhead may go from acceleration to deceleration. It is used to

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -130,9 +130,10 @@ The following standard commands are supported:
   samples taken during the test.
 - `TURN_OFF_HEATERS`: Turn off all heaters.
 - `SET_VELOCITY_LIMIT [VELOCITY=<value>] [ACCEL=<value>]
-  [ACCEL_TO_DECEL=<value>] [SQUARE_CORNER_VELOCITY=<value>]`: Modify
-  the printer's velocity limits. Note that one may only set values
-  less than or equal to the limits specified in the config file.
+  [ACCEL_TO_DECEL=<value>] [SQUARE_CORNER_VELOCITY=<value>]
+  [ACCEL_ORDER=<value>]`: Modify the printer's velocity limits. Note
+  that one may only set values less than or equal to the limits
+  specified in the config file.
 - `SET_HEATER_TEMPERATURE HEATER=<heater_name> [TARGET=<target_temperature>]`:
   Sets the target temperature for a heater. If a target temperature is
   not supplied, the target is 0.

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -44,6 +44,7 @@ defs_stepcompress = """
 
 defs_itersolve = """
     struct move *move_alloc(void);
+    void move_set_accel_order(struct move *m, int accel_order);
     void move_fill(struct move *m, double print_time
         , double accel_t, double cruise_t, double decel_t
         , double start_pos_x, double start_pos_y, double start_pos_z

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -8,7 +8,7 @@ struct coord {
 };
 
 struct move_accel {
-    double c1, c2;
+    double c1, c2, c3, c4, c5, c6;
 };
 
 struct move {
@@ -18,9 +18,11 @@ struct move {
     double cruise_v;
     struct move_accel accel, decel;
     struct coord start_pos, axes_r;
+    int accel_order;
 };
 
 struct move *move_alloc(void);
+void move_set_accel_order(struct move *m, int accel_order);
 void move_fill(struct move *m, double print_time
                , double accel_t, double cruise_t, double decel_t
                , double start_pos_x, double start_pos_y, double start_pos_z

--- a/klippy/chelper/kin_extruder.c
+++ b/klippy/chelper/kin_extruder.c
@@ -26,6 +26,50 @@ extruder_stepper_alloc(void)
     return sk;
 }
 
+// Determine the coefficients for a 4th order bezier position function
+static void
+extruder_bezier4(struct move_accel *ma, double start_v, double extra_v
+                      , double accel, double accel_t)
+{
+    if (!accel_t) {
+        ma->c4 = ma->c3 = ma->c2 = ma->c1 = 0.;
+        return;
+    }
+    double inv_accel_t = 1. / accel_t;
+    double accel_div_accel_t = accel * inv_accel_t;
+    double accel_div_accel_t2 = accel_div_accel_t * inv_accel_t;
+    double extra_v_div_accel_t = extra_v * inv_accel_t;
+    double extra_v_div_accel_t2 = extra_v_div_accel_t * inv_accel_t;
+    ma->c4 = -.5 * accel_div_accel_t2;
+    ma->c3 = accel_div_accel_t + (-2. * extra_v_div_accel_t2);
+    ma->c2 = 3. * extra_v_div_accel_t;
+    ma->c1 = start_v;
+}
+
+// Determine the coefficients for a 6th order bezier position function
+static void
+extruder_bezier6(struct move_accel *ma, double start_v, double extra_v
+                      , double accel, double accel_t)
+{
+    if (!accel_t) {
+        ma->c6 = ma->c5 = ma->c4 = ma->c3 = ma->c1 = 0.;
+        return;
+    }
+    double inv_accel_t = 1. / accel_t;
+    double accel_div_accel_t2 = accel * inv_accel_t * inv_accel_t;
+    double accel_div_accel_t3 = accel_div_accel_t2 * inv_accel_t;
+    double accel_div_accel_t4 = accel_div_accel_t3 * inv_accel_t;
+    double extra_v_div_accel_t = extra_v * inv_accel_t;
+    double extra_v_div_accel_t2 = extra_v_div_accel_t * inv_accel_t;
+    double extra_v_div_accel_t3 = extra_v_div_accel_t2 * inv_accel_t;
+    double extra_v_div_accel_t4 = extra_v_div_accel_t3 * inv_accel_t;
+    ma->c6 = accel_div_accel_t4;
+    ma->c5 = -3. * accel_div_accel_t3 + (6. * extra_v_div_accel_t4);
+    ma->c4 = 2.5 * accel_div_accel_t2 + (-15. * extra_v_div_accel_t3);
+    ma->c3 = 10. * extra_v_div_accel_t2;
+    ma->c1 = start_v;
+}
+
 // Populate a 'struct move' with an extruder velocity trapezoid
 void __visible
 extruder_move_fill(struct move *m, double print_time
@@ -44,10 +88,18 @@ extruder_move_fill(struct move *m, double print_time
 
     // Setup for accel/cruise/decel phases
     m->cruise_v = cruise_v;
-    m->accel.c1 = start_v + extra_accel_v;
-    m->accel.c2 = .5 * accel;
-    m->decel.c1 = cruise_v + extra_decel_v;
-    m->decel.c2 = -m->accel.c2;
+    if (m->accel_order == 4) {
+        extruder_bezier4(&m->accel, start_v, extra_accel_v, accel, accel_t);
+        extruder_bezier4(&m->decel, cruise_v, extra_decel_v, -accel, decel_t);
+    } else if (m->accel_order == 6) {
+        extruder_bezier6(&m->accel, start_v, extra_accel_v, accel, accel_t);
+        extruder_bezier6(&m->decel, cruise_v, extra_decel_v, -accel, decel_t);
+    } else {
+        m->accel.c1 = start_v + extra_accel_v;
+        m->accel.c2 = .5 * accel;
+        m->decel.c1 = cruise_v + extra_decel_v;
+        m->decel.c2 = -m->accel.c2;
+    }
 
     // Setup start distance
     m->start_pos.x = start_pos;

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -53,9 +53,9 @@ class PrinterExtruder:
         self.need_motor_enable = True
         self.extrude_pos = 0.
         # Setup iterative solver
-        ffi_main, ffi_lib = chelper.get_ffi()
-        self.cmove = ffi_main.gc(ffi_lib.move_alloc(), ffi_lib.free)
-        self.extruder_move_fill = ffi_lib.extruder_move_fill
+        ffi_main, self.ffi_lib = chelper.get_ffi()
+        self.cmove = ffi_main.gc(self.ffi_lib.move_alloc(), self.ffi_lib.free)
+        self.extruder_move_fill = self.ffi_lib.extruder_move_fill
         self.stepper.setup_itersolve('extruder_stepper_alloc')
         # Setup SET_PRESSURE_ADVANCE command
         gcode = self.printer.lookup_object('gcode')
@@ -82,6 +82,8 @@ class PrinterExtruder:
         return self.deactivate_gcode.render()
     def stats(self, eventtime):
         return self.heater.stats(eventtime)
+    def setup_accel_order(self, accel_order):
+        self.ffi_lib.move_set_accel_order(self.cmove, accel_order)
     def motor_off(self, print_time):
         self.stepper.motor_enable(print_time, 0)
         self.need_motor_enable = True
@@ -231,6 +233,8 @@ class PrinterExtruder:
 class DummyExtruder:
     def set_active(self, print_time, is_active):
         return 0.
+    def setup_accel_order(self, accel_order):
+        pass
     def motor_off(self, move_time):
         pass
     def check_move(self, move):


### PR DESCRIPTION
This is a pull request for the work-scurve-20180620 branch that has been under discussion in issue #57 for some time.  This branch has last been rebased on 20190701.

To test with this branch ssh into the host machine and run:
```
cd ~/klipper ; git fetch ; git checkout origin/work-scurve-20180620 ; sudo service klipper restart
```
You will then need to update the config file to specify an acceleration_order of 4 or 6.  (Alternatively, one may enable via the ACCEL_ORDER parameter in the SET_VELOCITY_LIMIT command.)

To the best of my knowledge, this support works as intended.  However, more people have reported a degradation in print quality (or no change) than people that have reported an improvement in quality.  It is believed that fundamentally s-curves improve performance at very low acceleration (eg, 500mm/s^2) and actually make quality worse at normal/high acceleration values (eg, 1000+ mm/s^2).

There is no immediate plan to merge this support into the master Klipper branch.  In order to merge the support, I believe comprehensive documentation would need to be written that describes how to test if s-curves improve quality on a printer.  I fear that without that documentation users may enable s-curves (because they're "better"), obtain poor results, and it would reflect poorly on Klipper.

To comment on this branch (or s-curves in general), please use the existing issue #57.

-Kevin