### PR TITLE
Use is operator for None comparison

### DIFF
--- a/klippy/extras/gcode_arcs.py
+++ b/klippy/extras/gcode_arcs.py
@@ -48,7 +48,7 @@ class ArcSupport:
         asF = float(params.get("F", -1))
 
         # --------- health checks of code -----------
-        if (asX == None or asY == None):
+        if (asX is None or asY is None):
             raise self.gcode.error("g2/g3: Coords missing")
 
         elif asR == 0 and asI == 0 and asJ==0:


### PR DESCRIPTION
When you compare an object to None, use is rather than `==`. `None` is a singleton object, comparing using `==` invokes the `__eq__` method on the object in question, which may be slower than identity comparison. Comparing to `None` using the is operator is also easier for other programmers to read.