### PR TITLE
ProbePointsHelper: Use PROBE_SPEED as lift_speed if passed

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -336,8 +336,7 @@ class ProbePointsHelper:
             return
         # Perform automatic probing
         lift_speed = self.gcode.get_float(
-            "PROBE_SPEED", params, self.speed, above=0.)
-        self.lift_speed = min(lift_speed, probe.speed)
+            "PROBE_SPEED", params, probe.speed, above=0.)
         self.probe_offsets = probe.get_offsets()
         if self.horizontal_move_z < self.probe_offsets[2]:
             raise self.gcode.error("horizontal_move_z can't be less than"

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -335,7 +335,9 @@ class ProbePointsHelper:
             self._manual_probe_start()
             return
         # Perform automatic probing
-        self.lift_speed = min(self.speed, probe.speed)
+        lift_speed = self.gcode.get_float(
+            "PROBE_SPEED", params, self.speed, above=0.)
+        self.lift_speed = min(lift_speed, probe.speed)
         self.probe_offsets = probe.get_offsets()
         if self.horizontal_move_z < self.probe_offsets[2]:
             raise self.gcode.error("horizontal_move_z can't be less than"

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -335,7 +335,7 @@ class ProbePointsHelper:
             self._manual_probe_start()
             return
         # Perform automatic probing
-        lift_speed = self.gcode.get_float(
+        self.lift_speed = self.gcode.get_float(
             "PROBE_SPEED", params, probe.speed, above=0.)
         self.probe_offsets = probe.get_offsets()
         if self.horizontal_move_z < self.probe_offsets[2]:


### PR DESCRIPTION
There is currently no way to control the lift speed of the probe when using modules like `QUAD_GANTRY_LEVEL` or any module that makes use of ProbePointsHelper. This PR uses `PROBE_SPEED` for the lift speed as well (like the base probe module uses the probing speed as the retract speed as well).

The intended use case is to be able to run, e.g., a fast, coarse `QUAD_GANTRY_LEVEL` with a large `SAMPLE_RETRACT_DIST` and high `PROBE_SPEED` and then running a slow, precise `QUAD_GANTRY_LEVEL` with low `SAMPLE_RESTRACT_DIST` and low `PROBE_SPEED`. At present, while one can plunge down fast by passing `PROBE_SPEED` to these commands, the lift will still be carried out using the speed of the base probe configuration, which will potentially be very slow.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>