### PR TITLE
Fix the exception raised when an included file is missing

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -164,7 +164,7 @@ class PrinterConfig:
         include_filenames = glob.glob(include_glob)
         if not include_filenames and not glob.has_magic(include_glob):
             # Empty set is OK if wildcard but not for direct file reference
-            raise error("Include file '%s' does not exist", include_glob)
+            raise error("Include file '%s' does not exist" % (include_glob,))
         include_filenames.sort()
         for include_filename in include_filenames:
             include_data = self._read_config_file(include_filename)


### PR DESCRIPTION
module: CONFIGFILE, Fixes the error raised when including a missing file

**before:**

```python
Unhandled exception during connect
(...)
  File "/home/pi/klipper/klippy/configfile.py", line 167, in _resolve_include
    raise error("Include file '%s' does not exist", include_glob)
TypeError: __init__() takes at most 2 arguments (3 given)
Internal error during connect: __init__() takes at most 2 arguments (3 given)
```

**after:**

```
Config error
(...)
  File "/home/pi/klipper-dev/klippy/configfile.py", line 167, in _resolve_include
    raise error("Include file '%s' does not exist" % (include_glob,))
Error: Include file '/home/pi/missing_file.cfg' does not exist
```

Signed-off-by: Julien Lirochon <julien@lirochon.net>