### PR TITLE
Safe Z Home improvements

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -313,7 +313,10 @@
 #z_hop: 0.0
 #   Lift the Z axis prior to homing. This is applied to any homing command,
 #   even if it doesn't home the Z axis. If the Z axis is already homed and
-#   the zhop would exceed the printer limits, the zhop is ignored.
+#   the zhop would exceed the printer limits, the zhop is ignored. If a lift
+#   has already been performed or the Z axis is known to be equally or higher
+#   than this distance, the zhop is ignored. After homing Z completed, the
+#   printhead is lifted to zhop, respecting the probe's z_offset.
 #   The default is 0.0mm.
 #z_hop_speed: 20.0
 #   Speed at which the Z axis is lifted prior to homing. The default is 20mm/s.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -317,6 +317,10 @@
 #   The default is 0.0mm.
 #z_hop_speed: 20.0
 #   Speed at which the Z axis is lifted prior to homing. The default is 20mm/s.
+#move_to_previous: True
+#   When set to True, xy are reset to their previous positions after z homing.
+#   The default is True.
+
 
 # Homing override. One may use this mechanism to run a series of
 # g-code commands in place of a G28 found in the normal g-code input.

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,10 @@ All dates in this document are approximate.
 
 # Changes
 
+20190918: The zhop option in [safe_z_homing] is always re-applied
+after Z axis homing completed. This might need users to update custom
+scripts based on this module.
+
 20190806: The SET_NEOPIXEL command has been renamed to SET_LED.
 
 20190726: The mcp4728 digital-to-analog code has changed. The default

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -35,10 +35,11 @@ class SafeZHoming:
 
         # Perform Z Hop if necessary
         if self.z_hop != 0.0:
-            # Check if the zhop would exceed the printer limits
             pos = toolhead.get_position()
             kin_status = kinematics.get_status()
+            # Check if Z axis is homed or has a known position
             if 'Z' in kin_status['homed_axes']:
+                # Check if the zhop would exceed the printer limits
                 if pos[2] + self.z_hop > self.max_z:
                     self.gcode.respond_info(
                         "No zhop performed, target Z out of bounds: " +

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -20,6 +20,7 @@ class SafeZHoming:
         self.z_hop_speed = config.getfloat('z_hop_speed', 15., above=0.)
         self.max_z = config.getsection('stepper_z').getfloat('position_max')
         self.speed = config.getfloat('speed', 50.0, above=0.)
+        self.move_to_previous = config.getboolean('move_to_previous', True)
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("G28", None)
         self.gcode.register_command("G28", self.cmd_G28)
@@ -71,6 +72,8 @@ class SafeZHoming:
         if need_z:
             # Move to safe XY homing position
             pos = toolhead.get_position()
+            prev_x = pos[0]
+            prev_y = pos[1]
             if self.home_x_pos:
                 pos[0] = self.home_x_pos
             if self.home_y_pos:
@@ -80,6 +83,12 @@ class SafeZHoming:
             # Home Z
             self.gcode.cmd_G28({'Z': '0'})
             self.did_hop = False
+            # Move XY back to previous positions
+            if (self.move_to_previous):
+                pos = toolhead.get_position()
+                pos[0] = prev_x
+                pos[1] = prev_y
+                toolhead.move(pos, self.speed)
 
 def load_config(config):
     return SafeZHoming(config)

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -9,7 +9,7 @@ class SafeZHoming:
         self.printer = config.get_printer()
         try:
             x_pos, y_pos = config.get("home_xy_position",
-                                            default=",").split(',')
+                                      default=",").split(',')
             self.home_x_pos, self.home_y_pos = float(x_pos), float(y_pos)
         except:
             raise config.error("Unable to parse home_xy_position in %s" % (
@@ -30,10 +30,9 @@ class SafeZHoming:
 
         if config.has_section("homing_override"):
             raise config.error("homing_override and safe_z_homing cannot"
-                                    +" be used simultaneously")
+                               +" be used simultaneously")
 
     def cmd_G28(self, params):
-
         toolhead = self.printer.lookup_object('toolhead')
         kinematics = toolhead.get_kinematics()
 

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -25,9 +25,6 @@ class SafeZHoming:
         self.gcode.register_command("G28", None)
         self.gcode.register_command("G28", self.cmd_G28)
 
-        self.printer.register_event_handler("toolhead:motor_off",
-                                            self.reset_z_hop)
-
         if config.has_section("homing_override"):
             raise config.error("homing_override and safe_z_homing cannot"
                                +" be used simultaneously")
@@ -47,7 +44,7 @@ class SafeZHoming:
                         "No zhop performed, target Z out of bounds: " +
                         str(pos[2] + self.z_hop)
                     )
-                elif pos[2] < self.z_hop and not self.did_hop:
+                elif pos[2] < self.z_hop:
                     self._perform_z_hop(pos)
             else:
                 self._perform_z_hop(pos)
@@ -100,10 +97,6 @@ class SafeZHoming:
         pos[2] = pos[2] + self.z_hop
         toolhead.move(pos, self.z_hop_speed)
         self.gcode.reset_last_position()
-        self.did_hop = True
-
-    def reset_z_hop(self, _):
-        self.did_hop = False
 
 def load_config(config):
     return SafeZHoming(config)

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -16,7 +16,6 @@ class SafeZHoming:
                 config.get_name()))
 
         self.z_hop = config.getfloat("z_hop", default=0.0)
-        self.did_hop = False
         self.z_hop_speed = config.getfloat('z_hop_speed', 15., above=0.)
         self.max_z = config.getsection('stepper_z').getfloat('position_max')
         self.speed = config.getfloat('speed', 50.0, above=0.)

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -53,12 +53,7 @@ class SafeZHoming:
                         str(pos[2]) + " >= " + str(self.z_hop)
                     )
             else:
-                # Perform the Z-Hop
-                toolhead.set_position(pos, homing_axes=[2])
-                pos[2] = pos[2] + self.z_hop
-                toolhead.move(pos, self.z_hop_speed)
-                self.gcode.reset_last_position()
-                self.did_hop = True
+                self._perform_z_hop(pos)
 
         # Determine which axes we need to home
         if not any([axis in params.keys() for axis in ['X', 'Y', 'Z']]):
@@ -99,6 +94,15 @@ class SafeZHoming:
                 pos[0] = prev_x
                 pos[1] = prev_y
                 toolhead.move(pos, self.speed)
+
+    def _perform_z_hop(self, pos):
+        toolhead = self.printer.lookup_object('toolhead')
+        # Perform the Z-Hop
+        toolhead.set_position(pos, homing_axes=[2])
+        pos[2] = pos[2] + self.z_hop
+        toolhead.move(pos, self.z_hop_speed)
+        self.gcode.reset_last_position()
+        self.did_hop = True
 
     def reset_z_hop(self, _):
         self.did_hop = False

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -47,12 +47,7 @@ class SafeZHoming:
                         "No zhop performed, target Z out of bounds: " +
                         str(pos[2] + self.z_hop)
                     )
-                elif pos[2] >= self.z_hop and self.did_hop:
-                    self.gcode.respond_info(
-                        "No zhop performed, already above target height " +
-                        str(pos[2]) + " >= " + str(self.z_hop)
-                    )
-                else:
+                elif pos[2] < self.z_hop and not self.did_hop:
                     self._perform_z_hop(pos)
             else:
                 self._perform_z_hop(pos)

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -100,7 +100,7 @@ class SafeZHoming:
                 pos[1] = prev_y
                 toolhead.move(pos, self.speed)
 
-    def reset_z_hop(self):
+    def reset_z_hop(self, _):
         self.did_hop = False
 
 def load_config(config):

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -52,6 +52,8 @@ class SafeZHoming:
                         "No zhop performed, already above target height " +
                         str(pos[2]) + " >= " + str(self.z_hop)
                     )
+                else:
+                    self._perform_z_hop(pos)
             else:
                 self._perform_z_hop(pos)
 
@@ -94,6 +96,7 @@ class SafeZHoming:
                 pos[0] = prev_x
                 pos[1] = prev_y
                 toolhead.move(pos, self.speed)
+            self.gcode.reset_last_position()
 
     def _perform_z_hop(self, pos):
         toolhead = self.printer.lookup_object('toolhead')

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -16,6 +16,7 @@ class SafeZHoming:
                 config.get_name()))
 
         self.z_hop = config.getfloat("z_hop", default=0.0)
+        self.did_hop = False
         self.z_hop_speed = config.getfloat('z_hop_speed', 15., above=0.)
         self.max_z = config.getsection('stepper_z').getfloat('position_max')
         self.speed = config.getfloat('speed', 50.0, above=0.)
@@ -33,7 +34,7 @@ class SafeZHoming:
         kinematics = toolhead.get_kinematics()
 
         # Perform Z Hop if necessary
-        if self.z_hop != 0.0:
+        if self.z_hop != 0.0 and self.did_hop == False:
             # Check if the zhop would exceed the printer limits
             pos = toolhead.get_position()
             kin_status = kinematics.get_status()
@@ -49,6 +50,7 @@ class SafeZHoming:
                 pos[2] = pos[2] + self.z_hop
                 toolhead.move(pos, self.z_hop_speed)
                 self.gcode.reset_last_position()
+                self.did_hop = True
 
         # Determine which axes we need to home
         if not any([axis in params.keys() for axis in ['X', 'Y', 'Z']]):
@@ -77,6 +79,7 @@ class SafeZHoming:
             self.gcode.reset_last_position()
             # Home Z
             self.gcode.cmd_G28({'Z': '0'})
+            self.did_hop = False
 
 def load_config(config):
     return SafeZHoming(config)


### PR DESCRIPTION
This PR updates the feature introduced with PR #1866. It adds the possibility to move X and Y axis back to their previous positions and hops only when a hop is necessary.

I tested it on an AM8 with a bltouch probe. I don't know about other than cartesian kinematics so this probably needs some review from other users with more knowledge about those other kinematics.

Signed-off-by: Nils Friedchen <Nils.Friedchen@googlemail.com>