### PR TITLE
Create printer-creality-ender5-skr-mini-e3-bltouch.cfg

### DIFF
--- a/config/printer-creality-ender5-skr-mini-e3-bltouch.cfg
+++ b/config/printer-creality-ender5-skr-mini-e3-bltouch.cfg
@@ -1,0 +1,166 @@
+# This file contains common pin mappings for the BIGTREETECH SKR mini
+# E3 v1.2. To use this config, the firmware should be compiled for the
+# STM32F103 with a "28KiB bootloader". Also, select "Enable extra
+# low-level configuration options" and configure "GPIO pins to set at
+# micro-controller startup" to "!PC13".
+
+# The "make flash" command does not work on the SKR mini E3. Instead,
+# after running "make", copy the generated "out/klipper.bin" file to a
+# file named "firmware.bin" on an SD card and then restart the SKR
+# mini E3 with that SD card.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: PB13
+dir_pin: !PB12
+enable_pin: !PB14
+step_distance: .0125
+endstop_pin: ^PC0
+position_endstop: 220
+position_max: 220
+homing_speed: 100
+
+[tmc2209 stepper_x]
+uart_pin: PB15
+microsteps: 16
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[stepper_y]
+step_pin: PB10
+dir_pin: !PB2
+enable_pin: !PB11
+step_distance: .0125
+endstop_pin: ^PC1
+position_endstop: 220
+position_max: 220
+homing_speed: 100
+
+[tmc2209 stepper_y]
+uart_pin: PC6
+microsteps: 16
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[stepper_z]
+step_pin: PB0
+dir_pin: !PC5
+enable_pin: !PB1
+step_distance: .0025
+position_max: 300
+position_min: -3
+endstop_pin: probe:z_virtual_endstop
+
+[tmc2209 stepper_z]
+uart_pin: PC10
+microsteps: 16
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[extruder]
+step_pin: PB3
+dir_pin: !PB4
+enable_pin: !PD2
+#step_distance: 0.010526
+step_distance: 0.0107526
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA0
+control: pid
+pid_Kp=24.345
+pid_Ki=1.298
+pid_Kd=114.117
+min_temp: 0
+max_temp: 250
+
+[tmc2209 extruder]
+uart_pin: PC11
+microsteps: 16
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[heater_bed]
+heater_pin: PC9
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC3
+control: pid
+pid_Kp=53.652
+pid_Ki=1.583
+pid_Kd=454.700
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PA8
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_stm32f103xe_33FFD6054242363216870157-if00
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[static_digital_output usb_pullup_enable]
+pins: !PC13
+
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=PB5, EXP1_3=PA9,   EXP1_5=PA10, EXP1_7=PB8, EXP1_9=<GND>,
+    EXP1_2=PB6, EXP1_4=<RST>, EXP1_6=PB9,  EXP1_8=PB7, EXP1_10=<5V>
+
+# See the sample-lcd.cfg file for definitions of common LCD displays.
+
+[display]
+lcd_type: st7920
+cs_pin: EXP1_7
+sclk_pin: EXP1_6
+sid_pin: EXP1_8
+encoder_pins: ^EXP1_5, ^EXP1_3
+click_pin: ^!EXP1_2
+#kill_pin: ^!EXP2_8
+
+[output_pin beeper]
+pin: EXP1_1
+
+[gcode_macro G29]
+gcode:
+        G28
+        G1 Z10 F600
+        BED_MESH_CALIBRATE
+
+[gcode_macro M420]
+gcode:
+        BED_MESH_PROFILE LOAD=default
+
+[bltouch]
+sensor_pin: PC14
+control_pin: PA1
+z_offset: 2.71
+x_offset: -44
+y_offset: -6
+speed: 100
+samples: 2
+
+# Example bed_mesh config section
+[bed_mesh]
+mesh_min: 0, 0
+mesh_max: 176, 214
+probe_count: 6, 6
+mesh_pps: 4,4
+
+[safe_z_home]
+home_xy_position: 110, 110
+speed: 100
+z_hop: 10
+z_hop_speed: 5


### PR DESCRIPTION
Added my config for Ender-5 with SKR Mini E3 board with TMC2209 drivers and Bltouch