### PR TITLE
TMC2130 stepper_z = wrong CS pin

### DIFF
--- a/config/generic-fysetc-f6.cfg
+++ b/config/generic-fysetc-f6.cfg
@@ -181,7 +181,7 @@ pins: PB0
 #stealthchop_threshold: 250
 
 #[tmc2130 stepper_z]
-#cs_pin: PJ6
+#cs_pin: PJ7
 #diag1_pin: PB6
 #microsteps: 16
 #run_current: 0.800


### PR DESCRIPTION
#[tmc2130 stepper_z]
#cs_pin: PJ7 

PJ6 = D77 and dont work, PJ7 = D74 and work it.