### PR TITLE
config: Update TAZ6 configuration

### DIFF
--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -2,6 +2,8 @@
 # use this config, the firmware should be compiled for the AVR
 # atmega2560.
 
+# For a TAZ6 with DualV3 extruder, see printer-lulzbot-taz6-dual-v3-2017.cfg.
+
 # See the example.cfg file for a description of available parameters.
 
 [stepper_x]
@@ -25,7 +27,6 @@ position_endstop: 306
 position_min: -20
 position_max: 306
 homing_speed: 50
-
 [stepper_z]
 step_pin: PC2
 dir_pin: PL2
@@ -37,6 +38,7 @@ position_min: -1.5
 position_max: 270
 homing_speed: 1
 
+# settings for "Tilapia" Hexagon extruder (TAZ6 standard)
 [extruder]
 step_pin: PC3
 dir_pin: !PL6
@@ -55,19 +57,33 @@ min_temp: 0
 max_temp: 300
 min_extrude_temp: 140
 
-#[extruder1]
-#step_pin: PC4
-#dir_pin: PL7
-#enable_pin: !PA3
-#heater_pin: PH4
-#sensor_pin: PF1
-#...
+# settings for "Angelfish" Aerostruder (E3D Titan Aero V6)
+#[extruder]
+#step_pin: PC3
+#dir_pin: !PL6
+#enable_pin: !PA4
+#step_distance: 0.002381
+#nozzle_diameter: 0.400
+#filament_diameter: 2.920
+#heater_pin: PH6
+#sensor_type: ATC Semitec 104GT-2
+#sensor_pin: PF0
+#control: pid
+#pid_Kp: 21.00
+#pid_Ki: 1.78
+#pid_Kd: 61.93
+#min_temp: 0
+#max_temp: 300
+#min_extrude_temp: 140
 
 [heater_bed]
 heater_pin: PE5
-sensor_type: EPCOS 100K B57560G104F
+sensor_type: Honeywell 100K 135-104LAG-J01
 sensor_pin: PF2
-control: watermark
+control: pid
+pid_Kp: 162.0
+pid_Ki: 17.0
+pid_Kd: 378.0
 min_temp: 0
 max_temp: 130
 
@@ -114,3 +130,33 @@ lcd_type: st7920
 cs_pin: PG4
 sclk_pin: PJ2
 sid_pin: PG3
+encoder_pins: ^PJ6,^PJ5
+click_pin: ^!PE2
+menu_timeout: 5
+
+[probe]
+pin: ^!PA0
+z_offset:1.377
+speed: 0.5
+lift_speed: 1.5
+samples: 2
+sample_retract_dist: 1.0
+samples_tolerance: 0.075
+
+[bed_tilt]
+points: -5,-3
+        290,-3
+        290,292
+        -5,292
+speed: 75
+horizontal_move_z: 5
+
+[safe_z_home]
+home_xy_position: -19,265
+speed: 50.0
+z_hop: 10.0
+
+# Perform ABL by running G29 in START gcode
+[gcode_macro G29]
+gcode:
+    BED_TILT_CALIBRATE


### PR DESCRIPTION
Support probing the corner washers for the bed tilt using G29, flesh out the rest of the configuration for the display, and add support for the Aerostruder (commented out by default).