### PR TITLE
FAN: Kick start fan when the increase is more than 50%

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -257,8 +257,9 @@ pin: ar9
 #   constrained by the implementation and may be significantly
 #   different than the requested cycle_time. The default is False.
 #kick_start_time: 0.100
-#   Time (in seconds) to run the fan at full speed when first enabling
-#   it (helps get the fan spinning). The default is 0.100 seconds.
+#   Time (in seconds) to run the fan at full speed when either first
+#   enabling or increasing it by more than 50% (helps get the fan spinning).
+#   The default is 0.100 seconds.
 #off_below: 0.0
 #   The minimum input speed which will power the fan (expressed as a
 #   value from 0.0 to 1.0). When a speed lower than off_below is

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -37,8 +37,8 @@ class PrinterFan:
         if value == self.last_fan_value:
             return
         print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)
-        if (value and value < self.max_power
-            and not self.last_fan_value and self.kick_start_time):
+        if (value and value < self.max_power and self.kick_start_time
+            and (not self.last_fan_value or value - self.last_fan_value > .5)):
             # Run fan at full speed for specified kick_start_time
             self.mcu_fan.set_pwm(print_time, self.max_power)
             print_time += self.kick_start_time


### PR DESCRIPTION
Large increases in fan speed can suffer from acceleration lag, so this
change kick starts the fan for a change of 50% or more in the same way
that starting the fan from 0% does.

Signed-off-by: Justin Schuh <code@justinschuh.com>