### PR TITLE
BED_TILT : chain transform with BED_MESH module

### DIFF
--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -32,11 +32,17 @@ class BedTilt:
     def move(self, newpos, speed):
         x, y, z, e = newpos
         if self.chain_transform is not None:
-            self.chain_transform.move([x, y, z + x*self.x_adjust + y*self.y_adjust
-                                + self.z_adjust, e], speed)
+            self.chain_transform.move([x, y,
+                                       z + x*self.x_adjust
+                                       + y*self.y_adjust
+                                       + self.z_adjust, e],
+                                      speed)
         else:
-            self.toolhead.move([x, y, z + x*self.x_adjust + y*self.y_adjust
-                                + self.z_adjust, e], speed)
+            self.toolhead.move([x, y,
+                                z + x*self.x_adjust
+                                + y*self.y_adjust
+                                + self.z_adjust, e],
+                               speed)
 
     def update_adjust(self, x_adjust, y_adjust, z_adjust):
         self.x_adjust = x_adjust


### PR DESCRIPTION
BED_TILT: chain transform with BED_MESH module

This change allows BED_TILT module to play nicely with BED_MESH module by allowing chained transforms during print but also BED_MESH_CALIBRATE operation. This makes bed tilt easier to manage for printers that require systematic bed level check and adaptation (Tevo Tarentula, HE3D Ei3)

Signed-off-by: Jerome Perrin <jperrin72@free.fr>