### PR TITLE
fan: scale value linearly between off_below and max_power

### DIFF
--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -31,9 +31,9 @@ class PrinterFan:
     def handle_request_restart(self, print_time):
         self.set_speed(print_time, 0.)
     def set_speed(self, print_time, value):
-        if value < self.off_below:
-            value = 0.
-        value = max(0., min(self.max_power, value * self.max_power))
+        if value != 0.:
+          value = max(self.off_below, min(self.max_power,
+                   self.off_below + value * (self.max_power - self.off_below)))
         if value == self.last_fan_value:
             return
         print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)


### PR DESCRIPTION
This is an addition to #1897 (FYI @seckar). The merged PR introduced the configuration parameter `off_below` which allows users to specify a PWM value below which a fan will not turn on. This avoids fan stalling and overheating, however it also causes M106 to essentially have no effect below values below `off_below`. In extreme cases, e.g. with an `off_below` value of 0.5, this will cause M106 to lose much of its functionality.

This PR changes the computation of the PWM value to a linear scale between `off_below` and `max_power`. While this will not cause a true 0-100% scale of fan RPM or fan CFM, it will at least cause M106 with a non-zero S value to always cause fan spinning.

e.g.
with a configuration like so:
```
max_power: 0.8
off_below: 0.2
```
`M106 S1` will result in a PWM value of `~0.204` causing the fan to spin as slow as possible (given the remaining configuration such as cycle_time), `M106 S127` will result in a PWM value of `0.5`, which will cause fan PWMs somewhere between its minimum fan speed and maximum fan speed at `max_power`, and `M106 S255` will result in a PWM value of `0.8`, which is the configured maximum speed of the fan (still slightly below its max RPM)


Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>

edit: One more addition could/should be to check at configuration time whether off_below is below max_power. If you agree I'll add this change in another commit.