### PR TITLE
[WIP] morgan_scara: Initial support for RepRap Morgan style SCARA printers

### DIFF
--- a/config/example-morgan-scara.cfg
+++ b/config/example-morgan-scara.cfg
@@ -1,0 +1,111 @@
+# Example config file for RepRap Morgan style SCARA robots
+#
+# Usage:
+#   make flash FLASH_DEVICE=/dev/serial/by-id/usb-Arduino__www.arduino.cc__0042_9533534303635180C241-if00
+#   ~/klippy-env/bin/python ~/src/klipper/klippy/klippy.py ~/scara.cfg -l /tmp/scara.log -I /tmp/scara
+#   socat open:/tmp/scara stdio
+[stepper_a]
+step_pin: ar54
+dir_pin: ar55
+enable_pin: !ar38
+# 2 * pi * (1.8/360) / 16 microsteps / 4.75 gear-ratio == 0.00413
+step_distance: .000413
+#endstop_pin: ^ar3
+#endstop_pin: ^ar2
+#position_endstop: 0
+#position_max: 200
+#homing_speed: 50
+
+[stepper_b]
+step_pin: ar60
+dir_pin: !ar61
+# NOTE: direction inverted when steppers sit opposite to each other
+enable_pin: !ar56
+step_distance: .000413
+#endstop_pin: ^ar14
+#endstop_pin: ^ar15
+#position_endstop: 0
+#position_max: 200
+#homing_speed: 50
+
+[stepper_z]
+step_pin: ar46
+dir_pin: !ar48
+enable_pin: !ar62
+step_distance: .0025
+endstop_pin: ^ar18
+#endstop_pin: ^ar19
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: ar26
+dir_pin: ar28
+enable_pin: !ar24
+step_distance: .002
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+# TODO: run without sensor
+min_temp: -100
+max_temp: 230
+
+#[heater_bed]
+#heater_pin: ar8
+#sensor_type: EPCOS 100K B57560G104F
+#sensor_pin: analog14
+#control: watermark
+#min_temp: -100
+#max_temp: 75
+#
+[fan]
+pin: ar9
+
+[mcu]
+serial: /dev/serial/by-id/usb-Arduino__www.arduino.cc__0042_9533534303635180C241-if00
+pin_map: arduino
+
+[printer]
+kinematics: morgan_scara
+# Configure kinematics for https://reprap.org/wiki/RepRap_Morgan style robots
+# which have one pair of actively driven arms and one pair of passive arms,
+# with the active arms revolving around a common Z axis at the base joint.
+inner_arm_length: 80.0
+# Length (in mm) of the active (driven) arms between the base and elbow joints
+outer_arm_length: 80.0
+# Length (in mm) of the passive arms between the elbow and effector joints
+min_base_distance: 40.0
+# Reject moves with a magnitude (distance in mm) too close to the base joint
+
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[homing_override]
+# End stops are not implemented so manually positioning the robot at
+# the below coordinates is required.
+gcode:
+set_position_x: 0
+set_position_y: 100
+set_position_z: 0
+
+# Common EXP1 / EXP2 (display) pins
+[board_pins]
+aliases:
+    # Common EXP1 header found on many "all-in-one" ramps clones
+    EXP1_1=ar37, EXP1_3=ar17, EXP1_5=ar23, EXP1_7=ar27, EXP1_9=<GND>,
+    EXP1_2=ar35, EXP1_4=ar16, EXP1_6=ar25, EXP1_8=ar29, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=ar50, EXP2_3=ar31, EXP2_5=ar33, EXP2_7=ar49, EXP2_9=<GND>,
+    EXP2_2=ar52, EXP2_4=ar53, EXP2_6=ar51, EXP2_8=ar41, EXP2_10=<RST>
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
+    # Note, some boards wire: EXP2_8=<RST>, EXP2_10=ar41
+
+# See the sample-lcd.cfg file for definitions of common LCD displays.

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -16,8 +16,8 @@ COMPILE_CMD = ("gcc -Wall -g -O2 -shared -fPIC"
                " -o %s %s")
 SOURCE_FILES = [
     'pyhelper.c', 'serialqueue.c', 'stepcompress.c', 'itersolve.c', 'trapq.c',
-    'kin_cartesian.c', 'kin_corexy.c', 'kin_delta.c', 'kin_polar.c',
-    'kin_rotary_delta.c', 'kin_winch.c', 'kin_extruder.c',
+    'kin_cartesian.c', 'kin_corexy.c', 'kin_delta.c', 'kin_morgan_scara.c',
+    'kin_polar.c', 'kin_rotary_delta.c', 'kin_winch.c', 'kin_extruder.c',
 ]
 DEST_LIB = "c_helper.so"
 OTHER_FILES = [
@@ -82,6 +82,11 @@ defs_kin_delta = """
         , double tower_x, double tower_y);
 """
 
+defs_kin_morgan_scara = """
+    struct stepper_kinematics *morgan_scara_stepper_alloc(
+        char axis, double inner_arm_length, double outer_arm_length);
+"""
+
 defs_kin_polar = """
     struct stepper_kinematics *polar_stepper_alloc(char type);
 """
@@ -143,8 +148,9 @@ defs_std = """
 defs_all = [
     defs_pyhelper, defs_serialqueue, defs_std,
     defs_stepcompress, defs_itersolve, defs_trapq,
-    defs_kin_cartesian, defs_kin_corexy, defs_kin_delta, defs_kin_polar,
-    defs_kin_rotary_delta, defs_kin_winch, defs_kin_extruder
+    defs_kin_cartesian, defs_kin_corexy, defs_kin_delta,
+    defs_kin_morgan_scara, defs_kin_polar, defs_kin_rotary_delta,
+    defs_kin_winch, defs_kin_extruder
 ]
 
 # Return the list of file modification times

--- a/klippy/chelper/kin_morgan_scara.c
+++ b/klippy/chelper/kin_morgan_scara.c
@@ -1,0 +1,80 @@
+// Morgan SCARA kinematics stepper pulse time generation
+//
+// Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2019  Noah <noah@hack.se>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <math.h> // sqrt, acos
+#include <stddef.h> // offsetof
+#include <stdlib.h> // malloc
+#include <stdio.h>
+#include <string.h> // memset
+#include "compiler.h" // __visible
+#include "itersolve.h" // struct stepper_kinematics
+#include "trapq.h" // move_get_coord
+
+struct morgan_stepper {
+    struct stepper_kinematics sk;
+    double inner_arm_length, outer_arm_length;
+    double inner_arm2, outer_arm2;
+};
+
+static double
+morgan_calc_shoulder_joint_angle(struct stepper_kinematics *sk, struct coord *c)
+{
+    struct morgan_stepper *ms = container_of(sk, struct morgan_stepper, sk);
+
+    // Calculate distance to (x, y) position
+    double distance2 = c->x*c->x + c->y*c->y;
+    double distance = sqrt(distance2);
+
+    // Find angles using law of cosines
+    double shoulder_joint_angle;
+    shoulder_joint_angle = acos((ms->inner_arm2 + distance2 - ms->outer_arm2) / (2*ms->inner_arm_length*distance));
+    //double elbow_joint_angle;
+    //elbow_joint_angle = acos((ms->outer_arm2 + ms->inner_arm2 - distance2) / (2*ms->outer_arm_length*ms->inner_arm_length));
+
+    return shoulder_joint_angle;
+}
+
+static double
+left_stepper_calc_position(struct stepper_kinematics *sk, struct move *m
+                             , double move_time)
+{
+    struct coord c = move_get_coord(m, move_time);
+    double angle = M_PI/2 + morgan_calc_shoulder_joint_angle(sk, &c) - atan2(c.x, c.y);
+
+    return angle;
+}
+
+static double
+right_stepper_calc_position(struct stepper_kinematics *sk, struct move *m
+                             , double move_time)
+{
+    struct coord c = move_get_coord(m, move_time);
+    double angle = M_PI/2 - morgan_calc_shoulder_joint_angle(sk, &c) - atan2(c.x, c.y);
+
+    return angle;
+}
+
+struct stepper_kinematics * __visible
+morgan_scara_stepper_alloc(char stepper, double inner_arm_length, double outer_arm_length)
+{
+    struct morgan_stepper *ms = malloc(sizeof(*ms));
+    memset(ms, 0, sizeof(*ms));
+    ms->inner_arm_length = inner_arm_length;
+    ms->outer_arm_length = outer_arm_length;
+    ms->inner_arm2 = inner_arm_length*inner_arm_length;
+    ms->outer_arm2 = outer_arm_length*outer_arm_length;
+
+    /* Ensure itersolve is called for all X and Y moves */
+    ms->sk.active_flags = AF_X | AF_Y;
+    /* Setup itersolve callback */
+    if (stepper == 'a')
+        ms->sk.calc_position_cb = left_stepper_calc_position;
+    else if (stepper == 'b')
+        ms->sk.calc_position_cb = right_stepper_calc_position;
+
+    return &ms->sk;
+}

--- a/klippy/kinematics/morgan_scara.py
+++ b/klippy/kinematics/morgan_scara.py
@@ -1,0 +1,161 @@
+# Code for handling the kinematics of RepRap Morgan Scara robots
+#
+# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019  Noah <noah@hack.se>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# Usage:
+#
+#    [stepper_a]
+#    ...
+#    [stepper_b]
+#    ...
+#    [stepper_z]
+#    ...
+#    [printer]
+#    kinematics: morgan_scara
+#    inner_arm_length: 80.0
+#    # Length (in mm) of the active (driven) arms between the base and elbow joints
+#    outer_arm_length: 80.0
+#    # Length (in mm) of the passive arms between the elbow and effector joints
+#    min_base_distance: 40.0
+#    # Reject moves with a magnitude (distance in mm) too close to the base joint
+#
+
+import math, logging
+import stepper, homing, mathutil, chelper
+
+class MorganScaraKinematics:
+    def __init__(self, toolhead, config):
+        # Read config
+        self.inner_arm_length = config.getfloat('inner_arm_length', above=0.)
+        self.outer_arm_length = config.getfloat('outer_arm_length', above=0.)
+        stepper_configs = [config.getsection('stepper_' + s) for s in 'abz']
+        if 1:
+            # Left arm
+            rail_a = stepper.PrinterStepper(
+                stepper_configs[0], units_in_radians=True)
+            rail_a.setup_itersolve('morgan_scara_stepper_alloc',
+                'a', self.inner_arm_length, self.outer_arm_length)
+            # Right arm
+            rail_b = stepper.PrinterStepper(
+                stepper_configs[1], units_in_radians=True)
+            rail_b.setup_itersolve('morgan_scara_stepper_alloc',
+                'b', self.inner_arm_length, self.outer_arm_length)
+            # Elevator
+            rail_z = stepper.LookupMultiRail(stepper_configs[2])
+            rail_z.setup_itersolve('cartesian_stepper_alloc', 'z')
+            self.steppers = [rail_a, rail_b] + rail_z.get_steppers()
+            self.rails = [rail_a]
+        else: # TODO:
+            # Left arm
+            rail_a = stepper.PrinterRail(
+                stepper_configs[0], need_position_minmax=False,
+                units_in_radians=True)
+            rail_a.setup_itersolve('morgan_scara_stepper_alloc',
+                'a', self.inner_arm_length, self.outer_arm_length)
+            # Right arm
+            rail_b = stepper.PrinterRail(
+                stepper_configs[1], need_position_minmax=False,
+                units_in_radians=True)
+            rail_b.setup_itersolve('morgan_scara_stepper_alloc',
+                'b', self.inner_arm_length, self.outer_arm_length)
+            # Elevator
+            rail_z = stepper.LookupMultiRail(stepper_configs[2])
+            rail_z.setup_itersolve('cartesian_stepper_alloc', 'z')
+            self.steppers = [rail_a, rail_b] + rail_z.get_steppers()
+            self.rails = [rail_a, rail_b, rail_z]
+
+        config.get_printer().register_event_handler("stepper_enable:motor_off",
+                                                    self._motor_off)
+        # Setup stepper max halt velocity
+        max_velocity, max_accel = toolhead.get_max_velocity()
+        self.max_z_velocity = config.getfloat('max_z_velocity', max_velocity,
+                                              above=0., maxval=max_velocity)
+        self.max_z_accel = config.getfloat(
+            'max_z_accel', max_accel, above=0., maxval=max_accel)
+        for rail in self.rails:
+            rail.set_max_jerk(9999999.9, 9999999.9)
+
+        for s in self.get_steppers():
+            s.set_trapq(toolhead.get_trapq())
+            toolhead.register_step_generator(s.generate_steps)
+
+        # Setup boundary checks
+        self.need_home = True    # TODO: not yet implemented
+        # Reject moves:
+        # - too close to the base joint
+        # - exceeding the reach of the arms
+        # - approaching a dangerous singularity (the "-1" below)
+        self.limit_xy_magnitude = (
+            config.getfloat('min_base_distance', 10., above=0.),
+            self.inner_arm_length + self.outer_arm_length - 1
+        )
+        #self.max_z = min(endstops)
+        #self.min_z = config.getfloat('minimum_z_position', 0, maxval=self.max_z)
+
+        logging.info('SCARA with inner/outer arms {:.1f}/{:.1f}mm'
+            .format(self.inner_arm_length, self.outer_arm_length))
+        logging.info('SCARA with min/max (x,y) distances {:.1f}/{:.1f}mm'
+            .format(self.limit_xy_magnitude[0], self.limit_xy_magnitude[1]))
+        self.home_position = (0, self.limit_xy_magnitude[0], 0)
+        self.set_position(self.home_position, ())
+
+    def get_steppers(self, flags=""):
+        if flags == "Z":
+            return self.rails[-1].get_steppers()
+        return self.steppers
+
+    def calc_tag_position(self):
+        # The pair of arms form a kite (or a rhomb if all have the same length).
+        # We need to determine the distance to the end effector and know two
+        # sides (arm lengths) of the triangle plus the angle at the base joint.
+        spos = [s.get_tag_position() for s in self.steppers]
+        a_angle, b_angle, z = spos
+        midpoint = (a_angle - b_angle) / 2.0
+        distance = self.inner_arm_length*math.cos(midpoint) - math.sqrt(
+                     self.outer_arm_length**2 - (self.inner_arm_length**2)*(math.sin(midpoint)**2)
+                   )
+        x, y = math.cos(a_angle-midpoint)*distance, math.sin(a_angle-midpoint)*distance
+        return [x, y, z]
+
+    def set_position(self, newpos, homing_axes):
+        for s in self.steppers:
+            s.set_position(newpos)
+        if tuple(homing_axes) == (0, 1, 2):
+            self.need_home = False
+
+    def _motor_off(self, print_time):
+        self.need_home = True
+
+    def home(self, homing_state):
+        # All axes are homed simultaneously
+        homing_state.set_axes([0, 1, 2])
+        forcepos = list(self.home_position)
+        forcepos[2] = -1.
+        homing_state.home_rails(self.rails, forcepos, self.home_position)
+
+    def check_move(self, move):
+        end_pos = move.end_pos
+        if self.need_home:
+            raise homing.EndstopMoveError(end_pos, "Must home (G28) first")
+
+        distance = math.sqrt(end_pos[0]**2 + end_pos[1]**2)
+        if distance < self.limit_xy_magnitude[0]:
+            raise homing.EndstopMoveError(end_pos, "(x,y) pos too close to base joint")
+        elif distance >= self.limit_xy_magnitude[1]:
+            raise homing.EndstopMoveError(end_pos, "(x,y) pos exceeds reach of arms")
+        elif not move.axes_d[2]:
+            # Normal XY move - use defaults
+            return
+        # Move with Z - update velocity and accel for slower Z axis
+        z_ratio = move.move_d / abs(move.axes_d[2])
+        move.limit_speed(
+            self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
+
+    def get_status(self):
+        return {'homed_axes': '' if self.need_home else 'XYZ'}
+
+def load_kinematics(toolhead, config):
+    return MorganScaraKinematics(toolhead, config)


### PR DESCRIPTION
Is this something that would be of interest to this project (or those in #154)?  I have [something](https://i.imgur.com/sqqJlaG.jpg) resembling a [RepRap Morgan](https://reprap.org/wiki/RepRap_Morgan),  a four-bar linkage with two rockers sharing a common Z axis, which is what this code supports.

Other SCARA variants like those with five-bar linkages (e.g. [RepRap Wally](https://www.youtube.com/watch?v=iVg7WrgHJik)) or those like [RepRap Helios](https://www.youtube.com/watch?v=CJ2F-YjHe2k) are not supported.

Not yet implemented:

- end stops (so arm rotation is not limited)
- homing (position manually and use overrides)

Also, I couldn't figure out if I was supposed to use `PrinterRail` or `PrinterStepper` when neither of the two steppers "own" an axis, so I went with the latter.
