### PR TITLE
heater: Add get_status() function

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -160,6 +160,13 @@ The following are common printer attributes:
 - `printer.toolhead.homed_axes`: The current cartesian axes considered
   to be in a "homed" state. This is a string containing one or more of
   "x", "y", "z".
+- `printer.heater.available_heaters`: Returns a list of all currently
+  available heaters by their full config section names,
+  e.g. `["extruder", "heater_bed", "heater_generic my_custom_heater"]`.
+- `printer.heater.available_sensors`: Returns a list of all currently
+  available temperature sensors by their full config section names,
+  e.g. `["extruder", "heater_bed", "heater_generic my_custom_heater",
+  "temperature_sensor electronics_temp"]`.
 
 The above list is subject to change - if using an attribute be sure to
 review the [Config Changes document](Config_Changes.md) when upgrading

--- a/klippy/extras/temperature_sensor.py
+++ b/klippy/extras/temperature_sensor.py
@@ -22,6 +22,8 @@ class PrinterSensorGeneric:
         self.last_temp = temp
     def get_temp(self, eventtime):
         return self.last_temp, 0.
+    def get_status(self, eventtime):
+        return {'temperature': self.last_temp}
 
 def load_config_prefix(config):
     return PrinterSensorGeneric(config)

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -233,6 +233,8 @@ class PrinterHeaters:
         self.sensor_factories = {}
         self.heaters = {}
         self.gcode_id_to_sensor = {}
+        self.available_heaters = []
+        self.available_sensors = []
         self.printer.register_event_handler("gcode:request_restart",
                                             self.turn_off_all_heaters)
         # Register TURN_OFF_HEATERS command
@@ -250,6 +252,7 @@ class PrinterHeaters:
         # Create heater
         self.heaters[heater_name] = heater = Heater(config, sensor)
         self.register_sensor(config, heater, gcode_id)
+        self.available_heaters.append(config.get_name())
         return heater
     def lookup_heater(self, heater_name):
         if heater_name not in self.heaters:
@@ -276,6 +279,7 @@ class PrinterHeaters:
             raise self.printer.config_error(
                 "G-Code sensor id %s already registered" % (gcode_id,))
         self.gcode_id_to_sensor[gcode_id] = psensor
+        self.available_sensors.append(config.get_name())
     def turn_off_all_heaters(self, print_time):
         for heater in self.heaters.values():
             heater.set_temp(print_time, 0.)
@@ -283,6 +287,9 @@ class PrinterHeaters:
     def cmd_TURN_OFF_HEATERS(self, params):
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         self.turn_off_all_heaters(print_time)
+    def get_status(self, eventtime):
+        return {'available_heaters': self.available_heaters,
+                'available_sensors': self.available_sensors}
 
 def add_printer_objects(config):
     config.get_printer().add_object('heater', PrinterHeaters(config))


### PR DESCRIPTION
This gives access to a list of available heater names in gcode macros as printer.heater.available_heaters (Edited after change of implementation, see conversation below)

Signed-off-by: Simon Kühling <mail@simonkuehling.de>