### PR TITLE
Docs update macro naming, variable naming and usage

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -389,7 +389,9 @@
 ######################################################################
 
 # G-Code macros (one may define any number of sections with a
-# "gcode_macro" prefix).
+# "gcode_macro" prefix). If G-Code macro names contain any numbers
+# they must all be at the end of the macro's name.
+# (example: test_macro25 is acceptable, but macro25_test3 is not).
 #[gcode_macro my_cmd]
 #gcode:
 #   A list of G-Code commands to execute in place of "my_cmd". See
@@ -409,9 +411,13 @@
 #   One may specify any number of options with a "variable_" prefix.
 #   The given variable name will be assigned the given value (parsed
 #   as a Python literal) and will be available during macro expansion.
-#   For example, a config with "variable_fan_speed = 75" might have
-#   gcode commands containing "M106 S{ fan_speed * 255 }". Variables
-#   can be changed at run-time using the SET_GCODE_VARIABLE command.
+#   For example, a macro called set_fan with
+#   "variable_fan_speed = 75" might have gcode commands containing
+#   "M106 S{ fan_speed * 255 }". Variables can be changed at run-time
+#   using the SET_GCODE_VARIABLE command from within any G-Code Macro.
+#   Example, from a macro called my_macro2 I could state:
+#   "SET_GCODE_VARIABLE MACRO=set_fan VARIABLE=fan_speed VALUE=50"
+#   Variable names may not use upper case characters.
 
 # Execute a gcode on a set delay.
 #[delayed_gcode my_delayed_gcode]

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -1,6 +1,12 @@
 This document provides information on implementing G-Code command
 sequences in gcode_macro (and similar) config sections.
 
+### G-Code Macro Naming
+Case is not important when creating a G-Code macro name. MY_MACRO and
+my_macro will evaluate the same and may be called in either upper or
+lower case. If any numerical digits are used in the macro name they
+must all be placed at the end of the name.
+
 ### Formatting of G-Code in the config
 
 Indentation is important when defining a macro in the config file. To
@@ -178,7 +184,8 @@ in future Klipper releases.
 ### Variables
 
 The SET_GCODE_VARIABLE command may be useful for saving state between
-macro calls. For example:
+macro calls. Variable names may not contain any upper case characters.
+For example:
 
 ```
 [gcode_macro start_probe]


### PR DESCRIPTION
Documentation

Add statements about restriction in numbers used in G-Code Macro Names.  Add statement about restriction of character case in variable names.  Added example of updating variable from other macros.

See issue #2307 and #2249 

Signed-off-by: David O Smith <davidosmith@gmail.com>