### PR TITLE
Add power% for M105 response

### DIFF
--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -386,6 +386,10 @@ class GCodeParser:
             for gcode_id, sensor in sorted(self.heaters.get_gcode_sensors()):
                 cur, target = sensor.get_temp(eventtime)
                 out.append("%s:%.1f /%.1f" % (gcode_id, cur, target))
+                if gcode_id.startswith( 'B' ) :
+                    out.append("B@:%d " % (sensor.last_pwm_value * 128))
+                else:
+                    out.append(("@%s:%d " % (gcode_id, (sensor.last_pwm_value * 128))).replace("T",""))
         if not out:
             return "T:0"
         return " ".join(out)

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -389,7 +389,8 @@ class GCodeParser:
                 if gcode_id.startswith( 'B' ) :
                     out.append("B@:%d " % (sensor.last_pwm_value * 128))
                 else:
-                    out.append(("@%s:%d " % (gcode_id, (sensor.last_pwm_value * 128))).replace("T",""))
+                    out.append(("@%s:%d " % (gcode_id,
+                        (sensor.last_pwm_value * 128))).replace("T",""))
         if not out:
             return "T:0"
         return " ".join(out)


### PR DESCRIPTION
Some firmware M105 response provided the current power% of the heater.

Example:
ok T:201 /202 B:117 /120 B@:128 @:128
ok T:201 /202 T0:201 /210 B:117 /120 B@:128 @:128 @0:128

Signed-off-by: Antonio Cheong <windo.ac@gmail.com>