### PR TITLE
Rework step generation to use a C based trapezoidal velocity queue

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -45,6 +45,11 @@ defs_stepcompress = """
 
 defs_itersolve = """
     int32_t itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m);
+    int32_t itersolve_generate_steps(struct stepper_kinematics *sk
+        , double flush_time);
+    double itersolve_check_active(struct stepper_kinematics *sk
+        , double flush_time);
+    void itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq);
     void itersolve_set_stepcompress(struct stepper_kinematics *sk
         , struct stepcompress *sc, double step_dist);
     double itersolve_calc_position_from_coord(struct stepper_kinematics *sk

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -60,6 +60,10 @@ defs_trapq = """
         , double start_pos_x, double start_pos_y, double start_pos_z
         , double axes_d_x, double axes_d_y, double axes_d_z
         , double start_v, double cruise_v, double accel);
+    struct trapq *trapq_alloc(void);
+    void trapq_free(struct trapq *tq);
+    void trapq_add_move(struct trapq *tq, struct move *m);
+    void trapq_free_moves(struct trapq *tq, double print_time);
 """
 
 defs_kin_cartesian = """

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -44,7 +44,6 @@ defs_stepcompress = """
 """
 
 defs_itersolve = """
-    int32_t itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m);
     int32_t itersolve_generate_steps(struct stepper_kinematics *sk
         , double flush_time);
     double itersolve_check_active(struct stepper_kinematics *sk

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -15,13 +15,14 @@ COMPILE_CMD = ("gcc -Wall -g -O2 -shared -fPIC"
                " -flto -fwhole-program -fno-use-linker-plugin"
                " -o %s %s")
 SOURCE_FILES = [
-    'pyhelper.c', 'serialqueue.c', 'stepcompress.c', 'itersolve.c',
+    'pyhelper.c', 'serialqueue.c', 'stepcompress.c', 'itersolve.c', 'trapq.c',
     'kin_cartesian.c', 'kin_corexy.c', 'kin_delta.c', 'kin_polar.c',
     'kin_winch.c', 'kin_extruder.c',
 ]
 DEST_LIB = "c_helper.so"
 OTHER_FILES = [
-    'list.h', 'serialqueue.h', 'stepcompress.h', 'itersolve.h', 'pyhelper.h'
+    'list.h', 'serialqueue.h', 'stepcompress.h', 'itersolve.h', 'pyhelper.h',
+    'trapq.h',
 ]
 
 defs_stepcompress = """
@@ -43,12 +44,6 @@ defs_stepcompress = """
 """
 
 defs_itersolve = """
-    struct move *move_alloc(void);
-    void move_fill(struct move *m, double print_time
-        , double accel_t, double cruise_t, double decel_t
-        , double start_pos_x, double start_pos_y, double start_pos_z
-        , double axes_d_x, double axes_d_y, double axes_d_z
-        , double start_v, double cruise_v, double accel);
     int32_t itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m);
     void itersolve_set_stepcompress(struct stepper_kinematics *sk
         , struct stepcompress *sc, double step_dist);
@@ -56,6 +51,15 @@ defs_itersolve = """
         , double x, double y, double z);
     void itersolve_set_commanded_pos(struct stepper_kinematics *sk, double pos);
     double itersolve_get_commanded_pos(struct stepper_kinematics *sk);
+"""
+
+defs_trapq = """
+    struct move *move_alloc(void);
+    void move_fill(struct move *m, double print_time
+        , double accel_t, double cruise_t, double decel_t
+        , double start_pos_x, double start_pos_y, double start_pos_z
+        , double axes_d_x, double axes_d_y, double axes_d_z
+        , double start_v, double cruise_v, double accel);
 """
 
 defs_kin_cartesian = """
@@ -127,7 +131,7 @@ defs_std = """
 
 defs_all = [
     defs_pyhelper, defs_serialqueue, defs_std,
-    defs_stepcompress, defs_itersolve,
+    defs_stepcompress, defs_itersolve, defs_trapq,
     defs_kin_cartesian, defs_kin_corexy, defs_kin_delta, defs_kin_polar,
     defs_kin_winch, defs_kin_extruder
 ]

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -61,7 +61,7 @@ defs_trapq = """
     void trapq_append(struct trapq *tq, double print_time
         , double accel_t, double cruise_t, double decel_t
         , double start_pos_x, double start_pos_y, double start_pos_z
-        , double axes_d_x, double axes_d_y, double axes_d_z
+        , double axes_r_x, double axes_r_y, double axes_r_z
         , double start_v, double cruise_v, double accel);
     struct trapq *trapq_alloc(void);
     void trapq_free(struct trapq *tq);

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -93,7 +93,7 @@ defs_kin_winch = """
 defs_kin_extruder = """
     struct stepper_kinematics *extruder_stepper_alloc(void);
     void extruder_add_move(struct trapq *tq, double print_time
-        , double accel_t, double cruise_t, double decel_t, double start_pos
+        , double accel_t, double cruise_t, double decel_t, double start_e_pos
         , double start_v, double cruise_v, double accel
         , double extra_accel_v, double extra_decel_v);
 """

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -58,15 +58,13 @@ defs_itersolve = """
 """
 
 defs_trapq = """
-    struct move *move_alloc(void);
-    void move_fill(struct move *m, double print_time
+    void trapq_append(struct trapq *tq, double print_time
         , double accel_t, double cruise_t, double decel_t
         , double start_pos_x, double start_pos_y, double start_pos_z
         , double axes_d_x, double axes_d_y, double axes_d_z
         , double start_v, double cruise_v, double accel);
     struct trapq *trapq_alloc(void);
     void trapq_free(struct trapq *tq);
-    void trapq_add_move(struct trapq *tq, struct move *m);
     void trapq_free_moves(struct trapq *tq, double print_time);
 """
 
@@ -94,7 +92,7 @@ defs_kin_winch = """
 
 defs_kin_extruder = """
     struct stepper_kinematics *extruder_stepper_alloc(void);
-    void extruder_move_fill(struct move *m, double print_time
+    void extruder_add_move(struct trapq *tq, double print_time
         , double accel_t, double cruise_t, double decel_t, double start_pos
         , double start_v, double cruise_v, double accel
         , double extra_accel_v, double extra_decel_v);

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -4,99 +4,13 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
-#include <math.h> // sqrt
-#include <stdlib.h> // malloc
+#include <math.h> // fabs
 #include <string.h> // memset
 #include "compiler.h" // __visible
-#include "itersolve.h" // struct coord
+#include "itersolve.h" // itersolve_gen_steps
 #include "pyhelper.h" // errorf
 #include "stepcompress.h" // queue_append_start
-
-
-/****************************************************************
- * Kinematic moves
- ****************************************************************/
-
-struct move * __visible
-move_alloc(void)
-{
-    struct move *m = malloc(sizeof(*m));
-    memset(m, 0, sizeof(*m));
-    return m;
-}
-
-// Populate a 'struct move' with a velocity trapezoid
-void __visible
-move_fill(struct move *m, double print_time
-          , double accel_t, double cruise_t, double decel_t
-          , double start_pos_x, double start_pos_y, double start_pos_z
-          , double axes_d_x, double axes_d_y, double axes_d_z
-          , double start_v, double cruise_v, double accel)
-{
-    // Setup velocity trapezoid
-    m->print_time = print_time;
-    m->move_t = accel_t + cruise_t + decel_t;
-    m->accel_t = accel_t;
-    m->cruise_t = cruise_t;
-    m->cruise_start_d = accel_t * .5 * (cruise_v + start_v);
-    m->decel_start_d = m->cruise_start_d + cruise_t * cruise_v;
-
-    // Setup for accel/cruise/decel phases
-    m->cruise_v = cruise_v;
-    m->accel.c1 = start_v;
-    m->accel.c2 = .5 * accel;
-    m->decel.c1 = cruise_v;
-    m->decel.c2 = -m->accel.c2;
-
-    // Setup for move_get_coord()
-    m->start_pos.x = start_pos_x;
-    m->start_pos.y = start_pos_y;
-    m->start_pos.z = start_pos_z;
-    double inv_move_d = 1. / sqrt(axes_d_x*axes_d_x + axes_d_y*axes_d_y
-                                  + axes_d_z*axes_d_z);
-    m->axes_r.x = axes_d_x * inv_move_d;
-    m->axes_r.y = axes_d_y * inv_move_d;
-    m->axes_r.z = axes_d_z * inv_move_d;
-}
-
-// Find the distance travel during acceleration/deceleration
-static inline double
-move_eval_accel(struct move_accel *ma, double move_time)
-{
-    return (ma->c1 + ma->c2 * move_time) * move_time;
-}
-
-// Return the distance moved given a time in a move
-inline double
-move_get_distance(struct move *m, double move_time)
-{
-    if (unlikely(move_time < m->accel_t))
-        // Acceleration phase of move
-        return move_eval_accel(&m->accel, move_time);
-    move_time -= m->accel_t;
-    if (likely(move_time <= m->cruise_t))
-        // Cruising phase
-        return m->cruise_start_d + m->cruise_v * move_time;
-    // Deceleration phase
-    move_time -= m->cruise_t;
-    return m->decel_start_d + move_eval_accel(&m->decel, move_time);
-}
-
-// Return the XYZ coordinates given a time in a move
-inline struct coord
-move_get_coord(struct move *m, double move_time)
-{
-    double move_dist = move_get_distance(m, move_time);
-    return (struct coord) {
-        .x = m->start_pos.x + m->axes_r.x * move_dist,
-        .y = m->start_pos.y + m->axes_r.y * move_dist,
-        .z = m->start_pos.z + m->axes_r.z * move_dist };
-}
-
-
-/****************************************************************
- * Iterative solver
- ****************************************************************/
+#include "trapq.h" // struct move
 
 struct timepos {
     double time, position;

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -8,7 +8,7 @@
 #include <stddef.h> // offsetof
 #include <string.h> // memset
 #include "compiler.h" // __visible
-#include "itersolve.h" // itersolve_gen_steps
+#include "itersolve.h" // itersolve_generate_steps
 #include "pyhelper.h" // errorf
 #include "stepcompress.h" // queue_append_start
 #include "trapq.h" // struct move
@@ -126,14 +126,6 @@ itersolve_gen_steps_range(struct stepper_kinematics *sk, struct move *m
     if (sk->post_cb)
         sk->post_cb(sk);
     return 0;
-}
-
-// Generate step times for a move
-int32_t __visible
-itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m)
-{
-    return itersolve_gen_steps_range(sk, m, m->print_time
-                                     , m->print_time + m->move_t);
 }
 
 // Check if a move is likely to cause movement on a stepper

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -5,6 +5,7 @@
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
 #include <math.h> // fabs
+#include <stddef.h> // offsetof
 #include <string.h> // memset
 #include "compiler.h" // __visible
 #include "itersolve.h" // itersolve_gen_steps
@@ -53,15 +54,17 @@ itersolve_find_step(struct stepper_kinematics *sk, struct move *m
     return best_guess;
 }
 
-// Generate step times for a stepper during a move
-int32_t __visible
-itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m)
+// Generate step times for a portion of a move
+static int32_t
+itersolve_gen_steps_range(struct stepper_kinematics *sk, struct move *m
+                          , double move_start, double move_end)
 {
     struct stepcompress *sc = sk->sc;
     sk_calc_callback calc_position_cb = sk->calc_position_cb;
     double half_step = .5 * sk->step_dist;
     double mcu_freq = stepcompress_get_mcu_freq(sc);
-    struct timepos last = { 0., sk->commanded_pos }, low = last, high = last;
+    double start = move_start - m->print_time, end = move_end - m->print_time;
+    struct timepos last = { start, sk->commanded_pos }, low = last, high = last;
     double seek_time_delta = 0.000100;
     int sdir = stepcompress_get_step_dir(sc);
     struct queue_append qa = queue_append_start(sc, m->print_time, .5);
@@ -70,15 +73,15 @@ itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m)
         double dist = high.position - last.position;
         if (fabs(dist) < half_step) {
         seek_new_high_range:
-            if (high.time >= m->move_t)
+            if (high.time >= end)
                 // At end of move
                 break;
             // Need to increase next step search range
             low = high;
             high.time = last.time + seek_time_delta;
             seek_time_delta += seek_time_delta;
-            if (high.time > m->move_t)
-                high.time = m->move_t;
+            if (high.time > end)
+                high.time = end;
             high.position = calc_position_cb(sk, m, high.time);
             continue;
         }
@@ -123,6 +126,87 @@ itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m)
     if (sk->post_cb)
         sk->post_cb(sk);
     return 0;
+}
+
+// Generate step times for a move
+int32_t __visible
+itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m)
+{
+    return itersolve_gen_steps_range(sk, m, m->print_time
+                                     , m->print_time + m->move_t);
+}
+
+// Check if a move is likely to cause movement on a stepper
+static inline int
+check_active(struct stepper_kinematics *sk, struct move *m)
+{
+    int af = sk->active_flags;
+    return ((af & AF_X && m->axes_r.x != 0.)
+            || (af & AF_Y && m->axes_r.y != 0.)
+            || (af & AF_Z && m->axes_r.z != 0.));
+}
+
+// Generate step times for a range of moves on the trapq
+int32_t __visible
+itersolve_generate_steps(struct stepper_kinematics *sk, double flush_time)
+{
+    double last_flush_time = sk->last_flush_time;
+    sk->last_flush_time = flush_time;
+    if (!sk->tq || list_empty(&sk->tq->moves))
+        return 0;
+    struct move *m = list_first_entry(&sk->tq->moves, struct move, node);
+    for (;;) {
+        double move_print_time = m->print_time;
+        double move_end_time = move_print_time + m->move_t;
+        if (last_flush_time >= move_end_time) {
+            if (list_is_last(&m->node, &sk->tq->moves))
+                break;
+            m = list_next_entry(m, node);
+            continue;
+        }
+        double start = move_print_time, end = move_end_time;
+        if (start < last_flush_time)
+            start = last_flush_time;
+        if (start >= flush_time)
+            break;
+        if (end > flush_time)
+            end = flush_time;
+        if (check_active(sk, m)) {
+            int32_t ret = itersolve_gen_steps_range(sk, m, start, end);
+            if (ret)
+                return ret;
+        }
+        last_flush_time = end;
+    }
+    return 0;
+}
+
+// Check if the given stepper is likely to be active in the given time range
+double __visible
+itersolve_check_active(struct stepper_kinematics *sk, double flush_time)
+{
+    if (!sk->tq || list_empty(&sk->tq->moves))
+        return 0.;
+    struct move *m = list_first_entry(&sk->tq->moves, struct move, node);
+    while (sk->last_flush_time >= m->print_time + m->move_t) {
+        if (list_is_last(&m->node, &sk->tq->moves))
+            return 0.;
+        m = list_next_entry(m, node);
+    }
+    while (m->print_time < flush_time) {
+        if (check_active(sk, m))
+            return m->print_time;
+        if (list_is_last(&m->node, &sk->tq->moves))
+            return 0.;
+        m = list_next_entry(m, node);
+    }
+    return 0.;
+}
+
+void __visible
+itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq)
+{
+    sk->tq = tq;
 }
 
 void __visible

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -174,8 +174,10 @@ itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m)
             if (fabs(dist) < half_step + .000000001)
                 // Only change direction if going past midway point
                 goto seek_new_high_range;
-            if (last.time >= low.time && high.time > last.time) {
+            if (last.time >= low.time) {
                 // Must seek new low range to avoid re-finding previous time
+                if (high.time < last.time + .000000001)
+                    goto seek_new_high_range;
                 high.time = (last.time + high.time) * .5;
                 high.position = calc_position(sk, m, high.time);
                 continue;

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -206,6 +206,8 @@ itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m)
     }
     queue_append_finish(qa);
     sk->commanded_pos = last.position;
+    if (sk->post_cb)
+        sk->post_cb(sk);
     return 0;
 }
 

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -215,7 +215,9 @@ itersolve_calc_position_from_coord(struct stepper_kinematics *sk
 {
     struct move m;
     memset(&m, 0, sizeof(m));
-    move_fill(&m, 0., 0., 1., 0., x, y, z, 0., 1., 0., 0., 1., 0.);
+    m.start_pos.x = x;
+    m.start_pos.y = y;
+    m.start_pos.z = z;
     return sk->calc_position_cb(sk, &m, 0.);
 }
 

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -30,12 +30,12 @@ double move_get_distance(struct move *m, double move_time);
 struct coord move_get_coord(struct move *m, double move_time);
 
 struct stepper_kinematics;
-typedef double (*sk_callback)(struct stepper_kinematics *sk, struct move *m
-                              , double move_time);
+typedef double (*sk_calc_callback)(struct stepper_kinematics *sk, struct move *m
+                                   , double move_time);
 struct stepper_kinematics {
     double step_dist, commanded_pos;
     struct stepcompress *sc;
-    sk_callback calc_position;
+    sk_calc_callback calc_position_cb;
 };
 
 int32_t itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m);

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -32,10 +32,12 @@ struct coord move_get_coord(struct move *m, double move_time);
 struct stepper_kinematics;
 typedef double (*sk_calc_callback)(struct stepper_kinematics *sk, struct move *m
                                    , double move_time);
+typedef void (*sk_post_callback)(struct stepper_kinematics *sk);
 struct stepper_kinematics {
     double step_dist, commanded_pos;
     struct stepcompress *sc;
     sk_calc_callback calc_position_cb;
+    sk_post_callback post_cb;
 };
 
 int32_t itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m);

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -1,35 +1,10 @@
 #ifndef ITERSOLVE_H
 #define ITERSOLVE_H
 
-#include <stdint.h> // uint32_t
-
-struct coord {
-    double x, y, z;
-};
-
-struct move_accel {
-    double c1, c2;
-};
-
-struct move {
-    double print_time, move_t;
-    double accel_t, cruise_t;
-    double cruise_start_d, decel_start_d;
-    double cruise_v;
-    struct move_accel accel, decel;
-    struct coord start_pos, axes_r;
-};
-
-struct move *move_alloc(void);
-void move_fill(struct move *m, double print_time
-               , double accel_t, double cruise_t, double decel_t
-               , double start_pos_x, double start_pos_y, double start_pos_z
-               , double axes_d_x, double axes_d_y, double axes_d_z
-               , double start_v, double cruise_v, double accel);
-double move_get_distance(struct move *m, double move_time);
-struct coord move_get_coord(struct move *m, double move_time);
+#include <stdint.h> // int32_t
 
 struct stepper_kinematics;
+struct move;
 typedef double (*sk_calc_callback)(struct stepper_kinematics *sk, struct move *m
                                    , double move_time);
 typedef void (*sk_post_callback)(struct stepper_kinematics *sk);

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -24,7 +24,6 @@ struct stepper_kinematics {
     sk_post_callback post_cb;
 };
 
-int32_t itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m);
 int32_t itersolve_generate_steps(struct stepper_kinematics *sk
                                  , double flush_time);
 double itersolve_check_active(struct stepper_kinematics *sk, double flush_time);

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h> // int32_t
 
+enum {
+    AF_X = 1 << 0, AF_Y = 1 << 1, AF_Z = 1 <<2,
+};
+
 struct stepper_kinematics;
 struct move;
 typedef double (*sk_calc_callback)(struct stepper_kinematics *sk, struct move *m
@@ -11,11 +15,20 @@ typedef void (*sk_post_callback)(struct stepper_kinematics *sk);
 struct stepper_kinematics {
     double step_dist, commanded_pos;
     struct stepcompress *sc;
+
+    double last_flush_time;
+    struct trapq *tq;
+    int active_flags;
+
     sk_calc_callback calc_position_cb;
     sk_post_callback post_cb;
 };
 
 int32_t itersolve_gen_steps(struct stepper_kinematics *sk, struct move *m);
+int32_t itersolve_generate_steps(struct stepper_kinematics *sk
+                                 , double flush_time);
+double itersolve_check_active(struct stepper_kinematics *sk, double flush_time);
+void itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq);
 void itersolve_set_stepcompress(struct stepper_kinematics *sk
                                 , struct stepcompress *sc, double step_dist);
 double itersolve_calc_position_from_coord(struct stepper_kinematics *sk

--- a/klippy/chelper/kin_cartesian.c
+++ b/klippy/chelper/kin_cartesian.c
@@ -7,8 +7,9 @@
 #include <stdlib.h> // malloc
 #include <string.h> // memset
 #include "compiler.h" // __visible
-#include "itersolve.h" // move_get_coord
+#include "itersolve.h" // struct stepper_kinematics
 #include "pyhelper.h" // errorf
+#include "trapq.h" // move_get_coord
 
 static double
 cart_stepper_x_calc_position(struct stepper_kinematics *sk, struct move *m

--- a/klippy/chelper/kin_cartesian.c
+++ b/klippy/chelper/kin_cartesian.c
@@ -37,10 +37,10 @@ cartesian_stepper_alloc(char axis)
     struct stepper_kinematics *sk = malloc(sizeof(*sk));
     memset(sk, 0, sizeof(*sk));
     if (axis == 'x')
-        sk->calc_position = cart_stepper_x_calc_position;
+        sk->calc_position_cb = cart_stepper_x_calc_position;
     else if (axis == 'y')
-        sk->calc_position = cart_stepper_y_calc_position;
+        sk->calc_position_cb = cart_stepper_y_calc_position;
     else if (axis == 'z')
-        sk->calc_position = cart_stepper_z_calc_position;
+        sk->calc_position_cb = cart_stepper_z_calc_position;
     return sk;
 }

--- a/klippy/chelper/kin_cartesian.c
+++ b/klippy/chelper/kin_cartesian.c
@@ -1,6 +1,6 @@
 // Cartesian kinematics stepper pulse time generation
 //
-// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -37,11 +37,15 @@ cartesian_stepper_alloc(char axis)
 {
     struct stepper_kinematics *sk = malloc(sizeof(*sk));
     memset(sk, 0, sizeof(*sk));
-    if (axis == 'x')
+    if (axis == 'x') {
         sk->calc_position_cb = cart_stepper_x_calc_position;
-    else if (axis == 'y')
+        sk->active_flags = AF_X;
+    } else if (axis == 'y') {
         sk->calc_position_cb = cart_stepper_y_calc_position;
-    else if (axis == 'z')
+        sk->active_flags = AF_Y;
+    } else if (axis == 'z') {
         sk->calc_position_cb = cart_stepper_z_calc_position;
+        sk->active_flags = AF_Z;
+    }
     return sk;
 }

--- a/klippy/chelper/kin_corexy.c
+++ b/klippy/chelper/kin_corexy.c
@@ -31,8 +31,8 @@ corexy_stepper_alloc(char type)
     struct stepper_kinematics *sk = malloc(sizeof(*sk));
     memset(sk, 0, sizeof(*sk));
     if (type == '+')
-        sk->calc_position = corexy_stepper_plus_calc_position;
+        sk->calc_position_cb = corexy_stepper_plus_calc_position;
     else if (type == '-')
-        sk->calc_position = corexy_stepper_minus_calc_position;
+        sk->calc_position_cb = corexy_stepper_minus_calc_position;
     return sk;
 }

--- a/klippy/chelper/kin_corexy.c
+++ b/klippy/chelper/kin_corexy.c
@@ -8,6 +8,7 @@
 #include <string.h> // memset
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
+#include "trapq.h" // move_get_coord
 
 static double
 corexy_stepper_plus_calc_position(struct stepper_kinematics *sk, struct move *m

--- a/klippy/chelper/kin_corexy.c
+++ b/klippy/chelper/kin_corexy.c
@@ -1,6 +1,6 @@
 // CoreXY kinematics stepper pulse time generation
 //
-// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -35,5 +35,6 @@ corexy_stepper_alloc(char type)
         sk->calc_position_cb = corexy_stepper_plus_calc_position;
     else if (type == '-')
         sk->calc_position_cb = corexy_stepper_minus_calc_position;
+    sk->active_flags = AF_X | AF_Y;
     return sk;
 }

--- a/klippy/chelper/kin_delta.c
+++ b/klippy/chelper/kin_delta.c
@@ -1,6 +1,6 @@
 // Delta kinematics stepper pulse time generation
 //
-// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -36,5 +36,6 @@ delta_stepper_alloc(double arm2, double tower_x, double tower_y)
     ds->tower_x = tower_x;
     ds->tower_y = tower_y;
     ds->sk.calc_position_cb = delta_stepper_calc_position;
+    ds->sk.active_flags = AF_X | AF_Y | AF_Z;
     return &ds->sk;
 }

--- a/klippy/chelper/kin_delta.c
+++ b/klippy/chelper/kin_delta.c
@@ -10,6 +10,7 @@
 #include <string.h> // memset
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
+#include "trapq.h" // move_get_coord
 
 struct delta_stepper {
     struct stepper_kinematics sk;

--- a/klippy/chelper/kin_delta.c
+++ b/klippy/chelper/kin_delta.c
@@ -34,6 +34,6 @@ delta_stepper_alloc(double arm2, double tower_x, double tower_y)
     ds->arm2 = arm2;
     ds->tower_x = tower_x;
     ds->tower_y = tower_y;
-    ds->sk.calc_position = delta_stepper_calc_position;
+    ds->sk.calc_position_cb = delta_stepper_calc_position;
     return &ds->sk;
 }

--- a/klippy/chelper/kin_extruder.c
+++ b/klippy/chelper/kin_extruder.c
@@ -9,6 +9,7 @@
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
 #include "pyhelper.h" // errorf
+#include "trapq.h" // move_get_distance
 
 static double
 extruder_calc_position(struct stepper_kinematics *sk, struct move *m

--- a/klippy/chelper/kin_extruder.c
+++ b/klippy/chelper/kin_extruder.c
@@ -22,7 +22,7 @@ extruder_stepper_alloc(void)
 {
     struct stepper_kinematics *sk = malloc(sizeof(*sk));
     memset(sk, 0, sizeof(*sk));
-    sk->calc_position = extruder_calc_position;
+    sk->calc_position_cb = extruder_calc_position;
     return sk;
 }
 

--- a/klippy/chelper/kin_extruder.c
+++ b/klippy/chelper/kin_extruder.c
@@ -1,6 +1,6 @@
 // Extruder stepper pulse time generation
 //
-// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -24,6 +24,7 @@ extruder_stepper_alloc(void)
     struct stepper_kinematics *sk = malloc(sizeof(*sk));
     memset(sk, 0, sizeof(*sk));
     sk->calc_position_cb = extruder_calc_position;
+    sk->active_flags = AF_X;
     return sk;
 }
 
@@ -52,4 +53,5 @@ extruder_move_fill(struct move *m, double print_time
 
     // Setup start distance
     m->start_pos.x = start_pos;
+    m->axes_r.x = 1.;
 }

--- a/klippy/chelper/kin_extruder.c
+++ b/klippy/chelper/kin_extruder.c
@@ -32,30 +32,49 @@ extruder_stepper_alloc(void)
 void __visible
 extruder_add_move(struct trapq *tq, double print_time
                   , double accel_t, double cruise_t, double decel_t
-                  , double start_pos
+                  , double start_e_pos
                   , double start_v, double cruise_v, double accel
                   , double extra_accel_v, double extra_decel_v)
 {
-    struct move *m = move_alloc();
+    struct coord start_pos, axes_r;
+    start_pos.x = start_e_pos;
+    axes_r.x = 1.;
+    start_pos.y = start_pos.z = axes_r.y = axes_r.z = 0.;
 
-    // Setup velocity trapezoid
-    m->print_time = print_time;
-    m->move_t = accel_t + cruise_t + decel_t;
-    m->accel_t = accel_t;
-    m->cruise_t = cruise_t;
-    m->cruise_start_d = accel_t * (.5 * (cruise_v + start_v) + extra_accel_v);
-    m->decel_start_d = m->cruise_start_d + cruise_t * cruise_v;
+    if (accel_t) {
+        struct move *m = move_alloc();
+        m->print_time = print_time;
+        m->move_t = accel_t;
+        m->start_v = start_v + extra_accel_v;
+        m->half_accel = .5 * accel;
+        m->start_pos = start_pos;
+        m->axes_r = axes_r;
+        trapq_add_move(tq, m);
 
-    // Setup for accel/cruise/decel phases
-    m->cruise_v = cruise_v;
-    m->accel.c1 = start_v + extra_accel_v;
-    m->accel.c2 = .5 * accel;
-    m->decel.c1 = cruise_v + extra_decel_v;
-    m->decel.c2 = -m->accel.c2;
+        print_time += accel_t;
+        start_pos.x += move_get_distance(m, accel_t);
+    }
+    if (cruise_t) {
+        struct move *m = move_alloc();
+        m->print_time = print_time;
+        m->move_t = cruise_t;
+        m->start_v = cruise_v;
+        m->half_accel = 0.;
+        m->start_pos = start_pos;
+        m->axes_r = axes_r;
+        trapq_add_move(tq, m);
 
-    // Setup start distance
-    m->start_pos.x = start_pos;
-    m->axes_r.x = 1.;
-
-    trapq_add_move(tq, m);
+        print_time += cruise_t;
+        start_pos.x += move_get_distance(m, cruise_t);
+    }
+    if (decel_t) {
+        struct move *m = move_alloc();
+        m->print_time = print_time;
+        m->move_t = decel_t;
+        m->start_v = cruise_v + extra_decel_v;
+        m->half_accel = -.5 * accel;
+        m->start_pos = start_pos;
+        m->axes_r = axes_r;
+        trapq_add_move(tq, m);
+    }
 }

--- a/klippy/chelper/kin_extruder.c
+++ b/klippy/chelper/kin_extruder.c
@@ -30,12 +30,14 @@ extruder_stepper_alloc(void)
 
 // Populate a 'struct move' with an extruder velocity trapezoid
 void __visible
-extruder_move_fill(struct move *m, double print_time
-                   , double accel_t, double cruise_t, double decel_t
-                   , double start_pos
-                   , double start_v, double cruise_v, double accel
-                   , double extra_accel_v, double extra_decel_v)
+extruder_add_move(struct trapq *tq, double print_time
+                  , double accel_t, double cruise_t, double decel_t
+                  , double start_pos
+                  , double start_v, double cruise_v, double accel
+                  , double extra_accel_v, double extra_decel_v)
 {
+    struct move *m = move_alloc();
+
     // Setup velocity trapezoid
     m->print_time = print_time;
     m->move_t = accel_t + cruise_t + decel_t;
@@ -54,4 +56,6 @@ extruder_move_fill(struct move *m, double print_time
     // Setup start distance
     m->start_pos.x = start_pos;
     m->axes_r.x = 1.;
+
+    trapq_add_move(tq, m);
 }

--- a/klippy/chelper/kin_polar.c
+++ b/klippy/chelper/kin_polar.c
@@ -54,5 +54,6 @@ polar_stepper_alloc(char type)
         sk->calc_position_cb = polar_stepper_angle_calc_position;
         sk->post_cb = polar_stepper_angle_post_fixup;
     }
+    sk->active_flags = AF_X | AF_Y;
     return sk;
 }

--- a/klippy/chelper/kin_polar.c
+++ b/klippy/chelper/kin_polar.c
@@ -9,6 +9,7 @@
 #include <string.h> // memset
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
+#include "trapq.h" // move_get_coord
 
 static double
 polar_stepper_radius_calc_position(struct stepper_kinematics *sk, struct move *m

--- a/klippy/chelper/kin_polar.c
+++ b/klippy/chelper/kin_polar.c
@@ -32,14 +32,26 @@ polar_stepper_angle_calc_position(struct stepper_kinematics *sk, struct move *m
     return angle;
 }
 
+static void
+polar_stepper_angle_post_fixup(struct stepper_kinematics *sk)
+{
+    // Normalize the stepper_bed angle
+    if (sk->commanded_pos < -M_PI)
+        sk->commanded_pos += 2 * M_PI;
+    else if (sk->commanded_pos > M_PI)
+        sk->commanded_pos -= 2 * M_PI;
+}
+
 struct stepper_kinematics * __visible
 polar_stepper_alloc(char type)
 {
     struct stepper_kinematics *sk = malloc(sizeof(*sk));
     memset(sk, 0, sizeof(*sk));
-    if (type == 'r')
+    if (type == 'r') {
         sk->calc_position_cb = polar_stepper_radius_calc_position;
-    else if (type == 'a')
+    } else if (type == 'a') {
         sk->calc_position_cb = polar_stepper_angle_calc_position;
+        sk->post_cb = polar_stepper_angle_post_fixup;
+    }
     return sk;
 }

--- a/klippy/chelper/kin_polar.c
+++ b/klippy/chelper/kin_polar.c
@@ -38,8 +38,8 @@ polar_stepper_alloc(char type)
     struct stepper_kinematics *sk = malloc(sizeof(*sk));
     memset(sk, 0, sizeof(*sk));
     if (type == 'r')
-        sk->calc_position = polar_stepper_radius_calc_position;
+        sk->calc_position_cb = polar_stepper_radius_calc_position;
     else if (type == 'a')
-        sk->calc_position = polar_stepper_angle_calc_position;
+        sk->calc_position_cb = polar_stepper_angle_calc_position;
     return sk;
 }

--- a/klippy/chelper/kin_winch.c
+++ b/klippy/chelper/kin_winch.c
@@ -10,6 +10,7 @@
 #include <string.h> // memset
 #include "compiler.h" // __visible
 #include "itersolve.h" // struct stepper_kinematics
+#include "trapq.h" // move_get_coord
 
 struct winch_stepper {
     struct stepper_kinematics sk;

--- a/klippy/chelper/kin_winch.c
+++ b/klippy/chelper/kin_winch.c
@@ -35,6 +35,6 @@ winch_stepper_alloc(double anchor_x, double anchor_y, double anchor_z)
     hs->anchor.x = anchor_x;
     hs->anchor.y = anchor_y;
     hs->anchor.z = anchor_z;
-    hs->sk.calc_position = winch_stepper_calc_position;
+    hs->sk.calc_position_cb = winch_stepper_calc_position;
     return &hs->sk;
 }

--- a/klippy/chelper/kin_winch.c
+++ b/klippy/chelper/kin_winch.c
@@ -1,6 +1,6 @@
 // Cable winch stepper kinematics
 //
-// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -37,5 +37,6 @@ winch_stepper_alloc(double anchor_x, double anchor_y, double anchor_z)
     hs->anchor.y = anchor_y;
     hs->anchor.z = anchor_z;
     hs->sk.calc_position_cb = winch_stepper_calc_position;
+    hs->sk.active_flags = AF_X | AF_Y | AF_Z;
     return &hs->sk;
 }

--- a/klippy/chelper/list.h
+++ b/klippy/chelper/list.h
@@ -30,6 +30,18 @@ list_empty(const struct list_head *h)
     return h->root.next == &h->root;
 }
 
+static inline int
+list_is_first(const struct list_node *n, const struct list_head *h)
+{
+    return n->prev == &h->root;
+}
+
+static inline int
+list_is_last(const struct list_node *n, const struct list_head *h)
+{
+    return n->next == &h->root;
+}
+
 static inline void
 list_del(struct list_node *n)
 {
@@ -90,8 +102,14 @@ list_join_tail(struct list_head *add, struct list_head *h)
 #define list_next_entry(pos, member)                            \
     container_of((pos)->member.next, typeof(*pos), member)
 
+#define list_prev_entry(pos, member)                            \
+    container_of((pos)->member.prev, typeof(*pos), member)
+
 #define list_first_entry(head, type, member)                    \
     container_of((head)->root.next, type, member)
+
+#define list_last_entry(head, type, member)                     \
+    container_of((head)->root.prev, type, member)
 
 #define list_for_each_entry(pos, head, member)                  \
     for (pos = list_first_entry((head), typeof(*pos), member)   \

--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -1,0 +1,87 @@
+// Trapezoidal velocity movement queue
+//
+// Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <math.h> // sqrt
+#include <stdlib.h> // malloc
+#include <string.h> // memset
+#include "compiler.h" // unlikely
+#include "trapq.h" // move_get_coord
+
+struct move * __visible
+move_alloc(void)
+{
+    struct move *m = malloc(sizeof(*m));
+    memset(m, 0, sizeof(*m));
+    return m;
+}
+
+// Populate a 'struct move' with a velocity trapezoid
+void __visible
+move_fill(struct move *m, double print_time
+          , double accel_t, double cruise_t, double decel_t
+          , double start_pos_x, double start_pos_y, double start_pos_z
+          , double axes_d_x, double axes_d_y, double axes_d_z
+          , double start_v, double cruise_v, double accel)
+{
+    // Setup velocity trapezoid
+    m->print_time = print_time;
+    m->move_t = accel_t + cruise_t + decel_t;
+    m->accel_t = accel_t;
+    m->cruise_t = cruise_t;
+    m->cruise_start_d = accel_t * .5 * (cruise_v + start_v);
+    m->decel_start_d = m->cruise_start_d + cruise_t * cruise_v;
+
+    // Setup for accel/cruise/decel phases
+    m->cruise_v = cruise_v;
+    m->accel.c1 = start_v;
+    m->accel.c2 = .5 * accel;
+    m->decel.c1 = cruise_v;
+    m->decel.c2 = -m->accel.c2;
+
+    // Setup for move_get_coord()
+    m->start_pos.x = start_pos_x;
+    m->start_pos.y = start_pos_y;
+    m->start_pos.z = start_pos_z;
+    double inv_move_d = 1. / sqrt(axes_d_x*axes_d_x + axes_d_y*axes_d_y
+                                  + axes_d_z*axes_d_z);
+    m->axes_r.x = axes_d_x * inv_move_d;
+    m->axes_r.y = axes_d_y * inv_move_d;
+    m->axes_r.z = axes_d_z * inv_move_d;
+}
+
+// Find the distance travel during acceleration/deceleration
+static inline double
+move_eval_accel(struct move_accel *ma, double move_time)
+{
+    return (ma->c1 + ma->c2 * move_time) * move_time;
+}
+
+// Return the distance moved given a time in a move
+inline double
+move_get_distance(struct move *m, double move_time)
+{
+    if (unlikely(move_time < m->accel_t))
+        // Acceleration phase of move
+        return move_eval_accel(&m->accel, move_time);
+    move_time -= m->accel_t;
+    if (likely(move_time <= m->cruise_t))
+        // Cruising phase
+        return m->cruise_start_d + m->cruise_v * move_time;
+    // Deceleration phase
+    move_time -= m->cruise_t;
+    return m->decel_start_d + move_eval_accel(&m->decel, move_time);
+}
+
+// Return the XYZ coordinates given a time in a move
+inline struct coord
+move_get_coord(struct move *m, double move_time)
+{
+    double move_dist = move_get_distance(m, move_time);
+    return (struct coord) {
+        .x = m->start_pos.x + m->axes_r.x * move_dist,
+        .y = m->start_pos.y + m->axes_r.y * move_dist,
+        .z = m->start_pos.z + m->axes_r.z * move_dist };
+}

--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -25,19 +25,11 @@ void __visible
 trapq_append(struct trapq *tq, double print_time
              , double accel_t, double cruise_t, double decel_t
              , double start_pos_x, double start_pos_y, double start_pos_z
-             , double axes_d_x, double axes_d_y, double axes_d_z
+             , double axes_r_x, double axes_r_y, double axes_r_z
              , double start_v, double cruise_v, double accel)
 {
-    struct coord axes_r, start_pos;
-    double inv_move_d = 1. / sqrt(axes_d_x*axes_d_x + axes_d_y*axes_d_y
-                                  + axes_d_z*axes_d_z);
-    axes_r.x = axes_d_x * inv_move_d;
-    axes_r.y = axes_d_y * inv_move_d;
-    axes_r.z = axes_d_z * inv_move_d;
-    start_pos.x = start_pos_x;
-    start_pos.y = start_pos_y;
-    start_pos.z = start_pos_z;
-
+    struct coord start_pos = { x: start_pos_x, y: start_pos_y, z: start_pos_z };
+    struct coord axes_r = { x: axes_r_x, y: axes_r_y, z: axes_r_z };
     if (accel_t) {
         struct move *m = move_alloc();
         m->print_time = print_time;

--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -12,7 +12,7 @@
 #include "trapq.h" // move_get_coord
 
 // Allocate a new 'move' object
-struct move * __visible
+struct move *
 move_alloc(void)
 {
     struct move *m = malloc(sizeof(*m));
@@ -20,14 +20,16 @@ move_alloc(void)
     return m;
 }
 
-// Populate a 'struct move' with a velocity trapezoid
+// Fill and add a move to the trapezoid velocity queue
 void __visible
-move_fill(struct move *m, double print_time
-          , double accel_t, double cruise_t, double decel_t
-          , double start_pos_x, double start_pos_y, double start_pos_z
-          , double axes_d_x, double axes_d_y, double axes_d_z
-          , double start_v, double cruise_v, double accel)
+trapq_append(struct trapq *tq, double print_time
+             , double accel_t, double cruise_t, double decel_t
+             , double start_pos_x, double start_pos_y, double start_pos_z
+             , double axes_d_x, double axes_d_y, double axes_d_z
+             , double start_v, double cruise_v, double accel)
 {
+    struct move *m = move_alloc();
+
     // Setup velocity trapezoid
     m->print_time = print_time;
     m->move_t = accel_t + cruise_t + decel_t;
@@ -52,6 +54,8 @@ move_fill(struct move *m, double print_time
     m->axes_r.x = axes_d_x * inv_move_d;
     m->axes_r.y = axes_d_y * inv_move_d;
     m->axes_r.z = axes_d_z * inv_move_d;
+
+    trapq_add_move(tq, m);
 }
 
 // Find the distance travel during acceleration/deceleration
@@ -111,12 +115,10 @@ trapq_free(struct trapq *tq)
 }
 
 // Add a move to the trapezoid velocity queue
-void __visible
+void
 trapq_add_move(struct trapq *tq, struct move *m)
 {
-    struct move *nm = move_alloc();
-    memcpy(nm, m, sizeof(*nm));
-    list_add_tail(&nm->node, &tq->moves);
+    list_add_tail(&m->node, &tq->moves);
 }
 
 // Free any moves older than `print_time` from the trapezoid velocity queue

--- a/klippy/chelper/trapq.h
+++ b/klippy/chelper/trapq.h
@@ -1,0 +1,30 @@
+#ifndef TRAPQ_H
+#define TRAPQ_H
+
+struct coord {
+    double x, y, z;
+};
+
+struct move_accel {
+    double c1, c2;
+};
+
+struct move {
+    double print_time, move_t;
+    double accel_t, cruise_t;
+    double cruise_start_d, decel_start_d;
+    double cruise_v;
+    struct move_accel accel, decel;
+    struct coord start_pos, axes_r;
+};
+
+struct move *move_alloc(void);
+void move_fill(struct move *m, double print_time
+               , double accel_t, double cruise_t, double decel_t
+               , double start_pos_x, double start_pos_y, double start_pos_z
+               , double axes_d_x, double axes_d_y, double axes_d_z
+               , double start_v, double cruise_v, double accel);
+double move_get_distance(struct move *m, double move_time);
+struct coord move_get_coord(struct move *m, double move_time);
+
+#endif // trapq.h

--- a/klippy/chelper/trapq.h
+++ b/klippy/chelper/trapq.h
@@ -1,6 +1,8 @@
 #ifndef TRAPQ_H
 #define TRAPQ_H
 
+#include "list.h" // list_node
+
 struct coord {
     double x, y, z;
 };
@@ -16,6 +18,8 @@ struct move {
     double cruise_v;
     struct move_accel accel, decel;
     struct coord start_pos, axes_r;
+
+    struct list_node node;
 };
 
 struct move *move_alloc(void);
@@ -26,5 +30,14 @@ void move_fill(struct move *m, double print_time
                , double start_v, double cruise_v, double accel);
 double move_get_distance(struct move *m, double move_time);
 struct coord move_get_coord(struct move *m, double move_time);
+
+struct trapq {
+    struct list_head moves;
+};
+
+struct trapq *trapq_alloc(void);
+void trapq_free(struct trapq *tq);
+void trapq_add_move(struct trapq *tq, struct move *m);
+void trapq_free_moves(struct trapq *tq, double print_time);
 
 #endif // trapq.h

--- a/klippy/chelper/trapq.h
+++ b/klippy/chelper/trapq.h
@@ -23,7 +23,7 @@ struct move *move_alloc(void);
 void trapq_append(struct trapq *tq, double print_time
                   , double accel_t, double cruise_t, double decel_t
                   , double start_pos_x, double start_pos_y, double start_pos_z
-                  , double axes_d_x, double axes_d_y, double axes_d_z
+                  , double axes_r_x, double axes_r_y, double axes_r_z
                   , double start_v, double cruise_v, double accel);
 double move_get_distance(struct move *m, double move_time);
 struct coord move_get_coord(struct move *m, double move_time);

--- a/klippy/chelper/trapq.h
+++ b/klippy/chelper/trapq.h
@@ -7,16 +7,9 @@ struct coord {
     double x, y, z;
 };
 
-struct move_accel {
-    double c1, c2;
-};
-
 struct move {
     double print_time, move_t;
-    double accel_t, cruise_t;
-    double cruise_start_d, decel_start_d;
-    double cruise_v;
-    struct move_accel accel, decel;
+    double start_v, half_accel;
     struct coord start_pos, axes_r;
 
     struct list_node node;

--- a/klippy/chelper/trapq.h
+++ b/klippy/chelper/trapq.h
@@ -22,19 +22,18 @@ struct move {
     struct list_node node;
 };
 
-struct move *move_alloc(void);
-void move_fill(struct move *m, double print_time
-               , double accel_t, double cruise_t, double decel_t
-               , double start_pos_x, double start_pos_y, double start_pos_z
-               , double axes_d_x, double axes_d_y, double axes_d_z
-               , double start_v, double cruise_v, double accel);
-double move_get_distance(struct move *m, double move_time);
-struct coord move_get_coord(struct move *m, double move_time);
-
 struct trapq {
     struct list_head moves;
 };
 
+struct move *move_alloc(void);
+void trapq_append(struct trapq *tq, double print_time
+                  , double accel_t, double cruise_t, double decel_t
+                  , double start_pos_x, double start_pos_y, double start_pos_z
+                  , double axes_d_x, double axes_d_y, double axes_d_z
+                  , double start_v, double cruise_v, double accel);
+double move_get_distance(struct move *m, double move_time);
+struct coord move_get_coord(struct move *m, double move_time);
 struct trapq *trapq_alloc(void);
 void trapq_free(struct trapq *tq);
 void trapq_add_move(struct trapq *tq, struct move *m);

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -56,10 +56,8 @@ class ForceMove:
         if not was_enable:
             stepper.motor_enable(print_time, 1)
             toolhead.dwell(STALL_TIME)
-        was_ignore = stepper.set_ignore_move(False)
-        return was_enable, was_ignore
-    def restore_enable(self, stepper, was_enable, was_ignore):
-        stepper.set_ignore_move(was_ignore)
+        return was_enable
+    def restore_enable(self, stepper, was_enable):
         if not was_enable:
             toolhead = self.printer.lookup_object('toolhead')
             toolhead.dwell(STALL_TIME)
@@ -89,14 +87,14 @@ class ForceMove:
     def cmd_STEPPER_BUZZ(self, params):
         stepper = self._lookup_stepper(params)
         logging.info("Stepper buzz %s", stepper.get_name())
-        was_enable, was_ignore = self.force_enable(stepper)
+        was_enable = self.force_enable(stepper)
         toolhead = self.printer.lookup_object('toolhead')
         for i in range(10):
             self.manual_move(stepper, 1., BUZZ_VELOCITY)
             toolhead.dwell(.050)
             self.manual_move(stepper, -1., BUZZ_VELOCITY)
             toolhead.dwell(.450)
-        self.restore_enable(stepper, was_enable, was_ignore)
+        self.restore_enable(stepper, was_enable)
     cmd_FORCE_MOVE_help = "Manually move a stepper; invalidates kinematics"
     def cmd_FORCE_MOVE(self, params):
         stepper = self._lookup_stepper(params)
@@ -105,9 +103,8 @@ class ForceMove:
         accel = self.gcode.get_float('ACCEL', params, 0., minval=0.)
         logging.info("FORCE_MOVE %s distance=%.3f velocity=%.3f accel=%.3f",
                      stepper.get_name(), distance, speed, accel)
-        was_enable, was_ignore = self.force_enable(stepper)
+        self.force_enable(stepper)
         self.manual_move(stepper, distance, speed, accel)
-        self.restore_enable(stepper, True, was_ignore)
     cmd_SET_KINEMATIC_POSITION_help = "Force a low-level kinematic position"
     def cmd_SET_KINEMATIC_POSITION(self, params):
         toolhead = self.printer.lookup_object('toolhead')

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -11,16 +11,19 @@ STALL_TIME = 0.100
 
 # Calculate a move's accel_t, cruise_t, and cruise_v
 def calc_move_time(dist, speed, accel):
-    dist = abs(dist)
+    axis_r = 1.
+    if dist < 0.:
+        axis_r = -1.
+        dist = -dist
     if not accel or not dist:
-        return 0., dist / speed, speed
+        return axis_r, 0., dist / speed, speed
     max_cruise_v2 = dist * accel
     if max_cruise_v2 < speed**2:
         speed = math.sqrt(max_cruise_v2)
     accel_t = speed / accel
     accel_decel_d = accel_t * speed
     cruise_t = (dist - accel_decel_d) / speed
-    return accel_t, cruise_t, speed
+    return axis_r, accel_t, cruise_t, speed
 
 class ForceMove:
     def __init__(self, config):
@@ -67,9 +70,9 @@ class ForceMove:
         print_time = toolhead.get_last_move_time()
         prev_sk = stepper.set_stepper_kinematics(self.stepper_kinematics)
         stepper.set_position((0., 0., 0.))
-        accel_t, cruise_t, cruise_v = calc_move_time(dist, speed, accel)
+        axis_r, accel_t, cruise_t, cruise_v = calc_move_time(dist, speed, accel)
         self.trapq_append(self.trapq, print_time, accel_t, cruise_t, accel_t,
-                          0., 0., 0., dist, 0., 0., 0., cruise_v, accel)
+                          0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
         print_time += accel_t + cruise_t + accel_t
         stepper.generate_steps(print_time)
         self.trapq_free_moves(self.trapq, print_time)

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -28,10 +28,8 @@ class ForceMove:
         self.steppers = {}
         # Setup iterative solver
         ffi_main, ffi_lib = chelper.get_ffi()
-        self.cmove = ffi_main.gc(ffi_lib.move_alloc(), ffi_lib.free)
-        self.move_fill = ffi_lib.move_fill
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
-        self.trapq_add_move = ffi_lib.trapq_add_move
+        self.trapq_append = ffi_lib.trapq_append
         self.trapq_free_moves = ffi_lib.trapq_free_moves
         self.stepper_kinematics = ffi_main.gc(
             ffi_lib.cartesian_stepper_alloc('x'), ffi_lib.free)
@@ -70,9 +68,8 @@ class ForceMove:
         prev_sk = stepper.set_stepper_kinematics(self.stepper_kinematics)
         stepper.set_position((0., 0., 0.))
         accel_t, cruise_t, cruise_v = calc_move_time(dist, speed, accel)
-        self.move_fill(self.cmove, print_time, accel_t, cruise_t, accel_t,
-                       0., 0., 0., dist, 0., 0., 0., cruise_v, accel)
-        self.trapq_add_move(self.trapq, self.cmove)
+        self.trapq_append(self.trapq, print_time, accel_t, cruise_t, accel_t,
+                          0., 0., 0., dist, 0., 0., 0., cruise_v, accel)
         print_time += accel_t + cruise_t + accel_t
         stepper.generate_steps(print_time)
         self.trapq_free_moves(self.trapq, print_time)

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -23,10 +23,8 @@ class ManualStepper:
         self.next_cmd_time = 0.
         # Setup iterative solver
         ffi_main, ffi_lib = chelper.get_ffi()
-        self.cmove = ffi_main.gc(ffi_lib.move_alloc(), ffi_lib.free)
-        self.move_fill = ffi_lib.move_fill
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
-        self.trapq_add_move = ffi_lib.trapq_add_move
+        self.trapq_append = ffi_lib.trapq_append
         self.trapq_free_moves = ffi_lib.trapq_free_moves
         self.stepper.setup_itersolve('cartesian_stepper_alloc', 'x')
         self.stepper.set_trapq(self.trapq)
@@ -58,11 +56,10 @@ class ManualStepper:
         dist = movepos - cp
         accel_t, cruise_t, cruise_v = force_move.calc_move_time(
             dist, speed, accel)
-        self.move_fill(self.cmove, self.next_cmd_time,
-                       accel_t, cruise_t, accel_t,
-                       cp, 0., 0., dist, 0., 0.,
-                       0., cruise_v, accel)
-        self.trapq_add_move(self.trapq, self.cmove)
+        self.trapq_append(self.trapq, self.next_cmd_time,
+                          accel_t, cruise_t, accel_t,
+                          cp, 0., 0., dist, 0., 0.,
+                          0., cruise_v, accel)
         self.next_cmd_time += accel_t + cruise_t + accel_t
         self.stepper.generate_steps(self.next_cmd_time)
         self.trapq_free_moves(self.trapq, self.next_cmd_time)

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -54,11 +54,11 @@ class ManualStepper:
         self.sync_print_time()
         cp = self.stepper.get_commanded_position()
         dist = movepos - cp
-        accel_t, cruise_t, cruise_v = force_move.calc_move_time(
+        axis_r, accel_t, cruise_t, cruise_v = force_move.calc_move_time(
             dist, speed, accel)
         self.trapq_append(self.trapq, self.next_cmd_time,
                           accel_t, cruise_t, accel_t,
-                          cp, 0., 0., dist, 0., 0.,
+                          cp, 0., 0., axis_r, 0., 0.,
                           0., cruise_v, accel)
         self.next_cmd_time += accel_t + cruise_t + accel_t
         self.stepper.generate_steps(self.next_cmd_time)

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -36,7 +36,7 @@ class ZAdjustHelper:
         gcode.respond_info(msg)
         # Disable Z stepper movements
         for s in self.z_steppers:
-            s.set_ignore_move(True)
+            s.set_trapq(None)
         # Move each z stepper (sorted from lowest to highest) until they match
         positions = [(-a, s) for a, s in zip(adjustments, self.z_steppers)]
         positions.sort()
@@ -45,7 +45,7 @@ class ZAdjustHelper:
         for i in range(len(positions)-1):
             stepper_offset, stepper = positions[i]
             next_stepper_offset, next_stepper = positions[i+1]
-            stepper.set_ignore_move(False)
+            stepper.set_trapq(toolhead.get_trapq())
             curpos[2] = z_low + next_stepper_offset
             try:
                 toolhead.move(curpos, speed)
@@ -53,11 +53,11 @@ class ZAdjustHelper:
             except:
                 logging.exception("ZAdjustHelper adjust_steppers")
                 for s in self.z_steppers:
-                    s.set_ignore_move(False)
+                    s.set_trapq(toolhead.get_trapq())
                 raise
         # Z should now be level - do final cleanup
         last_stepper_offset, last_stepper = positions[-1]
-        last_stepper.set_ignore_move(False)
+        last_stepper.set_trapq(toolhead.get_trapq())
         curpos[2] += first_stepper_offset
         toolhead.set_position(curpos)
         gcode.reset_last_position()

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -114,8 +114,6 @@ class CartKinematics:
         z_ratio = move.move_d / abs(move.axes_d[2])
         move.limit_speed(
             self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
-    def move(self, print_time, move):
-        pass
     def get_status(self):
         return {'homed_axes': "".join([a
                     for a, (l, h) in zip("XYZ", self.limits) if l <= h])

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -1,6 +1,6 @@
 # Code for handling the kinematics of cartesian robots
 #
-# Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
@@ -11,16 +11,18 @@ class CartKinematics:
         self.printer = config.get_printer()
         # Setup axis rails
         self.rails = [stepper.LookupMultiRail(config.getsection('stepper_' + n))
-                      for n in ['x', 'y', 'z']]
+                      for n in 'xyz']
         for rail, axis in zip(self.rails, 'xyz'):
             rail.setup_itersolve('cartesian_stepper_alloc', axis)
+        for s in self.get_steppers():
+            s.set_trapq(toolhead.get_trapq())
+            toolhead.register_move_handler(s.generate_steps)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
             'max_z_velocity', max_velocity, above=0., maxval=max_velocity)
         self.max_z_accel = config.getfloat(
             'max_z_accel', max_accel, above=0., maxval=max_accel)
-        self.need_motor_enable = True
         self.limits = [(1.0, -1.0)] * 3
         # Setup stepper max halt velocity
         max_halt_velocity = toolhead.get_max_axis_halt()
@@ -37,6 +39,8 @@ class CartKinematics:
             self.dual_carriage_axis = {'x': 0, 'y': 1}[dc_axis]
             dc_rail = stepper.LookupMultiRail(dc_config)
             dc_rail.setup_itersolve('cartesian_stepper_alloc', dc_axis)
+            for s in dc_rail.get_steppers():
+                toolhead.register_move_handler(s.generate_steps)
             dc_rail.set_max_jerk(max_halt_velocity, max_accel)
             self.dual_carriage_rails = [
                 self.rails[self.dual_carriage_axis], dc_rail]
@@ -86,14 +90,6 @@ class CartKinematics:
             rail.motor_enable(print_time, 0)
         for rail in self.dual_carriage_rails:
             rail.motor_enable(print_time, 0)
-        self.need_motor_enable = True
-    def _check_motor_enable(self, print_time, move):
-        need_motor_enable = False
-        for i, rail in enumerate(self.rails):
-            if move.axes_d[i]:
-                rail.motor_enable(print_time, 1)
-            need_motor_enable |= not rail.is_motor_enabled()
-        self.need_motor_enable = need_motor_enable
     def _check_endstops(self, move):
         end_pos = move.end_pos
         for i in (0, 1, 2):
@@ -119,11 +115,7 @@ class CartKinematics:
         move.limit_speed(
             self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
     def move(self, print_time, move):
-        if self.need_motor_enable:
-            self._check_motor_enable(print_time, move)
-        for i, rail in enumerate(self.rails):
-            if move.axes_d[i]:
-                rail.step_itersolve(move.cmove)
+        pass
     def get_status(self):
         return {'homed_axes': "".join([a
                     for a, (l, h) in zip("XYZ", self.limits) if l <= h])
@@ -134,6 +126,8 @@ class CartKinematics:
         toolhead.get_last_move_time()
         dc_rail = self.dual_carriage_rails[carriage]
         dc_axis = self.dual_carriage_axis
+        self.rails[dc_axis].set_trapq(None)
+        dc_rail.set_trapq(toolhead.get_trapq())
         self.rails[dc_axis] = dc_rail
         extruder_pos = toolhead.get_position()[3]
         toolhead.set_position(self.calc_position() + [extruder_pos])

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -91,8 +91,6 @@ class CoreXYKinematics:
         z_ratio = move.move_d / abs(move.axes_d[2])
         move.limit_speed(
             self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
-    def move(self, print_time, move):
-        pass
     def get_status(self):
         return {'homed_axes': "".join([a
                     for a, (l, h) in zip("XYZ", self.limits) if l <= h])

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -144,8 +144,6 @@ class DeltaKinematics:
             move.limit_speed(max_velocity * r, self.max_accel * r)
             limit_xy2 = -1.
         self.limit_xy2 = min(limit_xy2, self.slow_xy2)
-    def move(self, print_time, move):
-        pass
     def get_status(self):
         return {'homed_axes': '' if self.need_home else 'XYZ'}
 

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -1,6 +1,6 @@
 # Code for handling printer nozzle extruders
 #
-# Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
@@ -50,13 +50,18 @@ class PrinterExtruder:
             'pressure_advance', 0., minval=0.)
         self.pressure_advance_lookahead_time = config.getfloat(
             'pressure_advance_lookahead_time', 0.010, minval=0.)
-        self.need_motor_enable = True
         self.extrude_pos = 0.
         # Setup iterative solver
         ffi_main, ffi_lib = chelper.get_ffi()
         self.cmove = ffi_main.gc(ffi_lib.move_alloc(), ffi_lib.free)
         self.extruder_move_fill = ffi_lib.extruder_move_fill
+        self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
+        self.trapq_add_move = ffi_lib.trapq_add_move
+        self.trapq_free_moves = ffi_lib.trapq_free_moves
         self.stepper.setup_itersolve('extruder_stepper_alloc')
+        self.stepper.set_trapq(self.trapq)
+        toolhead.register_move_handler(self.stepper.generate_steps)
+        toolhead.register_move_handler(self._free_moves)
         # Setup SET_PRESSURE_ADVANCE command
         gcode = self.printer.lookup_object('gcode')
         if self.name in ('extruder', 'extruder0'):
@@ -66,6 +71,8 @@ class PrinterExtruder:
         gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER",
                                    self.name, self.cmd_SET_PRESSURE_ADVANCE,
                                    desc=self.cmd_SET_PRESSURE_ADVANCE_help)
+    def _free_moves(self, flush_time):
+        self.trapq_free_moves(self.trapq, flush_time)
     def get_status(self, eventtime):
         return dict(
             self.get_heater().get_status(eventtime),
@@ -84,7 +91,6 @@ class PrinterExtruder:
         return self.heater.stats(eventtime)
     def motor_off(self, print_time):
         self.stepper.motor_enable(print_time, 0)
-        self.need_motor_enable = True
     def check_move(self, move):
         move.extrude_r = move.axes_d[3] / move.move_d
         move.extrude_max_corner_v = 0.
@@ -167,9 +173,6 @@ class PrinterExtruder:
             move.extrude_max_corner_v = max_corner_v
         return flush_count
     def move(self, print_time, move):
-        if self.need_motor_enable:
-            self.stepper.motor_enable(print_time, 1)
-            self.need_motor_enable = False
         axis_d = move.axes_d[3]
         axis_r = axis_d / move.move_d
         accel = move.accel * axis_r
@@ -205,7 +208,7 @@ class PrinterExtruder:
         self.extruder_move_fill(
             self.cmove, print_time, accel_t, cruise_t, decel_t, start_pos,
             start_v, cruise_v, accel, extra_accel_v, extra_decel_v)
-        self.stepper.step_itersolve(self.cmove)
+        self.trapq_add_move(self.trapq, self.cmove)
         self.extrude_pos = start_pos + axis_d
     cmd_SET_PRESSURE_ADVANCE_help = "Set pressure advance parameters"
     def cmd_default_SET_PRESSURE_ADVANCE(self, params):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -53,10 +53,8 @@ class PrinterExtruder:
         self.extrude_pos = 0.
         # Setup iterative solver
         ffi_main, ffi_lib = chelper.get_ffi()
-        self.cmove = ffi_main.gc(ffi_lib.move_alloc(), ffi_lib.free)
-        self.extruder_move_fill = ffi_lib.extruder_move_fill
+        self.extruder_add_move = ffi_lib.extruder_add_move
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
-        self.trapq_add_move = ffi_lib.trapq_add_move
         self.trapq_free_moves = ffi_lib.trapq_free_moves
         self.stepper.setup_itersolve('extruder_stepper_alloc')
         self.stepper.set_trapq(self.trapq)
@@ -205,10 +203,9 @@ class PrinterExtruder:
                     extra_decel_v = extra_decel_d / decel_t
 
         # Generate steps
-        self.extruder_move_fill(
-            self.cmove, print_time, accel_t, cruise_t, decel_t, start_pos,
+        self.extruder_add_move(
+            self.trapq, print_time, accel_t, cruise_t, decel_t, start_pos,
             start_v, cruise_v, accel, extra_accel_v, extra_decel_v)
-        self.trapq_add_move(self.trapq, self.cmove)
         self.extrude_pos = start_pos + axis_d
     cmd_SET_PRESSURE_ADVANCE_help = "Set pressure advance parameters"
     def cmd_default_SET_PRESSURE_ADVANCE(self, params):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -90,7 +90,7 @@ class PrinterExtruder:
     def motor_off(self, print_time):
         self.stepper.motor_enable(print_time, 0)
     def check_move(self, move):
-        move.extrude_r = move.axes_d[3] / move.move_d
+        move.extrude_r = move.axes_r[3]
         move.extrude_max_corner_v = 0.
         if not self.heater.can_extrude:
             raise homing.EndstopError(
@@ -111,7 +111,7 @@ class PrinterExtruder:
                 # Permit extrusion if amount extruded is tiny
                 move.extrude_r = self.max_extrude_ratio
                 return
-            area = move.axes_d[3] * self.filament_area / move.move_d
+            area = move.axes_r[3] * self.filament_area
             logging.debug("Overextrude: %s vs %s (area=%.3f dist=%.3f)",
                           move.extrude_r, self.max_extrude_ratio,
                           area, move.move_d)
@@ -172,7 +172,7 @@ class PrinterExtruder:
         return flush_count
     def move(self, print_time, move):
         axis_d = move.axes_d[3]
-        axis_r = axis_d / move.move_d
+        axis_r = move.axes_r[3]
         accel = move.accel * axis_r
         start_v = move.start_v * axis_r
         cruise_v = move.cruise_v * axis_r

--- a/klippy/kinematics/none.py
+++ b/klippy/kinematics/none.py
@@ -19,8 +19,6 @@ class NoneKinematics:
         pass
     def check_move(self, move):
         pass
-    def move(self, print_time, move):
-        pass
     def get_status(self):
         return {'homed_axes': ''}
 

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -120,14 +120,7 @@ class PolarKinematics:
         cmove = move.cmove
         if axes_d[0] or axes_d[1]:
             self.rails[0].step_itersolve(cmove)
-            stepper_bed = self.steppers[0]
-            stepper_bed.step_itersolve(cmove)
-            # Normalize the stepper_bed angle
-            angle = stepper_bed.get_commanded_position()
-            if angle < -math.pi:
-                stepper_bed.set_commanded_position(angle + 2. * math.pi)
-            elif angle > math.pi:
-                stepper_bed.set_commanded_position(angle - 2. * math.pi)
+            self.steppers[0].step_itersolve(cmove)
         if axes_d[2]:
             self.rails[1].step_itersolve(cmove)
     def get_status(self):

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -104,8 +104,6 @@ class PolarKinematics:
             z_ratio = move.move_d / abs(move.axes_d[2])
             move.limit_speed(
                 self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
-    def move(self, print_time, move):
-        pass
     def get_status(self):
         return {'homed_axes': (("XY" if self.limit_xy2 >= 0. else "") +
                         ("Z" if self.limit_z[0] <= self.limit_z[1] else ""))}

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -48,8 +48,6 @@ class WinchKinematics:
     def check_move(self, move):
         # XXX - boundary checks and speed limits not implemented
         pass
-    def move(self, print_time, move):
-        pass
     def get_status(self):
         # XXX - homed_checks and rail limits not implemented
         return {'homed_axes': 'XYZ'}

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -21,11 +21,14 @@ class MCU_stepper:
         self._step_dist = 0.
         self._min_stop_interval = 0.
         self._reset_cmd_id = self._get_position_cmd = None
+        self._active_callbacks = []
         ffi_main, self._ffi_lib = chelper.get_ffi()
         self._stepqueue = ffi_main.gc(self._ffi_lib.stepcompress_alloc(oid),
                                       self._ffi_lib.stepcompress_free)
         self._mcu.register_stepqueue(self._stepqueue)
         self._stepper_kinematics = self._itersolve_gen_steps = None
+        self._itersolve_generate_steps = self._itersolve_check_active = None
+        self._trapq = ffi_main.NULL
         self.set_ignore_move(False)
     def get_mcu(self):
         return self._mcu
@@ -95,12 +98,16 @@ class MCU_stepper:
                 sk, self._stepqueue, self._step_dist)
         return old_sk
     def set_ignore_move(self, ignore_move):
-        was_ignore = (self._itersolve_gen_steps
-                      is not self._ffi_lib.itersolve_gen_steps)
+        fl = self._ffi_lib
+        was_ignore = self._itersolve_gen_steps is not fl.itersolve_gen_steps
         if ignore_move:
             self._itersolve_gen_steps = (lambda *args: 0)
+            self._itersolve_generate_steps = (lambda *args: 0)
+            self._itersolve_check_active = (lambda *args: 0.)
         else:
-            self._itersolve_gen_steps = self._ffi_lib.itersolve_gen_steps
+            self._itersolve_gen_steps = fl.itersolve_gen_steps
+            self._itersolve_generate_steps = fl.itersolve_generate_steps
+            self._itersolve_check_active = fl.itersolve_check_active
         return was_ignore
     def note_homing_end(self, did_trigger=False):
         ret = self._ffi_lib.stepcompress_reset(self._stepqueue, 0)
@@ -122,6 +129,31 @@ class MCU_stepper:
             self._stepper_kinematics, mcu_pos_dist - self._mcu_position_offset)
     def step_itersolve(self, cmove):
         ret = self._itersolve_gen_steps(self._stepper_kinematics, cmove)
+        if ret:
+            raise error("Internal error in stepcompress")
+    def set_trapq(self, tq):
+        if tq is None:
+            ffi_main, self._ffi_lib = chelper.get_ffi()
+            tq = ffi_main.NULL
+        self._ffi_lib.itersolve_set_trapq(self._stepper_kinematics, tq)
+        old_tq = self._trapq
+        self._trapq = tq
+        return old_tq
+    def add_active_callback(self, cb):
+        self._active_callbacks.append(cb)
+    def generate_steps(self, flush_time):
+        # Check for activity if necessary
+        if self._active_callbacks:
+            ret = self._itersolve_check_active(self._stepper_kinematics,
+                                               flush_time)
+            if ret:
+                cbs = self._active_callbacks
+                self._active_callbacks = []
+                for cb in cbs:
+                    cb(ret)
+        # Generate steps
+        ret = self._itersolve_generate_steps(self._stepper_kinematics,
+                                             flush_time)
         if ret:
             raise error("Internal error in stepcompress")
 

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -26,10 +26,11 @@ class MCU_stepper:
         self._stepqueue = ffi_main.gc(self._ffi_lib.stepcompress_alloc(oid),
                                       self._ffi_lib.stepcompress_free)
         self._mcu.register_stepqueue(self._stepqueue)
-        self._stepper_kinematics = self._itersolve_gen_steps = None
-        self._itersolve_generate_steps = self._itersolve_check_active = None
+        self._stepper_kinematics = None
+        self._itersolve_gen_steps = self._ffi_lib.itersolve_gen_steps
+        self._itersolve_generate_steps = self._ffi_lib.itersolve_generate_steps
+        self._itersolve_check_active = self._ffi_lib.itersolve_check_active
         self._trapq = ffi_main.NULL
-        self.set_ignore_move(False)
     def get_mcu(self):
         return self._mcu
     def setup_dir_pin(self, pin_params):
@@ -97,18 +98,6 @@ class MCU_stepper:
             self._ffi_lib.itersolve_set_stepcompress(
                 sk, self._stepqueue, self._step_dist)
         return old_sk
-    def set_ignore_move(self, ignore_move):
-        fl = self._ffi_lib
-        was_ignore = self._itersolve_gen_steps is not fl.itersolve_gen_steps
-        if ignore_move:
-            self._itersolve_gen_steps = (lambda *args: 0)
-            self._itersolve_generate_steps = (lambda *args: 0)
-            self._itersolve_check_active = (lambda *args: 0.)
-        else:
-            self._itersolve_gen_steps = fl.itersolve_gen_steps
-            self._itersolve_generate_steps = fl.itersolve_generate_steps
-            self._itersolve_check_active = fl.itersolve_check_active
-        return was_ignore
     def note_homing_end(self, did_trigger=False):
         ret = self._ffi_lib.stepcompress_reset(self._stepqueue, 0)
         if ret:

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -27,7 +27,6 @@ class MCU_stepper:
                                       self._ffi_lib.stepcompress_free)
         self._mcu.register_stepqueue(self._stepqueue)
         self._stepper_kinematics = None
-        self._itersolve_gen_steps = self._ffi_lib.itersolve_gen_steps
         self._itersolve_generate_steps = self._ffi_lib.itersolve_generate_steps
         self._itersolve_check_active = self._ffi_lib.itersolve_check_active
         self._trapq = ffi_main.NULL
@@ -116,10 +115,6 @@ class MCU_stepper:
             mcu_pos_dist = -mcu_pos_dist
         self._ffi_lib.itersolve_set_commanded_pos(
             self._stepper_kinematics, mcu_pos_dist - self._mcu_position_offset)
-    def step_itersolve(self, cmove):
-        ret = self._itersolve_gen_steps(self._stepper_kinematics, cmove)
-        if ret:
-            raise error("Internal error in stepcompress")
     def set_trapq(self, tq):
         if tq is None:
             ffi_main, self._ffi_lib = chelper.get_ffi()

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -76,7 +76,6 @@ class PrinterStepper:
         force_move = printer.try_load_module(config, 'force_move')
         force_move.register_stepper(self)
         # Wrappers
-        self.step_itersolve = mcu_stepper.step_itersolve
         self.setup_itersolve = mcu_stepper.setup_itersolve
         self.generate_steps = mcu_stepper.generate_steps
         self.set_trapq = mcu_stepper.set_trapq
@@ -133,7 +132,6 @@ class PrinterRail:
         stepper = PrinterStepper(config)
         self.steppers = [stepper]
         self.name = stepper.get_name(short=True)
-        self.step_itersolve = stepper.step_itersolve
         self.get_commanded_position = stepper.get_commanded_position
         self.is_motor_enabled = stepper.is_motor_enabled
         # Primary endstop and its position
@@ -199,7 +197,6 @@ class PrinterRail:
     def add_extra_stepper(self, config):
         stepper = PrinterStepper(config)
         self.steppers.append(stepper)
-        self.step_itersolve = self.step_multi_itersolve
         mcu_endstop = self.endstops[0][0]
         endstop_pin = config.get('endstop_pin', None)
         if endstop_pin is not None:
@@ -214,9 +211,6 @@ class PrinterRail:
     def add_to_endstop(self, mcu_endstop):
         for stepper in self.steppers:
             stepper.add_to_endstop(mcu_endstop)
-    def step_multi_itersolve(self, cmove):
-        for stepper in self.steppers:
-            stepper.step_itersolve(cmove)
     def setup_itersolve(self, alloc_func, *params):
         for stepper in self.steppers:
             stepper.setup_itersolve(alloc_func, *params)

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -81,7 +81,6 @@ class PrinterStepper:
         self.generate_steps = mcu_stepper.generate_steps
         self.set_trapq = mcu_stepper.set_trapq
         self.set_stepper_kinematics = mcu_stepper.set_stepper_kinematics
-        self.set_ignore_move = mcu_stepper.set_ignore_move
         self.calc_position_from_coord = mcu_stepper.calc_position_from_coord
         self.set_position = mcu_stepper.set_position
         self.get_commanded_position = mcu_stepper.get_commanded_position

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -70,6 +70,7 @@ class PrinterStepper:
         mcu_stepper.setup_dir_pin(dir_pin_params)
         step_dist = config.getfloat('step_distance', above=0.)
         mcu_stepper.setup_step_distance(step_dist)
+        mcu_stepper.add_active_callback(self._stepper_active)
         self.enable = lookup_enable_pin(ppins, config.get('enable_pin', None))
         # Register STEPPER_BUZZ command
         force_move = printer.try_load_module(config, 'force_move')
@@ -77,6 +78,8 @@ class PrinterStepper:
         # Wrappers
         self.step_itersolve = mcu_stepper.step_itersolve
         self.setup_itersolve = mcu_stepper.setup_itersolve
+        self.generate_steps = mcu_stepper.generate_steps
+        self.set_trapq = mcu_stepper.set_trapq
         self.set_stepper_kinematics = mcu_stepper.set_stepper_kinematics
         self.set_ignore_move = mcu_stepper.set_ignore_move
         self.calc_position_from_coord = mcu_stepper.calc_position_from_coord
@@ -105,10 +108,15 @@ class PrinterStepper:
             2. * step_dist, max_halt_velocity, max_accel)
         min_stop_interval = second_last_step_time - last_step_time
         self.mcu_stepper.setup_min_stop_interval(min_stop_interval)
+    def _stepper_active(self, active_time):
+        self.motor_enable(active_time, 1)
     def motor_enable(self, print_time, enable=0):
         if self.need_motor_enable != (not enable):
             self.enable.set_enable(print_time, enable)
         self.need_motor_enable = not enable
+        if not enable:
+            # Enable stepper on future stepper movement
+            self.mcu_stepper.add_active_callback(self._stepper_active)
     def is_motor_enabled(self):
         return not self.need_motor_enable
 
@@ -213,6 +221,12 @@ class PrinterRail:
     def setup_itersolve(self, alloc_func, *params):
         for stepper in self.steppers:
             stepper.setup_itersolve(alloc_func, *params)
+    def generate_steps(self, flush_time):
+        for stepper in self.steppers:
+            stepper.generate_steps(flush_time)
+    def set_trapq(self, trapq):
+        for stepper in self.steppers:
+            stepper.set_trapq(trapq)
     def set_max_jerk(self, max_halt_velocity, max_accel):
         for stepper in self.steppers:
             stepper.set_max_jerk(max_halt_velocity, max_accel)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -104,7 +104,6 @@ class Move:
                 self.axes_d[0], self.axes_d[1], self.axes_d[2],
                 self.start_v, self.cruise_v, self.accel)
             self.toolhead.trapq_add_move(self.toolhead.trapq, self.cmove)
-            self.toolhead.kin.move(next_move_time, self)
         if self.axes_d[3]:
             self.toolhead.extruder.move(next_move_time, self)
         self.toolhead.update_move_time(

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -79,19 +79,19 @@ class Move:
             , prev_move.max_smoothed_v2 + prev_move.smooth_delta_v2)
     def set_junction(self, start_v2, cruise_v2, end_v2):
         # Determine accel, cruise, and decel portions of the move distance
-        inv_delta_v2 = 1. / self.delta_v2
-        self.accel_r = accel_r = (cruise_v2 - start_v2) * inv_delta_v2
-        self.decel_r = decel_r = (cruise_v2 - end_v2) * inv_delta_v2
-        self.cruise_r = cruise_r = 1. - accel_r - decel_r
+        half_inv_accel = .5 / self.accel
+        accel_d = (cruise_v2 - start_v2) * half_inv_accel
+        decel_d = (cruise_v2 - end_v2) * half_inv_accel
+        cruise_d = self.move_d - accel_d - decel_d
         # Determine move velocities
         self.start_v = start_v = math.sqrt(start_v2)
         self.cruise_v = cruise_v = math.sqrt(cruise_v2)
         self.end_v = end_v = math.sqrt(end_v2)
         # Determine time spent in each portion of move (time is the
         # distance divided by average velocity)
-        self.accel_t = accel_r * self.move_d / ((start_v + cruise_v) * 0.5)
-        self.cruise_t = cruise_r * self.move_d / cruise_v
-        self.decel_t = decel_r * self.move_d / ((end_v + cruise_v) * 0.5)
+        self.accel_t = accel_d / ((start_v + cruise_v) * 0.5)
+        self.cruise_t = cruise_d / cruise_v
+        self.decel_t = decel_d / ((end_v + cruise_v) * 0.5)
 
 LOOKAHEAD_FLUSH_TIME = 0.250
 

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -92,27 +92,14 @@ class Move:
         self.accel_t = accel_r * self.move_d / ((start_v + cruise_v) * 0.5)
         self.cruise_t = cruise_r * self.move_d / cruise_v
         self.decel_t = decel_r * self.move_d / ((end_v + cruise_v) * 0.5)
-    def move(self):
-        # Generate step times for the move
-        next_move_time = self.toolhead.get_next_move_time()
-        if self.is_kinematic_move:
-            self.toolhead.trapq_append(
-                self.toolhead.trapq, next_move_time,
-                self.accel_t, self.cruise_t, self.decel_t,
-                self.start_pos[0], self.start_pos[1], self.start_pos[2],
-                self.axes_d[0], self.axes_d[1], self.axes_d[2],
-                self.start_v, self.cruise_v, self.accel)
-        if self.axes_d[3]:
-            self.toolhead.extruder.move(next_move_time, self)
-        self.toolhead.update_move_time(
-            self.accel_t + self.cruise_t + self.decel_t)
 
 LOOKAHEAD_FLUSH_TIME = 0.250
 
 # Class to track a list of pending move requests and to facilitate
 # "look-ahead" across moves to reduce acceleration between moves.
 class MoveQueue:
-    def __init__(self):
+    def __init__(self, toolhead):
+        self.toolhead = toolhead
         self.extruder_lookahead = None
         self.queue = []
         self.leftover = 0
@@ -176,8 +163,7 @@ class MoveQueue:
         # Allow extruder to do its lookahead
         move_count = self.extruder_lookahead(queue, flush_count, lazy)
         # Generate step times for all moves ready to be flushed
-        for move in queue[:move_count]:
-            move.move()
+        self.toolhead._process_moves(queue[:move_count])
         # Remove processed moves from the queue
         self.leftover = flush_count - move_count
         del queue[:move_count]
@@ -192,6 +178,7 @@ class MoveQueue:
             self.flush(lazy=True)
 
 STALL_TIME = 0.100
+MOVE_BATCH_TIME = 0.500
 
 DRIP_SEGMENT_TIME = 0.050
 DRIP_TIME = 0.150
@@ -206,7 +193,7 @@ class ToolHead:
         self.all_mcus = [
             m for n, m in self.printer.lookup_objects(module='mcu')]
         self.mcu = self.all_mcus[0]
-        self.move_queue = MoveQueue()
+        self.move_queue = MoveQueue(self)
         self.commanded_pos = [0., 0., 0., 0.]
         self.printer.register_event_handler("gcode:request_restart",
                                             self._handle_request_restart)
@@ -276,15 +263,20 @@ class ToolHead:
         self.printer.try_load_module(config, "manual_probe")
         self.printer.try_load_module(config, "tuning_tower")
     # Print time tracking
-    def update_move_time(self, movetime, lazy=True):
-        self.print_time = flush_to_time = self.print_time + movetime
-        for mh in self.move_handlers:
-            mh(flush_to_time)
-        self.trapq_free_moves(self.trapq, flush_to_time)
-        if lazy:
-            flush_to_time -= self.move_flush_time
-        for m in self.all_mcus:
-            m.flush_moves(flush_to_time)
+    def _update_move_time(self, next_print_time, lazy=True):
+        batch_time = MOVE_BATCH_TIME
+        while 1:
+            flush_to_time = min(self.print_time + batch_time, next_print_time)
+            self.print_time = flush_to_time
+            for mh in self.move_handlers:
+                mh(flush_to_time)
+            self.trapq_free_moves(self.trapq, flush_to_time)
+            if lazy:
+                flush_to_time -= self.move_flush_time
+            for m in self.all_mcus:
+                m.flush_moves(flush_to_time)
+            if self.print_time >= next_print_time:
+                break
     def _calc_print_time(self):
         curtime = self.reactor.monotonic()
         est_print_time = self.mcu.estimated_print_time(curtime)
@@ -293,26 +285,33 @@ class ToolHead:
             self.last_print_start_time = self.print_time
             self.printer.send_event("toolhead:sync_print_time",
                                     curtime, est_print_time, self.print_time)
-    def get_next_move_time(self):
-        if not self.special_queuing_state:
-            return self.print_time
+    def _process_moves(self, moves):
+        # Resync print_time if necessary
+        if self.special_queuing_state:
+            if self.special_queuing_state != "Drip":
+                # Transition from "Flushed"/"Priming" state to main state
+                self.special_queuing_state = ""
+                self.need_check_stall = -1.
+                self.reactor.update_timer(self.flush_timer, self.reactor.NOW)
+            self._calc_print_time()
+        # Queue moves into trapezoid motion queue (trapq)
+        next_move_time = self.print_time
+        for move in moves:
+            if move.is_kinematic_move:
+                self.trapq_append(
+                    self.trapq, next_move_time,
+                    move.accel_t, move.cruise_t, move.decel_t,
+                    move.start_pos[0], move.start_pos[1], move.start_pos[2],
+                    move.axes_d[0], move.axes_d[1], move.axes_d[2],
+                    move.start_v, move.cruise_v, move.accel)
+            if move.axes_d[3]:
+                self.extruder.move(next_move_time, move)
+            next_move_time += move.accel_t + move.cruise_t + move.decel_t
+        # Generate steps for moves
         if self.special_queuing_state == "Drip":
-            # In "Drip" state - wait until ready to send next move
-            while 1:
-                if self.drip_completion.test():
-                    raise DripModeEndSignal()
-                curtime = self.reactor.monotonic()
-                est_print_time = self.mcu.estimated_print_time(curtime)
-                wait_time = self.print_time - est_print_time - DRIP_TIME
-                if wait_time <= 0. or self.mcu.is_fileoutput():
-                    return self.print_time
-                self.drip_completion.wait(curtime + wait_time)
-        # Transition from "Flushed"/"Priming" state to main state
-        self.special_queuing_state = ""
-        self.need_check_stall = -1.
-        self.reactor.update_timer(self.flush_timer, self.reactor.NOW)
-        self._calc_print_time()
-        return self.print_time
+            self._update_drip_move_time(next_move_time)
+        else:
+            self._update_move_time(next_move_time)
     def _full_flush(self):
         # Transition from "Flushed"/"Priming"/main state to "Flushed" state
         self.move_queue.flush()
@@ -321,7 +320,7 @@ class ToolHead:
         self.reactor.update_timer(self.flush_timer, self.reactor.NEVER)
         self.move_queue.set_flush_time(self.buffer_time_high)
         self.idle_flush_print_time = 0.
-        self.update_move_time(0., lazy=False)
+        self._update_move_time(self.print_time, lazy=False)
     def _flush_lookahead(self):
         if self.special_queuing_state:
             return self._full_flush()
@@ -394,8 +393,8 @@ class ToolHead:
         if self.print_time > self.need_check_stall:
             self._check_stall()
     def dwell(self, delay):
-        self.get_last_move_time()
-        self.update_move_time(delay)
+        next_print_time = self.get_last_move_time() + max(0., delay)
+        self._update_move_time(next_print_time)
         self._check_stall()
     def motor_off(self):
         self.dwell(STALL_TIME)
@@ -423,41 +422,39 @@ class ToolHead:
         self.commanded_pos[3] = extrude_pos
     def get_extruder(self):
         return self.extruder
+    # Homing "drip move" handling
+    def _update_drip_move_time(self, next_print_time):
+        while self.print_time < next_print_time:
+            if self.drip_completion.test():
+                raise DripModeEndSignal()
+            curtime = self.reactor.monotonic()
+            est_print_time = self.mcu.estimated_print_time(curtime)
+            wait_time = self.print_time - est_print_time - DRIP_TIME
+            if wait_time > 0. and not self.mcu.is_fileoutput():
+                # Pause before sending more steps
+                self.drip_completion.wait(curtime + wait_time)
+                continue
+            npt = min(self.print_time + DRIP_SEGMENT_TIME, next_print_time)
+            self._update_move_time(npt)
     def drip_move(self, newpos, speed):
-        # Validate move
-        move = Move(self, self.commanded_pos, newpos, speed)
-        if move.axes_d[3]:
-            raise homing.CommandError("Invalid drip move")
-        if not move.move_d or not move.is_kinematic_move:
-            return
-        self.kin.check_move(move)
-        speed = math.sqrt(move.max_cruise_v2)
-        move_accel = move.accel
         # Transition to "Flushed" state and then to "Drip" state
         self._full_flush()
         self.special_queuing_state = "Drip"
         self.need_check_stall = self.reactor.NEVER
         self.reactor.update_timer(self.flush_timer, self.reactor.NEVER)
         self.drip_completion = self.reactor.completion()
-        # Split move into many tiny moves and queue them
-        num_moves = max(1, int(math.ceil(move.min_move_t / DRIP_SEGMENT_TIME)))
-        inv_num_moves = 1. / float(num_moves)
-        submove_d = [d * inv_num_moves for d in move.axes_d]
-        prev_pos = move.start_pos
-        self._calc_print_time()
+        # Submit move
         try:
-            for i in range(num_moves-1):
-                next_pos = [p + d for p, d in zip(prev_pos, submove_d)]
-                smove = Move(self, prev_pos, next_pos, speed)
-                smove.limit_speed(speed, move_accel)
-                self.move_queue.add_move(smove)
-                prev_pos = next_pos
-            smove = Move(self, prev_pos, move.end_pos, speed)
-            smove.limit_speed(speed, move_accel)
-            self.move_queue.add_move(smove)
+            self.move(newpos, speed)
+        except homing.CommandError as e:
+            self._full_flush()
+            raise
+        # Transmit move in "drip" mode
+        try:
             self.move_queue.flush()
         except DripModeEndSignal as e:
             self.move_queue.reset()
+            self.trapq_free_moves(self.trapq, self.reactor.NEVER)
         # Return to "Flushed" state
         self._full_flush()
     def signal_drip_mode_end(self):

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -306,7 +306,8 @@ class ToolHead:
                     move.start_v, move.cruise_v, move.accel)
             if move.axes_d[3]:
                 self.extruder.move(next_move_time, move)
-            next_move_time += move.accel_t + move.cruise_t + move.decel_t
+            next_move_time = (next_move_time + move.accel_t
+                              + move.cruise_t + move.decel_t)
         # Generate steps for moves
         if self.special_queuing_state == "Drip":
             self._update_drip_move_time(next_move_time)


### PR DESCRIPTION
This series is a large backend rework of the Klipper kinematics.  The current code generates the steps for each move, one move at a time.  This pull request changes the underlying step generation code to generate steps based on a time range.  Each host stepper object is associated with a list of moves, and steps are then generated from the moves on that list.  A step generation time range may be part of a move, multiple moves, or some combination.

This change should fix #1460.  It will also make it much easier to merging PR #1997.

-Kevin