### PR TITLE
config: Add Wanhao Duplicator 9 MK1

### DIFF
--- a/config/printer-wanhao-duplicator-9-2018.cfg
+++ b/config/printer-wanhao-duplicator-9-2018.cfg
@@ -41,7 +41,6 @@ enable_pin: !ar57
 step_distance: .009980
 nozzle_diameter: 0.4
 filament_diameter: 1.75
-pressure_advance: 0.070
 heater_pin: ar4
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: analog1
@@ -88,9 +87,6 @@ max_z_velocity: 225
 max_z_accel: 30
 square_corner_velocity: 15.0
 
-[pause_resume]
-recover_velocity: 50.
-
 [bed_mesh]
 speed: 120
 mesh_min: 0,0
@@ -108,7 +104,3 @@ screw3_name: back right screw
 screw4: 0,290
 screw4_name: back left screw
 probe_height: 0
-
-[respond]
-default_type: echo
-default_prefix: echo:

--- a/config/printer-wanhao-duplicator-9.cfg
+++ b/config/printer-wanhao-duplicator-9.cfg
@@ -1,5 +1,5 @@
 # This file contains pin mappings for the Wanhao Duplicator 9 MK1,
-# also sold as the Monoprice Maker Pro MK1. To use this config, 
+# also sold as the Monoprice Maker Pro MK1. To use this config,
 # the firmware should be compiled for the AVR atmega2560.
 
 # See the example.cfg file for a description of available parameters.

--- a/config/printer-wanhao-duplicator-9.cfg
+++ b/config/printer-wanhao-duplicator-9.cfg
@@ -1,0 +1,114 @@
+# This file contains pin mappings for the Wanhao Duplicator 9 MK1,
+# also sold as the Monoprice Maker Pro MK1. To use this config, 
+# the firmware should be compiled for the AVR atmega2560.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: ar61
+dir_pin: !ar62
+enable_pin: !ar60
+step_distance: .0125
+endstop_pin: ^!ar54
+position_endstop: 0
+position_max: 295
+homing_speed: 30.0
+
+[stepper_y]
+step_pin: ar64
+dir_pin: ar65
+enable_pin: !ar2
+step_distance: .0125
+endstop_pin: ^!ar24
+position_endstop: 0
+position_max: 290
+homing_speed: 30.0
+
+[stepper_z]
+step_pin: ar67
+dir_pin: ar69
+enable_pin: !ar66
+step_distance: .0025
+endstop_pin: probe:z_virtual_endstop
+position_endstop: 1.4
+position_max: 370
+position_min: -0.99
+
+[extruder]
+step_pin: ar58
+dir_pin: ar59
+enable_pin: !ar57
+step_distance: .009980
+nozzle_diameter: 0.4
+filament_diameter: 1.75
+pressure_advance: 0.070
+heater_pin: ar4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog1
+control: pid
+pid_Kp: 33.41
+pid_Ki: 1.47
+pid_Kd: 189.27
+min_temp: 0
+max_temp: 315
+
+[heater_bed]
+heater_pin: ar3
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+control: pid
+pid_Kp: 64.095903
+pid_Ki: 1.649830
+pid_Kd: 622.531455
+min_temp: 0
+max_temp: 120
+
+[fan]
+pin: ar5
+
+[probe]
+pin: !ar6
+x_offset: 27
+y_offset: 3
+z_offset: 1.4
+speed: 5.0
+samples: 2
+sample_retract_dist: 2.0
+samples_result: average
+
+[mcu]
+serial: /dev/ttyUSB0
+pin_map: arduino
+
+[printer]
+kinematics: cartesian
+max_velocity: 3000
+max_accel: 450
+max_z_velocity: 225
+max_z_accel: 30
+square_corner_velocity: 15.0
+
+[pause_resume]
+recover_velocity: 50.
+
+[bed_mesh]
+speed: 120
+mesh_min: 0,0
+mesh_max: 270,290
+probe_count: 5,3
+horizontal_move_z: 10
+
+[bed_screws]
+screw1: 5,5
+screw1_name: front left screw
+screw2: 295,0
+screw2_name: front right screw
+screw3: 295,290
+screw3_name: back right screw
+screw4: 0,290
+screw4_name: back left screw
+probe_height: 0
+
+[respond]
+default_type: echo
+default_prefix: echo:


### PR DESCRIPTION
Also applies to the Monoprice Maker Pro MK1.
This config is based on the version from Chris Barnes (https://www.facebook.com/Jarannis)
found on https://pastebin.com/raw/wm8PQezy. This config was mostly working and I
only had to change a few things:

  - updated key names for min_point and max_point to mesh_min and mesh_max
  - enabled PID control
  - tweaked bounds to allow movement during mesh leveling
  - removed all comments
  - decreased homing speed slightly
  - sane bed mesh sample defaults

Signed-off-by: Matt Shirley <mdshw5@gmail.com>