### PR TITLE
bed_mesh: account for probe offsets when generating points [WIP]

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -164,21 +164,24 @@
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-#bed_radius:
-#   Defines the radius to probe for round beds.  Note that the radius
-#   is relative to the nozzle's origin, if using a probe be sure to
-#   account for its offset.  This parameter must be provided for round
-#   beds and omitted for rectangular beds.
-#min_point:
-#   Defines the minimum x,y position to probe when for rectangular
-#   beds. Note that this refers to the nozzle position, take care that
-#   you do not define a point that will move the probe off of the bed.
-#   This parameter must be provided for rectangular beds.
-#max_point:
-#   Defines the maximum x,y position to probe when for rectangular
-#   beds. Follow the same precautions as listed in min_point. Also note
-#   that this does not necessarily define the last point probed, only
-#   the maximum coordinate. This parameter must be provided.
+#mesh_radius:
+#   Defines the radius of the mesh for round beds. This parameter must
+#   be provided for round beds and omitted for rectangular beds.
+#mesh_origin: 0, 0
+#   Defines the origin of the round mesh for round beds.  If using a probe,
+#   this coordinate will be probed at the center of the mesh.  Default is
+#   0, 0.
+#mesh_min:
+#   Defines the minimum x,y coordinate of the mesh for rectangular beds.
+#   If using a probe, this will be the first probed coordinate.  Note that
+#   your defined probe offsets will be used to determine the correct nozzle
+#   position, be sure that you don't chose a coordinate that the nozzle
+#   cannot reach. This parameter must be provided for rectangular beds.
+#mesh_max:
+#   Defines the maximum x,y coordinate of the mesh for rectangular beds.  As
+#   with mesh_min, the correct nozzle position will be calculated using your
+#   defined offsets if using a probe. This parameter must be provided for
+#   rectangular beds.
 #probe_count: 3,3
 #   For rectangular beds, this is a comma separate pair of integer
 #   values (X,Y) defining the number of points to probe along each axis.

--- a/config/kit-zav3d-2019.cfg
+++ b/config/kit-zav3d-2019.cfg
@@ -129,8 +129,8 @@ sample_retract_dist: 3.0
 [bed_mesh]
 speed: 100
 horizontal_move_z: 5
-min_point: 30,30
-max_point: 150,150
+mesh_min: 69,41
+mesh_max: 189,161
 probe_count: 3,3
 
 [homing_override]

--- a/config/printer-tevo-flash-2018.cfg
+++ b/config/printer-tevo-flash-2018.cfg
@@ -119,6 +119,6 @@ gcode:
 
 # Mesh Bed Leveling.
 [bed_mesh]
-min_point: 5,0
-max_point: 230,210
+mesh_min: 5,18
+mesh_max: 230,228
 probe_count: 9,9

--- a/config/printer-wanhao-duplicator-i3-plus-mark2-2019.cfg
+++ b/config/printer-wanhao-duplicator-i3-plus-mark2-2019.cfg
@@ -76,6 +76,6 @@ max_z_velocity: 5
 max_z_accel: 100
 
 [bed_mesh]
-min_point: 20,20
-max_point: 190,130
+mesh_min: 20,20
+mesh_max: 190,130
 probe_count: 4,4

--- a/config/sample-probe-as-z-endstop.cfg
+++ b/config/sample-probe-as-z-endstop.cfg
@@ -46,6 +46,6 @@ points:
 
 # Example bed_mesh config section
 [bed_mesh]
-min_point: 20,20
-max_point: 200,200
+mesh_min: 20,20
+mesh_max: 200,200
 probe_count: 4,4

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -303,8 +303,11 @@ section is enabled:
   specified then the manual probing tool is activated - see the
   MANUAL_PROBE command above for details on the additional commands
   available while this tool is active.
-- `BED_MESH_OUTPUT`: This command outputs the current probed z values
-  and current mesh values to the terminal.
+- `BED_MESH_OUTPUT [PGP=<0|1>]`: This command outputs the current
+  probed z values and current mesh values to the terminal. If PGP
+  (Print Generated Points) is set to a non-zero value, then all
+  generated points and their associated indices will be output to
+  the terminal.
 - `BED_MESH_MAP`: This command probes the bed in a similar fashion
   to BED_MESH_CALIBRATE, however no mesh is generated.  Instead,
   the probed z values are serialized to json and output to the

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -290,6 +290,8 @@ class ProbePointsHelper:
         if len(self.probe_points) < n:
             raise self.printer.config_error(
                 "Need at least %d probe points for %s" % (n, self.name))
+    def set_points(self, points):
+        self.probe_points = points
     def get_lift_speed(self):
         return self.lift_speed
     def _move_next(self):

--- a/test/klippy/bltouch.cfg
+++ b/test/klippy/bltouch.cfg
@@ -58,8 +58,8 @@ control_pin: ar32
 z_offset: 1.15
 
 [bed_mesh]
-min_point: 10,10
-max_point: 180,180
+mesh_min: 10,10
+mesh_max: 180,180
 
 [mcu]
 serial: /dev/ttyACM0

--- a/test/klippy/screws_tilt_adjust.cfg
+++ b/test/klippy/screws_tilt_adjust.cfg
@@ -61,8 +61,8 @@ sample_retract_dist: 2.
 samples_result: median
 
 [bed_mesh]
-min_point: 10,10
-max_point: 180,180
+mesh_min: 10,10
+mesh_max: 180,180
 
 [mcu]
 serial: /dev/ttyACM0

--- a/test/klippy/z_virtual_endstop.cfg
+++ b/test/klippy/z_virtual_endstop.cfg
@@ -57,8 +57,8 @@ pin: ar9
 z_offset: 1.15
 
 [bed_mesh]
-min_point: 10,10
-max_point: 180,180
+mesh_min: 10,10
+mesh_max: 180,180
 
 [mcu]
 serial: /dev/ttyACM0


### PR DESCRIPTION
This request attempts to account for the probe's x and y offsets when generating points, in hopes of reducing confusion as mentioned in #1888 and #1862.  When considering the various ways of doing this I have initially decided on going with the simplest method.  The `min_point` and `max_point` options have been renamed to `mesh_min` and `mesh_max`.   These options define the actual mesh rather than the tool position.  I considered attempting calculate these points based on the bed size, however I feel like this method provides the user maximum flexibility for defining where the mesh should be and what size it should be.

For circular beds `bed_radius` has been renamed to `mesh_radius`. and a new option `mesh_origin` has been added.  The `mesh_radius` defines the actual size of the mesh, where the `mesh_origin` allows the user to define the center of the mesh.  The origin defaults to 0,0 and accounts for probe offsets.  I felt this option is useful because an origin other than 0,0 might allow the user to probe a larger portion of the bed.

One outstanding issue with this implementation is when a user decides to do a manual probe with a [probe] configured.  In this scenario the generated points will be off as they include the probe's offsets.  I had considered generating two sets of points and am still open to it, but it could make loading saved  meshes tricky.  I need to further think on the best way to approach this.

I have done initial testing for rectangular beds and simulated testing for round beds.  Additional testing is welcome, particular for those with delta printers.  When we feel like this patch is ready I will update config_changes.md, as I intentionally broke prior configurations with the name changes.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>