### PR TITLE
bme280:  Add support for BME280 environmental sensor

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -821,6 +821,27 @@
 #   chips. The defaults for each parameter are next to the parameter
 #   name in the above list.
 
+# BME280 two wire interface (I2C) environmental sensor.  Note that this
+# sensor is not intended for use with extruders and heater beds, but rather
+# for montitoring ambient temperature (C), pressure (hPa), and relative
+# humidity. See sample-macros.cfg for a gcode_macro that may be used to report
+# pressure and humidity in addition to temperature.
+#[temperature_sensor my_sensor]
+# See the "temperature_sensor" section below for a description of its
+# parameters. The parameters below describe BME280 sensor parameters.
+#sensor_type:
+#   Must be "BME280"
+#i2c_address:
+#  Default is 118 (0x76).  Some BME280 sensors have an address of 119 (0x77).
+#i2c_mcu:
+#  MCU the sensor is connected to.  Default is the primary mcu.
+#i2c_bus:
+#  The I2C bus the sensor is connected to.  On some MCU platforms the default
+#  is bus 0.  On platforms without bus 0 this parameter is required.
+#i2c_speed:
+#  The I2C speed (in Hz) to use when communicating with the sensor.  Default
+#  is 100000.  On some MCUs changing this value has no effect.
+
 # Common temperature amplifiers. The following parameters are
 # available in heater sections that use one of these sensors.
 #[extruder]

--- a/config/sample-macros.cfg
+++ b/config/sample-macros.cfg
@@ -115,3 +115,35 @@ gcode:
     G91
     G1 E-50 F1000
     RESTORE_GCODE_STATE NAME=M600_state
+
+######################################################################
+# BME280 Environmental Sensor
+######################################################################
+
+# The macro below assumes you have a BME280 sensor_type defined in one
+# of the applicable sections in printer.cfg, such as:
+#
+#[temperature_sensor my_sensor]
+#sensor_type: BME280
+#gcode_id: AMB
+#
+# Note the format of the parameter SENSOR in the macro below.  The BME280
+# sensor status can be accessed using the format "bme280 <section_name>".
+# The example section above is named "my_sensor", thus the bme280 can be
+# queried as follows:
+#
+# QUERY_BME280 SENSOR='bme280 my_sensor'
+#
+# Since a default parameter is defined one could simply enter QUERY_BME280
+# as well.
+
+[gcode_macro QUERY_BME280]
+default_parameter_SENSOR: bme280 my_sensor
+gcode:
+    {printer.gcode.action_respond_info(
+        "Temperature: %.2f C\n"
+        "Pressure: %.2f hPa\n"
+        "Humidity: %.2f%%" % (
+            printer[SENSOR].temperature,
+            printer[SENSOR].pressure,
+            printer[SENSOR].humidity))}

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -1,0 +1,195 @@
+# Support for i2c based temperature sensors
+#
+# Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import bus
+import logging
+
+REPORT_TIME = .8
+BME280_CHIP_ADDR = 0x76
+BME280_REGS = {
+    'CHIP_ID': 0xD0, 'RESET': 0xE0, 'CTRL_HUM': 0xF2,
+    'STATUS': 0xF3, 'CTRL_MEAS': 0xF4, 'CONFIG': 0xF5,
+    'PRESSURE_MSB': 0xF7, 'PRESSURE_LSB': 0xF8, 'PRESSURE_XLSB': 0xF9,
+    'TEMP_MSB': 0xFA, 'TEMP_LSB': 0xFB, 'TEMP_XLSB': 0xFC,
+    'HUM_MSB': 0xFD, 'HUM_LSB': 0xFE, 'CAL_1': 0x88, 'CAL_2': 0xE1
+}
+# BME default settings
+STATUS_MEASURING = 1 << 3
+STATUS_IM_UPDATE = 1
+MODE = 1
+
+class BME280:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.reactor = self.printer.get_reactor()
+        self.i2c = bus.MCU_I2C_from_config(
+            config, default_addr=BME280_CHIP_ADDR, default_speed=100000)
+        self.os_temp = config.getint('bme280_oversample_temp', 2)
+        self.os_hum = config.getint('bme280_oversample_hum', 2)
+        self.os_pres = config.getint('bme280_oversample_pressure', 2)
+        self.temp = self.pressure = self.humidity = self.t_fine = 0.
+        self.max_sample_time = \
+            (1.25 + (2.3 * self.os_temp) + ((2.3 * self.os_pres) +
+             .575) + ((2.3 * self.os_hum) + .575)) / 1000
+        self.dig = None
+        self.sample_timer = self.reactor.register_timer(self._sample_bme280)
+        self.printer.add_object("bme280 " + self.name, self)
+        self.printer.register_event_handler("klippy:ready", self.handle_ready)
+
+    def handle_ready(self):
+        self._init_bme280()
+        self.reactor.update_timer(self.sample_timer, self.reactor.NOW)
+
+    def setup_minmax(self, min_temp, max_temp):
+        pass
+
+    def setup_callback(self, cb):
+        self._callback = cb
+
+    def get_report_time_delta(self):
+        return REPORT_TIME
+
+    def _init_bme280(self):
+        def get_twos_complement(val, bit_size):
+            if val & (1 << (bit_size - 1)):
+                val -= (1 << bit_size)
+            return val
+
+        def get_unsigned_short(bits):
+            return bits[1] << 8 | bits[0]
+
+        def get_signed_short(bits):
+            val = get_unsigned_short(bits)
+            return get_twos_complement(val, 16)
+
+        # Check the chip ID, should be 0x60
+        chip_id = self.read_register('CHIP_ID', 1)[0]
+        if chip_id != 0x60:
+            logging.info(
+                "bme280: Chip ID mismatch, expected 0x60, received %#x"
+                % (chip_id))
+
+        # Make sure non-volatile memory has been copied to registers
+        status = self.read_register('STATUS', 1)[0]
+        while status & STATUS_IM_UPDATE:
+            self.reactor.pause(self.reactor.monotonic() + .01)
+            status = self.read_register('STATUS', 1)[0]
+
+        c1 = self.read_register('CAL_1', 26)
+        c2 = self.read_register('CAL_2', 7)
+
+        # Read out and calculate the trimming parameters
+        dig = {}
+        unsigned_keys = ['T1', 'P1']
+        idx = 0
+        for cnt, prefix in [(3, 'T'), (9, 'P')]:
+            for i in range(cnt):
+                key = prefix + str(i + 1)
+                if key in unsigned_keys:
+                    dig[key] = get_unsigned_short(c1[idx:idx+2])
+                else:
+                    dig[key] = get_signed_short(c1[idx:idx+2])
+                idx += 2
+        dig['H1'] = c1[25] & 0xFF
+        dig['H2'] = get_signed_short(c2[0:2])
+        dig['H3'] = c2[2] & 0xFF
+        dig['H4'] = get_twos_complement(
+            ((c2[3] << 4) & 0xFF0) | (c2[4] & 0x0F), 12)
+        dig['H5'] = get_twos_complement(
+            (c2[4] & 0x0F) | ((c2[5] << 4) & 0xFF0), 12)
+        dig['H6'] = get_twos_complement(c2[6], 8)
+
+        self.dig = dig
+
+    def _sample_bme280(self, eventtime):
+        # Enter forced mode
+        self.write_register('CTRL_HUM', self.os_hum)
+        meas = self.os_temp << 5 | self.os_pres << 2 | MODE
+        self.write_register('CTRL_MEAS', meas)
+
+        # wait until results are ready
+        status = self.read_register('STATUS', 1)[0]
+        while status & STATUS_MEASURING:
+            self.reactor.pause(self.reactor.monotonic() + self.max_sample_time)
+            status = self.read_register('STATUS', 1)[0]
+
+        data = self.read_register('PRESSURE_MSB', 8)
+        pressure_raw = (data[0] << 12) | (data[1] << 4) | (data[2] >> 4)
+        temp_raw = (data[3] << 12) | (data[4] << 4) | (data[5] >> 4)
+        humid_raw = (data[6] << 8) | data[7]
+
+        self.temp = self._compensate_temp(temp_raw)
+        self.pressure = self._compensate_pressure(pressure_raw) / 100.
+        self.humidity = self._compensate_humidity(humid_raw)
+        measured_time = self.reactor.monotonic()
+        self._callback(measured_time, self.temp)
+        return measured_time + REPORT_TIME
+
+    def _compensate_temp(self, raw_temp):
+        dig = self.dig
+        var1 = ((raw_temp / 16384. - (dig['T1'] / 1024.)) * dig['T2'])
+        var2 = (
+            ((raw_temp / 131072.) - (dig['T1'] / 8192.)) *
+            ((raw_temp / 131072.) - (dig['T1'] / 8192.)) * dig['T3'])
+        self.t_fine = var1 + var2
+        return self.t_fine / 5120.0
+
+    def _compensate_pressure(self, raw_pressure):
+        dig = self.dig
+        t_fine = self.t_fine
+        var1 = t_fine / 2. - 64000.
+        var2 = var1 * var1 * dig['P6'] / 32768.
+        var2 = var2 + var1 * dig['P5'] * 2.
+        var2 = var2 / 4. + (dig['P4'] * 65536.)
+        var1 = (dig['P3'] * var1 * var1 / 524288. + dig['P2'] * var1) / 524288.
+        var1 = (1. + var1 / 32768.) * dig['P1']
+        if var1 == 0:
+            return 0.
+        else:
+            pressure = 1048576.0 - raw_pressure
+            pressure = ((pressure - var2 / 4096.) * 6250.) / var1
+            var1 = dig['P9'] * pressure * pressure / 2147483648.
+            var2 = pressure * dig['P8'] / 32768.
+            return pressure + (var1 + var2 + dig['P7']) / 16.
+
+    def _compensate_humidity(self, raw_humidity):
+        dig = self.dig
+        t_fine = self.t_fine
+        humidity = t_fine - 76800.
+        h1 = (
+            raw_humidity - (dig['H4'] * 64. + dig['H5'] / 16384. * humidity))
+        h2 = (dig['H2'] / 65536. * (1. + dig['H6'] / 67108864. * humidity *
+              (1. + dig['H3'] / 67108864. * humidity)))
+        humidity = h1 * h2
+        humidity = humidity * (1. - dig['H1'] * humidity / 524288.)
+        return min(100., max(0., humidity))
+
+    def read_register(self, reg_name, read_len):
+        # read a single register
+        regs = [BME280_REGS[reg_name]]
+        params = self.i2c.i2c_read(regs, read_len)
+        return bytearray(params['response'])
+
+    def write_register(self, reg_name, data):
+        if type(data) is not list:
+            data = [data]
+        reg = BME280_REGS[reg_name]
+        data.insert(0, reg)
+        self.i2c.i2c_write(data)
+
+    def get_status(self, eventtime):
+        return {
+            'temperature': self.temp,
+            'humidity': self.humidity,
+            'pressure': self.pressure
+        }
+
+
+def load_config(config):
+    # Register sensor
+    pheater = config.get_printer().lookup_object("heater")
+    pheater.add_sensor_factory("BME280", BME280)

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -259,6 +259,7 @@ class PrinterHeaters:
         self.printer.try_load_module(config, "thermistor")
         self.printer.try_load_module(config, "adc_temperature")
         self.printer.try_load_module(config, "spi_temperature")
+        self.printer.try_load_module(config, "bme280")
         sensor_type = config.get('sensor_type')
         if sensor_type not in self.sensor_factories:
             raise self.printer.config_error(

--- a/src/i2ccmds.c
+++ b/src/i2ccmds.c
@@ -42,7 +42,7 @@ command_i2c_read(uint32_t * args)
     struct i2cdev_s *i2c = oid_lookup(oid, command_config_i2c);
     uint8_t reg_len = args[1];
     uint8_t *reg = (void*)(size_t)args[2];
-    uint32_t data_len = args[3];
+    uint8_t data_len = args[3];
     uint8_t receive_array[data_len];
     uint8_t *data = (void*)(size_t)receive_array;
     i2c_read(i2c->i2c_config, reg_len, reg, data_len, data);

--- a/src/linux/Kconfig
+++ b/src/linux/Kconfig
@@ -9,6 +9,7 @@ config LINUX_SELECT
     select HAVE_GPIO_ADC
     select HAVE_GPIO_SPI
     select HAVE_GPIO_HARD_PWM
+    select HAVE_GPIO_I2C
 
 config BOARD_DIRECTORY
     string

--- a/src/linux/Makefile
+++ b/src/linux/Makefile
@@ -4,7 +4,7 @@ dirs-y += src/linux src/generic
 
 src-y += linux/main.c linux/timer.c linux/console.c linux/watchdog.c
 src-y += linux/pca9685.c linux/spidev.c linux/analog.c linux/hard_pwm.c
-src-y += generic/crc16_ccitt.c generic/alloc.c
+src-y += linux/i2c.c generic/crc16_ccitt.c generic/alloc.c
 
 CFLAGS_klipper.elf += -lutil
 

--- a/src/linux/gpio.h
+++ b/src/linux/gpio.h
@@ -35,4 +35,13 @@ struct gpio_pwm {
 struct gpio_pwm gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint16_t val);
 void gpio_pwm_write(struct gpio_pwm g, uint16_t val);
 
+struct i2c_config {
+    int fd;
+};
+
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
+void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
+              , uint8_t read_len, uint8_t *read);
+
 #endif // gpio.h

--- a/src/linux/i2c.c
+++ b/src/linux/i2c.c
@@ -1,0 +1,101 @@
+// Linux i2c implementation
+//
+// Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+#include <fcntl.h> // open
+#include <linux/i2c-dev.h> // I2C_SLAVE
+#include <stdio.h> // snprintf
+#include <sys/ioctl.h> // ioctl
+#include <unistd.h> // write
+#include "gpio.h" // i2c_setup
+#include "command.h" // shutdown
+#include "internal.h" // report_errno
+#include "sched.h" // sched_shutdown
+
+DECL_ENUMERATION_RANGE("i2c_bus", "i2c.0", 0, 2);
+
+struct i2c_s {
+    uint32_t bus;
+    uint8_t addr;
+    int fd;
+};
+
+static struct i2c_s devices[16];
+static int devices_count;
+
+static int
+i2c_open(uint32_t bus, uint8_t addr)
+{
+    // Find existing device (if already opened)
+    int i;
+    for (i=0; i<devices_count; i++) {
+        if (devices[i].bus == bus && devices[i].addr == addr) {
+            return devices[i].fd;
+        }
+    }
+
+    char fname[256];
+    snprintf(fname, sizeof(fname), "/dev/i2c-%d", bus);
+    int fd = open(fname, O_RDWR|O_CLOEXEC);
+    if (fd < 0) {
+        report_errno("open i2c", fd);
+        goto fail;
+    }
+    int ret = ioctl(fd, I2C_SLAVE, addr);
+    if (ret < 0) {
+        report_errno("ioctl i2c", fd);
+        goto fail;
+    }
+    ret = set_non_blocking(fd);
+    if (ret < 0)
+        goto fail;
+
+    devices[devices_count].bus = bus;
+    devices[devices_count].addr = addr;
+    devices[devices_count].fd = fd;
+    devices_count++;
+
+    return fd;
+
+fail:
+    if (fd >= 0)
+        close(fd);
+    shutdown("Unable to open i2c device");
+}
+
+struct i2c_config
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+{
+    // Note:  The rate is set by the kernel driver, for a Raspberry Pi this
+    // is done with the following setting in /boot/config.txt:
+    //
+    // dtparam=i2c_baudrate=<rate>
+
+    int fd = i2c_open(bus, addr);
+    return (struct i2c_config){.fd=fd};
+}
+
+void
+i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *data)
+{
+    int ret = write(config.fd, data, write_len);
+    if (ret != write_len) {
+        if (ret < 0)
+            report_errno("write value i2c", ret);
+        try_shutdown("Unable write i2c device");
+    }
+}
+
+void
+i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
+         , uint8_t read_len, uint8_t *data)
+{
+    i2c_write(config, reg_len, reg);
+    int ret = read(config.fd, data, read_len);
+    if (ret != read_len) {
+        if (ret < 0)
+            report_errno("read value i2c", ret);
+        try_shutdown("Unable to read i2c device");
+    }
+}


### PR DESCRIPTION
In addition to support for the BME280, this PR contains i2c read support for AVR platforms and i2c support for the linux mcu.  The sensor implementation has been tested using the above platforms as well as the SAM3X with an Arduino Due.

Below is the example configuration I used to test the sensor connected to a Raspberry Pi:

```
[temperature_sensor chamber]
sensor_type: BME280
i2c_mcu: linux
i2c_bus: i2c.1
gcode_id: AMB

[gcode_macro query_bme280]
default_parameter_SENSOR: bme280 chamber
gcode:
    {printer.gcode.action_respond_info(
        "Temperature: %.2f C\n"
        "Pressure: %.2f hPa\n"
        "Humidity: %.2f%%" % (
            printer[SENSOR].temperature,
            printer[SENSOR].pressure,
            printer[SENSOR].humidity))}
```

The temperature will show up in responses to M105 and the above macro can be used to query humidity and pressure in addition to temperature.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>