### PR TITLE
Update printer-lulzbot-mini1-2016.cfg

### DIFF
--- a/config/printer-lulzbot-mini1-2016.cfg
+++ b/config/printer-lulzbot-mini1-2016.cfg
@@ -89,6 +89,7 @@ pid_Kd: 108.51
 min_temp: 0
 max_temp: 280
 min_extrude_temp: 160
+max_extrude_cross_section: 8
 max_extrude_only_velocity: 500
 max_extrude_only_accel: 2000
 


### PR DESCRIPTION
@KevinOConnor accidentally removed the max_extrude_cross_section line, which is mandatory for this profile if it wants to be a drop-in replacement for Lulzbot Mini Marlin. The original Lulzbot Cura start g-code retracts a generous amount of filament to prevent oozing while probing the washers and purges it back just before printing (E-only move), causing a huge extrude cross section in air, but hardly any filament extruded. The "standard" Lulzbot Cura profile will fail without this line.