### PR TITLE
Fix definition reference for UPDATE_DELAYED_GCODE

### DIFF
--- a/klippy/extras/delayed_gcode.py
+++ b/klippy/extras/delayed_gcode.py
@@ -21,7 +21,7 @@ class DelayedGcode:
         self.gcode.register_mux_command(
             "UPDATE_DELAYED_GCODE", "ID", self.name,
             self.cmd_UPDATE_DELAYED_GCODE,
-            desc=self.cmd_UPDATE_DELAYED_GCODE)
+            desc=self.cmd_UPDATE_DELAYED_GCODE_help)
     def _handle_ready(self):
         waketime = self.reactor.NEVER
         if self.duration:


### PR DESCRIPTION
the define for UPDATE_DELAYED_GCODE had a misdirected definition and was showing code base instead of help text when "help" typed in terminal

signed off by: David Smith <davidosmith@gmail.com>