### PR TITLE
Display only one nozzle when extruder1 has shared heater.

### DIFF
--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -43,6 +43,7 @@ class PrinterLCD:
         self.fan = self.printer.lookup_object('fan', None)
         self.extruder = self.printer.lookup_object('extruder', None)
         self.extruder1 = self.printer.lookup_object('extruder1', None)
+        self.shared_heater = self.extruder1.get_has_shared_heater()
         self.heater_bed = self.printer.lookup_object('heater_bed', None)
         self.prg_time = .0
         self.progress = None
@@ -100,7 +101,7 @@ class PrinterLCD:
             info = self.extruder.get_heater().get_status(eventtime)
             lcd_chip.write_glyph(0, 0, 'extruder')
             self.draw_heater(1, 0, info)
-        if self.extruder1 is not None:
+        if self.extruder1 is not None and self.shared_heater is False:
             info = self.extruder1.get_heater().get_status(eventtime)
             lcd_chip.write_glyph(0, 1, 'extruder')
             self.draw_heater(1, 1, info)
@@ -144,7 +145,7 @@ class PrinterLCD:
             self.lcd_chip.write_glyph(0, 0, 'extruder')
             self.draw_heater(2, 0, info)
         extruder_count = 1
-        if self.extruder1 is not None:
+        if self.extruder1 is not None and self.shared_heater is False:
             info = self.extruder1.get_heater().get_status(eventtime)
             self.lcd_chip.write_glyph(0, 1, 'extruder')
             self.draw_heater(2, 1, info)

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -43,7 +43,10 @@ class PrinterLCD:
         self.fan = self.printer.lookup_object('fan', None)
         self.extruder = self.printer.lookup_object('extruder', None)
         self.extruder1 = self.printer.lookup_object('extruder1', None)
-        self.shared_heater = self.extruder1.get_has_shared_heater()
+        if self.extruder1 is not None:
+            self.shared_heater = self.extruder1.get_has_shared_heater()
+        else:
+            self.shared_heater = False
         self.heater_bed = self.printer.lookup_object('heater_bed', None)
         self.prg_time = .0
         self.progress = None

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -15,8 +15,10 @@ class PrinterExtruder:
         gcode_id = 'T%d' % (extruder_num,)
         if shared_heater is None:
             self.heater = pheater.setup_heater(config, gcode_id)
+            self.has_shared_heater = False
         else:
             self.heater = pheater.lookup_heater(shared_heater)
+            self.has_shared_heater = True
         self.stepper = stepper.PrinterStepper(config)
         self.nozzle_diameter = config.getfloat('nozzle_diameter', above=0.)
         filament_diameter = config.getfloat(
@@ -95,6 +97,8 @@ class PrinterExtruder:
         return self.name
     def get_heater(self):
         return self.heater
+    def get_has_shared_heater(self):
+        return self.has_shared_heater
     def stats(self, eventtime):
         return self.heater.stats(eventtime)
     def check_move(self, move):


### PR DESCRIPTION
Hi, 
I made an issue #2310 about that subject, but finally I did it myself since it was no big deal.

With this PR, when extruder1 is configured with a shared heater it will only display one nozzle instead of two. (because there is actually only one heater and nozzle). 