### PR TITLE
add support for z offset at each configured probe point

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -278,7 +278,8 @@ class ProbePointsHelper:
                 points = [line.split(',', 2) for line in points if line.strip()]
                 self.probe_points = [(float(p[0].strip()), float(p[1].strip()))
                                      for p in points]
-                #if a z coordinate was specified treat it as a replacement z_offset at this point
+                #if a z coordinate was specified treat it as a replacement 
+		#z_offset at this point
                 if len(points[0])==3:
                     self.probe_point_zoff = [(float(p[2].strip()))
                             for p in points]
@@ -350,7 +351,7 @@ class ProbePointsHelper:
                 raw=pos
                 my_offset=self.probe_point_zoff[len(self.results)]
                 self.gcode.respond_info("Adjusting raw point: " + str(pos) +
-                        " for point zoffset: " + str(my_offset) + 
+                        " for point zoffset: " + str(my_offset) +
                         " instead of z_offset: " + str(self.probe_offsets[2]))
                 pos[2]=pos[2]+(self.probe_offsets[2]-my_offset)
                 self.gcode.respond_info("cooked point: " + str(pos))


### PR DESCRIPTION
Some probes exhibit repeatable bias at certain bed points. This leads to a repeatable bed skew.

Currently the documentation says if your probe has bias you can't use it (https://github.com/KevinOConnor/klipper/blob/master/docs/Probe_Calibrate.md#location-bias-check).

This adds support to specify a per-point z offset to allow such a probe to be used. For example, my inductive probe is off by about 100-150 microns due to magnets in my build plate.

To use:
Determine probe offsets at each of your configured probe points (PROBE_CALIBRATE as described in the doc). Add the Z offset value that PROBE_CALIBRATE returns as a third coordinate to each configured probe point.

You need to do this for all configured probe points if you use the feature.

ex:
 points:
- 30,10
- 30,200
- 220,200
- 220,10
+ 30,10,5.361
+ 30,200,5.472
+ 220,200,5.391
+ 220,10,5.229

Also considered a delta but the sign was not intuitive whereas this approach allows the direct PROBE_CALIBRATE output to be used.

This was tested against 0.8.0 on a Voron 250mm in QUAD_GANTRY_LEVEL only. However, it should work elsewhere.

I suspect you will want the verbosity decreased, although it is mostly only verbose when enabled.

If the approach is something you are open to I can clean up the pull request and add docs/examples. This is my first time touching the Klipper code, I don't have much of a sense of the organization yet.
