### PR TITLE
On systemd, restart klipper service if it crashes

### DIFF
--- a/scripts/install-centos.sh
+++ b/scripts/install-centos.sh
@@ -56,6 +56,8 @@ Type=simple
 User=$USER
 RemainAfterExit=yes
 ExecStart=${PYTHONDIR}/bin/python ${SRCDIR}/klippy/klippy.py ${HOME}/printer.cfg -l /var/log/klippy.log
+Restart=always
+RestartSec=10
 EOF
 # Use systemctl to enable the klipper systemd service script
     sudo systemctl enable klipper.service

--- a/scripts/install-ubuntu-18.04.sh
+++ b/scripts/install-ubuntu-18.04.sh
@@ -63,6 +63,8 @@ Type=simple
 User=$KLIPPER_USER
 RemainAfterExit=yes
 ExecStart=${PYTHONDIR}/bin/python ${SRCDIR}/klippy/klippy.py ${HOME}/printer.cfg -l ${KLIPPER_LOG}
+Restart=always
+RestartSec=10
 EOF
 # Use systemctl to enable the klipper systemd service script
     sudo systemctl enable klipper.service


### PR DESCRIPTION
On systemd, restart klipper service if it crashes with a 10 second delay. This avoids having to ssh into system to start klipper service after a crash