### PR TITLE
scripts: Use current username in install-ubuntu-18.04.sh

### DIFF
--- a/scripts/install-ubuntu-18.04.sh
+++ b/scripts/install-ubuntu-18.04.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 # This script installs Klipper on an Ubuntu 18.04 machine with Octoprint
-# Assumes the user running this is named "octoprint"
 
 PYTHONDIR="${HOME}/klippy-env"
 SYSTEMDDIR="/etc/systemd/system"
-KLIPPER_USER="octoprint"
+KLIPPER_USER=$USER
 KLIPPER_GROUP=$KLIPPER_USER
 
 # Step 1: Install system packages


### PR DESCRIPTION
Set KLIPPER_USER to $USER instead of "octoprint".

Signed-off-by: Nathan Chiu <nhchiu2009@gmail.com>