### PR TITLE
config: add missing bed_mesh mesh_min coordinates

### DIFF
--- a/config/printer-wanhao-duplicator-9-2018.cfg
+++ b/config/printer-wanhao-duplicator-9-2018.cfg
@@ -89,7 +89,7 @@ square_corner_velocity: 15.0
 
 [bed_mesh]
 speed: 120
-mesh_min: 0,0
+mesh_min: 27,3
 mesh_max: 270,290
 probe_count: 5,3
 horizontal_move_z: 10


### PR DESCRIPTION
This is a small change I forgot to make when copying my config to this template. Ready to merge if tests are passing.

Signed-off-by: Matt Shirley <mdshw5@gmail.com>