### PR TITLE
Proposal: Replace step_distance in printer config

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -32,9 +32,24 @@ enable_pin: !ar38
 #   Enable pin (default is enable high; use ! to indicate enable
 #   low). If this parameter is not provided then the stepper motor
 #   driver must always be enabled.
-step_distance: .0225
-#   Distance in mm that each step causes the axis to travel. This
+rotation_distance: 40
+#   Distance (in mm) that the axis travels with one full rotation of
+#   the stepper motor. This parameter must be provided.
+microsteps: 16
+#   The number of microsteps the stepper motor driver uses. This
 #   parameter must be provided.
+#full_steps_per_rotation: 200
+#   The number of full steps for one rotation of the stepper motor.
+#   Set this to 200 for a 1.8 degree stepper motor or set to 400 for a
+#   0.9 degree motor. The default is 200.
+#gear_ratio:
+#   The gear ratio if the stepper motor is connected to the axis via a
+#   gearbox. For example, one may specify "5:1" if a 5 to 1 gearbox is
+#   in use. If the axis has multiple gearboxes one may specify a comma
+#   separated list of gear ratios (for example, "57:11, 2:1"). If a
+#   gear_ratio is specified then rotation_distance specifies the
+#   distance the axis travels for one full rotation of the final gear.
+#   The default is to not use a gear ratio.
 endstop_pin: ^ar3
 #   Endstop switch detection pin. This parameter must be provided for
 #   the X, Y, and Z steppers on cartesian style printers.
@@ -71,7 +86,8 @@ position_max: 200
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-step_distance: .0225
+rotation_distance: 40
+microsteps: 16
 endstop_pin: ^ar14
 position_endstop: 0
 position_max: 200
@@ -83,7 +99,8 @@ position_max: 200
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .005
+rotation_distance: 8
+microsteps: 16
 endstop_pin: ^ar18
 position_endstop: 0.5
 position_max: 200
@@ -97,7 +114,8 @@ position_max: 200
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .004242
+rotation_distance: 33.600
+microsteps: 16
 nozzle_diameter: 0.500
 #   Diameter of the nozzle orifice (in mm). This parameter must be
 #   provided.

--- a/config/printer-makergear-m2-2012.cfg
+++ b/config/printer-makergear-m2-2012.cfg
@@ -7,7 +7,8 @@
 step_pin: PC0
 dir_pin: !PL1
 enable_pin: !PA7
-step_distance: .0225
+rotation_distance: 36
+microsteps: 8
 endstop_pin: ^!PB6
 position_endstop: 0.0
 position_max: 200
@@ -21,7 +22,8 @@ endstop_accuracy: .200
 step_pin: PC1
 dir_pin: PL0
 enable_pin: !PA6
-step_distance: .0225
+rotation_distance: 36
+microsteps: 8
 endstop_pin: ^!PB5
 position_endstop: 0.0
 position_max: 250
@@ -35,7 +37,8 @@ endstop_accuracy: .200
 step_pin: PC2
 dir_pin: !PL2
 enable_pin: !PA5
-step_distance: .005
+rotation_distance: 8
+microsteps: 8
 endstop_pin: ^!PB4
 position_min: 0.1
 position_endstop: 0.7
@@ -50,7 +53,9 @@ endstop_accuracy: .070
 step_pin: PC3
 dir_pin: PL6
 enable_pin: !PA4
-step_distance: .004242
+rotation_distance: 35.170
+gear_ratio: 57:11
+microsteps: 8
 nozzle_diameter: 0.350
 filament_diameter: 1.750
 pressure_advance: 0.07

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -53,6 +53,10 @@ class ForceMove:
     def register_stepper(self, stepper):
         name = stepper.get_name()
         self.steppers[name] = stepper
+    def lookup_stepper(self, name):
+        if name not in self.steppers:
+            raise self.printer.config_error("Unknown stepper %s" % (name,))
+        return self.steppers[name]
     def force_enable(self, stepper):
         toolhead = self.printer.lookup_object('toolhead')
         print_time = toolhead.get_last_move_time()

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -274,21 +274,28 @@ class TMCMicrostepHelper:
         return (1023 - mscnt) >> self.fields.get_field("MRES")
 
 # Helper to configure "stealthchop" mode
-def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):
-    fields = mcu_tmc.get_fields()
-    en_pwm_mode = False
-    velocity = config.getfloat('stealthchop_threshold', 0., minval=0.)
-    if velocity:
-        stepper_name = " ".join(config.get_name().split()[1:])
-        stepper_config = config.getsection(stepper_name)
-        step_dist = stepper_config.getfloat('step_distance')
+class TMCStealthchopHelper:
+    def __init__(self, config, mcu_tmc, tmc_freq):
+        self.name = config.get_name()
+        self.fields = fields = mcu_tmc.get_fields()
+        self.tmc_freq = tmc_freq
+        printer = config.get_printer()
+        self.force_move = printer.try_load_module(config, "force_move")
+        en_pwm_mode = False
+        self.velocity = config.getfloat('stealthchop_threshold', 0., minval=0.)
+        if self.velocity:
+            printer.register_event_handler("connect", self.handle_connect)
+            en_pwm_mode = True
+        reg = fields.lookup_register("en_pwm_mode", None)
+        if reg is not None:
+            fields.set_field("en_pwm_mode", en_pwm_mode)
+        else:
+            # TMC2208 uses en_spreadCycle
+            fields.set_field("en_spreadCycle", not en_pwm_mode)
+    def handle_connect(self):
+        stepper_name = " ".join(self.name.split()[1:])
+        stepper = self.force_move.lookup_stepper(stepper_name)
+        step_dist = stepper.get_step_dist()
         step_dist_256 = step_dist / (1 << fields.get_field("MRES"))
-        threshold = int(tmc_freq * step_dist_256 / velocity + .5)
-        fields.set_field("TPWMTHRS", max(0, min(0xfffff, threshold)))
-        en_pwm_mode = True
-    reg = fields.lookup_register("en_pwm_mode", None)
-    if reg is not None:
-        fields.set_field("en_pwm_mode", en_pwm_mode)
-    else:
-        # TMC2208 uses en_spreadCycle
-        fields.set_field("en_spreadCycle", not en_pwm_mode)
+        threshold = int(self.tmc_freq * step_dist_256 / self.velocity + .5)
+        self.fields.set_field("TPWMTHRS", max(0, min(0xfffff, threshold)))


### PR DESCRIPTION
This is a proposal to replace the stepper `step_distance` with new `rotation_distance`, `microsteps`, `full_steps_per_rotation`, and `gear_ratio` parameters.  For a typical printer config this would mean converting from something like:
```
[stepper_x]
step_distance: .0125
...
```
To something like:
```
[stepper_x]
rotation_distance: 40
microsteps: 16
...
```

That is, this is a proposal to change Klipper so that it automatically calculates its internal step_distance from higher-level values stored in the printer config.  Specifically, it can calculate `step_distance = rotation_distance / (microsteps * full_steps_per_rotation * gear_ratio)` (where gear_ratio would default to "1:1" and full_steps_per_rotation would default to 200 (aka 1.8 degree steppers)).  I think there are a few advantages to doing this:
 - The rotation_distance is a whole number on most printers.  (The rotation_distance is the distance (in mm) that the axis travels with one full rotation of the stepper motor.)  The step_distance parameter seems to be viewed as a "magic number" by many users - a value that is obtained from somewhere  and is not understood or questioned.  In contrast, I hope that rotation_distance would be something that one can more easily inspect - on most printers one can obtain it by counting the teeth on a pulley and multiplying by the belt spacing (typically 2mm for GT2 belts).   So, for example, an axis with a 20 toothed pulley generally has a rotation_distance of 40mm.  (And, if nothing else, a user could manually rotate an axis one revolution and measure the resulting distance.)  Similarly, almost all printers today have an extruder rotation_distance of around 34mm (that is, the circumference of the hobbed bolt that pushes the filament is very similar across most printers).  So, although the extruder rotation_distance isn't generally a whole number, I hope specifying it directly will make it easier for users to quantify the value.
 - Many users are already specifying the stepper microsteps today (via the tmc config sections) and I expect that trend to continue with other stepper drivers in the future (such as the Mechaduino and similar).  It's more convenient to specify the microsteps independently from the step_distance as this allows one to change the microsteps without having to also update step_distance.  Part of this proposal would be to have the tmcXXX config sections automatically obtain the microsteps from the stepper sections and to eliminate the phases option from the endstop_phases config.
 - On some printer kinematics (eg, polar and rotary_delta) a step_distance does not make sense.  These kinematics have steppers with positions measured in angles.  It's more convenient to specify a gear_ratio (the number of rotations of the stepper required to make one rotation of the final gear) than to specify an artificial step_distance.

There is, of course, one big downside:
 - Changing the config would break all existing Klipper config files.

As a result, I think such a change would need to be implemented in phases.  That is, the new code would need to accept either step_distance or rotation_distance (et al.).  After 3-4 months the step_distance parameter would then be removed and any remaining configs would need to be updated.

Comments?
-Kevin