### PR TITLE
Set force for move actions

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -228,7 +228,7 @@ input_max: 200.0
 input_step: 10.0
 gcode:
     G90
-    G1 X{0:.1f}
+    G1 X{0:.1f} F2400
 
 [menu __control __move_10mm __axis_y]
 type: input
@@ -239,7 +239,7 @@ input_max: 200.0
 input_step: 10.0
 gcode:
     G90
-    G1 Y{0:.1f}
+    G1 Y{0:.1f} F2400
 
 [menu __control __move_10mm __axis_z]
 type: input
@@ -251,7 +251,7 @@ input_max: 200.0
 input_step: 10.0
 gcode:
     G90
-    G1 Z{0:.1f}
+    G1 Z{0:.1f} F240
 
 [menu __control __move_10mm __axis_e]
 type: input
@@ -284,7 +284,7 @@ input_max: 200.0
 input_step: 1.0
 gcode:
     G90
-    G1 X{0:.1f}
+    G1 X{0:.1f} F2400
 
 [menu __control __move_1mm __axis_y]
 type: input
@@ -295,7 +295,7 @@ input_max: 200.0
 input_step: 1.0
 gcode:
     G90
-    G1 Y{0:.1f}
+    G1 Y{0:.1f} F2400
 
 [menu __control __move_1mm __axis_z]
 type: input
@@ -307,7 +307,7 @@ input_max: 200.0
 input_step: 1.0
 gcode:
     G90
-    G1 Z{0:.1f}
+    G1 Z{0:.1f} F240
 
 [menu __control __move_1mm __axis_e]
 type: input
@@ -340,7 +340,7 @@ input_max: 200.0
 input_step: 0.1
 gcode:
     G90
-    G1 X{0:.1f}
+    G1 X{0:.1f} F2400
 
 [menu __control __move_01mm __axis_y]
 type: input
@@ -351,7 +351,7 @@ input_max: 200.0
 input_step: 0.1
 gcode:
     G90
-    G1 Y{0:.1f}
+    G1 Y{0:.1f} F2400
 
 [menu __control __move_01mm __axis_z]
 type: input
@@ -363,7 +363,7 @@ input_max: 200.0
 input_step: 0.1
 gcode:
     G90
-    G1 Z{0:.1f}
+    G1 Z{0:.1f} F240
 
 [menu __control __move_01mm __axis_e]
 type: input


### PR DESCRIPTION
Issue:
Navigate to the move menu (LCD Menu).
Select and deselect axis e
From this point all movements are performed only with F240

Solution:
Define a fixed F Value for all other axis. F2400 for X and Y, F240 for Z appears with as a good value


Signed-off-by: Christian Schnellrieder schnellrieder.cs@gmail.com