### PR TITLE
safe_z_home: Fix issue where 'home_xy_position: 0,0' did not po…

### DIFF
--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -70,10 +70,8 @@ class SafeZHoming:
             pos = toolhead.get_position()
             prev_x = pos[0]
             prev_y = pos[1]
-            if self.home_x_pos:
-                pos[0] = self.home_x_pos
-            if self.home_y_pos:
-                pos[1] = self.home_y_pos
+            pos[0] = self.home_x_pos
+            pos[1] = self.home_y_pos
             toolhead.move(pos, self.speed)
             self.gcode.reset_last_position()
             # Home Z


### PR DESCRIPTION
…sition at 0,0

If '[stepper_x]' and/or '[stepper_y]' have a 'position_min' that is non-zero, and
'[safe_z_home] home_xy_position' is '0,0'; then the 'G28' command will _not_ move
to '0,0'; but stay at 'position_min' during the Z endstop test.

This fix corrects this issue.