### PR TITLE
Experiment with s-curves

### DIFF
--- a/docs/prints/square_notch_tower.scad
+++ b/docs/prints/square_notch_tower.scad
@@ -1,0 +1,71 @@
+// Calibration test tower with corner notches (to induce resonance)
+//
+// Generate STL using OpenSCAD:
+//   openscad square_notch_tower.scad -o square_notch_tower.stl
+
+square_width = 5;
+square_size = 60;
+square_height = 50;
+antiwarp_height = .8;
+antiwarp_radius = 5;
+CUT = 0.01;
+
+module notch(x, y, rot) {
+    depth = .5;
+    width = 1;
+    translate([x, y, 0])
+        rotate([0, 0, rot])
+            translate([-depth, -width, -CUT])
+                cube([2*depth, 2*width, square_height + 2*CUT]);
+}
+
+module square_with_notches() {
+    CORNER_OFFSET = 4;
+    difference() {
+        // Start with initial square
+        cube([square_size, square_size, square_height]);
+        // Remove four notches on inside perimeter
+        notch(square_width, square_size/2 - 4, 0);
+        notch(square_size - square_width, square_size/2, 0);
+        notch(square_size/2, square_width, 90);
+        notch(square_size/2, square_size - square_width, 90);
+        // Remove eight notches near external corners
+        notch(0, CORNER_OFFSET, 90);
+        notch(0, square_size - CORNER_OFFSET, 90);
+        notch(square_size, CORNER_OFFSET, 90);
+        notch(square_size, square_size - CORNER_OFFSET, 90);
+        notch(CORNER_OFFSET, 0, 0);
+        notch(square_size - CORNER_OFFSET, 0, 0);
+        notch(CORNER_OFFSET, square_size, 0);
+        notch(square_size - CORNER_OFFSET, square_size, 0);
+    }
+}
+
+module anti_warp_feet() {
+    module anti_warp_cylinder() {
+        cylinder(r=antiwarp_radius, h=antiwarp_height, $fs=.5);
+    }
+    dist = antiwarp_radius / 2.5;
+    translate([dist, dist, 0])
+        anti_warp_cylinder();
+    translate([square_size-dist, dist, 0])
+        anti_warp_cylinder();
+    translate([dist, square_size-dist, 0])
+        anti_warp_cylinder();
+    translate([square_size-dist, square_size-dist, 0])
+        anti_warp_cylinder();
+}
+
+module hollow_square() {
+    difference() {
+        union() {
+            square_with_notches();
+            anti_warp_feet();
+        }
+        translate([square_width, square_width, -CUT])
+            cube([square_size-2*square_width, square_size-2*square_width,
+                  square_height + 2*CUT]);
+    }
+}
+
+hollow_square();

--- a/docs/prints/square_notch_tower.stl
+++ b/docs/prints/square_notch_tower.stl
@@ -1,0 +1,3922 @@
+solid OpenSCAD_Model
+  facet normal 1 -0 0
+    outer loop
+      vertex 60 56.5 50
+      vertex 60 60 0.799999
+      vertex 60 60 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 60 0.799999
+      vertex 60 56.5 50
+      vertex 60 56.5 0.799999
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 60 0 50
+      vertex 60 3.5 0.799999
+      vertex 60 3.5 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 3.5 0.799999
+      vertex 60 0 50
+      vertex 60 0 0.799999
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 55.5 50
+      vertex 60 53.4473 0.799999
+      vertex 60 55.5 0.799999
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 53.4473 0.799999
+      vertex 60 6.55274 0.799999
+      vertex 60 53.4473 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 55.5 50
+      vertex 60 6.55274 0.799999
+      vertex 60 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 60 4.5 50
+      vertex 60 6.55274 0.799999
+      vertex 60 55.5 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 6.55274 0.799999
+      vertex 60 4.5 50
+      vertex 60 4.5 0.799999
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 53.4473 0
+      vertex 60 6.55274 0.799999
+      vertex 60 6.55274 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 50
+      vertex 59 56.5 50
+      vertex 60 56.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55 55 50
+      vertex 59 55.5 50
+      vertex 59 56.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59 55.5 50
+      vertex 55.5 31 50
+      vertex 59 4.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 50
+      vertex 56.5 59 50
+      vertex 59 56.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.5 59 50
+      vertex 60 60 50
+      vertex 56.5 60 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59 55.5 50
+      vertex 60 4.5 50
+      vertex 60 55.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 4.5 50
+      vertex 59 55.5 50
+      vertex 59 4.5 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59 3.5 50
+      vertex 60 0 50
+      vertex 60 3.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55 55 50
+      vertex 59 56.5 50
+      vertex 56.5 59 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 55.5 29 50
+      vertex 59 4.5 50
+      vertex 55.5 31 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 56.5 1 50
+      vertex 60 0 50
+      vertex 59 3.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 50
+      vertex 56.5 1 50
+      vertex 56.5 0 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 55.5 50
+      vertex 1 4.5 50
+      vertex 1 55.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1 4.5 50
+      vertex 0 55.5 50
+      vertex 0 4.5 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 60 50
+      vertex 3.5 59 50
+      vertex 3.5 60 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 59 50
+      vertex 1 55.5 50
+      vertex 3.5 1 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 59 50
+      vertex 1 56.5 50
+      vertex 1 55.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 59 50
+      vertex 0 60 50
+      vertex 1 56.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1 56.5 50
+      vertex 0 60 50
+      vertex 0 56.5 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1 4.5 50
+      vertex 3.5 1 50
+      vertex 1 55.5 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1 3.5 50
+      vertex 3.5 1 50
+      vertex 1 4.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 50
+      vertex 3.5 1 50
+      vertex 1 3.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 50
+      vertex 1 3.5 50
+      vertex 0 3.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 1 50
+      vertex 0 0 50
+      vertex 3.5 0 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 25 50
+      vertex 4.5 25 50
+      vertex 5 5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 50
+      vertex 5 5 50
+      vertex 29 4.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55 55 50
+      vertex 56.5 59 50
+      vertex 55.5 59 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 55 5 50
+      vertex 59 4.5 50
+      vertex 55.5 29 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59 4.5 50
+      vertex 55 5 50
+      vertex 59 3.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59 3.5 50
+      vertex 55 5 50
+      vertex 56.5 1 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.5 1 50
+      vertex 55 5 50
+      vertex 55.5 1 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55 5 50
+      vertex 55.5 29 50
+      vertex 55 29 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 31 4.5 50
+      vertex 55.5 1 50
+      vertex 55 5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31 4.5 50
+      vertex 55 5 50
+      vertex 31 5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 1 50
+      vertex 31 4.5 50
+      vertex 55.5 0 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 29 4.5 50
+      vertex 55.5 0 50
+      vertex 31 4.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 1 50
+      vertex 29 4.5 50
+      vertex 5 5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 1 50
+      vertex 5 5 50
+      vertex 4.5 25 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 4.5 50
+      vertex 4.5 1 50
+      vertex 4.5 0 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 4.5 50
+      vertex 4.5 0 50
+      vertex 55.5 0 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31 55.5 50
+      vertex 55.5 59 50
+      vertex 55.5 60 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59 55.5 50
+      vertex 55 55 50
+      vertex 55.5 31 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 59 50
+      vertex 31 55.5 50
+      vertex 55 55 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 60 50
+      vertex 29 55.5 50
+      vertex 31 55.5 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 55.5 50
+      vertex 5 55 50
+      vertex 29 55 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.5 60 50
+      vertex 29 55.5 50
+      vertex 55.5 60 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.5 59 50
+      vertex 29 55.5 50
+      vertex 4.5 60 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 55.5 50
+      vertex 4.5 59 50
+      vertex 5 55 50
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.5 59 50
+      vertex 5 55 50
+      vertex 4.5 59 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 55 50
+      vertex 4.5 27 50
+      vertex 5 27 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 55 50
+      vertex 3.5 59 50
+      vertex 4.5 27 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 1 50
+      vertex 4.5 27 50
+      vertex 3.5 59 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 27 50
+      vertex 3.5 1 50
+      vertex 4.5 25 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 5 50
+      vertex 3.5 1 50
+      vertex 4.5 1 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 31 50
+      vertex 55 55 50
+      vertex 55 31 50
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55 55 50
+      vertex 31 55.5 50
+      vertex 31 55 50
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 63 2 0
+      vertex 62.8907 0.960441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 62.8907 0.960441 0
+      vertex 62.5677 -0.0336828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63 2 0
+      vertex 55 5 0
+      vertex 62.8907 3.03956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 62.5677 -0.0336828 0
+      vertex 62.0451 -0.938926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.8907 3.03956 0
+      vertex 55 5 0
+      vertex 62.5677 4.03368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 62.0451 -0.938926 0
+      vertex 61.3457 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.5677 4.03368 0
+      vertex 55 5 0
+      vertex 62.0451 4.93893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 61.3457 -1.71572 0
+      vertex 60.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0451 4.93893 0
+      vertex 55 5 0
+      vertex 61.3457 5.71572 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60 6.55274 0
+      vertex 61.3457 5.71572 0
+      vertex 55 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.3457 5.71572 0
+      vertex 60 6.55274 0
+      vertex 60.5 6.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 60.5 -2.33013 0
+      vertex 59.5451 -2.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 63 58 0
+      vertex 62.8907 56.9604 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 62.8907 56.9604 0
+      vertex 62.5677 55.9663 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63 58 0
+      vertex 55 55 0
+      vertex 62.8907 59.0396 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 62.5677 55.9663 0
+      vertex 62.0451 55.0611 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.8907 59.0396 0
+      vertex 55 55 0
+      vertex 62.5677 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 62.0451 55.0611 0
+      vertex 61.3457 54.2843 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.5677 60.0337 0
+      vertex 55 55 0
+      vertex 62.0451 60.9389 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 53.4473 0
+      vertex 61.3457 54.2843 0
+      vertex 60.5 53.6699 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.0451 60.9389 0
+      vertex 55 55 0
+      vertex 61.3457 61.7157 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.3457 54.2843 0
+      vertex 60 53.4473 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.3457 61.7157 0
+      vertex 55 55 0
+      vertex 60.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 6.55274 0
+      vertex 55.5 29 0
+      vertex 60 53.4473 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 59.5451 -2.75528 0
+      vertex 58.5226 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.5 31 0
+      vertex 60 53.4473 0
+      vertex 55.5 29 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 58.5226 -2.97261 0
+      vertex 57.4774 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 31 0
+      vertex 60 53.4473 0
+      vertex 55.5 31 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 57.4774 -2.97261 0
+      vertex 56.4549 -2.75528 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.5 62.3301 0
+      vertex 55 55 0
+      vertex 59.5451 62.7553 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 5 0
+      vertex 56.4549 -2.75528 0
+      vertex 55.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.5451 62.7553 0
+      vertex 55 55 0
+      vertex 58.5226 62.9726 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 58.5226 62.9726 0
+      vertex 55 55 0
+      vertex 57.4774 62.9726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.4774 62.9726 0
+      vertex 55 55 0
+      vertex 56.4549 62.7553 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60 53.4473 0
+      vertex 55 31 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.4549 62.7553 0
+      vertex 55 55 0
+      vertex 55.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 54.6543 61.7157 0
+      vertex 55.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 55 0
+      vertex 53.9549 60.9389 0
+      vertex 54.6543 61.7157 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.4213 60 0
+      vertex 53.9549 60.9389 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.9549 60.9389 0
+      vertex 53.4213 60 0
+      vertex 53.4323 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31 55 0
+      vertex 53.4213 60 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31 55.5 0
+      vertex 53.4213 60 0
+      vertex 31 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29 55.5 0
+      vertex 53.4213 60 0
+      vertex 31 55.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 53.4213 60 0
+      vertex 29 55.5 0
+      vertex 6.57867 60 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 53.4473 0
+      vertex 5 27 0
+      vertex 4.5 27 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29 55 0
+      vertex 6.57867 60 0
+      vertex 29 55.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.57867 60 0
+      vertex 6.04508 60.9389 0
+      vertex 6.56773 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 6.04508 60.9389 0
+      vertex 6.57867 60 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 6.57867 60 0
+      vertex 29 55 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.04508 60.9389 0
+      vertex 5 55 0
+      vertex 5.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 4.5 62.3301 0
+      vertex 5.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 27 0
+      vertex 0 53.4473 0
+      vertex 5 55 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.4213 0 0
+      vertex 29 4.5 0
+      vertex 31 4.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.57867 0 0
+      vertex 29 4.5 0
+      vertex 53.4213 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.57867 0 0
+      vertex 29 5 0
+      vertex 29 4.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.04508 -0.938926 0
+      vertex 6.57867 0 0
+      vertex 6.56773 -0.0336828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex 6.04508 -0.938926 0
+      vertex 5.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.57867 0 0
+      vertex 5 5 0
+      vertex 29 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.04508 -0.938926 0
+      vertex 5 5 0
+      vertex 6.57867 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.5 -2.33013 0
+      vertex 5 5 0
+      vertex 5.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.54508 -2.75528 0
+      vertex 5 5 0
+      vertex 4.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex 0 6.55274 0
+      vertex 5 25 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 5 25 0
+      vertex 0 6.55274 0
+      vertex 4.5 25 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 4.5 25 0
+      vertex 0 6.55274 0
+      vertex 4.5 27 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.52264 -2.97261 0
+      vertex 5 5 0
+      vertex 3.54508 -2.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 53.4473 0
+      vertex 4.5 27 0
+      vertex 0 6.55274 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.47736 -2.97261 0
+      vertex 5 5 0
+      vertex 2.52264 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.34565 54.2843 0
+      vertex 5 55 0
+      vertex 0 53.4473 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.454914 -2.75528 0
+      vertex 5 5 0
+      vertex 1.47736 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 3.54508 62.7553 0
+      vertex 4.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.5 -2.33013 0
+      vertex 5 5 0
+      vertex 0.454914 -2.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 2.52264 62.9726 0
+      vertex 3.54508 62.7553 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 1.47736 62.9726 0
+      vertex 2.52264 62.9726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.34565 -1.71572 0
+      vertex 5 5 0
+      vertex -0.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.04508 -0.938926 0
+      vertex 5 5 0
+      vertex -1.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.56773 -0.0336828 0
+      vertex 5 5 0
+      vertex -2.04508 -0.938926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 6.55274 0
+      vertex -1.34565 5.71572 0
+      vertex -0.5 6.33013 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -1.34565 5.71572 0
+      vertex 5 5 0
+      vertex -2.04508 4.93893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex -1.34565 5.71572 0
+      vertex 0 6.55274 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.89074 0.960441 0
+      vertex 5 5 0
+      vertex -2.56773 -0.0336828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex -2.56773 4.03368 0
+      vertex -2.04508 4.93893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3 2 0
+      vertex 5 5 0
+      vertex -2.89074 0.960441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex -2.89074 3.03956 0
+      vertex -2.56773 4.03368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 5 0
+      vertex -3 2 0
+      vertex -2.89074 3.03956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55 29 0
+      vertex 60 6.55274 0
+      vertex 55 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.6543 -1.71572 0
+      vertex 55 5 0
+      vertex 55.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.9549 -0.938926 0
+      vertex 55 5 0
+      vertex 54.6543 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.4213 0 0
+      vertex 53.9549 -0.938926 0
+      vertex 53.4323 -0.0336828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.9549 -0.938926 0
+      vertex 53.4213 0 0
+      vertex 55 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31 5 0
+      vertex 53.4213 0 0
+      vertex 31 4.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.4213 0 0
+      vertex 31 5 0
+      vertex 55 5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 6.55274 0
+      vertex 55 29 0
+      vertex 55.5 29 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex 0.454914 62.7553 0
+      vertex 1.47736 62.9726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.34565 54.2843 0
+      vertex 0 53.4473 0
+      vertex -0.5 53.6699 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -0.5 62.3301 0
+      vertex 0.454914 62.7553 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -1.34565 54.2843 0
+      vertex -2.04508 55.0611 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -1.34565 61.7157 0
+      vertex -0.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.56773 55.9663 0
+      vertex 5 55 0
+      vertex -2.04508 55.0611 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -2.04508 60.9389 0
+      vertex -1.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.89074 56.9604 0
+      vertex 5 55 0
+      vertex -2.56773 55.9663 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -2.56773 60.0337 0
+      vertex -2.04508 60.9389 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3 58 0
+      vertex 5 55 0
+      vertex -2.89074 56.9604 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -2.89074 59.0396 0
+      vertex -2.56773 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 55 0
+      vertex -3 58 0
+      vertex -2.89074 59.0396 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 56.5 0.799999
+      vertex 0 60 50
+      vertex 0 60 0.799999
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 60 50
+      vertex 0 56.5 0.799999
+      vertex 0 56.5 50
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0.799999
+      vertex 0 3.5 50
+      vertex 0 3.5 0.799999
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 3.5 50
+      vertex 0 0 0.799999
+      vertex 0 0 50
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 53.4473 0
+      vertex 0 6.55274 0
+      vertex 0 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 53.4473 0.799999
+      vertex 0 55.5 50
+      vertex 0 55.5 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 6.55274 0.799999
+      vertex 0 53.4473 0.799999
+      vertex 0 6.55274 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 53.4473 0.799999
+      vertex 0 6.55274 0.799999
+      vertex 0 55.5 50
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 4.5 50
+      vertex 0 6.55274 0.799999
+      vertex 0 4.5 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 6.55274 0.799999
+      vertex 0 4.5 50
+      vertex 0 55.5 50
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.5 60 0.799999
+      vertex 0 60 50
+      vertex 3.5 60 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 60 50
+      vertex 3.5 60 0.799999
+      vertex 0 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 60 60 0.799999
+      vertex 56.5 60 50
+      vertex 60 60 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 56.5 60 50
+      vertex 60 60 0.799999
+      vertex 56.5 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 53.4213 60 0
+      vertex 6.57867 60 0.799999
+      vertex 53.4213 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6.57867 60 0.799999
+      vertex 53.4213 60 0
+      vertex 6.57867 60 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 53.4213 60 0.799999
+      vertex 55.5 60 50
+      vertex 55.5 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 55.5 60 50
+      vertex 53.4213 60 0.799999
+      vertex 4.5 60 50
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 6.57867 60 0.799999
+      vertex 4.5 60 50
+      vertex 53.4213 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.5 60 50
+      vertex 6.57867 60 0.799999
+      vertex 4.5 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0.799999
+      vertex 3.5 0 50
+      vertex 0 0 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 3.5 0 50
+      vertex 0 0 0.799999
+      vertex 3.5 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 56.5 0 0.799999
+      vertex 60 0 50
+      vertex 56.5 0 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 60 0 50
+      vertex 56.5 0 0.799999
+      vertex 60 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6.57867 0 0
+      vertex 53.4213 0 0.799999
+      vertex 6.57867 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 53.4213 0 0.799999
+      vertex 6.57867 0 0
+      vertex 53.4213 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6.57867 0 0.799999
+      vertex 4.5 0 50
+      vertex 4.5 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 4.5 0 50
+      vertex 6.57867 0 0.799999
+      vertex 55.5 0 50
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 53.4213 0 0.799999
+      vertex 55.5 0 50
+      vertex 6.57867 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 55.5 0 50
+      vertex 53.4213 0 0.799999
+      vertex 55.5 0 0.799999
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 4.5 25 50
+      vertex 4.5 27 0
+      vertex 4.5 27 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 4.5 27 0
+      vertex 4.5 25 50
+      vertex 4.5 25 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 4.5 27 0
+      vertex 5 27 50
+      vertex 4.5 27 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 5 27 50
+      vertex 4.5 27 0
+      vertex 5 27 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5 25 0
+      vertex 4.5 25 50
+      vertex 5 25 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.5 25 50
+      vertex 5 25 0
+      vertex 4.5 25 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 55.5 29 0
+      vertex 55.5 31 50
+      vertex 55.5 31 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 55.5 31 50
+      vertex 55.5 29 0
+      vertex 55.5 29 50
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 55 31 0
+      vertex 55.5 31 50
+      vertex 55 31 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 55.5 31 50
+      vertex 55 31 0
+      vertex 55.5 31 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 55.5 29 0
+      vertex 55 29 50
+      vertex 55.5 29 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 55 29 50
+      vertex 55.5 29 0
+      vertex 55 29 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 31 4.5 0
+      vertex 29 4.5 50
+      vertex 31 4.5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 29 4.5 50
+      vertex 31 4.5 0
+      vertex 29 4.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 29 4.5 50
+      vertex 29 5 0
+      vertex 29 5 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 29 5 0
+      vertex 29 4.5 50
+      vertex 29 4.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 31 4.5 0
+      vertex 31 5 50
+      vertex 31 5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 31 5 50
+      vertex 31 4.5 0
+      vertex 31 4.5 50
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 29 55.5 0
+      vertex 31 55.5 50
+      vertex 29 55.5 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 31 55.5 50
+      vertex 29 55.5 0
+      vertex 31 55.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 29 55 50
+      vertex 29 55.5 0
+      vertex 29 55.5 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 29 55.5 0
+      vertex 29 55 50
+      vertex 29 55 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 31 55 0
+      vertex 31 55.5 50
+      vertex 31 55.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 31 55.5 50
+      vertex 31 55 0
+      vertex 31 55 50
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 4.5 0.799999
+      vertex 1 4.5 50
+      vertex 0 4.5 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1 4.5 50
+      vertex 0 4.5 0.799999
+      vertex 1 4.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1 3.5 0.799999
+      vertex 0 3.5 50
+      vertex 1 3.5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 3.5 50
+      vertex 1 3.5 0.799999
+      vertex 0 3.5 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 1 3.5 0.799999
+      vertex 1 4.5 50
+      vertex 1 4.5 0.799999
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 1 4.5 50
+      vertex 1 3.5 0.799999
+      vertex 1 3.5 50
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1 55.5 0.799999
+      vertex 0 55.5 50
+      vertex 1 55.5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 55.5 50
+      vertex 1 55.5 0.799999
+      vertex 0 55.5 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 1 55.5 0.799999
+      vertex 1 56.5 50
+      vertex 1 56.5 0.799999
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 1 56.5 50
+      vertex 1 55.5 0.799999
+      vertex 1 55.5 50
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 56.5 0.799999
+      vertex 1 56.5 50
+      vertex 0 56.5 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1 56.5 50
+      vertex 0 56.5 0.799999
+      vertex 1 56.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 59 4.5 0.799999
+      vertex 60 4.5 50
+      vertex 59 4.5 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 60 4.5 50
+      vertex 59 4.5 0.799999
+      vertex 60 4.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 60 3.5 0.799999
+      vertex 59 3.5 50
+      vertex 60 3.5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 59 3.5 50
+      vertex 60 3.5 0.799999
+      vertex 59 3.5 0.799999
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 59 3.5 50
+      vertex 59 4.5 0.799999
+      vertex 59 4.5 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 59 4.5 0.799999
+      vertex 59 3.5 50
+      vertex 59 3.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 60 55.5 0.799999
+      vertex 59 55.5 50
+      vertex 60 55.5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 59 55.5 50
+      vertex 60 55.5 0.799999
+      vertex 59 55.5 0.799999
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 59 55.5 50
+      vertex 59 56.5 0.799999
+      vertex 59 56.5 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 59 56.5 0.799999
+      vertex 59 55.5 50
+      vertex 59 55.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 59 56.5 0.799999
+      vertex 60 56.5 50
+      vertex 59 56.5 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 60 56.5 50
+      vertex 59 56.5 0.799999
+      vertex 60 56.5 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 4.5 0 0.799999
+      vertex 4.5 1 50
+      vertex 4.5 1 0.799999
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 4.5 1 50
+      vertex 4.5 0 0.799999
+      vertex 4.5 0 50
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 3.5 0 50
+      vertex 3.5 1 0.799999
+      vertex 3.5 1 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3.5 1 0.799999
+      vertex 3.5 0 50
+      vertex 3.5 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 3.5 1 0.799999
+      vertex 4.5 1 50
+      vertex 3.5 1 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 4.5 1 50
+      vertex 3.5 1 0.799999
+      vertex 4.5 1 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 56.5 0 0.799999
+      vertex 56.5 1 50
+      vertex 56.5 1 0.799999
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 56.5 1 50
+      vertex 56.5 0 0.799999
+      vertex 56.5 0 50
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 55.5 0 50
+      vertex 55.5 1 0.799999
+      vertex 55.5 1 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 55.5 1 0.799999
+      vertex 55.5 0 50
+      vertex 55.5 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 55.5 1 0.799999
+      vertex 56.5 1 50
+      vertex 55.5 1 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 56.5 1 50
+      vertex 55.5 1 0.799999
+      vertex 56.5 1 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 4.5 59 0.799999
+      vertex 4.5 60 50
+      vertex 4.5 60 0.799999
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 4.5 60 50
+      vertex 4.5 59 0.799999
+      vertex 4.5 59 50
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 3.5 59 50
+      vertex 3.5 60 0.799999
+      vertex 3.5 60 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3.5 60 0.799999
+      vertex 3.5 59 50
+      vertex 3.5 59 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 4.5 59 0.799999
+      vertex 3.5 59 50
+      vertex 4.5 59 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.5 59 50
+      vertex 4.5 59 0.799999
+      vertex 3.5 59 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 56.5 59 0.799999
+      vertex 56.5 60 50
+      vertex 56.5 60 0.799999
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 56.5 60 50
+      vertex 56.5 59 0.799999
+      vertex 56.5 59 50
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 55.5 59 50
+      vertex 55.5 60 0.799999
+      vertex 55.5 60 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 55.5 60 0.799999
+      vertex 55.5 59 50
+      vertex 55.5 59 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 56.5 59 0.799999
+      vertex 55.5 59 50
+      vertex 56.5 59 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 55.5 59 50
+      vertex 56.5 59 0.799999
+      vertex 55.5 59 0.799999
+    endloop
+  endfacet
+  facet normal 0.40673 -0.913548 0
+    outer loop
+      vertex 3.54508 -2.75528 0
+      vertex 4.5 -2.33013 0.799999
+      vertex 3.54508 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0.40673 -0.913548 0
+    outer loop
+      vertex 4.5 -2.33013 0.799999
+      vertex 3.54508 -2.75528 0
+      vertex 4.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal -0.587791 0.809013 0
+    outer loop
+      vertex -0.5 6.33013 0
+      vertex -1.34565 5.71572 0.799999
+      vertex -0.5 6.33013 0.799999
+    endloop
+  endfacet
+  facet normal -0.587791 0.809013 0
+    outer loop
+      vertex -1.34565 5.71572 0.799999
+      vertex -0.5 6.33013 0
+      vertex -1.34565 5.71572 0
+    endloop
+  endfacet
+  facet normal -0.40673 0.913548 0
+    outer loop
+      vertex 0 6.55274 0
+      vertex -0.5 6.33013 0.799999
+      vertex 0 6.55274 0.799999
+    endloop
+  endfacet
+  facet normal -0.40673 0.913548 0
+    outer loop
+      vertex -0.5 6.33013 0.799999
+      vertex 0 6.55274 0
+      vertex -0.5 6.33013 0
+    endloop
+  endfacet
+  facet normal -0.207914 -0.978147 0
+    outer loop
+      vertex 0.454914 -2.75528 0
+      vertex 1.47736 -2.97261 0.799999
+      vertex 0.454914 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal -0.207914 -0.978147 -0
+    outer loop
+      vertex 1.47736 -2.97261 0.799999
+      vertex 0.454914 -2.75528 0
+      vertex 1.47736 -2.97261 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104527 0
+    outer loop
+      vertex -2.89074 0.960441 0
+      vertex -3 2 0.799999
+      vertex -3 2 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104527 0
+    outer loop
+      vertex -3 2 0.799999
+      vertex -2.89074 0.960441 0
+      vertex -2.89074 0.960441 0.799999
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309017 0
+    outer loop
+      vertex -2.56773 -0.0336828 0
+      vertex -2.89074 0.960441 0.799999
+      vertex -2.89074 0.960441 0
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309017 0
+    outer loop
+      vertex -2.89074 0.960441 0.799999
+      vertex -2.56773 -0.0336828 0
+      vertex -2.56773 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0.951091 -0.30891 0
+    outer loop
+      vertex 6.56773 -0.0336828 0.799999
+      vertex 6.57867 0 0
+      vertex 6.57867 0 0.799999
+    endloop
+  endfacet
+  facet normal 0.951091 -0.30891 0
+    outer loop
+      vertex 6.57867 0 0
+      vertex 6.56773 -0.0336828 0.799999
+      vertex 6.56773 -0.0336828 0
+    endloop
+  endfacet
+  facet normal -0.743142 0.669133 0
+    outer loop
+      vertex -2.04508 4.93893 0
+      vertex -1.34565 5.71572 0.799999
+      vertex -1.34565 5.71572 0
+    endloop
+  endfacet
+  facet normal -0.743142 0.669133 0
+    outer loop
+      vertex -1.34565 5.71572 0.799999
+      vertex -2.04508 4.93893 0
+      vertex -2.04508 4.93893 0.799999
+    endloop
+  endfacet
+  facet normal 0.743144 -0.669131 0
+    outer loop
+      vertex 5.34565 -1.71572 0.799999
+      vertex 6.04508 -0.938926 0
+      vertex 6.04508 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0.743144 -0.669131 0
+    outer loop
+      vertex 6.04508 -0.938926 0
+      vertex 5.34565 -1.71572 0.799999
+      vertex 5.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal -0.406733 -0.913547 0
+    outer loop
+      vertex -0.5 -2.33013 0
+      vertex 0.454914 -2.75528 0.799999
+      vertex -0.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal -0.406733 -0.913547 -0
+    outer loop
+      vertex 0.454914 -2.75528 0.799999
+      vertex -0.5 -2.33013 0
+      vertex 0.454914 -2.75528 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.5 6.33013 0.799999
+      vertex 0 4.5 0.799999
+      vertex 0 6.55274 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.34565 5.71572 0.799999
+      vertex 0 4.5 0.799999
+      vertex -0.5 6.33013 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.04508 4.93893 0.799999
+      vertex 0 4.5 0.799999
+      vertex -1.34565 5.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 4.5 0.799999
+      vertex 1 3.5 0.799999
+      vertex 1 4.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1 3.5 0.799999
+      vertex 0 4.5 0.799999
+      vertex 0 3.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 0 0.799999
+      vertex 4.5 0 0.799999
+      vertex 4.5 1 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 0 0.799999
+      vertex 3.5 0 0.799999
+      vertex 4.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 0 0.799999
+      vertex 4.5 1 0.799999
+      vertex 3.5 1 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 -2.33013 0.799999
+      vertex 3.5 0 0.799999
+      vertex 3.54508 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 0 0.799999
+      vertex 2.52264 -2.97261 0.799999
+      vertex 3.54508 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 0 0.799999
+      vertex 1.47736 -2.97261 0.799999
+      vertex 2.52264 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex 1.47736 -2.97261 0.799999
+      vertex 3.5 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.47736 -2.97261 0.799999
+      vertex 0 0 0.799999
+      vertex 0.454914 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -0.5 -2.33013 0.799999
+      vertex 0.454914 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 4.5 0.799999
+      vertex -2.04508 4.93893 0.799999
+      vertex 0 3.5 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.56773 4.03368 0.799999
+      vertex 0 3.5 0.799999
+      vertex -2.04508 4.93893 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -1.34565 -1.71572 0.799999
+      vertex -0.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89074 3.03956 0.799999
+      vertex 0 3.5 0.799999
+      vertex -2.56773 4.03368 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -2.04508 -0.938926 0.799999
+      vertex -1.34565 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3 2 0.799999
+      vertex 0 3.5 0.799999
+      vertex -2.89074 3.03956 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -2.56773 -0.0336828 0.799999
+      vertex -2.04508 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 3.5 0.799999
+      vertex -3 2 0.799999
+      vertex 0 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -2.89074 0.960441 0.799999
+      vertex -2.56773 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.799999
+      vertex -3 2 0.799999
+      vertex -2.89074 0.960441 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.5 0 0.799999
+      vertex 6.56773 -0.0336828 0.799999
+      vertex 6.57867 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.56773 -0.0336828 0.799999
+      vertex 4.5 0 0.799999
+      vertex 6.04508 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.04508 -0.938926 0.799999
+      vertex 4.5 0 0.799999
+      vertex 5.34565 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.34565 -1.71572 0.799999
+      vertex 4.5 0 0.799999
+      vertex 4.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0.207915 -0.978147 0
+    outer loop
+      vertex 2.52264 -2.97261 0
+      vertex 3.54508 -2.75528 0.799999
+      vertex 2.52264 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0.207915 -0.978147 0
+    outer loop
+      vertex 3.54508 -2.75528 0.799999
+      vertex 2.52264 -2.97261 0
+      vertex 3.54508 -2.75528 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex -2.89074 3.03956 0
+      vertex -2.56773 4.03368 0.799999
+      vertex -2.56773 4.03368 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex -2.56773 4.03368 0.799999
+      vertex -2.89074 3.03956 0
+      vertex -2.89074 3.03956 0.799999
+    endloop
+  endfacet
+  facet normal 0.587791 -0.809013 0
+    outer loop
+      vertex 4.5 -2.33013 0
+      vertex 5.34565 -1.71572 0.799999
+      vertex 4.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0.587791 -0.809013 0
+    outer loop
+      vertex 5.34565 -1.71572 0.799999
+      vertex 4.5 -2.33013 0
+      vertex 5.34565 -1.71572 0
+    endloop
+  endfacet
+  facet normal -0.866022 -0.500005 0
+    outer loop
+      vertex -2.04508 -0.938926 0
+      vertex -2.56773 -0.0336828 0.799999
+      vertex -2.56773 -0.0336828 0
+    endloop
+  endfacet
+  facet normal -0.866022 -0.500005 0
+    outer loop
+      vertex -2.56773 -0.0336828 0.799999
+      vertex -2.04508 -0.938926 0
+      vertex -2.04508 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.47736 -2.97261 0
+      vertex 2.52264 -2.97261 0.799999
+      vertex 1.47736 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 2.52264 -2.97261 0.799999
+      vertex 1.47736 -2.97261 0
+      vertex 2.52264 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0.866022 -0.500005 0
+    outer loop
+      vertex 6.04508 -0.938926 0.799999
+      vertex 6.56773 -0.0336828 0
+      vertex 6.56773 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0.866022 -0.500005 0
+    outer loop
+      vertex 6.56773 -0.0336828 0
+      vertex 6.04508 -0.938926 0.799999
+      vertex 6.04508 -0.938926 0
+    endloop
+  endfacet
+  facet normal -0.866024 0.500003 0
+    outer loop
+      vertex -2.56773 4.03368 0
+      vertex -2.04508 4.93893 0.799999
+      vertex -2.04508 4.93893 0
+    endloop
+  endfacet
+  facet normal -0.866024 0.500003 0
+    outer loop
+      vertex -2.04508 4.93893 0.799999
+      vertex -2.56773 4.03368 0
+      vertex -2.56773 4.03368 0.799999
+    endloop
+  endfacet
+  facet normal -0.743144 -0.669131 0
+    outer loop
+      vertex -1.34565 -1.71572 0
+      vertex -2.04508 -0.938926 0.799999
+      vertex -2.04508 -0.938926 0
+    endloop
+  endfacet
+  facet normal -0.743144 -0.669131 0
+    outer loop
+      vertex -2.04508 -0.938926 0.799999
+      vertex -1.34565 -1.71572 0
+      vertex -1.34565 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0.587791 -0.809013 0
+    outer loop
+      vertex -1.34565 -1.71572 0
+      vertex -0.5 -2.33013 0.799999
+      vertex -1.34565 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0.587791 -0.809013 -0
+    outer loop
+      vertex -0.5 -2.33013 0.799999
+      vertex -1.34565 -1.71572 0
+      vertex -0.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex -3 2 0
+      vertex -2.89074 3.03956 0.799999
+      vertex -2.89074 3.03956 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex -2.89074 3.03956 0.799999
+      vertex -3 2 0
+      vertex -3 2 0.799999
+    endloop
+  endfacet
+  facet normal -0.207903 -0.978149 0
+    outer loop
+      vertex 56.4549 -2.75528 0
+      vertex 57.4774 -2.97261 0.799999
+      vertex 56.4549 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal -0.207903 -0.978149 -0
+    outer loop
+      vertex 57.4774 -2.97261 0.799999
+      vertex 56.4549 -2.75528 0
+      vertex 57.4774 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0.951059 0.309009 0
+    outer loop
+      vertex 62.8907 3.03956 0.799999
+      vertex 62.5677 4.03368 0
+      vertex 62.5677 4.03368 0.799999
+    endloop
+  endfacet
+  facet normal 0.951059 0.309009 0
+    outer loop
+      vertex 62.5677 4.03368 0
+      vertex 62.8907 3.03956 0.799999
+      vertex 62.8907 3.03956 0
+    endloop
+  endfacet
+  facet normal 0.994518 0.104564 0
+    outer loop
+      vertex 63 2 0.799999
+      vertex 62.8907 3.03956 0
+      vertex 62.8907 3.03956 0.799999
+    endloop
+  endfacet
+  facet normal 0.994518 0.104564 0
+    outer loop
+      vertex 62.8907 3.03956 0
+      vertex 63 2 0.799999
+      vertex 63 2 0
+    endloop
+  endfacet
+  facet normal 0.866045 0.499967 0
+    outer loop
+      vertex 62.5677 4.03368 0.799999
+      vertex 62.0451 4.93893 0
+      vertex 62.0451 4.93893 0.799999
+    endloop
+  endfacet
+  facet normal 0.866045 0.499967 0
+    outer loop
+      vertex 62.0451 4.93893 0
+      vertex 62.5677 4.03368 0.799999
+      vertex 62.5677 4.03368 0
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex 59.5451 -2.75528 0
+      vertex 60.5 -2.33013 0.799999
+      vertex 59.5451 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex 60.5 -2.33013 0.799999
+      vertex 59.5451 -2.75528 0
+      vertex 60.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0.994518 -0.104564 0
+    outer loop
+      vertex 62.8907 0.960441 0.799999
+      vertex 63 2 0
+      vertex 63 2 0.799999
+    endloop
+  endfacet
+  facet normal 0.994518 -0.104564 0
+    outer loop
+      vertex 63 2 0
+      vertex 62.8907 0.960441 0.799999
+      vertex 62.8907 0.960441 0
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 0
+    outer loop
+      vertex 55.5 -2.33013 0
+      vertex 56.4549 -2.75528 0.799999
+      vertex 55.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 -0
+    outer loop
+      vertex 56.4549 -2.75528 0.799999
+      vertex 55.5 -2.33013 0
+      vertex 56.4549 -2.75528 0
+    endloop
+  endfacet
+  facet normal 0.866043 -0.49997 0
+    outer loop
+      vertex 62.0451 -0.938926 0.799999
+      vertex 62.5677 -0.0336828 0
+      vertex 62.5677 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0.866043 -0.49997 0
+    outer loop
+      vertex 62.5677 -0.0336828 0
+      vertex 62.0451 -0.938926 0.799999
+      vertex 62.0451 -0.938926 0
+    endloop
+  endfacet
+  facet normal -0.587768 -0.809029 0
+    outer loop
+      vertex 54.6543 -1.71572 0
+      vertex 55.5 -2.33013 0.799999
+      vertex 54.6543 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal -0.587768 -0.809029 -0
+    outer loop
+      vertex 55.5 -2.33013 0.799999
+      vertex 54.6543 -1.71572 0
+      vertex 55.5 -2.33013 0
+    endloop
+  endfacet
+  facet normal 0.743158 -0.669116 0
+    outer loop
+      vertex 61.3457 -1.71572 0.799999
+      vertex 62.0451 -0.938926 0
+      vertex 62.0451 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0.743158 -0.669116 0
+    outer loop
+      vertex 62.0451 -0.938926 0
+      vertex 61.3457 -1.71572 0.799999
+      vertex 61.3457 -1.71572 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 57.4774 -2.97261 0
+      vertex 58.5226 -2.97261 0.799999
+      vertex 57.4774 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 58.5226 -2.97261 0.799999
+      vertex 57.4774 -2.97261 0
+      vertex 58.5226 -2.97261 0
+    endloop
+  endfacet
+  facet normal 0.951059 -0.309008 0
+    outer loop
+      vertex 62.5677 -0.0336828 0.799999
+      vertex 62.8907 0.960441 0
+      vertex 62.8907 0.960441 0.799999
+    endloop
+  endfacet
+  facet normal 0.951059 -0.309008 0
+    outer loop
+      vertex 62.8907 0.960441 0
+      vertex 62.5677 -0.0336828 0.799999
+      vertex 62.5677 -0.0336828 0
+    endloop
+  endfacet
+  facet normal -0.950593 -0.310441 0
+    outer loop
+      vertex 53.4323 -0.0336828 0
+      vertex 53.4213 0 0.799999
+      vertex 53.4213 0 0
+    endloop
+  endfacet
+  facet normal -0.950593 -0.310441 0
+    outer loop
+      vertex 53.4213 0 0.799999
+      vertex 53.4323 -0.0336828 0
+      vertex 53.4323 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0.40673 0.913548 -0
+    outer loop
+      vertex 60.5 6.33013 0
+      vertex 60 6.55274 0.799999
+      vertex 60.5 6.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0.40673 0.913548 0
+    outer loop
+      vertex 60 6.55274 0.799999
+      vertex 60.5 6.33013 0
+      vertex 60 6.55274 0
+    endloop
+  endfacet
+  facet normal 0.587768 -0.809029 0
+    outer loop
+      vertex 60.5 -2.33013 0
+      vertex 61.3457 -1.71572 0.799999
+      vertex 60.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0.587768 -0.809029 0
+    outer loop
+      vertex 61.3457 -1.71572 0.799999
+      vertex 60.5 -2.33013 0
+      vertex 61.3457 -1.71572 0
+    endloop
+  endfacet
+  facet normal -0.743158 -0.669116 0
+    outer loop
+      vertex 54.6543 -1.71572 0
+      vertex 53.9549 -0.938926 0.799999
+      vertex 53.9549 -0.938926 0
+    endloop
+  endfacet
+  facet normal -0.743158 -0.669116 0
+    outer loop
+      vertex 53.9549 -0.938926 0.799999
+      vertex 54.6543 -1.71572 0
+      vertex 54.6543 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0.743157 0.669117 0
+    outer loop
+      vertex 62.0451 4.93893 0.799999
+      vertex 61.3457 5.71572 0
+      vertex 61.3457 5.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0.743157 0.669117 0
+    outer loop
+      vertex 61.3457 5.71572 0
+      vertex 62.0451 4.93893 0.799999
+      vertex 62.0451 4.93893 0
+    endloop
+  endfacet
+  facet normal 0.587768 0.809029 -0
+    outer loop
+      vertex 61.3457 5.71572 0
+      vertex 60.5 6.33013 0.799999
+      vertex 61.3457 5.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0.587768 0.809029 0
+    outer loop
+      vertex 60.5 6.33013 0.799999
+      vertex 61.3457 5.71572 0
+      vertex 60.5 6.33013 0
+    endloop
+  endfacet
+  facet normal 0.207903 -0.978149 0
+    outer loop
+      vertex 58.5226 -2.97261 0
+      vertex 59.5451 -2.75528 0.799999
+      vertex 58.5226 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0.207903 -0.978149 0
+    outer loop
+      vertex 59.5451 -2.75528 0.799999
+      vertex 58.5226 -2.97261 0
+      vertex 59.5451 -2.75528 0
+    endloop
+  endfacet
+  facet normal -0.866043 -0.49997 0
+    outer loop
+      vertex 53.9549 -0.938926 0
+      vertex 53.4323 -0.0336828 0.799999
+      vertex 53.4323 -0.0336828 0
+    endloop
+  endfacet
+  facet normal -0.866043 -0.49997 0
+    outer loop
+      vertex 53.4323 -0.0336828 0.799999
+      vertex 53.9549 -0.938926 0
+      vertex 53.9549 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59 4.5 0.799999
+      vertex 60 3.5 0.799999
+      vertex 60 4.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 3.5 0.799999
+      vertex 59 4.5 0.799999
+      vertex 59 3.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 3.5 0.799999
+      vertex 63 2 0.799999
+      vertex 62.8907 3.03956 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60 3.5 0.799999
+      vertex 62.8907 3.03956 0.799999
+      vertex 62.5677 4.03368 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 63 2 0.799999
+      vertex 60 3.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 3.5 0.799999
+      vertex 62.5677 4.03368 0.799999
+      vertex 62.0451 4.93893 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63 2 0.799999
+      vertex 60 0 0.799999
+      vertex 62.8907 0.960441 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 4.5 0.799999
+      vertex 62.0451 4.93893 0.799999
+      vertex 61.3457 5.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8907 0.960441 0.799999
+      vertex 60 0 0.799999
+      vertex 62.5677 -0.0336828 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 4.5 0.799999
+      vertex 61.3457 5.71572 0.799999
+      vertex 60.5 6.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5677 -0.0336828 0.799999
+      vertex 60 0 0.799999
+      vertex 62.0451 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 4.5 0.799999
+      vertex 60.5 6.33013 0.799999
+      vertex 60 6.55274 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0451 4.93893 0.799999
+      vertex 60 4.5 0.799999
+      vertex 60 3.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0451 -0.938926 0.799999
+      vertex 60 0 0.799999
+      vertex 61.3457 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3457 -1.71572 0.799999
+      vertex 60 0 0.799999
+      vertex 60.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 59.5451 -2.75528 0.799999
+      vertex 60.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 0 0.799999
+      vertex 58.5226 -2.97261 0.799999
+      vertex 59.5451 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 56.5 0 0.799999
+      vertex 58.5226 -2.97261 0.799999
+      vertex 60 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5226 -2.97261 0.799999
+      vertex 56.5 0 0.799999
+      vertex 57.4774 -2.97261 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.4774 -2.97261 0.799999
+      vertex 56.5 0 0.799999
+      vertex 56.4549 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 0 0.799999
+      vertex 56.5 0 0.799999
+      vertex 56.5 1 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 0 0.799999
+      vertex 56.5 1 0.799999
+      vertex 55.5 1 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 -2.33013 0.799999
+      vertex 56.5 0 0.799999
+      vertex 55.5 0 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.5 0 0.799999
+      vertex 55.5 -2.33013 0.799999
+      vertex 56.4549 -2.75528 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 0 0.799999
+      vertex 54.6543 -1.71572 0.799999
+      vertex 55.5 -2.33013 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 0 0.799999
+      vertex 53.9549 -0.938926 0.799999
+      vertex 54.6543 -1.71572 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 0 0.799999
+      vertex 53.4323 -0.0336828 0.799999
+      vertex 53.9549 -0.938926 0.799999
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 53.4323 -0.0336828 0.799999
+      vertex 55.5 0 0.799999
+      vertex 53.4213 0 0.799999
+    endloop
+  endfacet
+  facet normal 0.951138 0.308767 0
+    outer loop
+      vertex 6.57867 60 0.799999
+      vertex 6.56773 60.0337 0
+      vertex 6.56773 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0.951138 0.308767 0
+    outer loop
+      vertex 6.56773 60.0337 0
+      vertex 6.57867 60 0.799999
+      vertex 6.57867 60 0
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex 6.56773 60.0337 0.799999
+      vertex 6.04508 60.9389 0
+      vertex 6.04508 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex 6.04508 60.9389 0
+      vertex 6.56773 60.0337 0.799999
+      vertex 6.56773 60.0337 0
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex -0.5 62.3301 0
+      vertex -1.34565 61.7157 0.799999
+      vertex -0.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex -1.34565 61.7157 0.799999
+      vertex -0.5 62.3301 0
+      vertex -1.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809017 0
+    outer loop
+      vertex -1.34565 54.2843 0
+      vertex -0.5 53.6699 0.799999
+      vertex -1.34565 54.2843 0.799999
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809017 -0
+    outer loop
+      vertex -0.5 53.6699 0.799999
+      vertex -1.34565 54.2843 0
+      vertex -0.5 53.6699 0
+    endloop
+  endfacet
+  facet normal -0.207886 0.978153 0
+    outer loop
+      vertex 1.47736 62.9726 0
+      vertex 0.454914 62.7553 0.799999
+      vertex 1.47736 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal -0.207886 0.978153 0
+    outer loop
+      vertex 0.454914 62.7553 0.799999
+      vertex 1.47736 62.9726 0
+      vertex 0.454914 62.7553 0
+    endloop
+  endfacet
+  facet normal 0.207888 0.978153 -0
+    outer loop
+      vertex 3.54508 62.7553 0
+      vertex 2.52264 62.9726 0.799999
+      vertex 3.54508 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0.207888 0.978153 0
+    outer loop
+      vertex 2.52264 62.9726 0.799999
+      vertex 3.54508 62.7553 0
+      vertex 2.52264 62.9726 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669129 0
+    outer loop
+      vertex -2.04508 60.9389 0
+      vertex -1.34565 61.7157 0.799999
+      vertex -1.34565 61.7157 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669129 0
+    outer loop
+      vertex -1.34565 61.7157 0.799999
+      vertex -2.04508 60.9389 0
+      vertex -2.04508 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal -0.951054 0.309023 0
+    outer loop
+      vertex -2.89074 59.0396 0
+      vertex -2.56773 60.0337 0.799999
+      vertex -2.56773 60.0337 0
+    endloop
+  endfacet
+  facet normal -0.951054 0.309023 0
+    outer loop
+      vertex -2.56773 60.0337 0.799999
+      vertex -2.89074 59.0396 0
+      vertex -2.89074 59.0396 0.799999
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104522 0
+    outer loop
+      vertex -2.89074 56.9604 0
+      vertex -3 58 0.799999
+      vertex -3 58 0
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104522 0
+    outer loop
+      vertex -3 58 0.799999
+      vertex -2.89074 56.9604 0
+      vertex -2.89074 56.9604 0.799999
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex -2.04508 55.0611 0
+      vertex -2.56773 55.9663 0.799999
+      vertex -2.56773 55.9663 0
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex -2.56773 55.9663 0.799999
+      vertex -2.04508 55.0611 0
+      vertex -2.04508 55.0611 0.799999
+    endloop
+  endfacet
+  facet normal -0.951054 -0.309023 0
+    outer loop
+      vertex -2.56773 55.9663 0
+      vertex -2.89074 56.9604 0.799999
+      vertex -2.89074 56.9604 0
+    endloop
+  endfacet
+  facet normal -0.951054 -0.309023 0
+    outer loop
+      vertex -2.89074 56.9604 0.799999
+      vertex -2.56773 55.9663 0
+      vertex -2.56773 55.9663 0.799999
+    endloop
+  endfacet
+  facet normal 0.40677 0.91353 -0
+    outer loop
+      vertex 4.5 62.3301 0
+      vertex 3.54508 62.7553 0.799999
+      vertex 4.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0.40677 0.91353 0
+    outer loop
+      vertex 3.54508 62.7553 0.799999
+      vertex 4.5 62.3301 0
+      vertex 3.54508 62.7553 0
+    endloop
+  endfacet
+  facet normal -0.994523 0.104522 0
+    outer loop
+      vertex -3 58 0
+      vertex -2.89074 59.0396 0.799999
+      vertex -2.89074 59.0396 0
+    endloop
+  endfacet
+  facet normal -0.994523 0.104522 0
+    outer loop
+      vertex -2.89074 59.0396 0.799999
+      vertex -3 58 0
+      vertex -3 58 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.52264 62.9726 0
+      vertex 1.47736 62.9726 0.799999
+      vertex 2.52264 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.47736 62.9726 0.799999
+      vertex 2.52264 62.9726 0
+      vertex 1.47736 62.9726 0
+    endloop
+  endfacet
+  facet normal -0.406772 0.913529 0
+    outer loop
+      vertex 0.454914 62.7553 0
+      vertex -0.5 62.3301 0.799999
+      vertex 0.454914 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal -0.406772 0.913529 0
+    outer loop
+      vertex -0.5 62.3301 0.799999
+      vertex 0.454914 62.7553 0
+      vertex -0.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0.743147 0.669129 0
+    outer loop
+      vertex 6.04508 60.9389 0.799999
+      vertex 5.34565 61.7157 0
+      vertex 5.34565 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0.743147 0.669129 0
+    outer loop
+      vertex 5.34565 61.7157 0
+      vertex 6.04508 60.9389 0.799999
+      vertex 6.04508 60.9389 0
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 0
+    outer loop
+      vertex -0.5 53.6699 0
+      vertex 0 53.4473 0.799999
+      vertex -0.5 53.6699 0.799999
+    endloop
+  endfacet
+  facet normal -0.406715 -0.913555 -0
+    outer loop
+      vertex 0 53.4473 0.799999
+      vertex -0.5 53.6699 0
+      vertex 0 53.4473 0
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 -0
+    outer loop
+      vertex 5.34565 61.7157 0
+      vertex 4.5 62.3301 0.799999
+      vertex 5.34565 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 0
+    outer loop
+      vertex 4.5 62.3301 0.799999
+      vertex 5.34565 61.7157 0
+      vertex 4.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.52264 62.9726 0.799999
+      vertex 3.5 60 0.799999
+      vertex 3.54508 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.47736 62.9726 0.799999
+      vertex 3.5 60 0.799999
+      vertex 2.52264 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 60 0.799999
+      vertex 1.47736 62.9726 0.799999
+      vertex 0.454914 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.47736 62.9726 0.799999
+      vertex 0 60 0.799999
+      vertex 3.5 60 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3 58 0.799999
+      vertex 0 56.5 0.799999
+      vertex 0 60 0.799999
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -2.89074 56.9604 0.799999
+      vertex 0 56.5 0.799999
+      vertex -3 58 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.5 62.3301 0.799999
+      vertex 0 60 0.799999
+      vertex 0.454914 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.34565 61.7157 0.799999
+      vertex 0 60 0.799999
+      vertex -0.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.04508 60.9389 0.799999
+      vertex 0 60 0.799999
+      vertex -1.34565 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.56773 60.0337 0.799999
+      vertex 0 60 0.799999
+      vertex -2.04508 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 55.5 0.799999
+      vertex -0.5 53.6699 0.799999
+      vertex 0 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 55.5 0.799999
+      vertex -2.04508 55.0611 0.799999
+      vertex -1.34565 54.2843 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 55.5 0.799999
+      vertex -1.34565 54.2843 0.799999
+      vertex -0.5 53.6699 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89074 59.0396 0.799999
+      vertex 0 60 0.799999
+      vertex -2.56773 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 56.5 0.799999
+      vertex -2.04508 55.0611 0.799999
+      vertex 0 55.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3 58 0.799999
+      vertex 0 60 0.799999
+      vertex -2.89074 59.0396 0.799999
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -2.04508 55.0611 0.799999
+      vertex 0 56.5 0.799999
+      vertex -2.56773 55.9663 0.799999
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -2.56773 55.9663 0.799999
+      vertex 0 56.5 0.799999
+      vertex -2.89074 56.9604 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 60 0.799999
+      vertex 6.56773 60.0337 0.799999
+      vertex 6.04508 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 60 0.799999
+      vertex 6.04508 60.9389 0.799999
+      vertex 5.34565 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 60 0.799999
+      vertex 5.34565 61.7157 0.799999
+      vertex 4.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.56773 60.0337 0.799999
+      vertex 4.5 60 0.799999
+      vertex 6.57867 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 60 0.799999
+      vertex 4.5 60 0.799999
+      vertex 4.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 60 0.799999
+      vertex 4.5 62.3301 0.799999
+      vertex 3.54508 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 60 0.799999
+      vertex 3.5 60 0.799999
+      vertex 4.5 59 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5 59 0.799999
+      vertex 3.5 60 0.799999
+      vertex 3.5 59 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 56.5 0.799999
+      vertex 1 55.5 0.799999
+      vertex 1 56.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1 55.5 0.799999
+      vertex 0 56.5 0.799999
+      vertex 0 55.5 0.799999
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex -2.56773 60.0337 0
+      vertex -2.04508 60.9389 0.799999
+      vertex -2.04508 60.9389 0
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex -2.04508 60.9389 0.799999
+      vertex -2.56773 60.0337 0
+      vertex -2.56773 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669129 0
+    outer loop
+      vertex -1.34565 54.2843 0
+      vertex -2.04508 55.0611 0.799999
+      vertex -2.04508 55.0611 0
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669129 0
+    outer loop
+      vertex -2.04508 55.0611 0.799999
+      vertex -1.34565 54.2843 0
+      vertex -1.34565 54.2843 0.799999
+    endloop
+  endfacet
+  facet normal 0.951057 0.309015 0
+    outer loop
+      vertex 62.8907 59.0396 0.799999
+      vertex 62.5677 60.0337 0
+      vertex 62.5677 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0.951057 0.309015 0
+    outer loop
+      vertex 62.5677 60.0337 0
+      vertex 62.8907 59.0396 0.799999
+      vertex 62.8907 59.0396 0
+    endloop
+  endfacet
+  facet normal 0.994519 0.10456 0
+    outer loop
+      vertex 63 58 0.799999
+      vertex 62.8907 59.0396 0
+      vertex 62.8907 59.0396 0.799999
+    endloop
+  endfacet
+  facet normal 0.994519 0.10456 0
+    outer loop
+      vertex 62.8907 59.0396 0
+      vertex 63 58 0.799999
+      vertex 63 58 0
+    endloop
+  endfacet
+  facet normal 0.866033 0.499987 0
+    outer loop
+      vertex 62.5677 60.0337 0.799999
+      vertex 62.0451 60.9389 0
+      vertex 62.0451 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0.866033 0.499987 0
+    outer loop
+      vertex 62.0451 60.9389 0
+      vertex 62.5677 60.0337 0.799999
+      vertex 62.5677 60.0337 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 58.5226 62.9726 0
+      vertex 57.4774 62.9726 0.799999
+      vertex 58.5226 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 57.4774 62.9726 0.799999
+      vertex 58.5226 62.9726 0
+      vertex 57.4774 62.9726 0
+    endloop
+  endfacet
+  facet normal 0.743161 -0.669113 0
+    outer loop
+      vertex 61.3457 54.2843 0.799999
+      vertex 62.0451 55.0611 0
+      vertex 62.0451 55.0611 0.799999
+    endloop
+  endfacet
+  facet normal 0.743161 -0.669113 0
+    outer loop
+      vertex 62.0451 55.0611 0
+      vertex 61.3457 54.2843 0.799999
+      vertex 61.3457 54.2843 0
+    endloop
+  endfacet
+  facet normal 0.207876 0.978155 -0
+    outer loop
+      vertex 59.5451 62.7553 0
+      vertex 58.5226 62.9726 0.799999
+      vertex 59.5451 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0.207876 0.978155 0
+    outer loop
+      vertex 58.5226 62.9726 0.799999
+      vertex 59.5451 62.7553 0
+      vertex 58.5226 62.9726 0
+    endloop
+  endfacet
+  facet normal 0.743161 0.669113 0
+    outer loop
+      vertex 62.0451 60.9389 0.799999
+      vertex 61.3457 61.7157 0
+      vertex 61.3457 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0.743161 0.669113 0
+    outer loop
+      vertex 61.3457 61.7157 0
+      vertex 62.0451 60.9389 0.799999
+      vertex 62.0451 60.9389 0
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309015 0
+    outer loop
+      vertex 62.5677 55.9663 0.799999
+      vertex 62.8907 56.9604 0
+      vertex 62.8907 56.9604 0.799999
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309015 0
+    outer loop
+      vertex 62.8907 56.9604 0
+      vertex 62.5677 55.9663 0.799999
+      vertex 62.5677 55.9663 0
+    endloop
+  endfacet
+  facet normal -0.950639 0.310298 0
+    outer loop
+      vertex 53.4213 60 0
+      vertex 53.4323 60.0337 0.799999
+      vertex 53.4323 60.0337 0
+    endloop
+  endfacet
+  facet normal -0.950639 0.310298 0
+    outer loop
+      vertex 53.4323 60.0337 0.799999
+      vertex 53.4213 60 0
+      vertex 53.4213 60 0.799999
+    endloop
+  endfacet
+  facet normal -0.406777 0.913527 0
+    outer loop
+      vertex 56.4549 62.7553 0
+      vertex 55.5 62.3301 0.799999
+      vertex 56.4549 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal -0.406777 0.913527 0
+    outer loop
+      vertex 55.5 62.3301 0.799999
+      vertex 56.4549 62.7553 0
+      vertex 55.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex 60 53.4473 0
+      vertex 60.5 53.6699 0.799999
+      vertex 60 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal 0.406715 -0.913555 0
+    outer loop
+      vertex 60.5 53.6699 0.799999
+      vertex 60 53.4473 0
+      vertex 60.5 53.6699 0
+    endloop
+  endfacet
+  facet normal 0.866033 -0.499987 0
+    outer loop
+      vertex 62.0451 55.0611 0.799999
+      vertex 62.5677 55.9663 0
+      vertex 62.5677 55.9663 0.799999
+    endloop
+  endfacet
+  facet normal 0.866033 -0.499987 0
+    outer loop
+      vertex 62.5677 55.9663 0
+      vertex 62.0451 55.0611 0.799999
+      vertex 62.0451 55.0611 0
+    endloop
+  endfacet
+  facet normal -0.743161 0.669113 0
+    outer loop
+      vertex 53.9549 60.9389 0
+      vertex 54.6543 61.7157 0.799999
+      vertex 54.6543 61.7157 0
+    endloop
+  endfacet
+  facet normal -0.743161 0.669113 0
+    outer loop
+      vertex 54.6543 61.7157 0.799999
+      vertex 53.9549 60.9389 0
+      vertex 53.9549 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal -0.587762 0.809034 0
+    outer loop
+      vertex 55.5 62.3301 0
+      vertex 54.6543 61.7157 0.799999
+      vertex 55.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal -0.587762 0.809034 0
+    outer loop
+      vertex 54.6543 61.7157 0.799999
+      vertex 55.5 62.3301 0
+      vertex 54.6543 61.7157 0
+    endloop
+  endfacet
+  facet normal 0.994519 -0.10456 0
+    outer loop
+      vertex 62.8907 56.9604 0.799999
+      vertex 63 58 0
+      vertex 63 58 0.799999
+    endloop
+  endfacet
+  facet normal 0.994519 -0.10456 0
+    outer loop
+      vertex 63 58 0
+      vertex 62.8907 56.9604 0.799999
+      vertex 62.8907 56.9604 0
+    endloop
+  endfacet
+  facet normal 0.587762 0.809034 -0
+    outer loop
+      vertex 61.3457 61.7157 0
+      vertex 60.5 62.3301 0.799999
+      vertex 61.3457 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0.587762 0.809034 0
+    outer loop
+      vertex 60.5 62.3301 0.799999
+      vertex 61.3457 61.7157 0
+      vertex 60.5 62.3301 0
+    endloop
+  endfacet
+  facet normal 0.406777 0.913527 -0
+    outer loop
+      vertex 60.5 62.3301 0
+      vertex 59.5451 62.7553 0.799999
+      vertex 60.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0.406777 0.913527 0
+    outer loop
+      vertex 59.5451 62.7553 0.799999
+      vertex 60.5 62.3301 0
+      vertex 59.5451 62.7553 0
+    endloop
+  endfacet
+  facet normal -0.866033 0.499987 0
+    outer loop
+      vertex 53.4323 60.0337 0
+      vertex 53.9549 60.9389 0.799999
+      vertex 53.9549 60.9389 0
+    endloop
+  endfacet
+  facet normal -0.866033 0.499987 0
+    outer loop
+      vertex 53.9549 60.9389 0.799999
+      vertex 53.4323 60.0337 0
+      vertex 53.4323 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0.587762 -0.809034 0
+    outer loop
+      vertex 60.5 53.6699 0
+      vertex 61.3457 54.2843 0.799999
+      vertex 60.5 53.6699 0.799999
+    endloop
+  endfacet
+  facet normal 0.587762 -0.809034 0
+    outer loop
+      vertex 61.3457 54.2843 0.799999
+      vertex 60.5 53.6699 0
+      vertex 61.3457 54.2843 0
+    endloop
+  endfacet
+  facet normal -0.207876 0.978155 0
+    outer loop
+      vertex 57.4774 62.9726 0
+      vertex 56.4549 62.7553 0.799999
+      vertex 57.4774 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal -0.207876 0.978155 0
+    outer loop
+      vertex 56.4549 62.7553 0.799999
+      vertex 57.4774 62.9726 0
+      vertex 56.4549 62.7553 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 54.6543 61.7157 0.799999
+      vertex 55.5 60 0.799999
+      vertex 55.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 53.9549 60.9389 0.799999
+      vertex 55.5 60 0.799999
+      vertex 54.6543 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 53.4323 60.0337 0.799999
+      vertex 55.5 60 0.799999
+      vertex 53.9549 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5 60 0.799999
+      vertex 53.4323 60.0337 0.799999
+      vertex 53.4213 60 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59 56.5 0.799999
+      vertex 60 55.5 0.799999
+      vertex 60 56.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 55.5 0.799999
+      vertex 59 56.5 0.799999
+      vertex 59 55.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 63 58 0.799999
+      vertex 62.8907 59.0396 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 62.8907 59.0396 0.799999
+      vertex 62.5677 60.0337 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63 58 0.799999
+      vertex 60 60 0.799999
+      vertex 60 56.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 62.5677 60.0337 0.799999
+      vertex 62.0451 60.9389 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63 58 0.799999
+      vertex 60 56.5 0.799999
+      vertex 62.8907 56.9604 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 62.0451 60.9389 0.799999
+      vertex 61.3457 61.7157 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8907 56.9604 0.799999
+      vertex 60 56.5 0.799999
+      vertex 62.5677 55.9663 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 60 0.799999
+      vertex 61.3457 61.7157 0.799999
+      vertex 60.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5677 55.9663 0.799999
+      vertex 60 56.5 0.799999
+      vertex 62.0451 55.0611 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60 55.5 0.799999
+      vertex 62.0451 55.0611 0.799999
+      vertex 60 56.5 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5451 62.7553 0.799999
+      vertex 60 60 0.799999
+      vertex 60.5 62.3301 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5226 62.9726 0.799999
+      vertex 60 60 0.799999
+      vertex 59.5451 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.5 60 0.799999
+      vertex 58.5226 62.9726 0.799999
+      vertex 57.4774 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5226 62.9726 0.799999
+      vertex 56.5 60 0.799999
+      vertex 60 60 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 56.4549 62.7553 0.799999
+      vertex 56.5 60 0.799999
+      vertex 57.4774 62.9726 0.799999
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 55.5 62.3301 0.799999
+      vertex 56.5 60 0.799999
+      vertex 56.4549 62.7553 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.5 60 0.799999
+      vertex 55.5 62.3301 0.799999
+      vertex 55.5 60 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.5 60 0.799999
+      vertex 55.5 60 0.799999
+      vertex 56.5 59 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.5 59 0.799999
+      vertex 55.5 60 0.799999
+      vertex 55.5 59 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0451 55.0611 0.799999
+      vertex 60 55.5 0.799999
+      vertex 61.3457 54.2843 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3457 54.2843 0.799999
+      vertex 60 55.5 0.799999
+      vertex 60.5 53.6699 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5 53.6699 0.799999
+      vertex 60 55.5 0.799999
+      vertex 60 53.4473 0.799999
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 55 5 0
+      vertex 55 29 50
+      vertex 55 29 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 55 29 50
+      vertex 55 5 0
+      vertex 55 5 50
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 55 31 0
+      vertex 55 55 50
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 55 55 50
+      vertex 55 31 0
+      vertex 55 31 50
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 5 27 50
+      vertex 5 55 0
+      vertex 5 55 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 55 0
+      vertex 5 27 50
+      vertex 5 27 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 5 5 50
+      vertex 5 25 0
+      vertex 5 25 50
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 25 0
+      vertex 5 5 50
+      vertex 5 5 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5 55 0
+      vertex 29 55 50
+      vertex 5 55 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 29 55 50
+      vertex 5 55 0
+      vertex 29 55 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 31 55 0
+      vertex 55 55 50
+      vertex 31 55 50
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 55 55 50
+      vertex 31 55 0
+      vertex 55 55 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 29 5 0
+      vertex 5 5 50
+      vertex 29 5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5 5 50
+      vertex 29 5 0
+      vertex 5 5 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 55 5 0
+      vertex 31 5 50
+      vertex 55 5 50
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 31 5 50
+      vertex 55 5 0
+      vertex 31 5 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -108,6 +108,8 @@ defs_kin_extruder = """
 defs_kin_smooth_axis = """
     void smooth_axis_set_time(struct stepper_kinematics *sk
         , double smooth_x, double smooth_y);
+    void smooth_axis_set_accel_comp(struct stepper_kinematics *sk
+        , double accel_comp_x, double accel_comp_y);
     int smooth_axis_set_sk(struct stepper_kinematics *sk
         , struct stepper_kinematics *orig_sk);
     struct stepper_kinematics * smooth_axis_alloc(void);

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -108,6 +108,8 @@ defs_kin_extruder = """
 defs_kin_smooth_axis = """
     void smooth_axis_set_time(struct stepper_kinematics *sk
         , double smooth_x, double smooth_y);
+    void smooth_axis_set_damping_comp(struct stepper_kinematics *sk
+        , double accel_comp_x, double accel_comp_y);
     void smooth_axis_set_accel_comp(struct stepper_kinematics *sk
         , double accel_comp_x, double accel_comp_y);
     int smooth_axis_set_sk(struct stepper_kinematics *sk

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -18,11 +18,12 @@ SOURCE_FILES = [
     'pyhelper.c', 'serialqueue.c', 'stepcompress.c', 'itersolve.c', 'trapq.c',
     'kin_cartesian.c', 'kin_corexy.c', 'kin_delta.c', 'kin_polar.c',
     'kin_rotary_delta.c', 'kin_winch.c', 'kin_extruder.c', 'kin_smooth_axis.c',
+    'integrate.c',
 ]
 DEST_LIB = "c_helper.so"
 OTHER_FILES = [
-    'list.h', 'serialqueue.h', 'stepcompress.h', 'itersolve.h', 'pyhelper.h',
-    'trapq.h',
+    'list.h', 'serialqueue.h', 'stepcompress.h', 'integrate.h', 'itersolve.h',
+    'pyhelper.h', 'trapq.h'
 ]
 
 defs_stepcompress = """

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -17,7 +17,7 @@ COMPILE_CMD = ("gcc -Wall -g -O2 -shared -fPIC"
 SOURCE_FILES = [
     'pyhelper.c', 'serialqueue.c', 'stepcompress.c', 'itersolve.c', 'trapq.c',
     'kin_cartesian.c', 'kin_corexy.c', 'kin_delta.c', 'kin_polar.c',
-    'kin_rotary_delta.c', 'kin_winch.c', 'kin_extruder.c',
+    'kin_rotary_delta.c', 'kin_winch.c', 'kin_extruder.c', 'kin_smooth_axis.c',
 ]
 DEST_LIB = "c_helper.so"
 OTHER_FILES = [
@@ -104,6 +104,14 @@ defs_kin_extruder = """
         , double smooth_time);
 """
 
+defs_kin_smooth_axis = """
+    void smooth_axis_set_time(struct stepper_kinematics *sk
+        , double smooth_x, double smooth_y);
+    int smooth_axis_set_sk(struct stepper_kinematics *sk
+        , struct stepper_kinematics *orig_sk);
+    struct stepper_kinematics * smooth_axis_alloc(void);
+"""
+
 defs_serialqueue = """
     #define MESSAGE_MAX 64
     struct pull_queue_message {
@@ -147,7 +155,8 @@ defs_all = [
     defs_pyhelper, defs_serialqueue, defs_std,
     defs_stepcompress, defs_itersolve, defs_trapq,
     defs_kin_cartesian, defs_kin_corexy, defs_kin_delta, defs_kin_polar,
-    defs_kin_rotary_delta, defs_kin_winch, defs_kin_extruder
+    defs_kin_rotary_delta, defs_kin_winch, defs_kin_extruder,
+    defs_kin_smooth_axis,
 ]
 
 # Return the list of file modification times

--- a/klippy/chelper/integrate.c
+++ b/klippy/chelper/integrate.c
@@ -1,0 +1,61 @@
+// Helpers to integrate the smoothing weight function.
+//
+// Copyright (C) 2019-2020  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "integrate.h"
+
+// Integrate (t^2-h^2)^2
+static inline double
+iwt0(double h, double t)
+{
+    double t2 = t*t;
+    double h2 = h*h;
+    double h4 = h2*h2;
+    return ((.2 * t2 - (2./3.) * h2) * t2 + h4) * t;
+}
+
+// Integrate t * (t^2-h^2)^2
+static inline double
+iwt1(double h, double t)
+{
+    double t2 = t*t;
+    double h2 = h*h;
+    double r = t2-h2;
+    return (1./6.) * r * r * r;
+}
+
+// Integrate t^2 * (t^2-h^2)^2
+static inline double
+iwt2(double h, double t)
+{
+    double t2 = t*t;
+    double h2 = h*h;
+    double h4 = h2*h2;
+    return (((1./7.) * t2 - .4 * h2) * t2 + (1./3.) * h4) * t2 * t;
+}
+
+// Integrate (pos + start_v*t + half_accel*t^2) with smoothing weight function
+// ((t-T)^2-h^2)^2 over the range [start; end] with T == -toff
+double
+integrate_weighted(double pos, double start_v, double half_accel
+                   , double start, double end, double toff, double hst)
+{
+    // Substitute the integration variable tnew = t + toff to simplify integrals
+    pos += (half_accel * toff - start_v) * toff;
+    start_v -= 2. * half_accel * toff;
+    start += toff; end += toff;
+    double res = half_accel * (iwt2(hst, end) - iwt2(hst, start));
+    res += start_v * (iwt1(hst, end) - iwt1(hst, start));
+    res += pos * (iwt0(hst, end) - iwt0(hst, start));
+    return res;
+}
+
+// Calculate the inverse of the norm of the weight function ((t-T)^2-h^2)^2
+double
+calc_inv_norm(double hst)
+{
+    return 15. / (16. * hst * hst * hst * hst * hst);
+}

--- a/klippy/chelper/integrate.c
+++ b/klippy/chelper/integrate.c
@@ -59,3 +59,11 @@ calc_inv_norm(double hst)
 {
     return 15. / (16. * hst * hst * hst * hst * hst);
 }
+
+// Return the instantaneous weighting of the function ((t-T)^2-h^2)^2
+double
+integrate_time_weight(double toff, double hst)
+{
+    double v = toff*toff - hst*hst;
+    return v*v;
+}

--- a/klippy/chelper/integrate.h
+++ b/klippy/chelper/integrate.h
@@ -1,0 +1,9 @@
+#ifndef INTEGRATE_H
+#define INTEGRATE_H
+
+double integrate_weighted(double pos, double start_v, double half_accel,
+                          double start, double end,
+                          double toff, double hst);
+double calc_inv_norm(double hst);
+
+#endif // integrate.h

--- a/klippy/chelper/integrate.h
+++ b/klippy/chelper/integrate.h
@@ -5,5 +5,6 @@ double integrate_weighted(double pos, double start_v, double half_accel,
                           double start, double end,
                           double toff, double hst);
 double calc_inv_norm(double hst);
+double integrate_time_weight(double toff, double hst);
 
 #endif // integrate.h

--- a/klippy/chelper/kin_smooth_axis.c
+++ b/klippy/chelper/kin_smooth_axis.c
@@ -1,0 +1,170 @@
+// Kinematic filter to smooth out cartesian XY movements
+//
+// Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <stddef.h> // offsetof
+#include <stdlib.h> // malloc
+#include <string.h> // memset
+#include "compiler.h" // __visible
+#include "itersolve.h" // struct stepper_kinematics
+#include "pyhelper.h" // errorf
+#include "trapq.h" // trapq_integrate
+
+// Calculate the definitive integral of the move distance
+static double
+move_integrate_distance(struct move *m, double start, double end)
+{
+    double half_v = .5 * m->start_v, sixth_a = (1. / 3.) * m->half_accel;
+    double si = start * start * (half_v + sixth_a * start);
+    double ei = end * end * (half_v + sixth_a * end);
+    return ei - si;
+}
+
+// Calculate the definitive integral on part of a move
+static double
+move_integrate(struct move *m, int axis, double start, double end)
+{
+    if (start < 0.)
+        start = 0.;
+    if (end > m->move_t)
+        end = m->move_t;
+    double base = m->start_pos.axis[axis - 'x'] * (end - start);
+    double integral = move_integrate_distance(m, start, end);
+    return base + integral * m->axes_r.axis[axis - 'x'];
+}
+
+// Calculate the definitive integral for a range of moves
+static double
+range_integrate(struct move *m, int axis, double start, double end)
+{
+    double res = move_integrate(m, axis, start, end);
+    // Integrate over previous moves
+    struct move *prev = m;
+    while (unlikely(start < 0.)) {
+        prev = list_prev_entry(prev, node);
+        start += prev->move_t;
+        res += move_integrate(prev, axis, start, prev->move_t);
+    }
+    // Integrate over future moves
+    while (unlikely(end > m->move_t)) {
+        end -= m->move_t;
+        m = list_next_entry(m, node);
+        res += move_integrate(m, axis, 0., end);
+    }
+    return res;
+}
+
+// Calculate average position over smooth_time window
+static inline double
+calc_position(struct move *m, int axis, double move_time
+              , double hst, double inv_smooth_time)
+{
+    double area = range_integrate(m, axis, move_time - hst, move_time + hst);
+    return area * inv_smooth_time;
+}
+
+struct smooth_axis {
+    struct stepper_kinematics sk;
+    struct stepper_kinematics *orig_sk;
+    double x_half_smooth_time, x_inv_smooth_time;
+    double y_half_smooth_time, y_inv_smooth_time;
+    struct move m;
+};
+
+#define DUMMY_T 500.0
+
+// Optimized calc_position when only x axis is needed
+static double
+smooth_x_calc_position(struct stepper_kinematics *sk, struct move *m
+                       , double move_time)
+{
+    struct smooth_axis *sa = container_of(sk, struct smooth_axis, sk);
+    double hst = sa->x_half_smooth_time;
+    if (!hst)
+        return sa->orig_sk->calc_position_cb(sa->orig_sk, m, move_time);
+    sa->m.start_pos.x = calc_position(m, 'x', move_time, hst
+                                      , sa->x_inv_smooth_time);
+    return sa->orig_sk->calc_position_cb(sa->orig_sk, &sa->m, DUMMY_T);
+}
+
+// Optimized calc_position when only y axis is needed
+static double
+smooth_y_calc_position(struct stepper_kinematics *sk, struct move *m
+                       , double move_time)
+{
+    struct smooth_axis *sa = container_of(sk, struct smooth_axis, sk);
+    double hst = sa->y_half_smooth_time;
+    if (!hst)
+        return sa->orig_sk->calc_position_cb(sa->orig_sk, m, move_time);
+    sa->m.start_pos.y = calc_position(m, 'y', move_time, hst
+                                      , sa->y_inv_smooth_time);
+    return sa->orig_sk->calc_position_cb(sa->orig_sk, &sa->m, DUMMY_T);
+}
+
+// General calc_position for both x and y axes
+static double
+smooth_xy_calc_position(struct stepper_kinematics *sk, struct move *m
+                        , double move_time)
+{
+    struct smooth_axis *sa = container_of(sk, struct smooth_axis, sk);
+    double x_hst = sa->x_half_smooth_time;
+    double y_hst = sa->y_half_smooth_time;
+    if (!x_hst && !y_hst)
+        return sa->orig_sk->calc_position_cb(sa->orig_sk, m, move_time);
+    sa->m.start_pos = move_get_coord(m, move_time);
+    if (x_hst)
+        sa->m.start_pos.x = calc_position(m, 'x', move_time, x_hst
+                                          , sa->x_inv_smooth_time);
+    if (y_hst)
+        sa->m.start_pos.y = calc_position(m, 'y', move_time, y_hst
+                                          , sa->y_inv_smooth_time);
+    return sa->orig_sk->calc_position_cb(sa->orig_sk, &sa->m, DUMMY_T);
+}
+
+void __visible
+smooth_axis_set_time(struct stepper_kinematics *sk
+                     , double smooth_x, double smooth_y)
+{
+    struct smooth_axis *sa = container_of(sk, struct smooth_axis, sk);
+    sa->x_half_smooth_time = .5 * smooth_x;
+    sa->x_inv_smooth_time = 1. / smooth_x;
+    sa->y_half_smooth_time = .5 * smooth_y;
+    sa->y_inv_smooth_time = 1. / smooth_y;
+
+    double hst = 0.;
+    if (sa->sk.active_flags & AF_X)
+        hst = sa->x_half_smooth_time;
+    if (sa->sk.active_flags & AF_Y)
+        hst = sa->y_half_smooth_time > hst ? sa->y_half_smooth_time : hst;
+    sa->sk.gen_steps_pre_active = sa->sk.gen_steps_post_active = hst;
+}
+
+int __visible
+smooth_axis_set_sk(struct stepper_kinematics *sk
+                   , struct stepper_kinematics *orig_sk)
+{
+    struct smooth_axis *sa = container_of(sk, struct smooth_axis, sk);
+    int af = orig_sk->active_flags & (AF_X | AF_Y);
+    if (af == (AF_X | AF_Y))
+        sa->sk.calc_position_cb = smooth_xy_calc_position;
+    else if (af & AF_X)
+        sa->sk.calc_position_cb = smooth_x_calc_position;
+    else if (af & AF_Y)
+        sa->sk.calc_position_cb = smooth_y_calc_position;
+    else
+        return -1;
+    sa->sk.active_flags = orig_sk->active_flags;
+    sa->orig_sk = orig_sk;
+    return 0;
+}
+
+struct stepper_kinematics * __visible
+smooth_axis_alloc(void)
+{
+    struct smooth_axis *sa = malloc(sizeof(*sa));
+    memset(sa, 0, sizeof(*sa));
+    sa->m.move_t = 2. * DUMMY_T;
+    return &sa->sk;
+}

--- a/klippy/extras/smooth_axis.py
+++ b/klippy/extras/smooth_axis.py
@@ -1,0 +1,69 @@
+# Positional smoother on cartesian XY axes
+#
+# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+import chelper
+
+class SmoothAxis:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.printer.register_event_handler("klippy:connect", self.connect)
+        self.toolhead = None
+        self.smooth_x = config.getfloat('smooth_x', 0., minval=0., maxval=.200)
+        self.smooth_y = config.getfloat('smooth_y', 0., minval=0., maxval=.200)
+        self.stepper_kinematics = []
+        self.orig_stepper_kinematics = []
+        # Stepper kinematics code
+        ffi_main, ffi_lib = chelper.get_ffi()
+        self._set_time = ffi_lib.smooth_axis_set_time
+        self._set_sk = ffi_lib.smooth_axis_set_sk
+        # Register gcode commands
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command("SET_SMOOTH_AXIS",
+                               self.cmd_SET_SMOOTH_AXIS,
+                               desc=self.cmd_SET_SMOOTH_AXIS_help)
+    def connect(self):
+        self.toolhead = self.printer.lookup_object("toolhead")
+        kin = self.toolhead.get_kinematics()
+        # Lookup stepper kinematics
+        ffi_main, ffi_lib = chelper.get_ffi()
+        steppers = kin.get_steppers()
+        for s in steppers:
+            sk = ffi_main.gc(ffi_lib.smooth_axis_alloc(), ffi_lib.free)
+            orig_sk = s.set_stepper_kinematics(sk)
+            res = ffi_lib.smooth_axis_set_sk(sk, orig_sk)
+            if res < 0:
+                s.set_stepper_kinematics(orig_sk)
+                continue
+            s.set_trapq(self.toolhead.get_trapq())
+            self.stepper_kinematics.append(sk)
+            self.orig_stepper_kinematics.append(orig_sk)
+        # Configure initial values
+        config_smooth_x = self.smooth_x
+        config_smooth_y = self.smooth_y
+        self.smooth_x = self.smooth_y = 0.
+        self._set_smooth_time(config_smooth_x, config_smooth_y)
+    def _set_smooth_time(self, smooth_x, smooth_y):
+        old_smooth_time = max(self.smooth_x, self.smooth_y) * .5
+        new_smooth_time = max(smooth_x, smooth_y) * .5
+        self.toolhead.note_step_generation_scan_time(new_smooth_time,
+                                                     old_delay=old_smooth_time)
+        self.smooth_x = smooth_x
+        self.smooth_y = smooth_y
+        ffi_main, ffi_lib = chelper.get_ffi()
+        for sk in self.stepper_kinematics:
+            ffi_lib.smooth_axis_set_time(sk, smooth_x, smooth_y)
+    cmd_SET_SMOOTH_AXIS_help = "Set cartesian time smoothing parameters"
+    def cmd_SET_SMOOTH_AXIS(self, params):
+        gcode = self.printer.lookup_object('gcode')
+        smooth_x = gcode.get_float('SMOOTH_X', params, self.smooth_x,
+                                   minval=0., maxval=.200)
+        smooth_y = gcode.get_float('SMOOTH_Y', params, self.smooth_y,
+                                   minval=0., maxval=.200)
+        self._set_smooth_time(smooth_x, smooth_y)
+        gcode.respond_info("smooth_x:%.6f smooth_y:%.6f" % (smooth_x, smooth_y))
+
+def load_config(config):
+    return SmoothAxis(config)

--- a/klippy/extras/smooth_axis.py
+++ b/klippy/extras/smooth_axis.py
@@ -3,27 +3,30 @@
 # Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging
+import logging, math
 import chelper
 
 MAX_DAMPING_COMPENSATION = 0.05
-MAX_ACCEL_COMPENSATION = 0.005
 
 class SmoothAxis:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.connect)
         self.toolhead = None
-        self.damping_comp_x = config.getfloat('damping_comp_x'
-                , 0., minval=0., maxval=MAX_DAMPING_COMPENSATION)
-        self.damping_comp_y = config.getfloat('damping_comp_y'
-                , 0., minval=0., maxval=MAX_DAMPING_COMPENSATION)
-        self.accel_comp_x = config.getfloat('accel_comp_x'
-                , 0., minval=0., maxval=MAX_ACCEL_COMPENSATION)
-        self.accel_comp_y = config.getfloat('accel_comp_y'
-                , 0., minval=0., maxval=MAX_ACCEL_COMPENSATION)
-        self.smooth_x = config.getfloat('smooth_x', 0., minval=0., maxval=.200)
-        self.smooth_y = config.getfloat('smooth_y', 0., minval=0., maxval=.200)
+        self.damping_comp_x = config.getfloat('damping_comp_x',
+                                              0., minval=0.,
+                                              maxval=MAX_DAMPING_COMPENSATION)
+        self.damping_comp_y = config.getfloat('damping_comp_y',
+                                              0., minval=0.,
+                                              maxval=MAX_DAMPING_COMPENSATION)
+        self.spring_period_x = config.getfloat('spring_period_x', 0., minval=0.)
+        self.spring_period_y = config.getfloat('spring_period_y', 0., minval=0.)
+        self.smooth_x = config.getfloat('smooth_x',
+                                        2. / 3. * self.spring_period_x,
+                                        minval=0., maxval=.200)
+        self.smooth_y = config.getfloat('smooth_y',
+                                        2. / 3. * self.spring_period_y,
+                                        minval=0., maxval=.200)
         self.stepper_kinematics = []
         self.orig_stepper_kinematics = []
         # Stepper kinematics code
@@ -56,10 +59,10 @@ class SmoothAxis:
         config_smooth_y = self.smooth_y
         self.smooth_x = self.smooth_y = 0.
         self._set_smoothing(self.damping_comp_x, self.damping_comp_y,
-                            self.accel_comp_x, self.accel_comp_y,
+                            self.spring_period_x, self.spring_period_y,
                             config_smooth_x, config_smooth_y)
     def _set_smoothing(self, damping_comp_x, damping_comp_y
-                       , accel_comp_x, accel_comp_y
+                       , spring_period_x, spring_period_y
                        , smooth_x, smooth_y):
         old_smooth_time = max(self.smooth_x, self.smooth_y) * .5
         new_smooth_time = max(smooth_x, smooth_y) * .5
@@ -69,8 +72,10 @@ class SmoothAxis:
         self.smooth_y = smooth_y
         self.damping_comp_x = damping_comp_x
         self.damping_comp_y = damping_comp_y
-        self.accel_comp_x = accel_comp_x
-        self.accel_comp_y = accel_comp_y
+        self.spring_period_x = spring_period_x
+        self.spring_period_y = spring_period_y
+        accel_comp_x = (spring_period_x / (2. * math.pi))**2
+        accel_comp_y = (spring_period_y / (2. * math.pi))**2
         ffi_main, ffi_lib = chelper.get_ffi()
         for sk in self.stepper_kinematics:
             ffi_lib.smooth_axis_set_time(sk, smooth_x, smooth_y)
@@ -80,47 +85,32 @@ class SmoothAxis:
     cmd_SET_SMOOTH_AXIS_help = "Set cartesian time smoothing parameters"
     def cmd_SET_SMOOTH_AXIS(self, params):
         gcode = self.printer.lookup_object('gcode')
-        damping_comp_xy = gcode.get_float(
-                'DAMPING_COMP_XY', params, -1.0,
-                minval=-1.0, maxval=MAX_DAMPING_COMPENSATION)
-        if damping_comp_xy < 0:
-            damping_comp_x = gcode.get_float(
-                    'DAMPING_COMP_X', params, self.damping_comp_x,
-                    minval=0., maxval=MAX_DAMPING_COMPENSATION)
-            damping_comp_y = gcode.get_float(
-                    'DAMPING_COMP_Y', params, self.damping_comp_y,
-                    minval=0., maxval=MAX_DAMPING_COMPENSATION)
-        else:
-            damping_comp_x = damping_comp_y = damping_comp_xy
-        accel_comp_xy = gcode.get_float(
-                'ACCEL_COMP_XY', params, -1.0,
-                minval=-1.0, maxval=MAX_ACCEL_COMPENSATION)
-        if accel_comp_xy < 0:
-            accel_comp_x = gcode.get_float(
-                    'ACCEL_COMP_X', params, self.accel_comp_x,
-                    minval=0., maxval=MAX_ACCEL_COMPENSATION)
-            accel_comp_y = gcode.get_float(
-                    'ACCEL_COMP_Y', params, self.accel_comp_y,
-                    minval=0., maxval=MAX_ACCEL_COMPENSATION)
-        else:
-            accel_comp_x = accel_comp_y = accel_comp_xy
-        smooth_xy = gcode.get_float('SMOOTH_XY', params, -1.0,
-                                    minval=-1.0, maxval=.200)
-        if smooth_xy < 0:
-            smooth_x = gcode.get_float('SMOOTH_X', params, self.smooth_x,
-                                       minval=0., maxval=.200)
-            smooth_y = gcode.get_float('SMOOTH_Y', params, self.smooth_y,
-                                       minval=0., maxval=.200)
-        else:
-            smooth_x = smooth_y = smooth_xy
+        damping_comp_x = gcode.get_float('DAMPING_COMP_X', params,
+                                         self.damping_comp_x, minval=0.,
+                                         maxval=MAX_DAMPING_COMPENSATION)
+        damping_comp_y = gcode.get_float('DAMPING_COMP_Y', params,
+                                         self.damping_comp_y, minval=0.,
+                                         maxval=MAX_DAMPING_COMPENSATION)
+        spring_period_x = gcode.get_float('SPRING_PERIOD_X', params,
+                                          self.spring_period_x, minval=0.)
+        spring_period_y = gcode.get_float('SPRING_PERIOD_Y', params,
+                                          self.spring_period_y, minval=0.)
+        smooth_x = gcode.get_float('SMOOTH_X', params, self.smooth_x,
+                                   minval=0., maxval=.200)
+        smooth_y = gcode.get_float('SMOOTH_Y', params, self.smooth_y,
+                                   minval=0., maxval=.200)
+        if 'SPRING_PERIOD_X' in params and 'SMOOTH_X' not in params:
+            smooth_x = 2./3. * spring_period_x
+        if 'SPRING_PERIOD_Y' in params and 'SMOOTH_Y' not in params:
+            smooth_y = 2./3. * spring_period_y
         self._set_smoothing(damping_comp_x, damping_comp_y,
-                            accel_comp_x, accel_comp_y,
+                            spring_period_x, spring_period_y,
                             smooth_x, smooth_y)
         gcode.respond_info("damping_comp_x:%.9f damping_comp_y:%.9f "
-                           "accel_comp_x:%.9f accel_comp_y:%.9f "
+                           "spring_period_x:%.9f spring_period_y:%.9f "
                            "smooth_x:%.6f smooth_y:%.6f" % (
                                damping_comp_x, damping_comp_y
-                               , accel_comp_x, accel_comp_y
+                               , spring_period_x, spring_period_y
                                , smooth_x, smooth_y))
 
 def load_config(config):

--- a/scripts/graph_motion.py
+++ b/scripts/graph_motion.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python2
+# Script to graph motion results
+#
+# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import optparse, datetime, math
+import matplotlib
+
+SEG_TIME = .000100
+INV_SEG_TIME = 1. / SEG_TIME
+
+
+######################################################################
+# Basic trapezoid motion
+######################################################################
+
+# List of moves: [(start_v, end_v, move_t), ...]
+Moves = [
+    # X velocities from: 0,0 -> 0,20 -> 40,40 -> 80,40 -> 80,80
+    (0., 0., .200),
+    (6.869, 89.443, None), (89.443, 89.443, .200), (89.443, 17.361, None),
+    (19.410, 100., None), (100., 100., .200), (100., 5., None),
+    (0., 0., .300)
+]
+ACCEL = 3000.
+
+# Standard constant acceleration generator
+def get_acc_pos_ao2(rel_t, start_v, accel, move_t):
+    return (start_v + 0.5 * accel * rel_t) * rel_t
+
+# Bezier curve "accel_order=4" generator
+def get_acc_pos_ao4(rel_t, start_v, accel, move_t):
+    inv_accel_t = 1. / move_t
+    accel_div_accel_t = accel * inv_accel_t
+    accel_div_accel_t2 = accel_div_accel_t * inv_accel_t
+
+    c4 = -.5 * accel_div_accel_t2;
+    c3 = accel_div_accel_t;
+    c1 = start_v
+    return ((c4 * rel_t + c3) * rel_t * rel_t + c1) * rel_t
+
+# Bezier curve "accel_order=6" generator
+def get_acc_pos_ao6(rel_t, start_v, accel, move_t):
+    inv_accel_t = 1. / move_t
+    accel_div_accel_t = accel * inv_accel_t
+    accel_div_accel_t2 = accel_div_accel_t * inv_accel_t
+    accel_div_accel_t3 = accel_div_accel_t2 * inv_accel_t
+    accel_div_accel_t4 = accel_div_accel_t3 * inv_accel_t
+
+    c6 = accel_div_accel_t4;
+    c5 = -3. * accel_div_accel_t3;
+    c4 = 2.5 * accel_div_accel_t2;
+    c1 = start_v;
+    return (((c6 * rel_t + c5) * rel_t + c4)
+            * rel_t * rel_t * rel_t + c1) * rel_t
+
+get_acc_pos = get_acc_pos_ao2
+
+# Calculate positions based on 'Moves' list
+def gen_positions():
+    out = []
+    start_d = start_t = t = 0.
+    for start_v, end_v, move_t in Moves:
+        if move_t is None:
+            move_t = abs(end_v - start_v) / ACCEL
+        accel = 0.
+        if end_v > start_v:
+            accel = ACCEL
+        elif start_v > end_v:
+            accel = -ACCEL
+        end_t = start_t + move_t
+        while t <= end_t:
+            rel_t = t - start_t
+            out.append(start_d + get_acc_pos(rel_t, start_v, accel, move_t))
+            t += SEG_TIME
+        start_d += get_acc_pos(move_t, start_v, accel, move_t)
+        start_t = end_t
+    return out
+
+def gen_deriv(data):
+    return [0.] + [(data[i+1] - data[i]) * INV_SEG_TIME
+                   for i in range(len(data)-1)]
+
+def time_to_index(t):
+    return int(t * INV_SEG_TIME + .5)
+
+
+######################################################################
+# Estimated motion with belt as spring
+######################################################################
+
+SPRING_FREQ = 35.0
+DAMPING = 30.
+
+def estimate_spring(positions):
+    ang_freq2 = (SPRING_FREQ * 2. * math.pi)**2
+    head_pos = head_v = 0.
+    out = []
+    for stepper_pos in positions:
+        head_pos += head_v * SEG_TIME
+        head_a = (stepper_pos - head_pos) * ang_freq2
+        head_v += head_a * SEG_TIME
+        head_v -= head_v * DAMPING * SEG_TIME
+        out.append(head_pos)
+    return out
+
+
+######################################################################
+# Motion functions
+######################################################################
+
+HALF_SMOOTH_T = .040 / 2.
+
+def calc_position_average(t, positions):
+    start_pos = positions[time_to_index(t - HALF_SMOOTH_T)]
+    end_pos = positions[time_to_index(t + HALF_SMOOTH_T)]
+    return .5 * (start_pos + end_pos)
+
+def calc_position_smooth(t, positions):
+    start_index = time_to_index(t - HALF_SMOOTH_T) + 1
+    end_index = time_to_index(t + HALF_SMOOTH_T)
+    return sum(positions[start_index:end_index]) / (end_index - start_index)
+
+def calc_position_weighted(t, positions):
+    base_index = time_to_index(t)
+    start_index = time_to_index(t - HALF_SMOOTH_T) + 1
+    end_index = time_to_index(t + HALF_SMOOTH_T)
+    diff = .5 * (end_index - start_index)
+    weighted_data = [positions[i] * (diff - abs(i-base_index))
+                     for i in range(start_index, end_index)]
+    return sum(weighted_data) / diff**2
+
+SPRING_ADVANCE = .000020
+RESISTANCE_ADVANCE = 0.
+#SPRING_ADVANCE = 1. / ((SPRING_FREQ * 2. * math.pi)**2)
+#RESISTANCE_ADVANCE = DAMPING * SPRING_ADVANCE
+
+def calc_spring_weighted(t, positions):
+    base_index = time_to_index(t)
+    start_index = time_to_index(t - HALF_SMOOTH_T)
+    end_index = time_to_index(t + HALF_SMOOTH_T)
+    diff = .5 * (end_index - start_index)
+    sa = SPRING_ADVANCE * INV_SEG_TIME * INV_SEG_TIME
+    ra = RESISTANCE_ADVANCE * INV_SEG_TIME
+    sa_data = [(positions[i]
+                + sa * (positions[i-1] - 2.*positions[i] + positions[i+1])
+                + ra * (positions[i+1] - positions[i]))
+               * (diff - abs(i-base_index))
+               for i in range(start_index, end_index)]
+    return sum(sa_data) / diff**2
+
+
+######################################################################
+# Plotting and startup
+######################################################################
+
+gen_updated_position = calc_position_weighted
+#gen_updated_position = calc_spring_weighted
+
+MARGIN_TIME = 0.100
+
+def plot_motion():
+    # Nominal motion
+    positions = gen_positions()
+    drop = int(MARGIN_TIME * INV_SEG_TIME)
+    times = [SEG_TIME * t for t in range(len(positions))][drop:-drop]
+    margin_positions = positions[drop:-drop]
+    velocities = gen_deriv(margin_positions)
+    accels = gen_deriv(velocities)
+    # Updated motion
+    upd_positions = [gen_updated_position(t, positions) for t in times]
+    upd_velocities = gen_deriv(upd_positions)
+    upd_accels = gen_deriv(upd_velocities)
+    # Estimated position with model of belt as spring
+    spring_orig = estimate_spring(margin_positions)
+    spring_upd = estimate_spring(upd_positions)
+    spring_diff_orig = [n-o for n, o in zip(spring_orig, margin_positions)]
+    spring_diff_upd = [n-o for n, o in zip(spring_upd, margin_positions)]
+    head_velocities = gen_deriv(spring_orig)
+    head_accels = gen_deriv(head_velocities)
+    head_upd_velocities = gen_deriv(spring_upd)
+    head_upd_accels = gen_deriv(head_upd_velocities)
+    # Build plot
+    shift_times = [t - MARGIN_TIME for t in times]
+    fig, (ax1, ax2, ax3) = matplotlib.pyplot.subplots(nrows=3, sharex=True)
+    ax1.set_title("Simulation (belt frequency=%.3f, damping=%.3f)"
+                  % (SPRING_FREQ, DAMPING))
+    ax1.set_ylabel('Velocity (mm/s)')
+    ax1.plot(shift_times, upd_velocities, 'r', label='New Velocity', alpha=0.8)
+    ax1.plot(shift_times, velocities, 'g', label='Nominal Velocity', alpha=0.8)
+    ax1.plot(shift_times, head_velocities, label='Head Velocity', alpha=0.4)
+    ax1.plot(shift_times, head_upd_velocities, label='New Head Velocity',
+             alpha=0.4)
+    fontP = matplotlib.font_manager.FontProperties()
+    fontP.set_size('x-small')
+    ax1.legend(loc='best', prop=fontP)
+    ax1.grid(True)
+    ax2.set_ylabel('Acceleration (mm/s^2)')
+    ax2.plot(shift_times, upd_accels, 'r', label='New Accel', alpha=0.8)
+    ax2.plot(shift_times, accels, 'g', label='Nominal Accel', alpha=0.8)
+    ax2.plot(shift_times, head_accels, alpha=0.4)
+    ax2.plot(shift_times, head_upd_accels, alpha=0.4)
+    ax2.set_ylim([-5. * ACCEL, 5. * ACCEL])
+    ax2.legend(loc='best', prop=fontP)
+    ax2.grid(True)
+    ax3.set_ylabel('Deviation (mm)')
+    ax3.plot(shift_times, spring_diff_upd, 'r', label='New', alpha=0.8)
+    ax3.plot(shift_times, spring_diff_orig, 'g', label='Nominal', alpha=0.8)
+    ax3.grid(True)
+    ax3.legend(loc='best', prop=fontP)
+    ax3.set_xlabel('Time (s)')
+    return fig
+
+def setup_matplotlib(output_to_file):
+    global matplotlib
+    if output_to_file:
+        matplotlib.use('Agg')
+    import matplotlib.pyplot, matplotlib.dates, matplotlib.font_manager
+    import matplotlib.ticker
+
+def main():
+    # Parse command-line arguments
+    usage = "%prog [options]"
+    opts = optparse.OptionParser(usage)
+    opts.add_option("-o", "--output", type="string", dest="output",
+                    default=None, help="filename of output graph")
+    options, args = opts.parse_args()
+    if len(args) != 0:
+        opts.error("Incorrect number of arguments")
+
+    # Draw graph
+    setup_matplotlib(options.output is not None)
+    fig = plot_motion()
+
+    # Show graph
+    if options.output is None:
+        matplotlib.pyplot.show()
+    else:
+        fig.set_size_inches(8, 6)
+        fig.savefig(options.output)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/graph_motion.py
+++ b/scripts/graph_motion.py
@@ -133,8 +133,6 @@ def calc_position_weighted(t, positions):
 
 SPRING_ADVANCE = .000020
 RESISTANCE_ADVANCE = 0.
-#SPRING_ADVANCE = 1. / ((SPRING_FREQ * 2. * math.pi)**2)
-#RESISTANCE_ADVANCE = DAMPING * SPRING_ADVANCE
 
 def calc_spring_weighted(t, positions):
     base_index = time_to_index(t)
@@ -150,13 +148,34 @@ def calc_spring_weighted(t, positions):
                for i in range(start_index, end_index)]
     return sum(sa_data) / diff**2
 
+def calc_spring_double_weighted(t, positions):
+    base_index = time_to_index(t)
+    start_index = time_to_index(t - HALF_SMOOTH_T)
+    end_index = time_to_index(t + HALF_SMOOTH_T)
+    avg_v = base_index - start_index
+    diff = .5 * (end_index - start_index)
+    sa = SPRING_ADVANCE * (INV_SEG_TIME / avg_v)**2
+    ra = RESISTANCE_ADVANCE * INV_SEG_TIME
+    sa_data = [(positions[i]
+                + sa * (positions[i-avg_v] - 2.*positions[i]
+                        + positions[i+avg_v])
+                + ra * (positions[i+1] - positions[i]))
+               * (diff - abs(i-base_index))
+               for i in range(start_index, end_index)]
+    return sum(sa_data) / diff**2
+
+# Ideal values
+SPRING_ADVANCE = 1. / ((SPRING_FREQ * 2. * math.pi)**2)
+RESISTANCE_ADVANCE = DAMPING * SPRING_ADVANCE
+HALF_SMOOTH_T = (1./3.) * 2. * math.pi * math.sqrt(SPRING_ADVANCE) / 2.
+
 
 ######################################################################
 # Plotting and startup
 ######################################################################
 
-gen_updated_position = calc_position_weighted
-#gen_updated_position = calc_spring_weighted
+#gen_updated_position = calc_position_weighted
+gen_updated_position = calc_spring_double_weighted
 
 MARGIN_TIME = 0.100
 

--- a/scripts/graph_motion.py
+++ b/scripts/graph_motion.py
@@ -155,8 +155,19 @@ def calc_weighted(positions, smooth_time):
         out[i] = sum(weighted_data) * weight
     return out
 
-# Exponential time weighted average (via integration) of smooth_time range
+# Weighted average (`h**2 - (t-T)**2`) of smooth_time range
 def calc_weighted2(positions, smooth_time):
+    offset = time_to_index(smooth_time * .5)
+    weight = .75 / offset**3
+    out = [0.] * len(positions)
+    for i in indexes(positions):
+        weighted_data = [positions[j] * (offset**2 - (j-i)**2)
+                         for j in range(i-offset, i+offset)]
+        out[i] = sum(weighted_data) * weight
+    return out
+
+# Weighted average (`(h - abs(t-T))**2 * (2 * abs(t-T) + h)`) of range
+def calc_weighted3(positions, smooth_time):
     offset = time_to_index(smooth_time * .5)
     weight = 1. / offset**4
     out = [0.] * len(positions)
@@ -205,7 +216,7 @@ SMOOTH_TIME = (2./3.) * 2. * math.pi * math.sqrt(SPRING_ADVANCE)
 def gen_updated_position(positions):
     #return calc_weighted(positions, 0.040)
     #return calc_spring_double_weighted(positions, SMOOTH_TIME)
-    return calc_weighted2(calc_spring_raw(positions), SMOOTH_TIME)
+    return calc_weighted3(calc_spring_raw(positions), SMOOTH_TIME)
 
 
 ######################################################################

--- a/scripts/graph_motion.py
+++ b/scripts/graph_motion.py
@@ -148,10 +148,25 @@ def calc_spring_weighted(t, positions):
                for i in range(start_index, end_index)]
     return sum(sa_data) / diff**2
 
-def calc_spring_double_weighted(t, positions):
+def calc_spring_weighted2(t, positions):
     base_index = time_to_index(t)
     start_index = time_to_index(t - HALF_SMOOTH_T)
     end_index = time_to_index(t + HALF_SMOOTH_T)
+    diff = .5 * (end_index - start_index)
+    sa = SPRING_ADVANCE * INV_SEG_TIME * INV_SEG_TIME
+    ra = RESISTANCE_ADVANCE * INV_SEG_TIME
+    sa_data = [(positions[i]
+                + sa * (positions[i-1] - 2.*positions[i] + positions[i+1])
+                + ra * (positions[i+1] - positions[i]))
+               * (diff - abs(i-base_index))**2
+               * (2.*abs(i-base_index) + diff)
+               for i in range(start_index, end_index)]
+    return sum(sa_data) / diff**4
+
+def calc_spring_double_weighted(t, positions):
+    base_index = time_to_index(t)
+    start_index = time_to_index(t - HALF_SMOOTH_T * .5)
+    end_index = time_to_index(t + HALF_SMOOTH_T * .5)
     avg_v = base_index - start_index
     diff = .5 * (end_index - start_index)
     sa = SPRING_ADVANCE * (INV_SEG_TIME / avg_v)**2
@@ -167,7 +182,7 @@ def calc_spring_double_weighted(t, positions):
 # Ideal values
 SPRING_ADVANCE = 1. / ((SPRING_FREQ * 2. * math.pi)**2)
 RESISTANCE_ADVANCE = DAMPING * SPRING_ADVANCE
-HALF_SMOOTH_T = (1./3.) * 2. * math.pi * math.sqrt(SPRING_ADVANCE) / 2.
+HALF_SMOOTH_T = (2./3.) * 2. * math.pi * math.sqrt(SPRING_ADVANCE) / 2.
 
 
 ######################################################################
@@ -175,7 +190,7 @@ HALF_SMOOTH_T = (1./3.) * 2. * math.pi * math.sqrt(SPRING_ADVANCE) / 2.
 ######################################################################
 
 #gen_updated_position = calc_position_weighted
-gen_updated_position = calc_spring_double_weighted
+gen_updated_position = calc_spring_weighted2
 
 MARGIN_TIME = 0.100
 

--- a/scripts/graph_motion.py
+++ b/scripts/graph_motion.py
@@ -166,6 +166,17 @@ def calc_weighted2(positions, smooth_time):
         out[i] = sum(weighted_data) * weight
     return out
 
+# Weighted average (`(h**2 - (t-T)**2)**2`) of smooth_time range
+def calc_weighted4(positions, smooth_time):
+    offset = time_to_index(smooth_time * .5)
+    weight = 15 / (16. * offset**5)
+    out = [0.] * len(positions)
+    for i in indexes(positions):
+        weighted_data = [positions[j] * ((offset**2 - (j-i)**2))**2
+                         for j in range(i-offset, i+offset)]
+        out[i] = sum(weighted_data) * weight
+    return out
+
 # Weighted average (`(h - abs(t-T))**2 * (2 * abs(t-T) + h)`) of range
 def calc_weighted3(positions, smooth_time):
     offset = time_to_index(smooth_time * .5)
@@ -216,7 +227,7 @@ SMOOTH_TIME = (2./3.) * 2. * math.pi * math.sqrt(SPRING_ADVANCE)
 def gen_updated_position(positions):
     #return calc_weighted(positions, 0.040)
     #return calc_spring_double_weighted(positions, SMOOTH_TIME)
-    return calc_weighted3(calc_spring_raw(positions), SMOOTH_TIME)
+    return calc_weighted4(calc_spring_raw(positions), SMOOTH_TIME)
 
 
 ######################################################################


### PR DESCRIPTION
This branch contains the code to implement an experiment with s-curves to try and reduce "ringing" (aka "ghosting") on prints.  This is just a test, and is likely only of interest to other developers.

The current Klipper code uses a standard "trapezoid" velocity motion planner.  PR #1776 changes that planner to implement "s-curves" during acceleration:

![trapezoid-bezier svg](https://user-images.githubusercontent.com/3004890/65993352-106b3c00-e45f-11e9-8fb8-800a79ec9e41.png)

This branch attempts a different approach:

![trapezoid-antires svg](https://user-images.githubusercontent.com/3004890/65993369-1e20c180-e45f-11e9-9177-bfb2e4b1e008.png)

That is, instead of implementing the curves within the time allotted for normal acceleration, the code permits acceleration leading up to and after the nominal acceleration time.  This does result in the steppers taking a "path" that deviates from the commanded path - but it is done with the high-level thinking that it actually results in the toolpath more closely following the commanded path.

For example, it is currently believed that "ringing" is the result of the toolhead not following the "stepper path":

![ringing](https://user-images.githubusercontent.com/3004890/65993592-8a032a00-e45f-11e9-9608-ee1f3a98b72b.png)

And thus commanding the steppers to take a deviated path could result in an improved overall toolhead path:

![ringing-avoid](https://user-images.githubusercontent.com/3004890/65993644-a43d0800-e45f-11e9-8e79-47aa1c5c8285.png)

This code is an experiment.  It defines new `spring_x`, `spring_x_smooth_time`, `spring_y`, `spring_y_smooth_time` config settings that define the new s-curves.  The duration of the s-curve is controlled by the smooth_time settings.  The amount of deviation is determined by the spring parameters and the amount of estimated acceleration.  (The code uses estimated acceleration instead of the nominal acceleration, and thus does not have the "double acceleration" type issues with the bezier s-curve implementation.)  Different s-curves may be used for x and y axes.

There are several caveats with this code:
- it only works on cartesian printers
- it does not work with dual_carriage or multiple x/y/z stepper rails
- it is based on the PR #1997 code and thus has all of its limitations
- likely other bugs and limitations

I was able to tune this on my Makergear M2 printer (a "bed slinger").  The results were a noticeable, but small improvement.  I suspect an improved calibration routine may yield better results.  The calibration method I used was: print a tuning tower and measure the resonance, set the smooth_time parameters based on 1/4th the resonance time, print a tuning tower with changing spring value for each level (eg, `TUNING_TOWER COMMAND=SET_SPRING PARAMETER=SPRING_Y START=0 FACTOR=.000010`, measure the point of least resonance, and finally test on typical xyz calibration cubes.  

-Kevin
