### PR TITLE
Update generic-fysetc-s6.cfg

### DIFF
--- a/config/generic-fysetc-s6.cfg
+++ b/config/generic-fysetc-s6.cfg
@@ -170,9 +170,7 @@ max_z_accel: 100
 # MOSI  PA7
 
 #[tmc2130 stepper_x]
-#spi_software_sclk_pin: PA5
-#spi_software_mosi_pin: PA7
-#spi_software_miso_pin: PA6
+#spi_bus: spi1
 #cs_pin: PE7
 #diag1_pin: PB14
 #microsteps: 16
@@ -181,9 +179,7 @@ max_z_accel: 100
 #stealthchop_threshold: 250
 
 #[tmc2130 stepper_y]
-#spi_software_sclk_pin: PA5
-#spi_software_mosi_pin: PA7
-#spi_software_miso_pin: PA6
+#spi_bus: spi1
 #cs_pin: PE15
 #diag1_pin: PB13
 #microsteps: 16
@@ -192,9 +188,7 @@ max_z_accel: 100
 #stealthchop_threshold: 250
 
 #[tmc2130 stepper_z]
-#spi_software_sclk_pin: PA5
-#spi_software_mosi_pin: PA7
-#spi_software_miso_pin: PA6
+#spi_bus: spi1
 #cs_pin: PD10
 #diag1_pin: PA0
 #microsteps: 16
@@ -203,9 +197,7 @@ max_z_accel: 100
 #stealthchop_threshold: 250
 
 #[tmc2130 extruder]
-#spi_software_sclk_pin: PA5
-#spi_software_mosi_pin: PA7
-#spi_software_miso_pin: PA6
+#spi_bus: spi1
 #cs_pin: PD7
 #diag1_pin: PA3
 #microsteps: 16
@@ -214,9 +206,7 @@ max_z_accel: 100
 #stealthchop_threshold: 250
 
 #[tmc2130 extruder1]
-#spi_software_sclk_pin: PA5
-#spi_software_mosi_pin: PA7
-#spi_software_miso_pin: PA6
+#spi_bus: spi1
 #cs_pin: PC14
 #diag1_pin: PA2
 #microsteps: 16
@@ -225,9 +215,7 @@ max_z_accel: 100
 #stealthchop_threshold: 250
 
 #[tmc2130 extruder2]
-#spi_software_sclk_pin: PA5
-#spi_software_mosi_pin: PA7
-#spi_software_miso_pin: PA6
+#spi_bus: spi1
 #cs_pin: PC15
 #diag1_pin: PA1
 #microsteps: 16


### PR DESCRIPTION
SPI communication with TMC drivers is possible with hardware SPI using the "spi1" bus.

#2220 
Signed-off-by: Tobias Weiß t.weiss@bk.ru