### PR TITLE
Template for Bigtreetech SKR Mini E3 DIP with TMC2208 UART

### DIFF
--- a/config/generic-bigtreetech-skr-mini-e3-dip.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-dip.cfg
@@ -147,4 +147,3 @@ click_pin: ^!EXP1_2
 
 [output_pin beeper]
 pin: PA15
-

--- a/config/generic-bigtreetech-skr-mini-e3-dip.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-dip.cfg
@@ -1,0 +1,150 @@
+[include printer.cfg.d/*]
+
+# This file contains common pin mappings for the BIGTREETECH SKR mini
+# E3 DIP. To use this config, the firmware should be compiled for the
+# STM32F103 with a "28KiB bootloader". Also, select "Enable extra
+# low-level configuration options" and configure "GPIO pins to set at
+# micro-controller startup" to "!PC13".
+
+# The "make flash" command does not work on the SKR mini E3. Instead,
+# after running "make", copy the generated "out/klipper.bin" file to a
+# file named "firmware.bin" on an SD card and then restart the SKR
+# mini E3 with that SD card.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: PC6
+dir_pin: !PB15
+enable_pin: !PC7
+step_distance: .0125
+endstop_pin: ^PC1
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[tmc2208 stepper_x]
+uart_pin: PC10
+microsteps: 16
+run_current: 0.760
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[stepper_y]
+step_pin: PB13
+dir_pin: !PB12
+enable_pin: !PB14
+step_distance: .0125
+endstop_pin: ^PC0
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[tmc2208 stepper_y]
+uart_pin: PC11
+microsteps: 16
+run_current: 0.760
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[stepper_z]
+step_pin: PB10
+dir_pin: PB2
+enable_pin: !PB11
+step_distance: .0025
+endstop_pin: ^PC15
+position_min: -0.05
+position_endstop: 0.0
+position_max: 250
+
+[tmc2208 stepper_z]
+uart_pin: PC12
+microsteps: 16
+run_current: 0.760
+hold_current: 0.500
+stealthchop_threshold: 5
+
+[extruder]
+step_pin: PB0
+dir_pin: PC5
+enable_pin: !PB1
+step_distance: 0.010526
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA0
+pid_Kp: 21.527
+pid_Ki: 1.063
+pid_Kd: 108.982
+min_temp: 0
+max_temp: 250
+
+[tmc2208 extruder]
+uart_pin: PD2
+microsteps: 16
+run_current: 0.900
+hold_current: 0.500
+stealthchop_threshold: 0
+
+[heater_bed]
+heater_pin: PC9
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC3
+control: pid
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+min_temp: 0
+max_temp: 130
+
+#[bltouch]
+#pin_up_touch_mode_reports_triggered: False
+#sensor_pin: PC14
+#control_pin: PA1
+#z_offset: 1.1
+#x_offset: 39
+#y_offset: 15
+
+#[safe_z_home]
+#home_xy_position: 71, 95
+#speed: 50.0
+#z_hop: 5.0
+#z_hop_speed: 20.0
+#move_to_previous: False
+
+[fan]
+pin: PA8
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[static_digital_output usb_pullup_enable]
+pins: !PC13
+
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=PB5, EXP1_3=PA9,   EXP1_5=PA10, EXP1_7=PB8, EXP1_9=<GND>,
+    EXP1_2=PB6, EXP1_4=<RST>, EXP1_6=PB9,  EXP1_8=PB7, EXP1_10=<5V>
+
+# See the sample-lcd.cfg file for definitions of common LCD displays.
+
+[display]
+lcd_type: st7920
+cs_pin: EXP1_7
+sclk_pin: EXP1_6
+sid_pin: EXP1_8
+encoder_pins: ^EXP1_5, ^EXP1_3
+click_pin: ^!EXP1_2
+
+[output_pin beeper]
+pin: PA15
+


### PR DESCRIPTION
Added a tempate file for the SKR Mini E3 dip.  There are some differences in the pin numbers compared with the non-dip version.