### PR TITLE
BLTOUCH-HIGH-SPEED-MODE

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -625,6 +625,9 @@
 #   the commands "pin_up" followed by "touch_mode". This should be
 #   True for a genuine BLTouch v2 and earlier; the BLTouch v3 and some
 #   BLTouch clones require False. The default is True.
+#high_speed_mode: False
+#   If set to True, intermediate STOW/DEPLOY sequences on certain
+#   operations that use the probe multiple times will be omitted.
 #x_offset:
 #y_offset:
 #z_offset:

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -791,6 +791,18 @@
 #   by during the check_gain_time check. It is rare to customize this
 #   value. The default is 2.
 
+# Tool to disable heaters when homing or probing an axis
+[homing_heaters]
+#   A comma separated list of steppers that should cause heaters to be
+#   disabled. The default is to disable heaters for any homing/probing
+#   move.
+#   Typical example: stepper_z
+steppers:
+#   A comma separated list of heaters to disable during homing/probing
+#   moves. The default is to disable all heaters.
+#   Typical example: extruder, heater_bed
+heaters:
+
 # MAXxxxxx serial peripheral interface (SPI) temperature based
 # sensors. The following parameters are available in heater sections
 # that use one of these sensor types.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -601,37 +601,39 @@
 #   not run any special G-Code commands on deactivation.
 
 # BLTouch probe. One may define this section (instead of a probe
-# section) to enable a BLTouch probe. (Note! This bltouch module may
-# not work correctly with some BLTouch "clones"!) A virtual
-# "probe:z_virtual_endstop" pin is also created (see the "probe"
-# section above for the details).
+# section) to enable a BLTouch probe. A virtual "probe:z_virtual_endstop"
+# pin is also created (see the "probe" section above for the details).
 #[bltouch]
+# high_speed_mode: False
+#   If set to True, intermediate STOW/DEPLOY sequences on certain
+#   operations that use the probe multiple times will be omitted.
+# min_cmd_time: 0.150
+#   you can specify an absolute minimum cmd time
+# test_sensor_before_use: False
+#   This makes use of SW mode to test the probe. Set this to false if
+#   the probe does not support SW mode OR you do not want to spend time
+#   testing the probe.
+# use_sw_mode: False
+#   choose to use SW (=Switch) Mode when probing if you want this
+#   instead of normal mode.
+# set_mode: none
+#   none=do nothing, 5V=set 5V mode, OD=set OD mode
+#   Only use a value other than "none" if it is a V3.0 or V3.1 probe and
+#   you are SURE that you need a setting other than the BLTouch default
+#   of OD mode on your printer board. If you use 5V mode, be SURE that
+#   your board is 5V tolerant on the BLTouch signal pin input. If in any
+#   doubt, use "none".
 #sensor_pin:
 #   Pin connected to the BLTouch sensor pin. This parameter must be
 #   provided.
 #control_pin:
 #   Pin connected to the BLTouch control pin. This parameter must be
 #   provided.
-#pin_move_time: 0.675
-#   The amount of time (in seconds) to wait for the BLTouch pin to
-#   move up or down. The default is 0.675 seconds.
-#pin_up_reports_not_triggered: True
-#   Set if the BLTouch consistently reports the probe in a "not
-#   triggered" state after a successful "pin_up" command. This should
-#   be True for a genuine BLTouch; some BLTouch clones may require
-#   False. The default is True.
-#pin_up_touch_mode_reports_triggered: True
-#   Set if the BLTouch consistently reports a "triggered" state after
-#   the commands "pin_up" followed by "touch_mode". This should be
-#   True for a genuine BLTouch v2 and earlier; the BLTouch v3 and some
-#   BLTouch clones require False. The default is True.
-#high_speed_mode: False
-#   If set to True, intermediate STOW/DEPLOY sequences on certain
-#   operations that use the probe multiple times will be omitted.
 #x_offset:
 #y_offset:
 #z_offset:
 #speed:
+#lift_speed:
 #samples:
 #sample_retract_dist:
 #samples_result:

--- a/config/example.cfg
+++ b/config/example.cfg
@@ -55,6 +55,10 @@ position_max: 200
 #   Distance to backoff (in mm) before homing a second time during
 #   homing. Set this to zero to disable the second home. The default
 #   is 5mm.
+#homing_retract_speed:
+#   Speed to use on the retract move after homing in case this should
+#   be different from the homing speed, which is the default for this
+#   parameter
 #second_homing_speed:
 #   Velocity (in mm/s) of the stepper when performing the second home.
 #   The default is homing_speed/2.

--- a/config/kit-zav3d-2019.cfg
+++ b/config/kit-zav3d-2019.cfg
@@ -122,7 +122,6 @@ control_pin: ar7
 x_offset: 39
 y_offset: 11
 z_offset: 0.9
-pin_up_touch_mode_reports_triggered: false
 samples: 2
 sample_retract_dist: 3.0
 

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -190,7 +190,6 @@ class BLTouchEndstopWrapper:
     def handle_deploy_needed(self, really_needed, endstops):
         if not self.check_eligible(endstops):
             return
-        hs_mode = True
         if really_needed or not self.hs_mode:
             self.deploy_probe()
     def deploy_probe(self):

--- a/klippy/extras/homing_heaters.py
+++ b/klippy/extras/homing_heaters.py
@@ -1,0 +1,54 @@
+# Heater handling on homing moves
+#
+# Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+
+class HomingHeaters:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.printer.register_event_handler("homing:move_begin",
+                                            self.handle_homing_move_begin)
+        self.printer.register_event_handler("homing:move_end",
+                                            self.handle_homing_move_end)
+        self.heaters_to_disable = config.get("heaters", "")
+        self.steppers_needing_quiet = config.get("steppers", "")
+        self.last_target = {}
+        self.pheater = self.printer.lookup_object('heater')
+
+    def check_eligible(self, endstops):
+        flaky_steppers = [n.strip()
+                         for n in self.steppers_needing_quiet.split(',')]
+        if flaky_steppers == [""]:
+            return True
+        endstop_instances, dummy = zip(*endstops)
+        steppers_being_homed = list()
+        for n in endstop_instances:
+            steppers_being_homed = steppers_being_homed + n.get_steppers()
+        steppernames_being_homed = list()
+        for n in steppers_being_homed:
+            steppernames_being_homed.append(n.get_name())
+        return any(x in flaky_steppers for x in steppernames_being_homed)
+    def bld_heater_list(self):
+        heaters = [n.strip() for n in self.heaters_to_disable.split(',')]
+        if heaters == [""]:
+            heaters = self.pheater.available_heaters
+        return heaters
+    def handle_homing_move_begin(self, endstops):
+        if not self.check_eligible(endstops):
+            return
+        for heater_name in self.bld_heater_list():
+            heater = self.pheater.lookup_heater(heater_name)
+            self.last_target[heater_name] = heater.get_temp(0)[1]
+            heater.set_temp(0.)
+    def handle_homing_move_end(self, endstops):
+        if not self.check_eligible(endstops):
+            return
+        for heater_name in self.bld_heater_list():
+            heater = self.pheater.lookup_heater(heater_name)
+            heater.set_temp(self.last_target[heater_name])
+
+def load_config(config):
+    return HomingHeaters(config)

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -66,6 +66,8 @@ class Homing:
                 print_time, ENDSTOP_SAMPLE_TIME, ENDSTOP_SAMPLE_COUNT,
                 rest_time, notify=self._endstop_notify)
         self.toolhead.dwell(HOMING_START_DELAY)
+        # notify anyone out there of move start
+        self.printer.send_event("homing:move_begin", endstops)
         # Issue move
         error = None
         try:
@@ -80,6 +82,8 @@ class Homing:
             except mcu_endstop.TimeoutError as e:
                 if error is None:
                     error = "Failed to home %s: %s" % (name, str(e))
+        # notify anyone out there of move end
+        self.printer.send_event("homing:move_end", endstops)
         # Determine stepper halt positions
         self.toolhead.flush_step_generation()
         end_mcu_pos = [(s, name, spos, s.get_mcu_position())

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -130,7 +130,7 @@ class Homing:
             retract_r = min(1., hi.retract_dist / move_d)
             retractpos = [mp - ad * retract_r
                           for mp, ad in zip(movepos, axes_d)]
-            self.toolhead.move(retractpos, hi.speed)
+            self.toolhead.move(retractpos, hi.retract_speed)
             # Home again
             forcepos = [rp - ad * retract_r
                         for rp, ad in zip(retractpos, axes_d)]

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -236,6 +236,8 @@ class PrinterRail:
         self.homing_speed = config.getfloat('homing_speed', 5.0, above=0.)
         self.second_homing_speed = config.getfloat(
             'second_homing_speed', self.homing_speed/2., above=0.)
+        self.homing_retract_speed = config.getfloat(
+            'homing_retract_speed', self.homing_speed, above=0.)
         self.homing_retract_dist = config.getfloat(
             'homing_retract_dist', 5., minval=0.)
         self.homing_positive_dir = config.getboolean(
@@ -254,11 +256,11 @@ class PrinterRail:
         return self.position_min, self.position_max
     def get_homing_info(self):
         homing_info = collections.namedtuple('homing_info', [
-            'speed', 'position_endstop', 'retract_dist', 'positive_dir',
-            'second_homing_speed'])(
+            'speed', 'position_endstop', 'retract_speed', 'retract_dist',
+            'positive_dir', 'second_homing_speed'])(
                 self.homing_speed, self.position_endstop,
-                self.homing_retract_dist, self.homing_positive_dir,
-                self.second_homing_speed)
+                self.homing_retract_speed, self.homing_retract_dist,
+                self.homing_positive_dir, self.second_homing_speed)
         return homing_info
     def get_steppers(self):
         return list(self.steppers)


### PR DESCRIPTION
**BLTOUCH HIGH SPEED MODE**

Duplicating all the BLTouch knowledge, testing and usage from this early summer when the same process was initiated by the unfortunate way the BLTouch V3.0 and V3.1 were released.

Please also refer to issue #2267 and to pull request #2170 and #2200 and some other BLTouch related issues.

**Overview**

A video says it all. 32bit LPC1768 on the left and an 8bit AVR MEGA2560 on the right probing the bed.
[link to video](https://youtu.be/8Ld0Q8PUWtk )

- Works for homing, all commands involving probing
- Probe repeatability is ok, see [video](https://youtu.be/rD5IWW271zQ )
`probe accuracy results: maximum 2.451250, minimum 2.441250, range 0.010000, average 2.444000, median 2.443125, standard deviation 0.002669`
- Enhanced timing
- Enhanced error detection and recovery
- Additional commands
- Support for 5V/OD mode selection on init
- Choice of Touch or Push-Pin-Down mode on probing
- High speed probing: (no intermediate pin-up-pin-down)
- Separate selection of retraction speed on probing
- Separate retract speed selection on homing
- Choice to turn off heaters on probing

**Comments**

1. With stock klipper, I experience a blinking but recoverable  bltouch on about every 20th probe, but only on the 8bit controller, the 32bit is absolutely rock solid. Using the same config but the changed bltouch.py, this does not happen. I think the new timing is beneficial. These errors cannot be due to the race conditions mentioned in #2267 et al
2. No idea how to proceed on this, there are also some other PRs hitting the same .py's and I think one would like this to be brought into a testing state before doing anything else with it. I also don't want to conflict/usurp the PR of @JohnEdwa who is also concerned about the same sort of functionality. So I am right now working on making TRAVIS happy.
_**edit:** See posts further down from here for updates, new developments and status_

**Config**

**Additional** parms are used in these sections of `printer.cfg`:

```
[stepper_z]
homing_retract_speed: nnn
```

Note: this parm is upwards limited by `max_z_velocity` in the `[printer]` section. Make sure this is set to a viable value.

```
[bltouch]
high_speed_mode: True
# you can specify an absolute minimum cmd time
min_cmd_time: 0.150
# set this to false if probe does not support it
test_sensor_before_use: True
# use SW Mode if you want instead of normal mode
use_sw_mode: True
# set_mode: none=do nothing, 5V=set 5V mode, OD=set OD mode
set_mode: 5V
```

Note: `[bltouch]` `retract_speed` is upwards limited by `max_z_velocity` in the `[printer]` section. Make sure this is set to a viable value.

**My configuration as a sample**

Here is the config file I use for the LPC1768 Anet A6 from the video:

[printer.txt](https://github.com/KevinOConnor/klipper/files/4181463/printer.txt)

**Additional Tips**

- Set the retract speeds in `[stepper_z]` and `[bltouch]`
- Judicious setting of the following parms is advised to get the most out of this:

```
[stepper_z]
homing_retract_dist: 2.5

[bed_mesh]
horizontal_move_z: 4.5

[z_tilt]
horizontal_move_z: 12.5

[bltouch]
samples: 1
sample_retract_dist: 2.5
```

**Conclusion**

If there is anything I may have forgotten, I will add to this. Meanwhile I am using it on two test printers.

Signed-off-by: Mike Stiemke **fandjango@gmx.de**
