### PR TITLE
stm32: enable chipid as usb serial number.

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -10,6 +10,7 @@ config STM32_SELECT
     select HAVE_GPIO_I2C
     select HAVE_GPIO_SPI
     select HAVE_GPIO_BITBANGING
+    select HAVE_CHIPID
 
 config BOARD_DIRECTORY
     string


### PR DESCRIPTION
Signed-off-by: Matt Baker <baker.matt.j@gmail.com>