### PR TITLE
filament_switch_sensor:  misc fixes

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -442,6 +442,9 @@ section is enabled.
  - `QUERY_FILAMENT_SENSOR SENSOR=<sensor_name>`: Queries the current status of
   the filament sensor.  The data displayed on the terminal will depend on the
   sensor type defined in the confguration.
+ - `SET_FILAMENT_SENSOR SENSOR=<sensor_name> ENABLE=[0|1]`:  Sets the
+   filament sensor on/off.  If ENABLE is set to 0, the filament sensor will
+   be disabled, if set to 1 it is enabled.
 
 ## Firmware Retraction
 

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -62,7 +62,7 @@ class BaseSensor(object):
         self.event_running = False
     def _exec_gcode(self, prefix, template):
         try:
-            self.gcode.run_script(prefix + template.render())
+            self.gcode.run_script(prefix + template.render() + "\nM400")
         except Exception:
             logging.exception("Script running error")
     def set_enable(self, runout, insert):

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -34,8 +34,6 @@ class BaseSensor(object):
         self.printer.register_event_handler(
             "idle_timeout:printing",
             (lambda e, s=self, st="printing": s._update_print_status(e, st)))
-    def _handle_ready(self):
-        self.toolhead = self.printer.lookup_object('toolhead')
     def _update_print_status(self, eventtime, status):
         if status == "printing":
             runout_en = self.runout_gcode is not None
@@ -95,7 +93,6 @@ class SwitchSensor(BaseSensor):
             desc=self.cmd_QUERY_FILAMENT_SENSOR_help)
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
     def _handle_ready(self):
-        super(SwitchSensor, self)._handle_ready()
         self.start_time = self.reactor.monotonic() + 2.
     def _button_handler(self, eventtime, state):
         if eventtime < self.start_time or state == self.last_button_state:


### PR DESCRIPTION
This pr includes several small fixes to the filament_switch_sensor module:

- The first patch removes a stale toolhead attribute in the BaseSensor class.  Since the toolhead is no longer required by the BaseSensor, its entire handle_ready function could be removed.

- The second a patch appends M400 to the event gcode.  This keeps the BaseSensor's "event_running" attribute set to true until all moves are complete, preventing an additional event from triggering while the printer is responding to the previous event.

- The last patch adds a "TOGGLE_FILAMENT_SENSOR" gcode.  Some users prefer to unload/remove filament while the extruder gears are still moving.   To prevent a runout event from triggering it is necessary that the user manually toggle the sensor off at the  beginning of the unload macro, and back on at the end.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>