### PR TITLE
Add additional on pause/resume gcode support

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -467,6 +467,12 @@
 #recover_velocity: 50.
 #   When capture/restore is enabled, the speed at which to return to
 #   the captured position (in mm/s).  Default is 50.0 mm/s.
+#pause_gcode:
+#   A list of G-Code commands to execute after PAUSE has taken place.
+#   The default is not to run any G-Code commands.
+#resume_gcode:
+#   A list of G-Code commands to execute before RESUME.
+#   The default is not to run any G-Code commands.
 
 # Firmware filament retraction. This enables G10 (retract) and G11
 # (unretract) GCODE commands issued by many slicers. The parameters


### PR DESCRIPTION
Sometimes one wishes to extend what happens on pause and resume.  ~~This helps address situations like https://github.com/KevinOConnor/klipper/issues/2287~~

example use could be:

```
[idle_timeout]
gcode:
  PRINT_IDLE_TIMEOUT

[gcode_macro PRINT_IDLE_TIMEOUT]
variable_extruder_temp: 0
gcode:
  {% if printer.pause_resume.is_paused %}
  SET_GCODE_VARIABLE MACRO=PRINT_IDLE_TIMEOUT VARIABLE=extruder_temp VALUE={printer[printer.toolhead.extruder].target}
  M104 S0 ; turn off extruder to not bake filament
  {% else %}
  TURN_OFF_HEATERS
  M84
  {% endif %}

[pause_resume]
pause_gcode:
  M117 Running after printer paused and state saved
resume_gcode:
  M117 Running just before restoring paused state and moving
  {% if printer.pause_resume.is_paused and printer.idle_timeout.state == 'Idle' %}
  M109 S{printer["gcode_macro PRINT_IDLE_TIMEOUT"].extruder_temp}
  {% endif %}

```

Signed off Douglas Hammond <wizhippo@gmail.com>