### PR TITLE
Fysetc Cheetah fixes

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -288,15 +288,16 @@ pin_map: arduino
 #   default is to not enable the aliases.
 #restart_method:
 #   This controls the mechanism the host will use to reset the
-#   micro-controller. The choices are 'arduino', 'rpi_usb', and
-#   'command'. The 'arduino' method (toggle DTR) is common on Arduino
-#   boards and clones. The 'rpi_usb' method is useful on Raspberry Pi
-#   boards with micro-controllers powered over USB - it briefly
-#   disables power to all USB ports to accomplish a micro-controller
-#   reset. The 'command' method involves sending a Klipper command to
-#   the micro-controller so that it can reset itself. The default is
-#   'arduino' if the micro-controller communicates over a serial port,
-#   'command' otherwise.
+#   micro-controller. The choices are 'arduino', 'cheetah', 'rpi_usb',
+#   and 'command'. The 'arduino' method (toggle DTR) is common on
+#   Arduino boards and clones. The 'cheetah' method is a special
+#   method needed for some Fysetc Cheetah boards. The 'rpi_usb' method
+#   is useful on Raspberry Pi boards with micro-controllers powered
+#   over USB - it briefly disables power to all USB ports to
+#   accomplish a micro-controller reset. The 'command' method involves
+#   sending a Klipper command to the micro-controller so that it can
+#   reset itself. The default is 'arduino' if the micro-controller
+#   communicates over a serial port, 'command' otherwise.
 
 # The printer section controls high level printer settings.
 [printer]

--- a/config/generic-fysetc-cheetah-v1.2.cfg
+++ b/config/generic-fysetc-cheetah-v1.2.cfg
@@ -103,6 +103,7 @@ pin: PC8
 
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
+restart_method: cheetah
 
 [printer]
 kinematics: cartesian


### PR DESCRIPTION
Fixes restart problems on Fysetc Cheetah boards. This changes how the RTS signal is used, so it might make sense to test it on various other boards. Or maybe a configuration toggle should be added?