### PR TITLE
stm32f4: Add Support for BIQU SKR-PRO 

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -66,11 +66,13 @@ config STACK_SIZE
     default 512
 
 choice
-    prompt "Bootloader offset" if MACH_STM32F103
+    prompt "Bootloader offset" if MACH_STM32F103 || MACH_STM32F4
     config STM32_FLASH_START_2000
         bool "8KiB bootloader (stm32duino)"
     config STM32_FLASH_START_7000
         bool "28KiB bootloader"
+    config STM32_FLASH_START_8000
+        bool "32KiB bootloader (SKR-PRO)"
     config STM32_FLASH_START_0000
         bool "No bootloader"
 endchoice
@@ -78,6 +80,7 @@ config FLASH_START
     hex
     default 0x2000 if STM32_FLASH_START_2000
     default 0x7000 if STM32_FLASH_START_7000
+    default 0x8000 if STM32_FLASH_START_8000
     default 0x0000
 
 choice

--- a/src/stm32/serial.c
+++ b/src/stm32/serial.c
@@ -26,12 +26,21 @@ DECL_CONSTANT_STR("RESERVE_PINS_serial", "PA3,PA2");
 #define USARTx_IRQn USART2_IRQn
 #define USARTx_IRQHandler USART2_IRQHandler
 #else
+#if CONFIG_MACH_STM32F407
+DECL_CONSTANT_STR("RESERVE_PINS_serial", "PD9,PD8");
+#define GPIO_Rx GPIO('D', 9)
+#define GPIO_Tx GPIO('D', 8)
+#define USARTx USART3
+#define USARTx_IRQn USART3_IRQn
+#define USARTx_IRQHandler USART3_IRQHandler
+#else
 DECL_CONSTANT_STR("RESERVE_PINS_serial", "PB11,PB10");
 #define GPIO_Rx GPIO('B', 11)
 #define GPIO_Tx GPIO('B', 10)
 #define USARTx USART3
 #define USARTx_IRQn USART3_IRQn
 #define USARTx_IRQHandler USART3_IRQHandler
+#endif
 #endif
 
 #define CR1_FLAGS (USART_CR1_UE | USART_CR1_RE | USART_CR1_TE   \


### PR DESCRIPTION
This pull request adds support for the SKR-PRO-V1.1 Board 

I've just added an option for the pre installed 32KiB bootloader and changed the Pins for the 3rd UART.
Tested on my own SKR-PRO.

Signed-off-by: Gerrit Sturm <gsturm16@gmail.com>