### PR TITLE
Update step_distance for creality ender 5 config

### DIFF
--- a/config/printer-creality-ender5-2019.cfg
+++ b/config/printer-creality-ender5-2019.cfg
@@ -35,7 +35,7 @@ homing_speed: 30
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: .0025
+step_distance: .001266
 endstop_pin: ^PC4
 position_endstop: 0.0
 position_max: 300


### PR DESCRIPTION
My stock Ender 5 (1.1.4 board) would start squeezing the model on the Z axis, this value for the step_distance had fixed it and prints correctly now after installing Klipper.