### PR TITLE
config: Fix pins for E6 in generic-duet2-duex.cfg

### DIFF
--- a/config/generic-duet2-duex.cfg
+++ b/config/generic-duet2-duex.cfg
@@ -17,7 +17,7 @@
 # | E3    |  PD22    |  PD1      |  PE1*        |  PD24       |
 # | E4    |  PD16    |  PD0      |  PE2*        |  PD25       |
 # | E5    |  PD17    |  PD3      |  PE3*        |  PD26       |
-# | E6    |  PA25    |  PD21     |  PA17*       |  PC28       |
+# | E6    |  PC0     |  PD27     |  PA17*       |  PB14       |
 # Pins marked with asterisks (*) are only assigned to these functions
 # if no duex is connected. If a duex is connected, these endstops are
 # remapped to the SX1509 on the Duex (unfortunately they can't be used
@@ -77,11 +77,10 @@
 # | LCD_DB7     |  PD18   |
 # | LCD_DB6     |  PD19   |
 # | LCD_DB5     |  PD20   |
-# | LCD_DB4     |  PD21** |
-# | LCD_RS      |  PC28** |
-# | LCD_E       |  PA25** |
+# | LCD_DB4     |  PD21   |
+# | LCD_RS      |  PC28   |
+# | LCD_E       |  PA25   |
 # Pins marked with one asterisk (*) replace E2_STOP-E6_STOP if a duex is present
-# Pins marked with two asterisks (**) share pins with drive E6.
 # For the remaining pins check the schematics provided here: https://github.com/T3P3/Duet
 
 [stepper_x]
@@ -169,13 +168,13 @@ sense_resistor: 0.051
 
 #On drive E6
 [stepper_z3]
-step_pin: PD21
-dir_pin: !PA25
+step_pin: PD27
+dir_pin: !PC0
 enable_pin: !PC6, tmc2660_stepper_z3:virtual_enable
 step_distance: .0025
 
 [tmc2660 stepper_z3]
-cs_pin: PC28
+cs_pin: PB14
 spi_bus: usart1
 microsteps: 16
 interpolate: True


### PR DESCRIPTION
Due to some misreading of the Duet2 schematic and CoreNG code on my part, the pin assignments for the E6 drive on the duex were incorrect. This PR fixes them.
Sources used:
https://github.com/T3P3/Duet/blob/master/Duet2/Duet2v1.04/DuetWifiv1.04a_Schematic.pdf
http://ww1.microchip.com/downloads/en/devicedoc/atmel-11157-32-bit-cortex-m4-microcontroller-sam4e16-sam4e8_datasheet.pdf
https://github.com/dc42/CoreNG/blob/master/variants/duetNG/variant.cpp

Sorry about the inconvenience!

-Florian

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>