### PR TITLE
Create generic-printrboard-revF.cfg

### DIFF
--- a/config/generic-printrboard-revF.cfg
+++ b/config/generic-printrboard-revF.cfg
@@ -1,0 +1,83 @@
+# This file contains common pin mappings for Printrboard boards (rev F). To use this config the firmware should be compiled for
+# the AVR at90usb1286.
+
+# Note that the "make flash" command is unlikely to work on the
+# Printrboard. See the RepRap Printrboard wiki page for instructions
+# on flashing.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: PA2
+dir_pin: PA3
+enable_pin: !PE6
+step_distance: .0125
+endstop_pin: ^PB4
+position_endstop: 0
+position_max: 250
+homing_speed: 50
+
+[stepper_y]
+step_pin: PA0
+dir_pin: !PA1
+enable_pin: !PE7
+step_distance: .0125
+endstop_pin: ^PE3
+position_endstop: 0
+position_max: 250
+homing_speed: 50
+
+[stepper_z]
+step_pin: PA4
+dir_pin: !PA5
+enable_pin: !PC7
+step_distance: .000498
+endstop_pin: ^!PE4
+position_endstop: 0.5
+position_max: 250
+
+[extruder]
+step_pin: PA6
+dir_pin: PA7
+enable_pin: !PC3
+step_distance: .010635
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF1
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PC4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF0
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PC6
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+# Use the following on a Printrboard RevF to control stepper current.
+#[mcp4728 stepper_current_dac]
+#scale: 2.327
+#channel_a: 0.6 # Extruder
+#channel_b: 0.5 # stepper_z
+#channel_c: 0.5 # stepper_y
+#channel_d: 0.5 # stepper_x


### PR DESCRIPTION
module: DEFAULT CONFIGURATION FOR PRINTRBOARD REV F (AND PRINTR METAL PLUS)

Default configuration for Printrboard Rev F (and Printrbot Metal Plus)
Inversion of [stepper_x]  and [stepper_y]
endstop_pin for [stepper_x]  and [stepper_z]

Signed-off-by: Christophe Chaudelet <christophe.chaudelet@gmail.com>