### PR TITLE
Add STEPPER_DISABLE gcode command to disable individual steppers

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -161,7 +161,7 @@ The following standard commands are supported:
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active
   extruder.
-- `STEPPER_DISABLE STEPPER=<config_name>`: Disable only the given 
+- `STEPPER_DISABLE STEPPER=<config_name>`: Disable only the given
   stepper. Disabling the X, Y, or Z steppers will require printer
   to be re-homed.
 - `STEPPER_BUZZ STEPPER=<config_name>`: Move the given stepper forward

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -161,6 +161,9 @@ The following standard commands are supported:
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active
   extruder.
+- `STEPPER_DISABLE STEPPER=<config_name>`: Disable only the given 
+  stepper. Disabling the X, Y, or Z steppers will require printer
+  to be re-homed.
 - `STEPPER_BUZZ STEPPER=<config_name>`: Move the given stepper forward
   one mm and then backward one mm, repeated 10 times. This is a
   diagnostic tool to help verify stepper connectivity.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -161,12 +161,12 @@ The following standard commands are supported:
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active
   extruder.
-- `STEPPER_DISABLE STEPPER=<config_name>`: Disable only the given
-  stepper. This is a diagnostic and debugging tool and must be used
-  with care. Disabling an axis motor does not reset the homing
-  information. Manually moving a disabled stepper may cause the
-  machine to operate the motor outside of safe limits. This can lead
-  to damage to axis components, hot ends, and print surface.
+- `SET_STEPPER_ENABLE STEPPER=<config_name> ENABLE=[0|1]`: Enable or
+  disable only the given stepper. This is a diagnostic and debugging
+  tool and must be used with care. Disabling an axis motor does not
+  reset the homing information. Manually moving a disabled stepper may
+  cause the machine to operate the motor outside of safe limits. This
+  can lead to damage to axis components, hot ends, and print surface.
 - `STEPPER_BUZZ STEPPER=<config_name>`: Move the given stepper forward
   one mm and then backward one mm, repeated 10 times. This is a
   diagnostic tool to help verify stepper connectivity.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -162,8 +162,11 @@ The following standard commands are supported:
   parameters. If EXTRUDER is not specified, it defaults to the active
   extruder.
 - `STEPPER_DISABLE STEPPER=<config_name>`: Disable only the given
-  stepper. Disabling the X, Y, or Z steppers will require printer
-  to be re-homed.
+  stepper. This is a diagnostic and debugging tool and must be used
+  with care. Disabling an axis motor does not reset the homing
+  information. Manually moving a disabled stepper may cause the
+  machine to operate the motor outside of safe limits. This can lead
+  to damage to axis components, hot ends, and print surface.
 - `STEPPER_BUZZ STEPPER=<config_name>`: Move the given stepper forward
   one mm and then backward one mm, repeated 10 times. This is a
   diagnostic tool to help verify stepper connectivity.

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -83,7 +83,7 @@ class PrinterStepperEnable:
     def register_stepper(self, stepper, pin):
         name = stepper.get_name()
         self.enable_lines[name] = EnableTracking(self.printer, stepper, pin)
-    def motor_off(self, stepper=None, enable=1):
+    def motor_off(self):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.dwell(DISABLE_STALL_TIME)
         print_time = toolhead.get_last_move_time()

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -71,6 +71,9 @@ class PrinterStepperEnable:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.enable_lines = {}
+        self.homed_steppers = ['stepper_a','stepper_b','stepper_c',
+                          'stepper_x','stepper_y','stepper_z',
+                          'stepper_bed','stepper_arm']
         self.printer.register_event_handler("gcode:request_restart",
                                             self._handle_request_restart)
         # Register M18/M84 commands
@@ -89,10 +92,12 @@ class PrinterStepperEnable:
         if stepper is not None:
             el = self.enable_lines.get(stepper, "")
             el.motor_disable(print_time)
+            if stepper in self.homed_steppers:
+                self.printer.send_event("stepper_enable:motor_off", print_time)
         else:
             for el in self.enable_lines.values():
                 el.motor_disable(print_time)
-        self.printer.send_event("stepper_enable:motor_off", print_time)
+            self.printer.send_event("stepper_enable:motor_off", print_time)
         toolhead.dwell(DISABLE_STALL_TIME)
         logging.debug('; Max time of %f', print_time)
     def _handle_request_restart(self, print_time):

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -87,9 +87,14 @@ class PrinterStepperEnable:
         toolhead.dwell(DISABLE_STALL_TIME)
         print_time = toolhead.get_last_move_time()
         if stepper is not None:
-            el = self.enable_lines.get(stepper, "")
-            el.motor_disable(print_time)
-            logging.info("%s has been manually disabled", stepper)
+            if stepper in self.enable_lines:
+                el = self.enable_lines.get(stepper, "")
+                el.motor_disable(print_time)
+                logging.info("%s has been manually disabled", stepper)
+            else:
+                gcode = self.printer.lookup_object('gcode')
+                gcode.respond_info('STEPPER_DISABLE: Invalid stepper "%s"'
+                                    % (stepper))
         else:
             for el in self.enable_lines.values():
                 el.motor_disable(print_time)

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -71,9 +71,6 @@ class PrinterStepperEnable:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.enable_lines = {}
-        self.homed_steppers = ['stepper_a','stepper_b','stepper_c',
-                          'stepper_x','stepper_y','stepper_z',
-                          'stepper_bed','stepper_arm']
         self.printer.register_event_handler("gcode:request_restart",
                                             self._handle_request_restart)
         # Register M18/M84 commands
@@ -92,8 +89,7 @@ class PrinterStepperEnable:
         if stepper is not None:
             el = self.enable_lines.get(stepper, "")
             el.motor_disable(print_time)
-            if stepper in self.homed_steppers:
-                self.printer.send_event("stepper_enable:motor_off", print_time)
+            logging.info("%s has been manually disabled", stepper)
         else:
             for el in self.enable_lines.values():
                 el.motor_disable(print_time)

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -77,8 +77,9 @@ class PrinterStepperEnable:
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("M18", self.cmd_M18)
         self.gcode.register_command("M84", self.cmd_M18)
-        self.gcode.register_command("SET_STEPPER_ENABLE", self.cmd_SET_STEPPER_ENABLE,
-                                desc = self.cmd_SET_STEPPER_ENABLE_help)
+        self.gcode.register_command("SET_STEPPER_ENABLE",
+                                    self.cmd_SET_STEPPER_ENABLE,
+                                    desc = self.cmd_SET_STEPPER_ENABLE_help)
     def register_stepper(self, stepper, pin):
         name = stepper.get_name()
         self.enable_lines[name] = EnableTracking(self.printer, stepper, pin)

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -77,7 +77,8 @@ class PrinterStepperEnable:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command("M18", self.cmd_M18)
         gcode.register_command("M84", self.cmd_M18)
-        gcode.register_command("STEPPER_DISABLE", self.cmd_STEPPER_DISABLE)
+        gcode.register_command("STEPPER_DISABLE", self.cmd_STEPPER_DISABLE,
+                              desc=self.cmd_STEPPER_DISABLE_help)
     def register_stepper(self, stepper, pin):
         name = stepper.get_name()
         self.enable_lines[name] = EnableTracking(self.printer, stepper, pin)


### PR DESCRIPTION
STEPPER_DISABLE extended G-Code for individual stepper disabling

Using command `STEPPER_DISABLE STEPPER=<config_name>` individual steppers can be disabled

Signed-off-by: David Smith <davidosmith@gmail.com>