### PR TITLE
BLTHS PART3 PROBE MODE (Ability to specify that a probe does not need a prepare and finalize action in between individual probe actions)

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -632,6 +632,9 @@
 #   the commands "pin_up" followed by "touch_mode". This should be
 #   True for a genuine BLTouch v2 and earlier; the BLTouch v3 and some
 #   BLTouch clones require False. The default is True.
+#stow_on_each_sample: True
+#   If set to False, intermediate STOW/DEPLOY sequences on certain
+#   operations that use the probe multiple times will be omitted.
 #x_offset:
 #y_offset:
 #z_offset:

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -137,26 +137,24 @@ class BLTouchEndstopWrapper:
         # Test was successful
         self.next_test_time = check_end_time + TEST_TIME
         self.sync_print_time()
-    def home_prepare(self):
+    def probe_prepare(self):
         self.test_sensor()
         self.sync_print_time()
         duration = max(MIN_CMD_TIME, self.pin_move_time - MIN_CMD_TIME)
         self.send_cmd('pin_down', duration=duration)
         self.send_cmd(None)
         self.sync_print_time()
-        self.mcu_endstop.home_prepare()
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.flush_step_generation()
         self.start_mcu_pos = [(s, s.get_mcu_position())
                               for s in self.mcu_endstop.get_steppers()]
-    def home_finalize(self):
+    def probe_finalize(self):
         self.raise_probe()
         self.sync_print_time()
         # Verify the probe actually deployed during the attempt
         for s, mcu_pos in self.start_mcu_pos:
             if s.get_mcu_position() == mcu_pos:
                 raise homing.EndstopError("BLTouch failed to deploy")
-        self.mcu_endstop.home_finalize()
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    notify=None):
         rest_time = min(rest_time, ENDSTOP_REST_TIME)

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -137,6 +137,10 @@ class BLTouchEndstopWrapper:
         # Test was successful
         self.next_test_time = check_end_time + TEST_TIME
         self.sync_print_time()
+    def multi_probe_begin(self):
+        pass
+    def multi_probe_end(self):
+        pass
     def probe_prepare(self):
         self.test_sensor()
         self.sync_print_time()

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -15,8 +15,8 @@ class EndstopPhase:
         # Register event handlers
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
-        self.printer.register_event_handler("homing:homed_rails",
-                                            self.handle_homed_rails)
+        self.printer.register_event_handler("homing:home_rails_end",
+                                            self.handle_home_rails_end)
         self.printer.try_load_module(config, "endstop_phase")
         self.printer.try_load_module(config, "force_move")
         # Read config
@@ -99,7 +99,7 @@ class EndstopPhase:
                 "Endstop %s incorrect phase (got %d vs %d)" % (
                     self.name, phase, self.endstop_phase))
         return delta * self.step_dist
-    def handle_homed_rails(self, homing_state, rails):
+    def handle_home_rails_end(self, rails):
         for rail in rails:
             stepper = rail.get_steppers()[0]
             if stepper.get_name() != self.name:
@@ -122,7 +122,7 @@ class EndstopPhases:
         self.tracking = {}
         # Register event handler
         self.printer.register_event_handler(
-            "homing:homed_rails", self.handle_homed_rails)
+            "homing:home_rails_end", self.handle_home_rails_end)
     def lookup_rail(self, stepper, stepper_name):
         mod_name = "endstop_phase %s" % (stepper_name,)
         m = self.printer.lookup_object(mod_name, None)
@@ -146,7 +146,7 @@ class EndstopPhases:
             logging.exception("Error in EndstopPhases get_phase")
             return
         phase_history[phase] += 1
-    def handle_homed_rails(self, homing_state, rails):
+    def handle_home_rails_end(self, rails):
         for rail in rails:
             stepper = rail.get_steppers()[0]
             stepper_name = stepper.get_name()

--- a/klippy/extras/homing_heaters.py
+++ b/klippy/extras/homing_heaters.py
@@ -11,9 +11,9 @@ class HomingHeaters:
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
-        self.printer.register_event_handler("homing:move_begin",
+        self.printer.register_event_handler("homing:homing_move_begin",
                                             self.handle_homing_move_begin)
-        self.printer.register_event_handler("homing:move_end",
+        self.printer.register_event_handler("homing:homing_move_end",
                                             self.handle_homing_move_end)
         self.heaters_to_disable = config.get("heaters", "")
         self.disable_heaters = []
@@ -49,7 +49,7 @@ class HomingHeaters:
         if self.flaky_steppers == [""]:
             return True
         steppers_being_homed = [s.get_name()
-                                for es, name in endstops
+                                for es in endstops
                                 for s in es.get_steppers()]
         return any(x in self.flaky_steppers for x in steppers_being_homed)
     def handle_homing_move_begin(self, endstops):

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -77,12 +77,9 @@ class ManualStepper:
     def do_homing_move(self, movepos, speed, accel, triggered):
         if not self.can_home:
             raise self.gcode.error("No endstop for this manual stepper")
-        # Notify endstops of upcoming home
-        endstops = self.rail.get_endstops()
-        for mcu_endstop, name in endstops:
-            mcu_endstop.home_prepare()
         # Start endstop checking
         self.sync_print_time()
+        endstops = self.rail.get_endstops()
         for mcu_endstop, name in endstops:
             min_step_dist = min([s.get_step_dist()
                                  for s in mcu_endstop.get_steppers()])
@@ -99,12 +96,6 @@ class ManualStepper:
             except mcu_endstop.TimeoutError as e:
                 if error is None:
                     error = "Failed to home %s: %s" % (name, str(e))
-        for mcu_endstop, name in endstops:
-            try:
-                mcu_endstop.home_finalize()
-            except homing.CommandError as e:
-                if error is None:
-                    error = str(e)
         self.sync_print_time()
         if error is not None:
             raise homing.CommandError(error)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -23,6 +23,7 @@ class PrinterProbe:
         self.y_offset = config.getfloat('y_offset', 0.)
         self.z_offset = config.getfloat('z_offset')
         self.probe_calibrate_z = 0.
+        self.multi_probe_pending = False
         # Infer Z position to move to during a probe
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')
@@ -48,6 +49,12 @@ class PrinterProbe:
                                             self._handle_homing_move_begin)
         self.printer.register_event_handler("homing:homing_move_end",
                                             self._handle_homing_move_end)
+        self.printer.register_event_handler("homing:home_rails_begin",
+                                            self._handle_home_rails_begin)
+        self.printer.register_event_handler("homing:home_rails_end",
+                                            self._handle_home_rails_end)
+        self.printer.register_event_handler("gcode:command_error",
+                                            self.multi_probe_end)
         # Register PROBE/QUERY_PROBE commands
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command('PROBE', self.cmd_PROBE,
@@ -64,6 +71,21 @@ class PrinterProbe:
     def _handle_homing_move_end(self, endstops):
         if self.mcu_probe in endstops:
             self.mcu_probe.probe_finalize()
+    def _handle_home_rails_begin(self, rails):
+        endstops = [es for rail in rails for es, name in rail.get_endstops()]
+        if self.mcu_probe in endstops:
+            self.multi_probe_begin()
+    def _handle_home_rails_end(self, rails):
+        endstops = [es for rail in rails for es, name in rail.get_endstops()]
+        if self.mcu_probe in endstops:
+            self.multi_probe_end()
+    def multi_probe_begin(self):
+        self.mcu_probe.multi_probe_begin()
+        self.multi_probe_pending = True
+    def multi_probe_end(self):
+        if self.multi_probe_pending:
+            self.multi_probe_pending = False
+            self.mcu_probe.multi_probe_end()
     def setup_pin(self, pin_type, pin_params):
         if pin_type != 'endstop' or pin_params['pin'] != 'z_virtual_endstop':
             raise pins.error("Probe virtual endstop only useful as endstop pin")
@@ -131,6 +153,9 @@ class PrinterProbe:
             "SAMPLES_TOLERANCE_RETRIES", params, self.samples_retries, minval=0)
         samples_result = self.gcode.get_str(
             "SAMPLES_RESULT", params, self.samples_result)
+        must_notify_multi_probe = not self.multi_probe_pending
+        if must_notify_multi_probe:
+            self.multi_probe_begin()
         retries = 0
         positions = []
         while len(positions) < sample_count:
@@ -151,6 +176,8 @@ class PrinterProbe:
             if len(positions) < sample_count:
                 liftpos = [None, None, pos[2] + sample_retract_dist]
                 self._move(liftpos, lift_speed)
+        if must_notify_multi_probe:
+            self.multi_probe_end()
         # Calculate and return result
         if samples_result == 'median':
             return self._calc_median(positions)
@@ -183,6 +210,7 @@ class PrinterProbe:
                                    sample_count, sample_retract_dist,
                                    speed, lift_speed))
         # Probe bed sample_count times
+        self.multi_probe_begin()
         positions = []
         while len(positions) < sample_count:
             # Probe position
@@ -191,6 +219,7 @@ class PrinterProbe:
             # Retract
             liftpos = [None, None, pos[2] + sample_retract_dist]
             self._move(liftpos, lift_speed)
+        self.multi_probe_end()
         # Calculate maximum, minimum and average values
         max_value = max([p[2] for p in positions])
         min_value = min([p[2] for p in positions])
@@ -266,6 +295,10 @@ class ProbeEndstopWrapper:
         for stepper in kin.get_steppers():
             if stepper.is_active_axis('z'):
                 self.add_stepper(stepper)
+    def multi_probe_begin(self):
+        pass
+    def multi_probe_end(self):
+        pass
     def probe_prepare(self):
         toolhead = self.printer.lookup_object('toolhead')
         start_pos = toolhead.get_position()
@@ -361,12 +394,14 @@ class ProbePointsHelper:
         if self.horizontal_move_z < self.probe_offsets[2]:
             raise self.gcode.error("horizontal_move_z can't be less than"
                                    " probe's z_offset")
+        probe.multi_probe_begin()
         while 1:
             done = self._move_next()
             if done:
                 break
             pos = probe.run_probe(params)
             self.results.append(pos)
+        probe.multi_probe_end()
     def _manual_probe_start(self):
         done = self._move_next()
         if not done:

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -235,6 +235,7 @@ class GCodeParser:
             except self.error as e:
                 self.respond_error(str(e))
                 self.reset_last_position()
+                self.printer.send_event("gcode:command_error")
                 if not need_ack:
                     raise
             except:

--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -109,6 +109,8 @@ class Homing:
                     raise EndstopError(
                         "Endstop %s still triggered after retract" % (name,))
     def home_rails(self, rails, forcepos, movepos):
+        # Notify of upcoming homing operation
+        ret = self.printer.send_event("homing:home_rails_begin", rails)
         # Alter kinematics class to think printer is at forcepos
         homing_axes = [axis for axis in range(3) if forcepos[axis] is not None]
         forcepos = self._fill_coord(forcepos)
@@ -138,7 +140,7 @@ class Homing:
         kin = self.toolhead.get_kinematics()
         for s in kin.get_steppers():
             s.set_tag_position(s.get_commanded_position())
-        ret = self.printer.send_event("homing:homed_rails", self, rails)
+        ret = self.printer.send_event("homing:home_rails_end", rails)
         if any(ret):
             # Apply any homing offsets
             adjustpos = kin.calc_tag_position()

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -54,8 +54,6 @@ class MCU_endstop:
             " rest_ticks=%u pin_value=%c", cq=cmd_queue)
         self._query_cmd = self._mcu.lookup_command(
             "endstop_query_state oid=%c", cq=cmd_queue)
-    def home_prepare(self):
-        pass
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    triggered=True, notify=None):
         clock = self._mcu.print_time_to_clock(print_time)
@@ -112,8 +110,6 @@ class MCU_endstop:
             s.note_homing_end(did_trigger=did_trigger)
         if not did_trigger:
             raise self.TimeoutError("Timeout during endstop homing")
-    def home_finalize(self):
-        pass
     def query_endstop(self, print_time):
         clock = self._mcu.print_time_to_clock(print_time)
         if self._mcu.is_fileoutput():


### PR DESCRIPTION
This is **part3** of the **BLTOUCH-HIGH-SPEED** PR split (see #2309).

**OVERVIEW**

Some types of probe, like the BLTouch for example, do not need an intermediate STOW/DEPLOY command sequence when moving from one probing point to the next or when performing multiple probes in the same location.

**COMMENTS**

The speed gain to be achieved here is significant if a few other things are also tweaked. For a BLTouch in HIGH-SPEED-MODE, it is advantageous to lift up as fast as possible after a homing or probing trigger, even if the downward movement on homing or probing is slow. Therefore it is a good idea to configure `lift_speed` as high as possible, the same goes for `homing_retract_speed`. Note that both of these are upward limited by `max_z_velocity`, so check that value as well.

**IMPORTANT NOTE:** This "high-speed-mode" uses the original `bltouch.py` module with minimum changes to enable the message passing of DEPLOY and STOW actions by the send_event mechanism. This does increase the probing speed, especially if you also increase the retract speeds on homing and the lift_speed on probing.  

**CONFIG**

If this "**high_speed_mode**" is desired, add a `stow_on_each_sample` parameter to the probes config section. Currently there is only one probe that supports this parameter: the BLTouch - so we are talking about adding this parameter to the `[bltouch]` section.

```
[bltouch]
stow_on_each_sample: False
```

**ADDITIONAL INFORMATION**

The branch associated with PR #2309 contains this code (BLTHS PART3 PROBE MODE) and can be found at [this place](https://github.com/FanDjango/klipper/tree/BLTOUCH-HIGH-SPEED) for all that would like to help test this stuff

Signed-off-by: Mike Stiemke **fandjango@gmx.de**