### PR TITLE
BLTHS PART1 HEATERS (turn off heaters during homing/probing)

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -791,6 +791,18 @@
 #   by during the check_gain_time check. It is rare to customize this
 #   value. The default is 2.
 
+# Tool to disable heaters when homing or probing an axis
+[homing_heaters]
+#   A comma separated list of steppers that should cause heaters to be
+#   disabled. The default is to disable heaters for any homing/probing
+#   move.
+#   Typical example: stepper_z
+steppers:
+#   A comma separated list of heaters to disable during homing/probing
+#   moves. The default is to disable all heaters.
+#   Typical example: extruder, heater_bed
+heaters:
+
 # MAXxxxxx serial peripheral interface (SPI) temperature based
 # sensors. The following parameters are available in heater sections
 # that use one of these sensor types.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -792,16 +792,16 @@
 #   value. The default is 2.
 
 # Tool to disable heaters when homing or probing an axis
-[homing_heaters]
+#[homing_heaters]
+#steppers:
 #   A comma separated list of steppers that should cause heaters to be
 #   disabled. The default is to disable heaters for any homing/probing
 #   move.
 #   Typical example: stepper_z
-steppers:
+#heaters:
 #   A comma separated list of heaters to disable during homing/probing
 #   moves. The default is to disable all heaters.
 #   Typical example: extruder, heater_bed
-heaters:
 
 # MAXxxxxx serial peripheral interface (SPI) temperature based
 # sensors. The following parameters are available in heater sections

--- a/klippy/extras/homing_heaters.py
+++ b/klippy/extras/homing_heaters.py
@@ -1,0 +1,54 @@
+# Heater handling on homing moves
+#
+# Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+
+class HomingHeaters:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.printer.register_event_handler("homing:move_begin",
+                                            self.handle_homing_move_begin)
+        self.printer.register_event_handler("homing:move_end",
+                                            self.handle_homing_move_end)
+        self.heaters_to_disable = config.get("heaters", "")
+        self.steppers_needing_quiet = config.get("steppers", "")
+        self.last_target = {}
+        self.pheater = self.printer.lookup_object('heater')
+
+    def check_eligible(self, endstops):
+        flaky_steppers = [n.strip()
+                         for n in self.steppers_needing_quiet.split(',')]
+        if flaky_steppers == [""]:
+            return True
+        endstop_instances, dummy = zip(*endstops)
+        steppers_being_homed = list()
+        for n in endstop_instances:
+            steppers_being_homed = steppers_being_homed + n.get_steppers()
+        steppernames_being_homed = list()
+        for n in steppers_being_homed:
+            steppernames_being_homed.append(n.get_name())
+        return any(x in flaky_steppers for x in steppernames_being_homed)
+    def bld_heater_list(self):
+        heaters = [n.strip() for n in self.heaters_to_disable.split(',')]
+        if heaters == [""]:
+            heaters = self.pheater.available_heaters
+        return heaters
+    def handle_homing_move_begin(self, endstops):
+        if not self.check_eligible(endstops):
+            return
+        for heater_name in self.bld_heater_list():
+            heater = self.pheater.lookup_heater(heater_name)
+            self.last_target[heater_name] = heater.get_temp(0)[1]
+            heater.set_temp(0.)
+    def handle_homing_move_end(self, endstops):
+        if not self.check_eligible(endstops):
+            return
+        for heater_name in self.bld_heater_list():
+            heater = self.pheater.lookup_heater(heater_name)
+            heater.set_temp(self.last_target[heater_name])
+
+def load_config(config):
+    return HomingHeaters(config)

--- a/klippy/extras/homing_heaters.py
+++ b/klippy/extras/homing_heaters.py
@@ -29,7 +29,7 @@ class HomingHeaters:
     def bld_heater_list(self):
         heaters = [n.strip() for n in self.heaters_to_disable.split(',')]
         if heaters == [""]:
-            heaters = self.pheater.available_heaters
+            heaters = self.pheater.get_all_heaters()
         return heaters
     def handle_homing_move_begin(self, endstops):
         if not self.check_eligible(endstops):

--- a/klippy/extras/homing_heaters.py
+++ b/klippy/extras/homing_heaters.py
@@ -9,41 +9,62 @@ import logging
 class HomingHeaters:
     def __init__(self, config):
         self.printer = config.get_printer()
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
         self.printer.register_event_handler("homing:move_begin",
                                             self.handle_homing_move_begin)
         self.printer.register_event_handler("homing:move_end",
                                             self.handle_homing_move_end)
         self.heaters_to_disable = config.get("heaters", "")
+        self.disable_heaters = []
         self.steppers_needing_quiet = config.get("steppers", "")
-        self.last_target = {}
+        self.flaky_steppers = []
         self.pheater = self.printer.lookup_object('heater')
-    def check_eligible(self, endstops):
-        flaky_steppers = [n.strip()
+        self.target_save = {}
+
+    def handle_connect(self):
+        # heaters to disable
+        all_heaters = self.pheater.get_all_heaters()
+        self.disable_heaters = [n.strip()
+                          for n in self.heaters_to_disable.split(',')]
+        if self.disable_heaters == [""]:
+            self.disable_heaters = all_heaters
+        else:
+            if not all(x in all_heaters for x in self.disable_heaters):
+                raise self.printer.config_error(
+                    "One or more of these heaters are unknown: %s" % (
+                        self.disable_heaters))
+        # steppers valid?
+        kin = self.printer.lookup_object('toolhead').get_kinematics()
+        all_steppers = [s.get_name() for s in kin.get_steppers()]
+        self.flaky_steppers = [n.strip()
                          for n in self.steppers_needing_quiet.split(',')]
-        if flaky_steppers == [""]:
+        if self.flaky_steppers == [""]:
+            return
+        if not all(x in all_steppers for x in self.flaky_steppers):
+            raise self.printer.config_error(
+                "One or more of these steppers are unknown: %s" % (
+                    self.flaky_steppers))
+    def check_eligible(self, endstops):
+        if self.flaky_steppers == [""]:
             return True
         steppers_being_homed = [s.get_name()
                                 for es, name in endstops
                                 for s in es.get_steppers()]
-        return any(x in flaky_steppers for x in steppers_being_homed)
-    def bld_heater_list(self):
-        heaters = [n.strip() for n in self.heaters_to_disable.split(',')]
-        if heaters == [""]:
-            heaters = self.pheater.get_all_heaters()
-        return heaters
+        return any(x in self.flaky_steppers for x in steppers_being_homed)
     def handle_homing_move_begin(self, endstops):
         if not self.check_eligible(endstops):
             return
-        for heater_name in self.bld_heater_list():
+        for heater_name in self.disable_heaters:
             heater = self.pheater.lookup_heater(heater_name)
-            self.last_target[heater_name] = heater.get_temp(0)[1]
+            self.target_save[heater_name] = heater.get_temp(0)[1]
             heater.set_temp(0.)
     def handle_homing_move_end(self, endstops):
         if not self.check_eligible(endstops):
             return
-        for heater_name in self.bld_heater_list():
+        for heater_name in self.disable_heaters:
             heater = self.pheater.lookup_heater(heater_name)
-            heater.set_temp(self.last_target[heater_name])
+            heater.set_temp(self.target_save[heater_name])
 
 def load_config(config):
     return HomingHeaters(config)

--- a/klippy/extras/homing_heaters.py
+++ b/klippy/extras/homing_heaters.py
@@ -17,20 +17,15 @@ class HomingHeaters:
         self.steppers_needing_quiet = config.get("steppers", "")
         self.last_target = {}
         self.pheater = self.printer.lookup_object('heater')
-
     def check_eligible(self, endstops):
         flaky_steppers = [n.strip()
                          for n in self.steppers_needing_quiet.split(',')]
         if flaky_steppers == [""]:
             return True
-        endstop_instances, dummy = zip(*endstops)
-        steppers_being_homed = list()
-        for n in endstop_instances:
-            steppers_being_homed = steppers_being_homed + n.get_steppers()
-        steppernames_being_homed = list()
-        for n in steppers_being_homed:
-            steppernames_being_homed.append(n.get_name())
-        return any(x in flaky_steppers for x in steppernames_being_homed)
+        steppers_being_homed = [s.get_name()
+                                for es, name in endstops
+                                for s in es.get_steppers()]
+        return any(x in flaky_steppers for x in steppers_being_homed)
     def bld_heater_list(self):
         heaters = [n.strip() for n in self.heaters_to_disable.split(',')]
         if heaters == [""]:

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -250,6 +250,8 @@ class PrinterHeaters:
         self.register_sensor(config, heater, gcode_id)
         self.available_heaters.append(config.get_name())
         return heater
+    def get_all_heaters(self):
+        return self.available_heaters
     def lookup_heater(self, heater_name):
         if heater_name not in self.heaters:
             raise self.printer.config_error(

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -66,6 +66,8 @@ class Homing:
                 print_time, ENDSTOP_SAMPLE_TIME, ENDSTOP_SAMPLE_COUNT,
                 rest_time, notify=self._endstop_notify)
         self.toolhead.dwell(HOMING_START_DELAY)
+        # notify anyone out there of move start
+        self.printer.send_event("homing:move_begin", endstops)
         # Issue move
         error = None
         try:
@@ -80,6 +82,8 @@ class Homing:
             except mcu_endstop.TimeoutError as e:
                 if error is None:
                     error = "Failed to home %s: %s" % (name, str(e))
+        # notify anyone out there of move end
+        self.printer.send_event("homing:move_end", endstops)
         # Determine stepper halt positions
         self.toolhead.flush_step_generation()
         end_mcu_pos = [(s, name, spos, s.get_mcu_position())


### PR DESCRIPTION
This is **part1** of the **BLTOUCH-HIGH-SPEED** PR split (see #2309).

**OVERVIEW**

For those that choose to home or probe with any heaters (either nozzle(s) or bed) **turned on**, any power-supply or wiring situation or a probe that is sensitive to the heater PWM causing any kind of noise or supply variations can profit from having the heaters **turned off for the duration of the homing or probing movement**. As soon as the endstop/probe is triggered, the heaters will be turned on again.

**COMMENTS**

Alternatively, one could use GCODE macros to surround the relevant commands by heaters-off and heaters-on commands. The adavantage of this PR is that during a bed level, for example, there would be at least some heating in between the probing movements to keep the bed at the desired temperature. An additional option would be _(future_ _enhancement?)_ to wait until the bed is once again at the desired temperature before continuing the levelling operation.

**CONFIG**

To enable this feature, add a `[homing-heaters]` section to `printer.cfg`.
Note: This works for any axis, but typically it would be used for `stepper-z`

```
# Tool to disable heaters when homing or probing an axis
[homing_heaters]
#   A comma separated list of steppers that should cause heaters to be
#   disabled. The default is to disable heaters for any homing/probing
#   move.
#   Typical example: stepper_z
steppers:
#   A comma separated list of heaters to disable during homing/probing
#   moves. The default is to disable all heaters.
#   Typical example: extruder, heater_bed
heaters:
```

**ADDITIONAL INFORMATION**

The branch associated with PR #2309 contains this code (BLTHS PART1 HEATERS) and can be found at [this place](https://github.com/FanDjango/klipper/tree/BLTOUCH-HIGH-SPEED) for all that would like to help test this stuff

Signed-off-by: Mike Stiemke **fandjango@gmx.de**
