### PR TITLE
Add example for including a parameter in a macro call

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -401,10 +401,10 @@
 #   For example, if one were to define the macro MY_DELAY with gcode
 #   "G4 P{DELAY}" along with "default_parameter_DELAY = 50" then the
 #   command "MY_DELAY" would evaluate to "G4 P50". To override the
-#   default parameter when calling the command then using "MY_DELAY 
-#   DELAY=30" would evaluate to "G4 P30". The default is to require 
-#   that all parameters used in the gcode script be present in the 
-#   command invoking the macro.
+#   default parameter when calling the command then using
+#   "MY_DELAY DELAY=30" would evaluate to "G4 P30". The default is
+#   to require that all parameters used in the gcode script be
+#   present in the command invoking the macro.
 #variable_<name>:
 #   One may specify any number of options with a "variable_" prefix.
 #   The given variable name will be assigned the given value (parsed


### PR DESCRIPTION
Update to example-extras.cfg

In the default_parameter description in _G-Code macros and events_ add instructions on how to call a macro containing a default parameter with a different, non-default, parameter included in the command.

Signed-off-by: David Smith davidosmith@gmail.com