### PR TITLE
Add support for multi stepper extruders

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -713,7 +713,7 @@
 #position_max:
 #   See the example.cfg for the definition of the above parameters.
 
-# Support for synchronized extra steppers an extruder.
+# Support for multiple synchronized steppers in a single filament extruder.
 # Add a section for each additional stepper as required
 # with an "extruder_stepper" prefix.
 #[extruder_stepper s1]

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -713,6 +713,18 @@
 #position_max:
 #   See the example.cfg for the definition of the above parameters.
 
+# Support for extra stepper for a single filament extruder.
+# Currently supports only one extra stepper for one extruder.
+#[extruder_stepper]
+#add_to_extruder: extruder
+#   The extruder that has this stepper physically attached to.
+#step_pin: ar36
+#dir_pin: ar34
+#enable_pin: !ar30
+#step_distance:
+#   See the example.cfg for the definition of the above parameters.
+#   Defaults for RAMPS E1 stepper driver.
+
 # Manual steppers (one may define any number of sections with a
 # "manual_stepper" prefix). These are steppers that are controlled by
 # the MANUAL_STEPPER g-code command. For example: "MANUAL_STEPPER

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -713,8 +713,8 @@
 #position_max:
 #   See the example.cfg for the definition of the above parameters.
 
-# Support for synchronized extra steppers for a single filament
-# extruder. Add a section for each additional stepper as required
+# Support for synchronized extra steppers an extruder.
+# Add a section for each additional stepper as required
 # with an "extruder_stepper" prefix.
 #[extruder_stepper s1]
 #add_to_extruder: extruder

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -713,11 +713,12 @@
 #position_max:
 #   See the example.cfg for the definition of the above parameters.
 
-# Support for extra stepper for a single filament extruder.
-# Currently supports only one extra stepper for one extruder.
-#[extruder_stepper]
+# Support for synchronized extra steppers an extruder.
+# Add a section for each additional stepper as required
+# with an "extruder_stepper" prefix.
+#[extruder_stepper s1]
 #add_to_extruder: extruder
-#   The extruder that has this stepper physically attached to.
+#   The extruder this stepper is physically attached to.
 #step_pin: ar36
 #dir_pin: ar34
 #enable_pin: !ar30

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -713,8 +713,8 @@
 #position_max:
 #   See the example.cfg for the definition of the above parameters.
 
-# Support for synchronized extra steppers an extruder.
-# Add a section for each additional stepper as required
+# Support for synchronized extra steppers for a single filament
+# extruder. Add a section for each additional stepper as required
 # with an "extruder_stepper" prefix.
 #[extruder_stepper s1]
 #add_to_extruder: extruder

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -1,0 +1,25 @@
+# Code for handling printer nozzle extruders
+#
+# Copyright (C) 2019-2020  Simo Apell <simo.apell@live.fi>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+import stepper, extruder
+
+class ExtruderStepper:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name()
+        self.extruder_name = config.get('add_to_extruder')
+        self.stepper = stepper.PrinterStepper(config)
+        self.printer.register_event_handler("klippy:connect", self.add_stepper_to_extruder)
+    def add_stepper_to_extruder(self):
+        extruder_list = extruder.get_printer_extruders(self.printer)
+        for e in extruder_list:
+            if e.name == self.extruder_name:
+                e.add_stepper(self.stepper)
+                break
+
+def load_config(config):
+    return ExtruderStepper(config)
+

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -12,7 +12,8 @@ class ExtruderStepper:
         self.name = config.get_name()
         self.extruder_name = config.get('add_to_extruder')
         self.stepper = stepper.PrinterStepper(config)
-        self.printer.register_event_handler("klippy:connect", self.add_stepper_to_extruder)
+        self.printer.register_event_handler("klippy:connect", \
+                                            self.add_stepper_to_extruder)
     def add_stepper_to_extruder(self):
         extruder_list = extruder.get_printer_extruders(self.printer)
         for e in extruder_list:
@@ -22,4 +23,3 @@ class ExtruderStepper:
 
 def load_config_prefix(config):
     return ExtruderStepper(config)
-

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -1,4 +1,4 @@
-# Code for handling printer nozzle extruders
+# Code for supporting multiple steppers in single filament extruder.
 #
 # Copyright (C) 2019-2020  Simo Apell <simo.apell@live.fi>
 #

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -12,8 +12,7 @@ class ExtruderStepper:
         self.name = config.get_name()
         self.extruder_name = config.get('add_to_extruder')
         self.stepper = stepper.PrinterStepper(config)
-        self.printer.register_event_handler("klippy:connect", \
-                                    self.add_stepper_to_extruder)
+        self.printer.register_event_handler("klippy:connect", self.add_stepper_to_extruder)
     def add_stepper_to_extruder(self):
         extruder_list = extruder.get_printer_extruders(self.printer)
         for e in extruder_list:
@@ -23,3 +22,4 @@ class ExtruderStepper:
 
 def load_config_prefix(config):
     return ExtruderStepper(config)
+

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -12,7 +12,8 @@ class ExtruderStepper:
         self.name = config.get_name()
         self.extruder_name = config.get('add_to_extruder')
         self.stepper = stepper.PrinterStepper(config)
-        self.printer.register_event_handler("klippy:connect", self.add_stepper_to_extruder)
+        self.printer.register_event_handler("klippy:connect", \
+                                    self.add_stepper_to_extruder)
     def add_stepper_to_extruder(self):
         extruder_list = extruder.get_printer_extruders(self.printer)
         for e in extruder_list:
@@ -22,4 +23,3 @@ class ExtruderStepper:
 
 def load_config_prefix(config):
     return ExtruderStepper(config)
-

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -20,6 +20,6 @@ class ExtruderStepper:
                 e.add_stepper(self.stepper)
                 break
 
-def load_config(config):
+def load_config_prefix(config):
     return ExtruderStepper(config)
 

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -1,6 +1,6 @@
 # Code for supporting multiple steppers in single filament extruder.
 #
-# Copyright (C) 2019-2020  Simo Apell <simo.apell@live.fi>
+# Copyright (C) 2019 Simo Apell <simo.apell@live.fi>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
@@ -12,6 +12,8 @@ class ExtruderStepper:
         self.name = config.get_name()
         self.extruder_name = config.get('add_to_extruder')
         self.stepper = stepper.PrinterStepper(config)
+        self.stepper.set_max_jerk(9999999.9, 9999999.9)
+        self.stepper.setup_itersolve('extruder_stepper_alloc')
         self.printer.register_event_handler("klippy:connect", \
                                             self.add_stepper_to_extruder)
     def add_stepper_to_extruder(self):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -213,10 +213,6 @@ class PrinterExtruder:
             s.step_itersolve(self.cmove)
         self.extrude_pos = start_pos + axis_d
     def add_stepper(self, stepper):
-        if stepper == None:
-            return
-        stepper.set_max_jerk(9999999.9, 9999999.9)
-        stepper.setup_itersolve('extruder_stepper_alloc')
         self.stepper_list.append(stepper)
         logging.info("Added stepper to '%s'" % self.name)
     cmd_SET_PRESSURE_ADVANCE_help = "Set pressure advance parameters"


### PR DESCRIPTION
Adds support for multi stepper extruders as referred to in issue #1267 discussion.

Commit https://github.com/KevinOConnor/klipper/commit/1f2b766e0fffcea54a72e825989606582ff42645 changes extruder.py to prepare for supporting multiple steppers.
Commit https://github.com/KevinOConnor/klipper/commit/2893cca2e53aa765d5dad77a5db7d28966de2c06 adds extruder_stepper.py to initially implement multiple stepper support. The commit comment 'Todo: Error handling for invalid config items.' is apparently unnecessary as invalid config causes error(s) at startup.
Commit https://github.com/KevinOConnor/klipper/commit/10192db8fbd15b1ba5567682e64818201f19bcd9 adds multiple instance support to extruder_stepper.py.

Signed-off-by: Simo Apell <simo.apell@live.fi>
