### PR TITLE
Add range to probe accuracy results

### DIFF
--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -93,22 +93,23 @@ Recv: // probe at -0.003,0.005 is z=2.506948
 Recv: // probe at -0.003,0.005 is z=2.506948
 Recv: // probe at -0.003,0.005 is z=2.519448
 Recv: // probe at -0.003,0.005 is z=2.506948
-Recv: // probe accuracy results: maximum 2.506948, minimum 2.519448, average 2.513198, median 2.513198, standard deviation 0.006250
+Recv: // probe accuracy results: maximum 2.519448, minimum 2.506948, range 0.012500, average 2.513198, median 2.513198, standard deviation 0.006250
 ```
 
 Ideally the tool will report an identical maximum and minimum value.
 (That is, ideally the probe obtains an identical result on all ten
-probes.) However, it's normal for the minimum/maximum distance to
-differ by one Z step_distance or up to 5 microns (.005mm). So, in the
-above example, since the printer uses a Z step_distance of .0125, the
-results would be considered normal.
+probes.) However, it's normal for the minimum and maximum values
+to differ by one Z step_distance or up to 5 microns (.005mm).
+The distance between the minimum and the maximum value is called the
+range. So, in the above example, since the printer uses a
+Z step_distance of .0125, a range of 0.012500 would be considered normal.
 
-If the results of the test show a minimum and maximum distance that
-differs by more than 25 microns (.025mm) then the probe does not have
-sufficient accuracy for typical bed leveling procedures. It may be
-possible to tune the probe speed and/or probe start height to improve
-the repeatability of the probe. The `PROBE_ACCURACY` command allows
-one to run tests with different parameters to see their impact - see
+If the results of the test show a range value that is greater than
+25 microns (.025mm) then the probe does not have sufficient accuracy 
+for typical bed leveling procedures. It may be possible to tune the 
+probe speed and/or probe start height to improve the repeatability 
+of the probe. The `PROBE_ACCURACY` command allows one to run tests 
+with different parameters to see their impact - see
 the [G-Codes document](G-Codes.md) for further details. If the probe
 generally obtains repeatable results but has an occasional outlier,
 then it may be possible to account for that by using multiple samples

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -105,10 +105,10 @@ range. So, in the above example, since the printer uses a
 Z step_distance of .0125, a range of 0.012500 would be considered normal.
 
 If the results of the test show a range value that is greater than
-25 microns (.025mm) then the probe does not have sufficient accuracy 
-for typical bed leveling procedures. It may be possible to tune the 
-probe speed and/or probe start height to improve the repeatability 
-of the probe. The `PROBE_ACCURACY` command allows one to run tests 
+25 microns (.025mm) then the probe does not have sufficient accuracy
+for typical bed leveling procedures. It may be possible to tune the
+probe speed and/or probe start height to improve the repeatability
+of the probe. The `PROBE_ACCURACY` command allows one to run tests
 with different parameters to see their impact - see
 the [G-Codes document](G-Codes.md) for further details. If the probe
 generally obtains repeatable results but has an occasional outlier,

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -173,6 +173,7 @@ class PrinterProbe:
         # Calculate maximum, minimum and average values
         max_value = max([p[2] for p in positions])
         min_value = min([p[2] for p in positions])
+        range_value = max_value - min_value
         avg_value = self._calc_mean(positions)[2]
         median = self._calc_median(positions)[2]
         # calculate the standard deviation
@@ -182,9 +183,9 @@ class PrinterProbe:
         sigma = (deviation_sum / len(positions)) ** 0.5
         # Show information
         self.gcode.respond_info(
-            "probe accuracy results: maximum %.6f, minimum %.6f, "
+            "probe accuracy results: maximum %.6f, minimum %.6f, range %.6f, "
             "average %.6f, median %.6f, standard deviation %.6f" % (
-            max_value, min_value, avg_value, median, sigma))
+            max_value, min_value, range_value, avg_value, median, sigma))
     def probe_calibrate_finalize(self, kin_pos):
         if kin_pos is None:
             return


### PR DESCRIPTION
The documentation recommends checking the distance between maximum and minimum values, and it was a bit tedious to calculate at the end of each result when you are tweaking your probe parameters.

If i am not mistaken the distance between the maximum and the minimum value of a series is called the range.

I added `range` to probe accuracy results and updated the documentation.

Signed-off-by: Julien Lirochon julien@lirochon.net