### PR TITLE
menu: use MOVE=1 for offset_z menu

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -59,7 +59,7 @@ input_min: -5
 input_max: 5
 input_step: 0.005
 realtime: true
-gcode: SET_GCODE_OFFSET Z={0:.3f}
+gcode: SET_GCODE_OFFSET Z={0:.3f} MOVE=1
 
 ### menu octoprint ###
 [menu __octoprint]


### PR DESCRIPTION
use SET_GCODE_OFFSET's MOVE=1 parameter in the z offset menu.
Less confusing for people who think nothing happened.