### PR TITLE
Add min_power option for fans

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -259,6 +259,19 @@ pin: ar9
 #kick_start_time: 0.100
 #   Time (in seconds) to run the fan at full speed when first enabling
 #   it (helps get the fan spinning). The default is 0.100 seconds.
+#off_below: 0.0
+#   The minimum input speed which will power the fan (expressed as a
+#   value from 0.0 to 1.0). When a speed lower than off_below is
+#   requested the fan will instead be turned off. This setting may be
+#   used to prevent fan stalls and to ensure kick starts are
+#   effective. The default is 0.0.
+#
+#   This setting should be recalibrated whenever max_power is adjusted.
+#   To calibrate this setting, start with off_below set to 0.0 and the
+#   fan spinning. Gradually lower the fan speed to determine the lowest
+#   input speed which reliably drives the fan without stalls. Set
+#   off_below to the duty cycle corresponding to this value (for
+#   example, 12% -> 0.12) or slightly higher.
 
 # Micro-controller information.
 [mcu]

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -16,6 +16,8 @@ class PrinterFan:
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
         self.kick_start_time = config.getfloat('kick_start_time', 0.1,
                                                minval=0.)
+        self.off_below = config.getfloat(
+            'off_below', default=0., minval=0., maxval=1.)
         ppins = printer.lookup_object('pins')
         self.mcu_fan = ppins.setup_pin('pwm', config.get('pin'))
         self.mcu_fan.setup_max_duration(0.)
@@ -29,6 +31,8 @@ class PrinterFan:
     def handle_request_restart(self, print_time):
         self.set_speed(print_time, 0.)
     def set_speed(self, print_time, value):
+        if value < self.off_below:
+            value = 0.
         value = max(0., min(self.max_power, value * self.max_power))
         if value == self.last_fan_value:
             return


### PR DESCRIPTION
Below min_power the fan will be turned off. When configured correctly this
can prevent stalling, which may lead to overheating and failed fans.

Signed-off-by: Nicholas Seckar <nseckar@gmail.com>