### PR TITLE
Updates to allow stm32f0 to work with klipper and a bootloader.

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -130,3 +130,7 @@ config INLINE_STEPPER_HACK
     bool
     depends on HAVE_GPIO
     default y
+
+config BOOTLOADER_SIZE
+    hex
+    default 0x0000

--- a/src/generic/armcm_boot.c
+++ b/src/generic/armcm_boot.c
@@ -8,6 +8,9 @@
 #include "autoconf.h" // CONFIG_MCU
 #include "command.h" // DECL_CONSTANT_STR
 #include "misc.h" // dynmem_start
+#if CONFIG_ARMCM_RAM_VECTORTABLE
+#include "stm32/internal.h"
+#endif
 
 // Export MCU type
 DECL_CONSTANT_STR("MCU", CONFIG_MCU);
@@ -15,16 +18,55 @@ DECL_CONSTANT_STR("MCU", CONFIG_MCU);
 // Symbols created by armcm_link.lds.S linker script
 extern uint32_t _data_start, _data_end, _data_flash;
 extern uint32_t _bss_start, _bss_end, _stack_start;
-
+#if CONFIG_ARMCM_RAM_VECTORTABLE
+extern uint32_t _text_vectortable_start, _text_vectortable_end;
+extern uint32_t _ram_vectortable_start;
+extern uint32_t _stack_end;
+#endif
 
 /****************************************************************
  * Basic interrupt handlers
  ****************************************************************/
-
 // Initial code entry point - invoked by the processor after a reset
 void
 ResetHandler(void)
 {
+#if CONFIG_ARMCM_RAM_VECTORTABLE
+    // disable systick for malyan bootloaders
+    // other interrupts may need to be disabled because of different bootloaders
+    SysTick->CTRL &= ~(SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk);
+
+    // feed watchdog if enabled
+    if(IWDG->KR) IWDG->KR = 0x0000AAAAU;
+
+    // disable interrupts
+    asm volatile("cpsid i" ::: "memory");
+    asm volatile("cpsid f" ::: "memory");
+
+    // force clear backup registers
+    RCC->BDCR |= RCC_BDCR_BDRST;
+    RCC->BDCR &= ~RCC_BDCR_BDRST;
+
+    // set stack pointer
+    asm volatile(
+        "  ldr r0, =_stack_end\n"
+        "  mov sp, r0\n"
+        ::: "memory");
+
+    // copy vectortable
+    uint32_t count_vt = (&_text_vectortable_end - &_text_vectortable_start) * 4;
+    __builtin_memcpy(&_ram_vectortable_start, &_text_vectortable_start,
+        count_vt);
+
+    // remap 0x0 to sram vector table
+    SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_MEM_MODE_0 | SYSCFG_CFGR1_MEM_MODE_1);
+    SYSCFG->CFGR1 |= (SYSCFG_CFGR1_MEM_MODE_0 | SYSCFG_CFGR1_MEM_MODE_1);
+
+    // enable interrupts
+    asm volatile("cpsie i" ::: "memory");
+    asm volatile("cpsie f" ::: "memory");
+#endif
+
     // Copy global variables from flash to ram
     uint32_t count = (&_data_end - &_data_start) * 4;
     __builtin_memcpy(&_data_start, &_data_flash, count);

--- a/src/generic/armcm_link.lds.S
+++ b/src/generic/armcm_link.lds.S
@@ -11,23 +11,38 @@ OUTPUT_ARCH(arm)
 
 MEMORY
 {
-  rom (rx) : ORIGIN = CONFIG_FLASH_START , LENGTH = CONFIG_FLASH_SIZE
-  ram (rwx) : ORIGIN = CONFIG_RAM_START , LENGTH = CONFIG_RAM_SIZE
+  rom (rx) : ORIGIN = CONFIG_FLASH_START , LENGTH = CONFIG_FLASH_SIZE - CONFIG_BOOTLOADER_SIZE
+#if !CONFIG_ARMCM_RAM_VECTORTABLE
+  ram (rwx) : ORIGIN = CONFIG_RAM_START, LENGTH = CONFIG_RAM_SIZE
+#else
+  vt (rwx) : ORIGIN = CONFIG_RAM_START , LENGTH = CONFIG_ARMCM_RAM_VECTORTABLE_SIZE
+  ram (rwx) : ORIGIN = CONFIG_RAM_START + CONFIG_ARMCM_RAM_VECTORTABLE_SIZE,
+    LENGTH = CONFIG_RAM_SIZE - CONFIG_ARMCM_RAM_VECTORTABLE_SIZE
+#endif
 }
 
 SECTIONS
 {
     .text : {
         . = ALIGN(4);
+        _text_vectortable_start = .;
         KEEP(*(.vector_table))
+        _text_vectortable_end = .;
         *(.text .text.*)
         *(.rodata .rodata*)
     } > rom
 
-    . = ALIGN(4);
-    _data_flash = .;
+#if CONFIG_ARMCM_RAM_VECTORTABLE
+    .ram_vectortable (NOLOAD) : {
+        _ram_vectortable_start = .;
+        . = . + ( _text_vectortable_end - _text_vectortable_start ) ;
+        _ram_vectortable_end = .;
+    } > vt
+#endif
 
-    .data : AT (_data_flash)
+    _data_flash = LOADADDR(.data);
+
+    .data :
     {
         . = ALIGN(4);
         _data_start = .;
@@ -35,7 +50,7 @@ SECTIONS
         *(.data .data.*);
         . = ALIGN(4);
         _data_end = .;
-    } > ram
+    } > ram AT>rom
 
     .bss (NOLOAD) :
     {

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -92,9 +92,9 @@ config STACK_SIZE
     default 512
 
 choice
-    prompt "Bootloader offset" if MACH_STM32F407 || MACH_STM32F103
+    prompt "Bootloader offset" if MACH_STM32F407 || MACH_STM32F103 || MACH_STM32F070
     config STM32_FLASH_START_2000
-        bool "8KiB bootloader (stm32duino)" if MACH_STM32F103
+        bool "8KiB bootloader (stm32duino)" if MACH_STM32F103 || MACH_STM32F070
     config STM32_FLASH_START_7000
         bool "28KiB bootloader" if MACH_STM32F103
     config STM32_FLASH_START_8000
@@ -102,12 +102,28 @@ choice
     config STM32_FLASH_START_0000
         bool "No bootloader"
 endchoice
+config BOOTLOADER_SIZE
+    hex
+    default 0x2000 if STM32_FLASH_START_2000
+    default 0x7000 if STM32_FLASH_START_7000
+    default 0x8000 if STM32_FLASH_START_8000
+    default 0x0000
+
 config FLASH_START
     hex
     default 0x8002000 if STM32_FLASH_START_2000
     default 0x8007000 if STM32_FLASH_START_7000
     default 0x8008000 if STM32_FLASH_START_8000
     default 0x8000000
+
+config ARMCM_RAM_VECTORTABLE
+    bool
+    default y if MACH_STM32F0 && FLASH_START != 0x8000000
+    default n
+config ARMCM_RAM_VECTORTABLE_SIZE
+    hex
+    default 0xC0 if MACH_STM32F0 && FLASH_START != 0x8000000
+    default 0x00
 
 choice
     prompt "Clock Reference" if LOW_LEVEL_OPTIONS


### PR DESCRIPTION
Includes code by KevinOConnor.  Special thanks to JC Nelson for much
help.

Tested on Monoprice Mini Delta (malyan) stm32f070xb board.

Signed-off-by: Chris Lombardi <clearchris@hotmail.com>