### PR TITLE
Addition of SET_PID_TERMS, RESET_PID_TERMS, GET_PID_TERMS, and RESET_PID_INTEGRATOR

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/klipper.iml
+++ b/.idea/klipper.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/klippy" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/src" />
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 2.7 (klipper)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7 (klipper)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/klipper.iml" filepath="$PROJECT_DIR$/.idea/klipper.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/klipper" vcs="Git" />
+  </component>
+</project>

--- a/.idea/webResources.xml
+++ b/.idea/webResources.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="WebResourcesPaths">
+    <contentEntries>
+      <entry url="file://$PROJECT_DIR$">
+        <entryData>
+          <resourceRoots>
+            <path value="file://$PROJECT_DIR$/config" />
+            <path value="file://$PROJECT_DIR$/docs" />
+            <path value="file://$PROJECT_DIR$/lib" />
+          </resourceRoots>
+        </entryData>
+      </entry>
+    </contentEntries>
+  </component>
+</project>

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -107,6 +107,26 @@ The following standard commands are supported:
   equivalent resistance given that pullup is reported.
 - `GET_POSITION`: Return information on the current location of the
   toolhead.
+- `SET_PID_TERMS [HEATER_NAME=<Heater>] [P=<Kp term>] [I=<Ki term>] 
+  [D=<Kd term]`: Set the Kp, Ki, and/or Kd terms for the specified 
+  heater PID controller.  All arguments are optional and you
+  can choose to only specify the terms you want to modify instead of
+  changing them all at once.  If any term is not supplied as a
+  parameter then that term is not modified.  The default HEATER_NAME
+  is 'extruder'.  Changes to the PID terms via this command are NOT 
+  saved to the config file.  This command will reset the summation 
+  (by setting it to 0) for the Ki and Kd terms ONLY IF those terms 
+  are specified as parameters to the command.
+- `RESET_PID_TERMS [HEATER_NAME=<Heater>]`: Reset the Kp, Ki, and Kd 
+  terms on the specified heater PID controller to the values that were 
+  loaded from the printer configuration file on startup.  The default 
+  HEATER_NAME is 'extruder'.  This command will reset the summation for
+  the Ki and the Kd terms.
+- `GET_PID_TERMS [HEATER_NAME=<Heater>]`: Get the Kp, Ki, and Kd terms
+  that are currently set for the specified heater.
+- `RESET_PID_INTEGRATOR [HEATER_NAME=<Heater>]`: Set the PID integral
+  summation to 0 for the specified heater.  This is useful if the
+  controller has windup that is causing unstable steady-state control.
 - `SET_GCODE_OFFSET [X=<pos>|X_ADJUST=<adjust>]
   [Y=<pos>|Y_ADJUST=<adjust>] [Z=<pos>|Z_ADJUST=<adjust>]
   [MOVE=1 [MOVE_SPEED=<speed>]]`: Set a positional offset to apply to

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -52,16 +52,18 @@ class PrinterFan:
         self.last_fan_value = value
     def get_status(self, eventtime):
         return {'speed': self.last_fan_value}
+    def _delayed_set_speed(self, value):
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.register_lookahead_callback((lambda pt:
+                                              self.set_speed(pt, value)))
     def cmd_M106(self, params):
         # Set fan speed
-        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         gcode = self.printer.lookup_object('gcode')
         value = gcode.get_float('S', params, 255., minval=0.) / 255.
-        self.set_speed(print_time, value)
+        self._delayed_set_speed(value)
     def cmd_M107(self, params):
         # Turn fan off
-        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
-        self.set_speed(print_time, 0.)
+        self._delayed_set_speed(0.)
 
 def load_config(config):
     return PrinterFan(config)

--- a/klippy/extras/heater_bed.py
+++ b/klippy/extras/heater_bed.py
@@ -20,8 +20,7 @@ class PrinterHeaterBed:
         gcode = self.printer.lookup_object('gcode')
         temp = gcode.get_float('S', params, 0.)
         toolhead = self.printer.lookup_object('toolhead')
-        print_time = toolhead.get_last_move_time()
-        self.heater.set_temp(print_time, temp)
+        self.heater.set_temp(temp)
         if wait and temp:
             gcode.wait_for_temperature(self.heater)
     def cmd_M190(self, params):

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -23,11 +23,11 @@ class PIDCalibrate:
             heater = pheater.lookup_heater(heater_name)
         except self.printer.config_error as e:
             raise self.gcode.error(str(e))
-        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
+        self.printer.lookup_object('toolhead').get_last_move_time()
         calibrate = ControlAutoTune(heater, target)
         old_control = heater.set_control(calibrate)
         try:
-            heater.set_temp(print_time, target)
+            heater.set_temp(target)
         except self.printer.command_error as e:
             heater.set_control(old_control)
             raise

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -437,9 +437,9 @@ class GCodeParser:
     all_handlers = [
         'G1', 'G4', 'G28', 'M400',
         'G20', 'M82', 'M83', 'G90', 'G91', 'G92', 'M114', 'M220', 'M221',
-        'SET_GCODE_OFFSET', 'SAVE_GCODE_STATE', 'RESTORE_GCODE_STATE',
-        'M105', 'M112', 'M115', 'IGNORE', 'GET_POSITION',
-        'RESTART', 'FIRMWARE_RESTART', 'ECHO', 'STATUS', 'HELP']
+        'SET_PID_TERMS', 'GET_PID_TERMS', 'RESET_PID_INTEGRATOR', 'SET_GCODE_OFFSET',
+        'SAVE_GCODE_STATE', 'RESTORE_GCODE_STATE', 'M105', 'M112', 'M115', 'IGNORE',
+        'GET_POSITION', 'RESTART', 'FIRMWARE_RESTART', 'ECHO', 'STATUS', 'HELP']
     # G-Code movement commands
     cmd_G1_aliases = ['G0']
     def cmd_G1(self, params):

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -437,7 +437,7 @@ class GCodeParser:
     all_handlers = [
         'G1', 'G4', 'G28', 'M400',
         'G20', 'M82', 'M83', 'G90', 'G91', 'G92', 'M114', 'M220', 'M221',
-        'SET_PID_TERMS', 'GET_PID_TERMS', 'RESET_PID_INTEGRATOR', 'SET_GCODE_OFFSET',
+        'SET_PID_TERMS', 'RESET_PID_TERMS', 'GET_PID_TERMS', 'RESET_PID_INTEGRATOR', 'SET_GCODE_OFFSET',
         'SAVE_GCODE_STATE', 'RESTORE_GCODE_STATE', 'M105', 'M112', 'M115', 'IGNORE',
         'GET_POSITION', 'RESTART', 'FIRMWARE_RESTART', 'ECHO', 'STATUS', 'HELP']
     # G-Code movement commands
@@ -541,8 +541,8 @@ class GCodeParser:
     cmd_SET_PID_TERMS_help = "Set the PID terms for HEATER_NAME"
     def cmd_SET_PID_TERMS(self, params):
         heater_name = self.get_str('HEATER_NAME', params, 'extruder')
-	try:
-	    Kp = self.get_float('P', params, None)
+        try:
+            Kp = self.get_float('P', params, None)
             Ki = self.get_float('I', params, None)
             Kd = self.get_float('D', params, None)
             heater = self.heaters.lookup_heater(heater_name)
@@ -553,8 +553,22 @@ class GCodeParser:
                               "Ki: %s\n"
                               "Kd: %s\n"
                               % (heater_name, Kp, Ki, Kd))
-	except Exception as e:
-	    self.respond_info(str(e))
+        except Exception as e:
+            self.respond_info(str(e))
+    cmd_RESET_PID_TERMS_help = "Reset the PID terms for HEATER_NAME to default"
+    def cmd_RESET_PID_TERMS(self, params):
+        heater_name = self.get_str('HEATER_NAME', params, 'extruder')
+        try:
+            heater = self.heaters.lookup_heater(heater_name)
+            heater.control.reset_terms()
+            Kp, Ki, Kd = heater.control.get_terms()
+            self.respond_info("Heater: %s\n"
+                              "Kp: %s\n"
+                              "Ki: %s\n"
+                              "Kd: %s\n"
+                              % (heater_name, Kp, Ki, Kd))
+        except Exception as e:
+            self.respond_info(str(e))
     cmd_GET_PID_TERMS_help = "Query HEATER_NAME for its PID terms"
     def cmd_GET_PID_TERMS(self, params):
         heater_name = self.get_str('HEATER_NAME', params, 'extruder')
@@ -574,8 +588,8 @@ class GCodeParser:
         try:
             heater = self.heaters.lookup_heater(heater_name)
             heater.control.reset_integrator()
-        except:
-            self.respond_info("Invalid heater '%s'" % heater_name)
+        except Exception as e:
+            self.respond_info(str(e))
     cmd_SET_GCODE_OFFSET_help = "Set a virtual offset to g-code positions"
     def cmd_SET_GCODE_OFFSET(self, params):
         move_delta = [0., 0., 0., 0.]

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -541,26 +541,41 @@ class GCodeParser:
     cmd_SET_PID_TERMS_help = "Set the PID terms for HEATER_NAME"
     def cmd_SET_PID_TERMS(self, params):
         heater_name = self.get_str('HEATER_NAME', params, 'extruder')
-        Kp = self.get_float('P', params, None)
-        Ki = self.get_float('I', params, None)
-        Kd = self.get_float('D', params, None)
-        heater = self.heaters.lookup_heater(heater_name)
-        heater.set_pid_terms(Kp, Ki, Kd)
+	try:
+	    Kp = self.get_float('P', params, None)
+            Ki = self.get_float('I', params, None)
+            Kd = self.get_float('D', params, None)
+            heater = self.heaters.lookup_heater(heater_name)
+            heater.control.set_terms(Kp, Ki, Kd)
+            Kp, Ki, Kd = heater.control.get_terms()
+            self.respond_info("Heater: %s\n"
+                              "Kp: %s\n"
+                              "Ki: %s\n"
+                              "Kd: %s\n"
+                              % (heater_name, Kp, Ki, Kd))
+	except Exception as e:
+	    self.respond_info(str(e))
     cmd_GET_PID_TERMS_help = "Query HEATER_NAME for its PID terms"
     def cmd_GET_PID_TERMS(self, params):
         heater_name = self.get_str('HEATER_NAME', params, 'extruder')
-        heater = self.heaters.lookup_heater(heater_name)
-        Kp, Ki, Kd = heater.get_pid_terms()
-        self.respond_info("Heater: %s\n"
-                          "Kp: %s\n"
-                          "Ki: %s\n"
-                          "Kd: %s\n"
-                          % (heater_name, Kp, Ki, Kd))
+        try:
+            heater = self.heaters.lookup_heater(heater_name)
+            Kp, Ki, Kd = heater.control.get_terms()
+            self.respond_info("Heater: %s\n"
+                              "Kp: %s\n"
+                              "Ki: %s\n"
+                              "Kd: %s\n"
+                              % (heater_name, Kp, Ki, Kd))
+        except Exception as e:
+            self.respond_info(str(e))
     cmd_RESET_PID_INTEGRATOR_help = "Clear the PID integrator history"
     def cmd_RESET_PID_INTEGRATOR(self, params):
         heater_name = self.get_str('HEATER_NAME', params, 'extruder')
-        heater = self.heaters.lookup_heater(heater_name)
-        heater.reset_integrator()
+        try:
+            heater = self.heaters.lookup_heater(heater_name)
+            heater.control.reset_integrator()
+        except:
+            self.respond_info("Invalid heater '%s'" % heater_name)
     cmd_SET_GCODE_OFFSET_help = "Set a virtual offset to g-code positions"
     def cmd_SET_GCODE_OFFSET(self, params):
         move_delta = [0., 0., 0., 0.]

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -538,24 +538,29 @@ class GCodeParser:
         e_value = (last_e_pos - self.base_position[3]) / self.extrude_factor
         self.base_position[3] = last_e_pos - e_value * new_extrude_factor
         self.extrude_factor = new_extrude_factor
+    cmd_SET_PID_TERMS_help = "Sets the P, I, and D terms for the specified HEATER_NAME"
     def cmd_SET_PID_TERMS(self, params):
         heater_name = self.get_str('HEATER_NAME', params, "extruder")
         Kp = self.get_float('P', params, None)
         Ki = self.get_float('I', params, None)
         Kd = self.get_float('D', params, None)
-        if self.heaters is not None:
+        if self.heaters is not None and heater_name is not None:
             heater = self.heaters.lookup_heater(heater_name)
             if heater is not None:
-                heater.update_pid_terms(Kp, Ki, Kd)
+                heater.set_pid_terms(Kp, Ki, Kd)
+    cmd_GET_PID_TERMS_help = "Queries the specified HEATER_NAME for its current PID terms"
     def cmd_GET_PID_TERMS(self, params):
         heater_name = self.get_str('HEATER_NAME', params, "extruder")
-        Kp = self.get_float('P', params, None)
-        Ki = self.get_float('I', params, None)
-        Kd = self.get_float('D', params, None)
-        if self.heaters is not None:
+        if self.heaters is not None and heater_name is not None:
             heater = self.heaters.lookup_heater(heater_name)
             if heater is not None:
-                heater.update_pid_terms(Kp, Ki, Kd)
+                Kp, Ki, Kd = heater.get_pid_terms()
+                self.respond_info("Heater: %s\n"
+                                  "Kp: %s\n"
+                                  "Ki: %s\n"
+                                  "Kd: %s\n"
+                                  % (heater_name, Kp, Ki, Kd))
+    cmd_RESET_PID_INTEGRATOR_help = "Clears the PID integrators history by setting it to zero"
     def cmd_RESET_PID_INTEGRATOR(self, params):
         heater_name = self.get_str('HEATER_NAME', params, "extruder")
         if self.heaters is not None:

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -60,6 +60,7 @@ class GCodeParser:
         self.need_ack = False
         self.toolhead = None
         self.heaters = None
+        self.heaters
         self.axis2pos = {'X': 0, 'Y': 1, 'Z': 2, 'E': 3}
     def register_command(self, cmd, func, when_not_ready=False, desc=None):
         if func is None:
@@ -166,6 +167,7 @@ class GCodeParser:
         self._respond_state("Disconnect")
     def _handle_ready(self):
         self.is_printer_ready = True
+        self
         self.gcode_handlers = self.ready_gcode_handlers
         # Lookup printer components
         self.heaters = self.printer.lookup_object('heater')
@@ -536,6 +538,30 @@ class GCodeParser:
         e_value = (last_e_pos - self.base_position[3]) / self.extrude_factor
         self.base_position[3] = last_e_pos - e_value * new_extrude_factor
         self.extrude_factor = new_extrude_factor
+    def cmd_SET_PID_TERMS(self, params):
+        heater_name = self.get_str('HEATER_NAME', params, "extruder")
+        Kp = self.get_float('P', params, None)
+        Ki = self.get_float('I', params, None)
+        Kd = self.get_float('D', params, None)
+        if self.heaters is not None:
+            heater = self.heaters.lookup_heater(heater_name)
+            if heater is not None:
+                heater.update_pid_terms(Kp, Ki, Kd)
+    def cmd_GET_PID_TERMS(self, params):
+        heater_name = self.get_str('HEATER_NAME', params, "extruder")
+        Kp = self.get_float('P', params, None)
+        Ki = self.get_float('I', params, None)
+        Kd = self.get_float('D', params, None)
+        if self.heaters is not None:
+            heater = self.heaters.lookup_heater(heater_name)
+            if heater is not None:
+                heater.update_pid_terms(Kp, Ki, Kd)
+    def cmd_RESET_PID_INTEGRATOR(self, params):
+        heater_name = self.get_str('HEATER_NAME', params, "extruder")
+        if self.heaters is not None:
+            heater = self.heaters.lookup_heater(heater_name)
+            if heater is not None:
+                heater.reset_integrator()
     cmd_SET_GCODE_OFFSET_help = "Set a virtual offset to g-code positions"
     def cmd_SET_GCODE_OFFSET(self, params):
         move_delta = [0., 0., 0., 0.]

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -538,35 +538,29 @@ class GCodeParser:
         e_value = (last_e_pos - self.base_position[3]) / self.extrude_factor
         self.base_position[3] = last_e_pos - e_value * new_extrude_factor
         self.extrude_factor = new_extrude_factor
-    cmd_SET_PID_TERMS_help = "Sets the P, I, and D terms for the specified HEATER_NAME"
+    cmd_SET_PID_TERMS_help = "Set the PID terms for HEATER_NAME"
     def cmd_SET_PID_TERMS(self, params):
-        heater_name = self.get_str('HEATER_NAME', params, "extruder")
+        heater_name = self.get_str('HEATER_NAME', params, 'extruder')
         Kp = self.get_float('P', params, None)
         Ki = self.get_float('I', params, None)
         Kd = self.get_float('D', params, None)
-        if self.heaters is not None and heater_name is not None:
-            heater = self.heaters.lookup_heater(heater_name)
-            if heater is not None:
-                heater.set_pid_terms(Kp, Ki, Kd)
-    cmd_GET_PID_TERMS_help = "Queries the specified HEATER_NAME for its current PID terms"
+        heater = self.heaters.lookup_heater(heater_name)
+        heater.set_pid_terms(Kp, Ki, Kd)
+    cmd_GET_PID_TERMS_help = "Query HEATER_NAME for its PID terms"
     def cmd_GET_PID_TERMS(self, params):
-        heater_name = self.get_str('HEATER_NAME', params, "extruder")
-        if self.heaters is not None and heater_name is not None:
-            heater = self.heaters.lookup_heater(heater_name)
-            if heater is not None:
-                Kp, Ki, Kd = heater.get_pid_terms()
-                self.respond_info("Heater: %s\n"
-                                  "Kp: %s\n"
-                                  "Ki: %s\n"
-                                  "Kd: %s\n"
-                                  % (heater_name, Kp, Ki, Kd))
-    cmd_RESET_PID_INTEGRATOR_help = "Clears the PID integrators history by setting it to zero"
+        heater_name = self.get_str('HEATER_NAME', params, 'extruder')
+        heater = self.heaters.lookup_heater(heater_name)
+        Kp, Ki, Kd = heater.get_pid_terms()
+        self.respond_info("Heater: %s\n"
+                          "Kp: %s\n"
+                          "Ki: %s\n"
+                          "Kd: %s\n"
+                          % (heater_name, Kp, Ki, Kd))
+    cmd_RESET_PID_INTEGRATOR_help = "Clear the PID integrator history"
     def cmd_RESET_PID_INTEGRATOR(self, params):
-        heater_name = self.get_str('HEATER_NAME', params, "extruder")
-        if self.heaters is not None:
-            heater = self.heaters.lookup_heater(heater_name)
-            if heater is not None:
-                heater.reset_integrator()
+        heater_name = self.get_str('HEATER_NAME', params, 'extruder')
+        heater = self.heaters.lookup_heater(heater_name)
+        heater.reset_integrator()
     cmd_SET_GCODE_OFFSET_help = "Set a virtual offset to g-code positions"
     def cmd_SET_GCODE_OFFSET(self, params):
         move_delta = [0., 0., 0., 0.]

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -97,7 +97,7 @@ class Heater:
         return self.max_power
     def get_smooth_time(self):
         return self.smooth_time
-    def set_temp(self, print_time, degrees):
+    def set_temp(self, degrees):
         if degrees and (degrees < self.min_temp or degrees > self.max_temp):
             raise self.printer.command_error(
                 "Requested temperature (%.1f) out of range (%.1f:%.1f)"
@@ -139,9 +139,8 @@ class Heater:
         return {'temperature': smoothed_temp, 'target': target_temp}
     cmd_SET_HEATER_TEMPERATURE_help = "Sets a heater temperature"
     def cmd_SET_HEATER_TEMPERATURE(self, params):
-        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         temp = self.gcode.get_float('TARGET', params, 0.)
-        self.set_temp(print_time, temp)
+        self.set_temp(temp)
 
 
 ######################################################################
@@ -277,13 +276,12 @@ class PrinterHeaters:
                 "G-Code sensor id %s already registered" % (gcode_id,))
         self.gcode_id_to_sensor[gcode_id] = psensor
         self.available_sensors.append(config.get_name())
-    def turn_off_all_heaters(self, print_time):
+    def turn_off_all_heaters(self, print_time=0.):
         for heater in self.heaters.values():
-            heater.set_temp(print_time, 0.)
+            heater.set_temp(0.)
     cmd_TURN_OFF_HEATERS_help = "Turn off all heaters"
     def cmd_TURN_OFF_HEATERS(self, params):
-        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
-        self.turn_off_all_heaters(print_time)
+        self.turn_off_all_heaters()
     def get_status(self, eventtime):
         return {'available_heaters': self.available_heaters,
                 'available_sensors': self.available_sensors}

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -140,11 +140,11 @@ class Heater:
     def set_pid_terms(self, Kp=None, Ki=None, Kd=None):
         if self.control is not None:
             if type(self.control) is ControlPID:
-                self.control.set_pid_terms(Kp, Ki, Kd)
+                self.control.set_terms(Kp, Ki, Kd)
     def get_pid_terms(self):
         if self.control is not None:
             if type(self.control) is ControlPID:
-                return self.control.get_pid_terms()
+                return self.control.get_terms()
     def reset_pid_integrator(self):
         if self.control is not None:
             if type(self.control) is ControlPID:

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -177,12 +177,14 @@ class ControlPID:
         self.heater = heater
         self.heater_max_power = heater.get_max_power()
         self.min_deriv_time = heater.get_smooth_time()
-        self.imax = config.getfloat('pid_integral_max', self.heater_max_power,
-                               minval=0.)
-        self.Kp = config.getfloat('pid_Kp') / PID_PARAM_BASE
-        self.Ki = config.getfloat('pid_Ki') / PID_PARAM_BASE
-        self.Kd = config.getfloat('pid_Kd') / PID_PARAM_BASE
-        self.temp_integ_max = self.imax / self.Ki
+        self.IMAX = config.getfloat('pid_integral_max', self.heater_max_power, minval=0.)
+        self.INITIAL_KP = config.getfloat('pid_Kp') / PID_PARAM_BASE
+        self.INITIAL_KI = config.getfloat('pid_Ki') / PID_PARAM_BASE
+        self.INITIAL_KD = config.getfloat('pid_Kd') / PID_PARAM_BASE
+        self.Kp = self.INITIAL_KP
+        self.Ki = self.INITIAL_KI
+        self.Kd = self.INITIAL_KD
+        self.temp_integ_max = self.IMAX / self.Ki
         self.prev_temp = AMBIENT_TEMP
         self.prev_temp_time = 0.
         self.prev_temp_deriv = 0.
@@ -222,11 +224,13 @@ class ControlPID:
                 self.temp_integ_max = 0.
             else:
                 self.Ki = Ki / PID_PARAM_BASE
-                self.temp_integ_max = self.imax / self.Ki
+                self.temp_integ_max = self.IMAX / self.Ki
             self.prev_temp_integ = 0.
         if Kd is not None:
             self.Kd = Kd / PID_PARAM_BASE
             self.prev_temp_deriv = 0.
+    def reset_terms(self):
+        self.set_terms(self.INITIAL_KP, self.INITIAL_KID, self.INITIAL_KD)
     def get_terms(self):
         return (self.Kp * PID_PARAM_BASE), (self.Ki * PID_PARAM_BASE), (self.Kd * PID_PARAM_BASE)
     def reset_integrator(self):

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -230,7 +230,7 @@ class ControlPID:
             self.Kd = Kd / PID_PARAM_BASE
             self.prev_temp_deriv = 0.
     def reset_terms(self):
-        self.set_terms(self.INITIAL_KP, self.INITIAL_KID, self.INITIAL_KD)
+        self.set_terms(self.INITIAL_KP, self.INITIAL_KI, self.INITIAL_KD)
     def get_terms(self):
         return (self.Kp * PID_PARAM_BASE), (self.Ki * PID_PARAM_BASE), (self.Kd * PID_PARAM_BASE)
     def reset_integrator(self):

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -178,12 +178,12 @@ class ControlPID:
         self.heater_max_power = heater.get_max_power()
         self.min_deriv_time = heater.get_smooth_time()
         self.IMAX = config.getfloat('pid_integral_max', self.heater_max_power, minval=0.)
-        self.INITIAL_KP = config.getfloat('pid_Kp') / PID_PARAM_BASE
-        self.INITIAL_KI = config.getfloat('pid_Ki') / PID_PARAM_BASE
-        self.INITIAL_KD = config.getfloat('pid_Kd') / PID_PARAM_BASE
-        self.Kp = self.INITIAL_KP
-        self.Ki = self.INITIAL_KI
-        self.Kd = self.INITIAL_KD
+        self.INITIAL_KP = config.getfloat('pid_Kp')
+        self.INITIAL_KI = config.getfloat('pid_Ki')
+        self.INITIAL_KD = config.getfloat('pid_Kd')
+        self.Kp = self.INITIAL_KP / PID_PARAM_BASE
+        self.Ki = self.INITIAL_KI / PID_PARAM_BASE
+        self.Kd = self.INITIAL_KD / PID_PARAM_BASE
         self.temp_integ_max = self.IMAX / self.Ki
         self.prev_temp = AMBIENT_TEMP
         self.prev_temp_time = 0.
@@ -218,12 +218,10 @@ class ControlPID:
         if Kp is not None:
             self.Kp = Kp / PID_PARAM_BASE
         if Ki is not None:
-            print type(Ki)
+            self.Ki = Ki / PID_PARAM_BASE
             if Ki is 0:
-                self.Ki = 0.
                 self.temp_integ_max = 0.
             else:
-                self.Ki = Ki / PID_PARAM_BASE
                 self.temp_integ_max = self.IMAX / self.Ki
             self.prev_temp_integ = 0.
         if Kd is not None:

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -145,7 +145,6 @@ class PrinterExtruder:
                           start_v, cruise_v, accel)
     def cmd_M104(self, params, wait=False):
         # Set Extruder Temperature
-        toolhead = self.printer.lookup_object('toolhead')
         gcode = self.printer.lookup_object('gcode')
         temp = gcode.get_float('S', params, 0.)
         if 'T' in params:
@@ -159,10 +158,9 @@ class PrinterExtruder:
                     return
                 raise gcode.error("Extruder not configured")
         else:
-            extruder = toolhead.get_extruder()
-        print_time = toolhead.get_last_move_time()
+            extruder = self.printer.lookup_object('toolhead').get_extruder()
         heater = extruder.get_heater()
-        heater.set_temp(print_time, temp)
+        heater.set_temp(temp)
         if wait and temp:
             gcode.wait_for_temperature(heater)
     def cmd_M109(self, params):


### PR DESCRIPTION
These commands allow updating PID terms "on-the-fly".  This allows anyone to script different terms for different portions of their print.  It also allows for more advanced PID tuning for those of us interested in doing so.

Fixes #1167 , #2324 , #2331, #1215 

I apologize that there is probably some cleanup here to be done but I was just trying to get something out there before the end of the day.