### PR TITLE
Fix order of gpio registers in gpio_out_reset

### DIFF
--- a/src/lpc176x/gpio.c
+++ b/src/lpc176x/gpio.c
@@ -80,12 +80,12 @@ gpio_out_reset(struct gpio_out g, uint8_t val)
     LPC_GPIO_TypeDef *regs = g.regs;
     int pin = regs_to_pin(regs, g.bit);
     irqstatus_t flag = irq_save();
+    gpio_peripheral(pin, 0, 0);
+    regs->FIODIR |= g.bit;
     if (val)
         regs->FIOSET = g.bit;
     else
         regs->FIOCLR = g.bit;
-    regs->FIODIR |= g.bit;
-    gpio_peripheral(pin, 0, 0);
     irq_restore(flag);
 }
 


### PR DESCRIPTION
I am testing klipper and I recently switched over from an old MKS board to a newer SKR 1.3 board. I noticed a minor annoyance with the beeper on my LCD 2004 board. Afaik the default for LPC176x GPIO pins is input mode with pull-up resistors enabled. This can cause whining or fully enable the beeper on power on (and during reset) depending on conditions until the connection with Klippy is (re)established. 

The correct solution is to add an external pull-down resistor to the appropriate place on the LCD board. That is quite a lot of work however so I thought a quick fix would be to use the GPIO facility in the firmware configuration. The correct string to switch the beeper pin to output mode / low is `!P1.30`
This however does not work and appears to crash the LPC1768 as the RasPi then posts an error when trying to connect the USB and the beeper pin also remains high.

Searching online it appears the correct order should be as given in this pull request. I have tested this and can confirm the beeper is fully disabled after a brief period (it seems to go high briefly when switching mode). I have also completed a few test prints which have completed correctly with this patch in operation. I can also confirm that FIODIR needs to be set before FIOCLR even if gpio_peripheral is moved up. It appears that trying to access FIOCLR before setting the relevant bit in FIODIR causes the issue. As it appears this could cause potential problems setting up the output pins I believe it should be considered for inclusion.