### PR TITLE
buttons: initialize mcu buttons based on inverted state

### DIFF
--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -49,8 +49,9 @@ class MCU_buttons:
         rest_ticks = self.mcu.seconds_to_clock(QUERY_TIME)
         self.mcu.add_config_cmd(
             "buttons_query oid=%d clock=%d"
-            " rest_ticks=%d retransmit_count=%d" % (
-                self.oid, clock, rest_ticks, RETRANSMIT_COUNT), is_init=True)
+            " rest_ticks=%d retransmit_count=%d invert=%d" % (
+                self.oid, clock, rest_ticks, RETRANSMIT_COUNT,
+                self.invert), is_init=True)
         self.mcu.register_response(self.handle_buttons_state,
                                    "buttons_state", self.oid)
     def handle_buttons_state(self, params):

--- a/src/buttons.c
+++ b/src/buttons.c
@@ -102,7 +102,7 @@ command_buttons_query(uint32_t *args)
     sched_del_timer(&b->time);
     b->time.waketime = args[1];
     b->rest_ticks = args[2];
-    b->pressed = b->last_pressed = 0;
+    b->pressed = b->last_pressed = args[4];
     b->ack_count = b->report_count = 0;
     b->retransmit_state = BF_ACKED;
     b->retransmit_count = args[3];
@@ -113,7 +113,8 @@ command_buttons_query(uint32_t *args)
     sched_add_timer(&b->time);
 }
 DECL_COMMAND(command_buttons_query,
-             "buttons_query oid=%c clock=%u rest_ticks=%u retransmit_count=%c");
+             "buttons_query oid=%c clock=%u rest_ticks=%u retransmit_count=%c"
+             " invert=%c");
 
 void
 command_buttons_ack(uint32_t *args)


### PR DESCRIPTION
This should solve the issue where inverted buttons are not properly initialized on the host when the pin is low at startup.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>