### PR TITLE
add support for per-point z_offsets for gantry leveling with a biased probe

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -272,6 +272,12 @@
 #   Z2, and Z3 location in order.
 #   This parameter must be provided.
 #   For maximum accuracy, ensure your probe offsets are configured.
+#   If your probe has a different but repeatable z_offset at each of
+#   these locations (bad, fix your probe if possible) you can specify a list of
+#   four X,Y,Z coordinates instead where the Z value used will replace
+#   your configured z_offset at the specified point for QGL purposes.
+#   you need to provide Z offsets for all four points. You can get the correct
+#   values by moving to each of the positions and running PROBE_CALIBRATE.
 #speed: 50
 #   The speed (in mm/s) of non-probing moves during the calibration.
 #   The default is 50.

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -349,7 +349,7 @@ class ProbePointsHelper:
             if done:
                 break
             pos = probe.run_probe(params)
-            if self.probe_point_z_offset:
+            if hasattr(self, 'probe_point_z_offset'):
                 raw=pos
                 point_z_offset=self.probe_point_z_offset[len(self.results)]
                 global_z_offset=self.probe_offsets[2]

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -339,7 +339,7 @@ class ProbePointsHelper:
         # Perform automatic probing
         self.lift_speed = min(self.speed, probe.speed)
         self.probe_offsets = probe.get_offsets()
-        self.gcode.respond_info("configured global z_offset: %.3f" +
+        self.gcode.respond_info("configured global z_offset: %.3f" %
                 self.probe_offsets[2])
         if self.horizontal_move_z < self.probe_offsets[2]:
             raise self.gcode.error("horizontal_move_z can't be less than"

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -324,7 +324,6 @@ class ProbePointsHelper:
         self.gcode.reset_last_position()
         return False
     def start_probe(self, params):
-        self.gcode.respond_info("start_probe")
         manual_probe.verify_no_manual_probe(self.printer)
         # Lookup objects
         probe = self.printer.lookup_object('probe', None)
@@ -339,8 +338,6 @@ class ProbePointsHelper:
         # Perform automatic probing
         self.lift_speed = min(self.speed, probe.speed)
         self.probe_offsets = probe.get_offsets()
-        self.gcode.respond_info("configured global z_offset: %.3f" %
-                self.probe_offsets[2])
         if self.horizontal_move_z < self.probe_offsets[2]:
             raise self.gcode.error("horizontal_move_z can't be less than"
                                    " probe's z_offset")
@@ -350,6 +347,8 @@ class ProbePointsHelper:
                 break
             pos = probe.run_probe(params)
             if hasattr(self, 'probe_point_z_offset'):
+                self.gcode.respond_info("overriding global z_offset: %.3f" %
+                    self.probe_offsets[2])
                 raw=pos
                 point_z_offset=self.probe_point_z_offset[len(self.results)]
                 global_z_offset=self.probe_offsets[2]


### PR DESCRIPTION
Some probes exhibit repeatable bias at certain bed points. This leads to a repeatable bed skew.
Currently the documentation says if your probe has bias you can't use it (https://github.com/KevinOConnor/klipper/blob/master/docs/Probe_Calibrate.md#location-bias-check).

This PR adds support to specify a per-point z offset to allow such a probe to be used. For example, my inductive probe is off by about 100-150 microns due to magnets in my build plate.

To use:
Determine probe offsets at each of your configured probe points (PROBE_CALIBRATE as described in the doc). Add the Z offset value that PROBE_CALIBRATE returns as a third coordinate to each configured probe point.
You need to do this for all configured probe points if you use the feature.

I also considered a delta at each point instead of an absolute offset but the sign was not intuitive. This approach allows the direct PROBE_CALIBRATE output to be used.

This was tested against 0.8.0 on a Voron 250mm in QUAD_GANTRY_LEVEL only. However, it should work with other leveling modes based on z_tilt.

I also very slightly increased the verbosity of quad_gantry_level to make it easier to copy/paste/run through analysis scripts. Most of the additional output is conditional on having configured per-point z_offsets.