### PR TITLE
Remove multi-extruder T0/T1/... commands

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -677,19 +677,6 @@
 #   config section should define the heater and the extruder4 section
 #   should specify "shared_heater: extruder3". The default is to not
 #   reuse an existing heater.
-#deactivate_gcode:
-#   A list of G-Code commands to execute on a G-Code tool change
-#   command (eg, "T1") that deactivates this extruder and activates
-#   some other extruder. See docs/Command_Templates.md for G-Code
-#   format. It only makes sense to define this section on
-#   multi-extruder printers. The default is to not run any special
-#   G-Code commands on deactivation.
-#activate_gcode:
-#   A list of G-Code commands to execute on a G-Code tool change
-#   command (eg, "T0") that activates this extruder. See
-#   docs/Command_Templates.md for G-Code format. It only makes sense
-#   to define this section on multi-extruder printers. The default is
-#   to not run any special G-Code commands on activation.
 
 # Support for cartesian printers with dual carriages on a single
 # axis. The active carriage is set via the SET_DUAL_CARRIAGE extended

--- a/config/sample-idex.cfg
+++ b/config/sample-idex.cfg
@@ -1,0 +1,93 @@
+# This file contains a configuration snippet for a dual extruder
+# printer using dual carriages (an "IDEX" printer).
+
+# See example.cfg and example-extras.cfg for a description of
+# available parameters.
+
+# Definition for the primary carriage (holding the primary extruder)
+[stepper_x]
+step_pin: ar54
+dir_pin: ar55
+enable_pin: !ar38
+step_distance: .0125
+endstop_pin: ^ar3
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+# The definition for the primary extruder
+[extruder]
+step_pin: ar26
+dir_pin: ar28
+enable_pin: !ar24
+step_distance: .002
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+# Helper script to park the carriage (called from T0 and T1 macros)
+[gcode_macro PARK_extruder]
+gcode:
+    SAVE_GCODE_STATE NAME=park0
+    G90
+    G1 X0
+    RESTORE_GCODE_STATE NAME=park0
+
+# Activate the primary extruder
+[gcode_macro T0]
+gcode:
+    PARK_{printer.toolhead.extruder}
+    ACTIVATE_EXTRUDER EXTRUDER=extruder
+    SET_DUAL_CARRIAGE CARRIAGE=0
+    SET_GCODE_OFFSET Y=0
+
+# Definition for the secondary carriage and extruder1
+[dual_carriage]
+axis: x
+step_pin: ar16
+dir_pin: ar17
+enable_pin: !ar23
+step_distance: .0125
+endstop_pin: ^ar2
+position_endstop: 200
+position_max: 200
+homing_speed: 50
+
+[extruder1]
+step_pin: ar36
+dir_pin: ar34
+enable_pin: !ar30
+step_distance: .002
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar11
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog15
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[gcode_macro PARK_extruder1]
+gcode:
+    SAVE_GCODE_STATE NAME=park1
+    G90
+    G1 X200
+    RESTORE_GCODE_STATE NAME=park1
+
+[gcode_macro T1]
+gcode:
+    PARK_{printer.toolhead.extruder}
+    ACTIVATE_EXTRUDER EXTRUDER=extruder1
+    SET_DUAL_CARRIAGE CARRIAGE=1
+    SET_GCODE_OFFSET Y=15

--- a/config/sample-multi-extruder.cfg
+++ b/config/sample-multi-extruder.cfg
@@ -1,0 +1,61 @@
+# This file contains a configuration snippet for a printer using two
+# extruders that are selected by a servo.
+
+# See example.cfg and example-extras.cfg for a description of
+# available parameters.
+
+# The primary extruder
+[extruder]
+step_pin: ar26
+dir_pin: ar28
+enable_pin: !ar24
+step_distance: .004242
+nozzle_diameter: 0.500
+filament_diameter: 3.500
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 210
+
+# Script to change back to the main extruder
+[gcode_macro T0]
+gcode:
+    SET_SERVO SERVO=extruder_servo angle=100    # Lift secondary extruder
+    SET_GCODE_OFFSET Z=0 MOVE=1                 # Adjust z-height
+    SET_GCODE_OFFSET X=0                        # Clear X offset
+    ACTIVATE_EXTRUDER EXTRUDER=extruder
+
+# Secondary extruder
+[extruder1]
+step_pin: ar36
+dir_pin: ar34
+enable_pin: !ar30
+step_distance: .004242
+nozzle_diameter: 0.500
+filament_diameter: 3.500
+heater_pin: ar9
+sensor_pin: analog15
+sensor_type: EPCOS 100K B57560G104F
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 210
+
+# Script to activate second extruder
+[gcode_macro T1]
+gcode:
+    SET_GCODE_OFFSET Z=0.100 MOVE=1             # Adjust z-height
+    SET_SERVO SERVO=extruder_servo angle=100    # Position second extruder
+    SET_GCODE_OFFSET X=5                        # Account for different X offset
+    ACTIVATE_EXTRUDER EXTRUDER=extruder1
+
+# Servo definition
+[servo extruder_servo]
+pin: ar7

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,12 @@ All dates in this document are approximate.
 
 # Changes
 
+20191210: The builtin T0, T1, T2, ... commands have been removed.  The
+extruder activate_gcode and deactivate_gcode config options have been
+removed.  If these commands (and scripts) are needed then define
+individual [gcode_macro T0] style macros that call the
+ACTIVATE_EXTRUDER command.
+
 20191210: Support for the M206 command has been removed.  Replace with
 calls to SET_GCODE_OFFSET.  If support for M206 is needed, add a
 [gcode_macro M206] config section that calls SET_GCODE_OFFSET.  (For

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,11 @@ All dates in this document are approximate.
 
 # Changes
 
+20191210: Support for the M206 command has been removed.  Replace with
+calls to SET_GCODE_OFFSET.  If support for M206 is needed, add a
+[gcode_macro M206] config section that calls SET_GCODE_OFFSET.  (For
+example "SET_GCODE_OFFSET Z=-{params.Z}".)
+
 20191202: Support for the undocumented "S" parameter of the "G4"
 command has been removed.  Replace any occurrences of S with the
 standard "P" parameter (the delay specified in milliseconds).

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -9,7 +9,6 @@ Klipper supports the following standard G-Code commands:
 - Move to origin: `G28 [X] [Y] [Z]`
 - Turn off motors: `M18` or `M84`
 - Wait for current moves to finish: `M400`
-- Select tool: `T<index>`
 - Use absolute/relative distances for extrusion: `M82`, `M83`
 - Use absolute/relative coordinates: `G90`, `G91`
 - Set position: `G92 [X<pos>] [Y<pos>] [Z<pos>] [E<pos>]`
@@ -44,7 +43,7 @@ If one requires a less common G-Code command then it may be possible
 to implement it with a custom Klipper gcode_macro (see
 [example-extras.cfg](https://github.com/KevinOConnor/klipper/tree/master/config/example-extras.cfg)
 for details). For example, one might use this to implement: `G12`,
-`G29`, `G30`, `G31`, `M42`, `M80`, `M81`, etc.
+`G29`, `G30`, `G31`, `M42`, `M80`, `M81`, `T1`, etc.
 
 ## G-Code SD card commands
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -153,6 +153,9 @@ The following standard commands are supported:
 - `SET_HEATER_TEMPERATURE HEATER=<heater_name> [TARGET=<target_temperature>]`:
   Sets the target temperature for a heater. If a target temperature is
   not supplied, the target is 0.
+- `ACTIVATE_EXTRUDER EXTRUDER=<config_name>`: In a printer with
+  multiple extruders this command is used to change the active
+  extruder.
 - `SET_PRESSURE_ADVANCE [EXTRUDER=<config_name>] [ADVANCE=<pressure_advance>]
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -83,8 +83,6 @@ config section is enabled:
 
 The following standard G-Code commands are currently available, but
 using them is not recommended:
-- Offset axes: `M206 [X<offset>] [Y<offset>] [Z<offset>]` (Use
-  SET_GCODE_OFFSET instead.)
 - Get Endstop Status: `M119` (Use QUERY_ENDSTOPS instead.)
 
 # Extended G-Code Commands

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -17,6 +17,8 @@ class GCodeParser:
         printer.register_event_handler("klippy:shutdown", self._handle_shutdown)
         printer.register_event_handler("klippy:disconnect",
                                        self._handle_disconnect)
+        printer.register_event_handler("extruder:activate_extruder",
+                                       self._handle_activate_extruder)
         # Input handling
         self.reactor = printer.get_reactor()
         self.is_processing_data = False
@@ -175,6 +177,10 @@ class GCodeParser:
             self.fd_handle = self.reactor.register_fd(self.fd,
                                                       self._process_data)
         self._respond_state("Ready")
+    def _handle_activate_extruder(self):
+        self.reset_last_position()
+        self.extrude_factor = 1.
+        self.base_position[3] = self.last_position[3]
     def reset_last_position(self):
         self.last_position = self.position_with_transform()
     def _dump_debug(self):

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -476,7 +476,7 @@ class GCodeParser:
     all_handlers = [
         'G1', 'G4', 'G28', 'M400',
         'G20', 'M82', 'M83', 'G90', 'G91', 'G92', 'M114', 'M220', 'M221',
-        'SET_GCODE_OFFSET', 'M206', 'SAVE_GCODE_STATE', 'RESTORE_GCODE_STATE',
+        'SET_GCODE_OFFSET', 'SAVE_GCODE_STATE', 'RESTORE_GCODE_STATE',
         'M105', 'M104', 'M109', 'M140', 'M190',
         'M112', 'M115', 'IGNORE', 'GET_POSITION',
         'RESTART', 'FIRMWARE_RESTART', 'ECHO', 'STATUS', 'HELP']
@@ -599,14 +599,6 @@ class GCodeParser:
             for pos, delta in enumerate(move_delta):
                 self.last_position[pos] += delta
             self.move_with_transform(self.last_position, speed)
-    def cmd_M206(self, params):
-        # Offset axes
-        offsets = { self.axis2pos[a]: -self.get_float(a, params)
-                    for a in 'XYZ' if a in params }
-        for pos, offset in offsets.items():
-            delta = offset - self.homing_position[pos]
-            self.base_position[pos] += delta
-            self.homing_position[pos] = offset
     cmd_SAVE_GCODE_STATE_help = "Save G-Code coordinate state"
     def cmd_SAVE_GCODE_STATE(self, params):
         state_name = self.get_str('NAME', params, 'default')

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -41,11 +41,6 @@ class PrinterExtruder:
             'max_extrude_only_distance', 50., minval=0.)
         self.instant_corner_v = config.getfloat(
             'instantaneous_corner_velocity', 1., minval=0.)
-        gcode_macro = self.printer.try_load_module(config, 'gcode_macro')
-        self.activate_gcode = gcode_macro.load_template(
-            config, 'activate_gcode', '')
-        self.deactivate_gcode = gcode_macro.load_template(
-            config, 'deactivate_gcode', '')
         self.pressure_advance = self.pressure_advance_smooth_time = 0.
         pressure_advance = config.getfloat('pressure_advance', 0., minval=0.)
         smooth_time = config.getfloat('pressure_advance_smooth_time',
@@ -99,12 +94,6 @@ class PrinterExtruder:
         return self.name
     def get_heater(self):
         return self.heater
-    def set_active(self, print_time, is_active):
-        return self.extrude_pos
-    def get_activate_gcode(self, is_active):
-        if is_active:
-            return self.activate_gcode.render()
-        return self.deactivate_gcode.render()
     def stats(self, eventtime):
         return self.heater.stats(eventtime)
     def check_move(self, move):
@@ -184,8 +173,6 @@ class PrinterExtruder:
 
 # Dummy extruder class used when a printer has no extruder at all
 class DummyExtruder:
-    def set_active(self, print_time, is_active):
-        return 0.
     def update_move_time(self, flush_time):
         pass
     def check_move(self, move):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -73,6 +73,9 @@ class PrinterExtruder:
         gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER",
                                    self.name, self.cmd_SET_PRESSURE_ADVANCE,
                                    desc=self.cmd_SET_PRESSURE_ADVANCE_help)
+        gcode.register_mux_command("ACTIVATE_EXTRUDER", "EXTRUDER",
+                                   self.name, self.cmd_ACTIVATE_EXTRUDER,
+                                   desc=self.cmd_ACTIVATE_EXTRUDER_help)
     def update_move_time(self, flush_time):
         self.trapq_free_moves(self.trapq, flush_time)
     def _set_pressure_advance(self, pressure_advance, smooth_time):
@@ -168,6 +171,16 @@ class PrinterExtruder:
                    pressure_advance, smooth_time))
         self.printer.set_rollover_info(self.name, "%s: %s" % (self.name, msg))
         gcode.respond_info(msg, log=False)
+    cmd_ACTIVATE_EXTRUDER_help = "Change the active extruder"
+    def cmd_ACTIVATE_EXTRUDER(self, params):
+        gcode = self.printer.lookup_object('gcode')
+        toolhead = self.printer.lookup_object('toolhead')
+        if toolhead.get_extruder() is self:
+            gcode.respond_info("Extruder %s already active" % (self.name))
+            return
+        gcode.respond_info("Activating extruder %s" % (self.name))
+        toolhead.set_extruder(self, self.extrude_pos)
+        self.printer.send_event("extruder:activate_extruder")
 
 # Dummy extruder class used when a printer has no extruder at all
 class DummyExtruder:

--- a/test/klippy/dual_carriage.cfg
+++ b/test/klippy/dual_carriage.cfg
@@ -55,10 +55,16 @@ pid_Ki: 1.08
 pid_Kd: 114
 min_temp: 0
 max_temp: 250
-deactivate_gcode:
+
+[gcode_macro PARK_extruder0]
+gcode:
     G90
     G1 X0
-activate_gcode:
+
+[gcode_macro T0]
+gcode:
+    PARK_{printer.toolhead.extruder}
+    ACTIVATE_EXTRUDER EXTRUDER=extruder
     SET_DUAL_CARRIAGE CARRIAGE=0
 
 [extruder1]
@@ -77,12 +83,18 @@ pid_Ki: 1.08
 pid_Kd: 114
 min_temp: 0
 max_temp: 250
-deactivate_gcode:
+
+[gcode_macro PARK_extruder1]
+gcode:
     SET_SERVO SERVO=my_servo angle=100
     G90
     G1 X200
-activate_gcode:
+
+[gcode_macro T1]
+gcode:
+    PARK_{printer.toolhead.extruder}
     SET_SERVO SERVO=my_servo angle=50
+    ACTIVATE_EXTRUDER EXTRUDER=extruder1
     SET_DUAL_CARRIAGE CARRIAGE=1
 
 [servo my_servo]


### PR DESCRIPTION
This is a proposal to remove the built-in `T0`, `T1`, ... G-Code commands.  This would require users with multiple extruders to update their configs to add `[gcode_macro T1]` macros that call a new `ACTIVATE_EXTRUDER EXTRUDER=extruder1` command.

There are two main reasons for this proposal:
* The current `T1` style support is not flexible enough to handle the requirements of some printers.  In particular, there is a desire to create "virtual extruders" that alter the behaviour of an existing extruder.  For example, the "mmu2" could be thought of as having several virtual extruders (eg, `T1`, `T2`, `T3`, `T4`) that switch filaments on a single hardware extruder.  Implementing this functionality via individual `T1` macros is notably easier than working with the existing `Tn` g-code support.
* The real-world multi-extruder configurations I've seen tend to include complex `activate_gcode` and `deactivate_gcode` macros.  I believe directly defining the `T1` macros would actually make these complex scripts easier for users to implement and maintain.

This series adds a couple of sample config snippets (config/sample-idex.cfg and config/sample-multi-extruder.cfg) to provide examples for users needing to migrate.

Along with this change, I'm also proposing the removal of the built-in `M206` command.  That old-style g-code command doesn't have a well defined implementation (different firmware do different things with it) and its parameters are confusing.  I suspect it's only used in extruder switching scripts today (so if we're breaking those scripts, might as well fix this as well).  The SET_GCODE_OFFSET command offers a superset of functionality and it's easy to introduce an M206 macro that calls SET_GCODE_OFFSET if desired.

-Kevin