### PR TITLE
Add support for board specific pin aliases

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1366,6 +1366,19 @@
 #   be provided.
 
 
+# Board pin aliases. One may define aliases for the pins on a
+# micro-controller. (If a micro-controller name is omitted in the
+# board_pins config section name then it defaults to "mcu".)
+#[board_pins mcu]
+#aliases:
+#   A comma separated list of "name=value" aliases to create for the
+#   given micro-controller. For example, "EXP1_1=PE6" would create an
+#   "EXP1_1" alias for the "PE6" pin. However, if "value" is enclosed
+#   in "<>" then "name" is created as a reserved pin (for example,
+#   "EXP1_9=<GND>" would reserve "EXP1_9"). This parameter must be
+#   provided.
+
+
 # Support for a display attached to the micro-controller.
 #[display]
 #lcd_type:

--- a/config/generic-bigtreetech-skr-v1.3.cfg
+++ b/config/generic-bigtreetech-skr-v1.3.cfg
@@ -134,9 +134,9 @@ max_z_accel: 100
 
 #[tmc2130 stepper_x]
 #cs_pin: P1.17
-#spi_software_sclk_pin: P0.4
-#spi_software_mosi_pin: P4.28
 #spi_software_miso_pin: P0.5
+#spi_software_mosi_pin: P4.28
+#spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.29
 #microsteps: 16
 #run_current: 0.800
@@ -145,9 +145,9 @@ max_z_accel: 100
 
 #[tmc2130 stepper_y]
 #cs_pin: P1.15
-#spi_software_sclk_pin: P0.4
-#spi_software_mosi_pin: P4.28
 #spi_software_miso_pin: P0.5
+#spi_software_mosi_pin: P4.28
+#spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.27
 #microsteps: 16
 #run_current: 0.800
@@ -156,9 +156,9 @@ max_z_accel: 100
 
 #[tmc2130 stepper_z]
 #cs_pin: P1.10
-#spi_software_sclk_pin: P0.4
-#spi_software_mosi_pin: P4.28
 #spi_software_miso_pin: P0.5
+#spi_software_mosi_pin: P4.28
+#spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.25
 #microsteps: 16
 #run_current: 0.650
@@ -167,9 +167,9 @@ max_z_accel: 100
 
 #[tmc2130 extruder]
 #cs_pin: P1.8
-#spi_software_sclk_pin: P0.4
-#spi_software_mosi_pin: P4.28
 #spi_software_miso_pin: P0.5
+#spi_software_mosi_pin: P4.28
+#spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.28
 #microsteps: 16
 #run_current: 0.800
@@ -178,9 +178,9 @@ max_z_accel: 100
 
 #[tmc2130 extruder1]
 #cs_pin: P1.1
-#spi_software_sclk_pin: P0.4
-#spi_software_mosi_pin: P4.28
 #spi_software_miso_pin: P0.5
+#spi_software_mosi_pin: P4.28
+#spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.26
 #microsteps: 16
 #run_current: 0.800
@@ -189,63 +189,17 @@ max_z_accel: 100
 
 
 ########################################
-# Optional LCD configuration
+# EXP1 / EXP2 (display) pins
 ########################################
 
-# "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
-#[display]
-#lcd_type: st7920
-#cs_pin: P1.19
-#sclk_pin: P1.20
-#sid_pin: P1.18
-#encoder_pins: ^P3.26, ^P3.25
-#click_pin: ^!P0.28
-#
-#[output_pin beeper]
-#pin: P1.30
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=P1.30, EXP1_3=P1.18, EXP1_5=P1.20, EXP1_7=P1.22, EXP1_9=<GND>,
+    EXP1_2=P0.28, EXP1_4=P1.19, EXP1_6=P1.21, EXP1_8=P1.23, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=P0.17, EXP2_3=P3.26, EXP2_5=P3.25, EXP2_7=P1.31, EXP2_9=<GND>,
+    EXP2_2=P0.15, EXP2_4=P0.16, EXP2_6=P0.18, EXP2_8=<RST>, EXP2_10=<NC>
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "ssp0"
 
-# "RepRapDiscount 2004 Smart Controller" type displays
-#[display]
-#lcd_type: hd44780
-#rs_pin: P1.19
-#e_pin: P1.18
-#d4_pin: P1.20
-#d5_pin: P1.21
-#d6_pin: P1.22
-#d7_pin: P1.23
-#encoder_pins: ^P3.26, ^P3.25
-#click_pin: ^!P0.28
-#
-#[output_pin beeper]
-#pin: P1.30
-
-# 128x64 Full Graphic Creality CR10 / ENDER 3 stockdisplay
-#[display]
-#lcd_type: st7920
-#cs_pin: P1.19
-#sclk_pin: P1.21
-#sid_pin: P1.23
-#encoder_pins: ^P1.18, ^P1.20
-#click_pin: !P0.28
-#
-#[output_pin beeper]
-#pin: P1.30
-
-# MKS Mini 12864 LCD.
-# Make sure that the EXP1 and EXP2 are rotated correctly on the
-# display board. The cutouts on the connectors should be towards the
-# center of the PCB. See:
-#   https://reprap.org/wiki/MKS_MINI_12864#Physical_Interface
-# If they are wrong, the connector housing can be pried off carefully
-# with a small screwdriver and relocated the correct way.
-#
-#[display]
-#lcd_type: uc1701
-#cs_pin: P1.21
-#a0_pin: P1.22
-#contrast: 40
-#encoder_pins: ^P3.25, ^P3.26
-#click_pin: ^!P0.28
-#
-#[output_pin beeper]
-#pin: P1.30
+# See the sample-lcd.cfg file for definitions of common LCD displays.

--- a/config/generic-duet2-maestro.cfg
+++ b/config/generic-duet2-maestro.cfg
@@ -134,14 +134,15 @@ max_z_accel: 100
 [static_digital_output led]
 pins: !PC26
 
-# "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
-#[display]
-#lcd_type: st7920
-#cs_pin: PC9
-#sclk_pin: PA2
-#sid_pin: PA6
-#encoder_pins: ^PC3, ^PB5
-#click_pin: ^!PA7
-#
-#[output_pin BEEPER_pin]
-#pin: PA15
+# EXP1 / EXP2 (display) pins
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=PA15, EXP1_3=PA6, EXP1_5=PA2,  EXP1_7=<NC>, EXP1_9=<GND>,
+    EXP1_2=PA7,  EXP1_4=PC9, EXP1_6=<NC>, EXP1_8=<NC>, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PA5, EXP2_3=PC3,  EXP2_5=PB5, EXP2_7=<NC>,  EXP2_9=<GND>,
+    EXP2_2=PA2, EXP2_4=PB13, EXP2_6=PA6, EXP2_8=<RST>, EXP2_10=<NC>
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "usart0"
+
+# See the sample-lcd.cfg file for definitions of common LCD displays.

--- a/config/generic-rambo.cfg
+++ b/config/generic-rambo.cfg
@@ -108,19 +108,15 @@ pins:
 [static_digital_output yellow_led]
 pins: !PB7
 
-# "RepRapDiscount 2004 Smart Controller" type displays
-#[display]
-#lcd_type: hd44780
-#rs_pin: PG4
-#e_pin: PG3
-#d4_pin: PJ2
-#d5_pin: PJ3
-#d6_pin: PJ7
-#d7_pin: PJ4
+# Common EXP1 / EXP2 (display) pins
+[board_pins]
+aliases:
+    # Common EXP1/EXP2 headers found on RAMBo v1.4
+    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
+    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
 
-# "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
-#[display]
-#lcd_type: st7920
-#cs_pin: PG4
-#sclk_pin: PJ2
-#sid_pin: PG3
+# See the sample-lcd.cfg file for definitions of common LCD displays.

--- a/config/generic-ramps.cfg
+++ b/config/generic-ramps.cfg
@@ -83,33 +83,16 @@ max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
 
-# "RepRapDiscount 2004 Smart Controller" type displays
-#[display]
-#lcd_type: hd44780
-#rs_pin: ar16
-#e_pin: ar17
-#d4_pin: ar23
-#d5_pin: ar25
-#d6_pin: ar27
-#d7_pin: ar29
-#encoder_pins: ^ar31, ^ar33
-#click_pin: ^!ar35
+# Common EXP1 / EXP2 (display) pins
+[board_pins]
+aliases:
+    # Common EXP1 header found on many "all-in-one" ramps clones
+    EXP1_1=ar37, EXP1_3=ar17, EXP1_5=ar23, EXP1_7=ar27, EXP1_9=<GND>,
+    EXP1_2=ar35, EXP1_4=ar16, EXP1_6=ar25, EXP1_8=ar29, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=ar50, EXP2_3=ar31, EXP2_5=ar33, EXP2_7=ar49, EXP2_9=<GND>,
+    EXP2_2=ar52, EXP2_4=ar53, EXP2_6=ar51, EXP2_8=ar41, EXP2_10=<RST>
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
+    # Note, some boards wire: EXP2_8=<RST>, EXP2_10=ar41
 
-# "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
-#[display]
-#lcd_type: st7920
-#cs_pin: ar16
-#sclk_pin: ar23
-#sid_pin: ar17
-#encoder_pins: ^ar31, ^ar33
-#click_pin: ^!ar35
-#kill_pin: ^!ar41
-
-# 128x64 Full Graphic Creality CR10 / ENDER 3 stockdisplay
-#[display]
-#lcd_type: st7920
-#cs_pin: ar27
-#sclk_pin: ar25
-#sid_pin: ar29
-#encoder_pins: ^ar23, ^ar17
-#click_pin: ^!ar35
+# See the sample-lcd.cfg file for definitions of common LCD displays.

--- a/config/sample-lcd.cfg
+++ b/config/sample-lcd.cfg
@@ -1,0 +1,91 @@
+# This file provides example configuration for common "RepRap" style
+# LCD displays that use EXP1/EXP2 plugs.
+#
+# To configure a display from this file, make sure the main
+# printer.cfg file has a [board_pins] config section defining pin
+# aliases for the EXP1/EXP2 plugs, find the appropriate LCD type in
+# this file, and then copy-and-paste that section into printer.cfg.
+#
+# See the "example-extras.cfg" file for description of config parameters.
+
+
+######################################################################
+# "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
+######################################################################
+
+[display]
+lcd_type: st7920
+cs_pin: EXP1_4
+sclk_pin: EXP1_5
+sid_pin: EXP1_3
+encoder_pins: ^EXP2_3, ^EXP2_5
+click_pin: ^!EXP1_2
+#kill_pin: ^!EXP2_8
+
+[output_pin beeper]
+pin: EXP1_1
+
+
+######################################################################
+# "RepRapDiscount 2004 Smart Controller" type displays
+######################################################################
+
+[display]
+lcd_type: hd44780
+rs_pin: EXP1_4
+e_pin: EXP1_3
+d4_pin: EXP1_5
+d5_pin: EXP1_6
+d6_pin: EXP1_7
+d7_pin: EXP1_8
+encoder_pins: ^EXP2_3, ^EXP2_5
+click_pin: ^!EXP1_2
+#kill_pin: ^!EXP2_8
+
+[output_pin beeper]
+pin: EXP1_1
+
+
+######################################################################
+# 128x64 Full Graphic Creality CR10 / ENDER 3 stockdisplay
+######################################################################
+
+[display]
+lcd_type: st7920
+cs_pin: EXP1_7
+sclk_pin: EXP1_6
+sid_pin: EXP1_8
+encoder_pins: ^EXP1_5, ^EXP1_3
+click_pin: ^!EXP1_2
+
+[output_pin beeper]
+pin: EXP1_1
+
+
+######################################################################
+# MKS Mini 12864 LCD
+######################################################################
+
+# Make sure that the EXP1 and EXP2 are rotated correctly on the
+# display board. The cutouts on the connectors should be towards the
+# center of the PCB. See:
+#   https://reprap.org/wiki/MKS_MINI_12864#Physical_Interface
+# If they are wrong, the connector housing can be pried off carefully
+# with a small screwdriver and relocated the correct way.
+
+[display]
+lcd_type: uc1701
+cs_pin: EXP1_6
+a0_pin: EXP1_7
+contrast: 40
+encoder_pins: ^EXP2_3, ^EXP2_5
+click_pin: ^!EXP1_2
+## Some micro-controller boards may require an spi bus to be specified:
+#spi_bus: spi
+## Alternatively, some micro-controller boards may work with software spi:
+#spi_software_miso_pin: EXP2_1
+#spi_software_mosi_pin: EXP2_6
+#spi_software_sclk_pin: EXP2_2
+
+[output_pin beeper]
+pin: EXP1_1

--- a/klippy/console.py
+++ b/klippy/console.py
@@ -38,7 +38,7 @@ class KeyboardReader:
         self.fd = sys.stdin.fileno()
         util.set_nonblock(self.fd)
         self.mcu_freq = 0
-        self.pins = None
+        self.pins = pins.PinResolver({}, validate_aliases=False)
         self.data = ""
         reactor.register_fd(self.fd, self.process_kbd)
         reactor.register_callback(self.connect)
@@ -63,8 +63,6 @@ class KeyboardReader:
         self.ser.handle_default = self.handle_default
         self.ser.register_response(self.handle_output, '#output')
         self.mcu_freq = msgparser.get_constant_float('CLOCK_FREQ')
-        mcu_type = msgparser.get_constant('MCU')
-        self.pins = pins.PinResolver(mcu_type, {}, validate_aliases=False)
         self.output("="*20 + "       connected       " + "="*20)
         return self.reactor.NEVER
     def output(self, msg):
@@ -83,7 +81,8 @@ class KeyboardReader:
         self.eval_globals['freq'] = self.mcu_freq
         self.eval_globals['clock'] = self.clocksync.get_clock(eventtime)
     def command_PINS(self, parts):
-        self.pins.update_aliases(parts[1])
+        mcu_type = self.ser.get_msgparser().get_constant('MCU')
+        self.pins.add_pin_mapping(mcu_type, parts[1])
     def command_SET(self, parts):
         val = parts[2]
         try:
@@ -164,12 +163,11 @@ class KeyboardReader:
                 return None
             line = ''.join(evalparts)
             self.output("Eval: %s" % (line,))
-        if self.pins is not None:
-            try:
-                line = self.pins.update_command(line).strip()
-            except:
-                self.output("Unable to map pin: %s" % (line,))
-                return None
+        try:
+            line = self.pins.update_command(line).strip()
+        except:
+            self.output("Unable to map pin: %s" % (line,))
+            return None
         if line:
             parts = line.split()
             if parts[0] in self.local_commands:

--- a/klippy/extras/board_pins.py
+++ b/klippy/extras/board_pins.py
@@ -1,0 +1,24 @@
+# Support for custom board pin aliases
+#
+# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+class PrinterBoardAliases:
+    def __init__(self, config, chip_name):
+        ppins = config.get_printer().lookup_object('pins')
+        pin_resolver = ppins.get_pin_resolver(chip_name)
+        aliases = config.get("aliases")
+        parts = [a.split('=', 1) for a in aliases.split(',')]
+        for name, value in parts:
+            name, value = name.strip(), value.strip()
+            if value.startswith('<') and value.endswith('>'):
+                pin_resolver.reserve_pin(name, value)
+            else:
+                pin_resolver.alias_pin(name, value)
+
+def load_config(config):
+    return PrinterBoardAliases(config, "mcu")
+
+def load_config_prefix(config):
+    return PrinterBoardAliases(config, config.get_name().split()[1])

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -26,9 +26,10 @@ def resolve_bus_name(mcu, param, bus):
     # Check for reserved bus pins
     constants = mcu.get_constants()
     reserve_pins = constants.get('BUS_PINS_%s' % (bus,), None)
+    pin_resolver = ppins.get_pin_resolver(mcu_name)
     if reserve_pins is not None:
         for pin in reserve_pins.split(','):
-            ppins.reserve_pin(mcu_name, pin, bus)
+            pin_resolver.reserve_pin(pin, bus)
     return bus
 
 

--- a/klippy/extras/replicape.py
+++ b/klippy/extras/replicape.py
@@ -128,8 +128,9 @@ class servo_pwm:
         pru_mcu = replicape.mcu_pwm_enable.get_mcu()
         printer = pru_mcu.get_printer()
         ppins = printer.lookup_object('pins')
-        ppins.reserve_pin(pru_mcu.get_name(), resv1, config_name)
-        ppins.reserve_pin(pru_mcu.get_name(), resv2, config_name)
+        pin_resolver = ppins.get_pin_resolver(pru_mcu.get_name())
+        pin_resolver.reserve_pin(resv1, config_name)
+        pin_resolver.reserve_pin(resv2, config_name)
     def setup_cycle_time(self, cycle_time, hardware_pwm=False):
         self.mcu_pwm.setup_cycle_time(cycle_time, True);
 

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -568,10 +568,9 @@ class MCU:
         # Resolve pin names
         mcu_type = self._serial.get_msgparser().get_constant('MCU')
         ppins = self._printer.lookup_object('pins')
-        reserved_pins = ppins.get_reserved_pins(self._name)
-        pin_resolver = pins.PinResolver(mcu_type, reserved_pins)
+        pin_resolver = ppins.get_pin_resolver(self._name)
         if self._pin_map is not None:
-            pin_resolver.update_aliases(self._pin_map)
+            pin_resolver.add_pin_mapping(mcu_type, self._pin_map)
         for i, cmd in enumerate(self._config_cmds):
             self._config_cmds[i] = pin_resolver.update_command(cmd)
         for i, cmd in enumerate(self._init_cmds):
@@ -651,10 +650,11 @@ class MCU:
                 ["%s=%s" % (k, v) for k, v in self.get_constants().items()]))]
         logging.info("\n".join(log_info))
         ppins = self._printer.lookup_object('pins')
+        pin_resolver = ppins.get_pin_resolver(name)
         for cname, value in self.get_constants().items():
             if cname.startswith("RESERVE_PINS_"):
                 for pin in value.split(','):
-                    ppins.reserve_pin(name, pin, cname[13:])
+                    pin_resolver.reserve_pin(pin, cname[13:])
         self._mcu_freq = self.get_constant_float('CLOCK_FREQ')
         self._stats_sumsq_base = self.get_constant_float('STATS_SUMSQ_BASE')
         self._emergency_stop_cmd = self.lookup_command("emergency_stop")

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -151,17 +151,21 @@ def get_aliases_beaglebone(mcu):
 re_pin = re.compile(r'(?P<prefix>[ _]pin=)(?P<name>[^ ]*)')
 
 class PinResolver:
-    def __init__(self, mcu_type, reserved_pins, validate_aliases=True):
-        self.mcu_type = mcu_type
-        self.reserved_pins = reserved_pins
+    def __init__(self, validate_aliases=True):
         self.validate_aliases = validate_aliases
+        self.reserved = {}
         self.aliases = {}
         self.active_pins = {}
-    def update_aliases(self, mapping_name):
+    def reserve_pin(self, pin, reserve_name):
+        if pin in self.reserved and self.reserved[pin] != reserve_name:
+            raise error("Pin %s reserved for %s - can't reserve for %s" % (
+                pin, self.reserved[pin], reserve_name))
+        self.reserved[pin] = reserve_name
+    def add_pin_mapping(self, mcu_type, mapping_name):
         if mapping_name == 'arduino':
-            self.aliases = get_aliases_arduino(self.mcu_type)
+            self.aliases = get_aliases_arduino(mcu_type)
         elif mapping_name == 'beaglebone':
-            self.aliases = get_aliases_beaglebone(self.mcu_type)
+            self.aliases = get_aliases_beaglebone(mcu_type)
         else:
             raise error("Unknown pin alias mapping '%s'" % (mapping_name,))
     def update_command(self, cmd):
@@ -172,9 +176,9 @@ class PinResolver:
                 and self.validate_aliases):
                 raise error("pin %s is an alias for %s" % (
                     name, self.active_pins[pin_id]))
-            if pin_id in self.reserved_pins:
+            if pin_id in self.reserved:
                 raise error("pin %s is reserved for %s" % (
-                    name, self.reserved_pins[pin_id]))
+                    name, self.reserved[pin_id]))
             return m.group('prefix') + str(pin_id)
         return re_pin.sub(pin_fixup, cmd)
 
@@ -188,7 +192,7 @@ class PrinterPins:
     def __init__(self):
         self.chips = {}
         self.active_pins = {}
-        self.reserved_pins = {}
+        self.pin_resolvers = {}
     def parse_pin(self, pin_desc, can_invert=False, can_pullup=False):
         desc = pin_desc.strip()
         pullup = invert = 0
@@ -242,19 +246,16 @@ class PrinterPins:
     def reset_pin_sharing(self, pin_params):
         share_name = "%s:%s" % (pin_params['chip_name'], pin_params['pin'])
         del self.active_pins[share_name]
-    def reserve_pin(self, chip_name, pin, reserve_name):
-        chip_reserve = self.reserved_pins.setdefault(chip_name, {})
-        if pin in chip_reserve and chip_reserve[pin] != reserve_name:
-            raise error("Pin %s:%s reserved for %s - can't reserve for %s" % (
-                chip_name, pin, chip_reserve[pin], reserve_name))
-        chip_reserve[pin] = reserve_name
-    def get_reserved_pins(self, chip_name):
-        return self.reserved_pins.get(chip_name, {})
+    def get_pin_resolver(self, chip_name):
+        if chip_name not in self.pin_resolvers:
+            raise error("Unknown chip name '%s'" % (chip_name,))
+        return self.pin_resolvers[chip_name]
     def register_chip(self, chip_name, chip):
         chip_name = chip_name.strip()
         if chip_name in self.chips:
             raise error("Duplicate chip name '%s'" % (chip_name,))
         self.chips[chip_name] = chip
+        self.pin_resolvers[chip_name] = PinResolver()
 
 def add_printer_objects(config):
     config.get_printer().add_object('pins', PrinterPins())

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -161,13 +161,25 @@ class PinResolver:
             raise error("Pin %s reserved for %s - can't reserve for %s" % (
                 pin, self.reserved[pin], reserve_name))
         self.reserved[pin] = reserve_name
+    def alias_pin(self, alias, pin):
+        if alias in self.aliases and self.aliases[alias] != pin:
+            raise error("Alias %s mapped to %s - can't alias to %s" % (
+                alias, self.aliases[alias], pin))
+        if pin in self.aliases:
+            pin = self.aliases[pin]
+        self.aliases[alias] = pin
+        for existing_alias, existing_pin in self.aliases.items():
+            if existing_pin == alias:
+                self.aliases[existing_alias] = pin
     def add_pin_mapping(self, mcu_type, mapping_name):
         if mapping_name == 'arduino':
-            self.aliases = get_aliases_arduino(mcu_type)
+            pin_mapping = get_aliases_arduino(mcu_type)
         elif mapping_name == 'beaglebone':
-            self.aliases = get_aliases_beaglebone(mcu_type)
+            pin_mapping = get_aliases_beaglebone(mcu_type)
         else:
             raise error("Unknown pin alias mapping '%s'" % (mapping_name,))
+        for alias, pin in pin_mapping.items():
+            self.alias_pin(alias, pin)
     def update_command(self, cmd):
         def pin_fixup(m):
             name = m.group('name')


### PR DESCRIPTION
This is a proposal to add a module for generic board specific pin aliases.  This also updates a few config files to use these aliases for defining the EXP1/EXP2 lcd display adapter plugs.

It's becoming increasingly difficult to track all the various LCD configurations.  It is hoped that adding aliases may make this a little easier.

@FHeilmann - FYI - this is very similar to your past PR #848.

Feedback welcome.
-Kevin