### PR TITLE
fixes in anycubic delta plus default config file

### DIFF
--- a/config/printer-anycubic-kossel-plus-2017.cfg
+++ b/config/printer-anycubic-kossel-plus-2017.cfg
@@ -19,7 +19,7 @@ homing_speed: 60
 # and meassure the distance from nozzle to bed.
 # This value then needs to be added.
 position_endstop: 295.6
-arm_length: 271.50
+arm_length: 269.0
 
 [stepper_b]
 step_pin: ar60
@@ -39,7 +39,7 @@ endstop_pin: ^ar19
 step_pin: ar26
 dir_pin: !ar28
 enable_pin: !ar24
-step_distance: 0.010989
+step_distance: 0.0104166
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10
@@ -53,13 +53,16 @@ min_extrude_temp: 150
 min_temp: 0
 max_temp: 275
 
-#[heater_bed]
-#heater_pin: ar8
-#sensor_type: EPCOS 100K B57560G104F
-#sensor_pin: analog14
-#control: watermark
-#min_temp: 0
-#max_temp: 130
+[heater_bed]
+heater_pin: ar8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+control: pid
+pid_kp: 73.517
+pid_ki: 1.132
+pid_kd: 1193.728
+min_temp: 0
+max_temp: 130
 
 [fan]
 pin: ar9
@@ -67,6 +70,12 @@ kick_start_time: 0.200
 
 [heater_fan extruder_cooler_fan]
 pin: ar44
+
+# if you want to use your probe for DELTA_CALIBRATE you will need that
+#[probe]
+#pin: ^ar18
+#z_offset: 15.9
+#samples: 3
 
 [mcu]
 serial: /dev/ttyUSB0
@@ -77,23 +86,15 @@ kinematics: delta
 max_velocity: 500
 max_accel: 3000
 max_z_velocity: 200
-delta_radius: 115
+delta_radius: 134.4
 # if you want to DELTA_CALIBRATE you may need that
 #minimum_z_position: -5
 
 [idle_timeout]
 timeout: 360
 
-#[delta_calibrate]
-#radius: 115
-#manual_probe:
-#   If true, then DELTA_CALIBRATE will perform manual probing. If
-#   false, then a PROBE command will be run at each probe
-#   point. Manual probing is accomplished by manually jogging the Z
-#   position of the print head at each probe point and then issuing a
-#   NEXT extended g-code command to record the position at that
-#   point. The default is false if a [probe] config section is present
-#   and true otherwise.
+[delta_calibrate]
+radius: 115
 
 # "RepRapDiscount 2004 Smart Controller" type displays
 [display]


### PR DESCRIPTION
Default parameters for Anycubic delta linear plus have to be changed. Current parameters are incorrect and during calibration may cause damage to the printer, so it is rather important to change them to correct values (copied from Marlin firmware and tested on my printer).

Also I uncommented "heather bed" because all currently sold printers have this feature. Pids are calculated on my printer - I believe that they will work well for others as starting values.