### PR TITLE
filament_switch_sensor: Add delay after pause dispatch

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1683,6 +1683,11 @@
 #   The minimum amount of time in seconds to delay between events.
 #   Events triggered during this time period will be silently
 #   ignored. The default is 3 seconds.
+#pause_delay: 0.5
+#   The amount of time to delay, in seconds, between the pause command
+#   dispatch and execution of the runout_gcode.  It may be useful to
+#   increase this delay if Octoprint exhibits strange pause behavior.
+#   Default is 0.5 seconds.
 #switch_pin:
 #   The pin on which the switch is connected. This parameter must be
 #   provided.

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -21,6 +21,7 @@ class BaseSensor(object):
         if config.get('insert_gcode', None) is not None:
             self.insert_gcode = gcode_macro.load_template(
                 config, 'insert_gcode')
+        self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
         self.runout_enabled = False
         self.insert_enabled = self.insert_gcode is not None
         self.event_running = False
@@ -52,6 +53,7 @@ class BaseSensor(object):
             pause_resume = self.printer.lookup_object('pause_resume')
             pause_resume.send_pause_command()
             pause_prefix = "PAUSE\n"
+            self.printer.get_reactor().pause(eventtime + self.pause_delay)
         self._exec_gcode(pause_prefix, self.runout_gcode)
         self.event_running = False
     def _insert_event_handler(self, eventtime):


### PR DESCRIPTION
This patch adds a configurable delay between dispatch of the pause command and execution of the runout_gcode.  This delay should eliminate a possible race condition in the event that the switch is triggered just after Klipper acknowledges a move.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>