### PR TITLE
Document SKR Mini E3 USB pin Requirements

### DIFF
--- a/config/generic-bigtreetech-skr-mini-e3.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3.cfg
@@ -16,7 +16,7 @@ step_pin: PB13
 dir_pin: PB12
 enable_pin: !PB14
 step_distance: .0025
-endstop_pin: PC0
+endstop_pin: ^!PC0
 position_endstop: 0
 position_max: 200
 homing_speed: 50
@@ -35,7 +35,7 @@ step_pin: PB10
 dir_pin: PB2
 enable_pin: !PB11
 step_distance: .0025
-endstop_pin: PC1
+endstop_pin: ^!PC1
 position_endstop: 0
 position_max: 200
 homing_speed: 50
@@ -54,7 +54,7 @@ step_pin: PB0
 dir_pin: PC5
 enable_pin: !PB1
 step_distance: .0125
-endstop_pin: PC2
+endstop_pin: ^!PC2
 position_endstop: 0.5
 position_max: 200
 

--- a/config/generic-bigtreetech-skr-mini-e3.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3.cfg
@@ -1,6 +1,8 @@
 # This file contains common pin mappings for the BIGTREETECH SKR mini
 # E3. To use this config, the firmware should be compiled for the
-# STM32F103 with a "28KiB bootloader".
+# STM32F103 with a "28KiB bootloader". The 'GPIO pins to set at
+# micro-controller startup' option must also include '!PC13' otherwise the
+# USB connection will be unreliable.
 
 # The "make flash" command does not work on the SKR mini E3. Instead,
 # after running "make", copy the generated "out/klipper.bin" file to a


### PR DESCRIPTION
The SKR Mini E3 must have PC13 set to output low at startup to properly initialise the USB connection, this is mentioned in [this comment](https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3-/issues/2#issuecomment-513149032) on the the SKR mini e3 github, and fixed in [PR  #14679](https://github.com/MarlinFirmware/Marlin/pull/14679) in marlin.