### PR TITLE
tmc2130,5160: warn if run current below hold current

### DIFF
--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -147,7 +147,7 @@ class TMCCurrentHelper:
             hold_current = self._calc_current_from_field("IHOLD")
         if 'CURRENT' in params:
             run_current = gcode.get_float(
-                'CURRENT', params, minval=hold_current, maxval=MAX_CURRENT)
+                'CURRENT', params, minval=0., maxval=MAX_CURRENT)
         else:
             run_current = self._calc_current_from_field("IRUN")
         if 'HOLDCURRENT' not in params and 'CURRENT' not in params:
@@ -155,6 +155,10 @@ class TMCCurrentHelper:
             gcode.respond_info("Run Current: %0.2fA Hold Current: %0.2fA"
                                % (run_current, hold_current))
             return
+        if run_current < hold_current:
+            gcode.respond_info("SET_TMC_CURRENT ignored. Run Current lower" +
+                               " than Hold Current")
+            return    
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         vsense, irun, ihold = self._calc_current(run_current, hold_current)
         if vsense != self.fields.get_field("vsense"):

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -123,11 +123,13 @@ class TMCCurrentHelper:
     def _calc_current(self, run_current, hold_current):
         vsense = False
         irun = self._calc_current_bits(run_current, vsense)
-        ihold = self._calc_current_bits(min(hold_current, run_current), vsense)
+        ihold = self._calc_current_bits(min(hold_current, run_current),
+                                        vsense)
         if irun < 16 and ihold < 16:
             vsense = True
             irun = self._calc_current_bits(run_current, vsense)
-            ihold = self._calc_current_bits(min(hold_current, run_current), vsense)
+            ihold = self._calc_current_bits(min(hold_current, run_current),
+                                            vsense)
         return vsense, irun, ihold
     def _calc_current_from_field(self, field_name):
         bits = self.fields.get_field(field_name)

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -158,7 +158,7 @@ class TMCCurrentHelper:
         if run_current < hold_current:
             gcode.respond_info("SET_TMC_CURRENT ignored. Run Current lower" +
                                " than Hold Current")
-            return    
+            return
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         vsense, irun, ihold = self._calc_current(run_current, hold_current)
         if vsense != self.fields.get_field("vsense"):

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -123,11 +123,11 @@ class TMCCurrentHelper:
     def _calc_current(self, run_current, hold_current):
         vsense = False
         irun = self._calc_current_bits(run_current, vsense)
-        ihold = self._calc_current_bits(hold_current, vsense)
+        ihold = self._calc_current_bits(min(hold_current, run_current), vsense)
         if irun < 16 and ihold < 16:
             vsense = True
             irun = self._calc_current_bits(run_current, vsense)
-            ihold = self._calc_current_bits(hold_current, vsense)
+            ihold = self._calc_current_bits(min(hold_current, run_current), vsense)
         return vsense, irun, ihold
     def _calc_current_from_field(self, field_name):
         bits = self.fields.get_field(field_name)
@@ -154,10 +154,6 @@ class TMCCurrentHelper:
             # Query only
             gcode.respond_info("Run Current: %0.2fA Hold Current: %0.2fA"
                                % (run_current, hold_current))
-            return
-        if run_current < hold_current:
-            gcode.respond_info("SET_TMC_CURRENT ignored. Run Current lower" +
-                               " than Hold Current")
             return
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         vsense, irun, ihold = self._calc_current(run_current, hold_current)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -267,13 +267,17 @@ class TMC5160CurrentHelper:
             hold_current = self._calc_current_from_field("IHOLD")
         if 'CURRENT' in params:
             run_current = gcode.get_float(
-                'CURRENT', params, minval=hold_current, maxval=MAX_CURRENT)
+                'CURRENT', params, minval=0., maxval=MAX_CURRENT)
         else:
             run_current = self._calc_current_from_field("IRUN")
         if 'HOLDCURRENT' not in params and 'CURRENT' not in params:
             # Query only
             gcode.respond_info("Run Current: %0.2fA Hold Current: %0.2fA"
                                % (run_current, hold_current))
+            return
+        if run_current < hold_current:
+            gcode.respond_info("SET_TMC_CURRENT ignored. Run Current lower" +
+                               " than Hold Current")
             return
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         irun, ihold = self._calc_current(run_current, hold_current)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -250,7 +250,7 @@ class TMC5160CurrentHelper:
         return max(0, min(31, cs))
     def _calc_current(self, run_current, hold_current):
         irun = self._calc_current_bits(run_current)
-        ihold = self._calc_current_bits(hold_current)
+        ihold = self._calc_current_bits(min(hold_current, run_current))
         return irun, ihold
     def _calc_current_from_field(self, field_name):
         bits = self.fields.get_field(field_name)
@@ -274,10 +274,6 @@ class TMC5160CurrentHelper:
             # Query only
             gcode.respond_info("Run Current: %0.2fA Hold Current: %0.2fA"
                                % (run_current, hold_current))
-            return
-        if run_current < hold_current:
-            gcode.respond_info("SET_TMC_CURRENT ignored. Run Current lower" +
-                               " than Hold Current")
             return
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         irun, ihold = self._calc_current(run_current, hold_current)


### PR DESCRIPTION
This PR changes the behavior if a user attempts to set a `RUN_CURRENT` lower than the `HOLD_CURRENT` via `SET_TMC_CURRENT`.

In it's current state, the `get_float` call will cause an error if `run_current` is below `hold_current`, causing the printer to shut down and running print jobs to be canceled. With this PR, a warning is printed instead, and the GCode command is ignored.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>