### PR TITLE
bed_mesh: configuration error bug fix

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -40,12 +40,12 @@ def parse_pair(config, param, check=True, cast=float,
         if pair[0] < minval or pair[1] < minval:
             raise config.error(
                 "Option '%s' in section bed_mesh must have a minimum of %s"
-                % (param[0]), minval)
+                % (param[0], str(minval)))
     if maxval is not None:
         if pair[0] > maxval or pair[1] > maxval:
             raise config.error(
                 "Option '%s' in section bed_mesh must have a maximum of %s"
-                % (param[0]), str(minval))
+                % (param[0], str(maxval)))
     return pair
 
 


### PR DESCRIPTION
A minor bug fix to correct the config errors raised in the parse_pair() helper.  Resolves #2080 and #2035.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>