### PR TITLE
safe_z_home: Fix unintended change in default behavior

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -320,9 +320,9 @@
 #   The default is 0.0mm.
 #z_hop_speed: 20.0
 #   Speed at which the Z axis is lifted prior to homing. The default is 20mm/s.
-#move_to_previous: True
+#move_to_previous: False
 #   When set to True, xy are reset to their previous positions after z homing.
-#   The default is True.
+#   The default is False.
 
 
 # Homing override. One may use this mechanism to run a series of

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -19,7 +19,7 @@ class SafeZHoming:
         self.z_hop_speed = config.getfloat('z_hop_speed', 15., above=0.)
         self.max_z = config.getsection('stepper_z').getfloat('position_max')
         self.speed = config.getfloat('speed', 50.0, above=0.)
-        self.move_to_previous = config.getboolean('move_to_previous', True)
+        self.move_to_previous = config.getboolean('move_to_previous', False)
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("G28", None)
         self.gcode.register_command("G28", self.cmd_G28)


### PR DESCRIPTION
As discussed in #2020, PR #1970 introduced a new parameter, changing the default behavior of the safe_z_home-module. To avoid unexpected changes, the value of the `move_to_previous`-parameter is now defaulted to `False`.

@FHeilmann, @ezrec - FYI.

Signed-off-by: Nils Friedchen <Nils.Friedchen@googlemail.com>