### PR TITLE
BLTHS PART2 HOMING RETRACT (Ability to set retract speed between homing moves)

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -55,6 +55,10 @@ position_max: 200
 #   Distance to backoff (in mm) before homing a second time during
 #   homing. Set this to zero to disable the second home. The default
 #   is 5mm.
+#homing_retract_speed:
+#   Speed to use on the retract move after homing in case this should
+#   be different from the homing speed, which is the default for this
+#   parameter
 #second_homing_speed:
 #   Velocity (in mm/s) of the stepper when performing the second home.
 #   The default is homing_speed/2.

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -126,7 +126,7 @@ class Homing:
             retract_r = min(1., hi.retract_dist / move_d)
             retractpos = [mp - ad * retract_r
                           for mp, ad in zip(movepos, axes_d)]
-            self.toolhead.move(retractpos, hi.speed)
+            self.toolhead.move(retractpos, hi.retract_speed)
             # Home again
             forcepos = [rp - ad * retract_r
                         for rp, ad in zip(retractpos, axes_d)]

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -236,6 +236,8 @@ class PrinterRail:
         self.homing_speed = config.getfloat('homing_speed', 5.0, above=0.)
         self.second_homing_speed = config.getfloat(
             'second_homing_speed', self.homing_speed/2., above=0.)
+        self.homing_retract_speed = config.getfloat(
+            'homing_retract_speed', self.homing_speed, above=0.)
         self.homing_retract_dist = config.getfloat(
             'homing_retract_dist', 5., minval=0.)
         self.homing_positive_dir = config.getboolean(
@@ -254,11 +256,11 @@ class PrinterRail:
         return self.position_min, self.position_max
     def get_homing_info(self):
         homing_info = collections.namedtuple('homing_info', [
-            'speed', 'position_endstop', 'retract_dist', 'positive_dir',
-            'second_homing_speed'])(
+            'speed', 'position_endstop', 'retract_speed', 'retract_dist',
+            'positive_dir', 'second_homing_speed'])(
                 self.homing_speed, self.position_endstop,
-                self.homing_retract_dist, self.homing_positive_dir,
-                self.second_homing_speed)
+                self.homing_retract_speed, self.homing_retract_dist,
+                self.homing_positive_dir, self.second_homing_speed)
         return homing_info
     def get_steppers(self):
         return list(self.steppers)


### PR DESCRIPTION
This is **part2** of the **BLTOUCH-HIGH-SPEED** PR split (see #2309).

**OVERVIEW**

Similarly to the `lift-speed` parameter for probe related config-sections, this enables the speed of the retract-move between homing moves to be configurable.

**COMMENTS**

The speed gain to be achieved here is minimal. For a BLTouch in HIGH-SPEED-MODE, though, it is advantageous to lift up as fast as possible after a homing trigger, even if the downward movement on homing is slow.

**CONFIG**

Add `homing-retract-speed: nnn` to the `[stepper-...]` section of `printer.cfg`
Note: This works for any axis, but typically it would be used for stepper-z

```
[stepper-z]
homing-retract-speed: nnn
```

Note: for a BLTouch type probe being used for Z-axis homing, a high upward retract speed is advantageous. This value is effectively limited by `max_z_velocity` in the `[printer]` section. Make sure this is set to a viable value.

**ADDITIONAL INFORMATION**

The branch associated with PR #2309 contains this code (BLTHS PART2 HOMING RETRACT) and can be found at [this place](https://github.com/FanDjango/klipper/tree/BLTOUCH-HIGH-SPEED) for all that would like to help test this stuff

Signed-off-by: Mike Stiemke **fandjango@gmx.de**