### PR TITLE
module: simple-pid implementation for PID heater control

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -107,6 +107,24 @@ The following standard commands are supported:
   equivalent resistance given that pullup is reported.
 - `GET_POSITION`: Return information on the current location of the
   toolhead.
+- `SET_PID_TERMS [HEATER_NAME=<Heater>] [P=<Kp value>] [I=<Ki value>] 
+  [D=<Kd value]`: Set the Kp, Ki, and/or Kd terms for the 
+  specified PID controller.  All arguments are optional and you
+  can choose to only specify the terms you want to modify instead of
+  changing them all at once.  If any term is not supplied as a
+  parameter then it remains unchanged.  The default HEATER_NAME
+  is 'extruder'.  Changes to the PID terms via this command are NOT 
+  saved to the config file.
+- `RESET_PID_TERMS_TO_DEFAULT [HEATER_NAME=<Heater>]`: Reset the Kp, Ki, 
+  and Kd terms on the specified heater PID controller to the values that 
+  were loaded from the printer configuration file on startup.  The default 
+  HEATER_NAME is 'extruder'.
+- `GET_PID_INFO [HEATER_NAME=<Heater>]`: Return all of the information relevant
+  to the PID controller of the specified heater.  Useful when tuning your PID
+  to view additional information about how it is performing.
+- `RESET_PID [HEATER_NAME=<Heater>]`: Reset the PID controller internals, 
+  setting each term to 0 as well as cleaning the integral, the last output 
+  and the last input (derivative calculation).
 - `SET_GCODE_OFFSET [X=<pos>|X_ADJUST=<adjust>]
   [Y=<pos>|Y_ADJUST=<adjust>] [Z=<pos>|Z_ADJUST=<adjust>]
   [MOVE=1 [MOVE_SPEED=<speed>]]`: Set a positional offset to apply to

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -107,23 +107,23 @@ The following standard commands are supported:
   equivalent resistance given that pullup is reported.
 - `GET_POSITION`: Return information on the current location of the
   toolhead.
-- `SET_PID_TERMS [HEATER_NAME=<Heater>] [P=<Kp value>] [I=<Ki value>] 
-  [D=<Kd value]`: Set the Kp, Ki, and/or Kd terms for the 
+- `SET_PID_TERMS [HEATER_NAME=<Heater>] [P=<Kp value>] [I=<Ki value>]
+  [D=<Kd value]`: Set the Kp, Ki, and/or Kd terms for the
   specified PID controller.  All arguments are optional and you
   can choose to only specify the terms you want to modify instead of
   changing them all at once.  If any term is not supplied as a
   parameter then it remains unchanged.  The default HEATER_NAME
-  is 'extruder'.  Changes to the PID terms via this command are NOT 
+  is 'extruder'.  Changes to the PID terms via this command are NOT
   saved to the config file.
-- `RESET_PID_TERMS_TO_DEFAULT [HEATER_NAME=<Heater>]`: Reset the Kp, Ki, 
-  and Kd terms on the specified heater PID controller to the values that 
-  were loaded from the printer configuration file on startup.  The default 
+- `RESET_PID_TERMS_TO_DEFAULT [HEATER_NAME=<Heater>]`: Reset the Kp, Ki,
+  and Kd terms on the specified heater PID controller to the values that
+  were loaded from the printer configuration file on startup.  The default
   HEATER_NAME is 'extruder'.
 - `GET_PID_INFO [HEATER_NAME=<Heater>]`: Return all of the information relevant
   to the PID controller of the specified heater.  Useful when tuning your PID
   to view additional information about how it is performing.
-- `RESET_PID [HEATER_NAME=<Heater>]`: Reset the PID controller internals, 
-  setting each term to 0 as well as cleaning the integral, the last output 
+- `RESET_PID [HEATER_NAME=<Heater>]`: Reset the PID controller internals,
+  setting each term to 0 as well as cleaning the integral, the last output
   and the last input (derivative calculation).
 - `SET_GCODE_OFFSET [X=<pos>|X_ADJUST=<adjust>]
   [Y=<pos>|Y_ADJUST=<adjust>] [Z=<pos>|Z_ADJUST=<adjust>]

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -444,9 +444,11 @@ class GCodeParser:
     all_handlers = [
         'G1', 'G4', 'G28', 'M400',
         'G20', 'M82', 'M83', 'G90', 'G91', 'G92', 'M114', 'M220', 'M221',
-        'GET_PID_INFO', 'SET_PID_TERMS', 'RESET_PID_TERMS_TO_DEFAULT', 'RESET_PID',
-        'SET_GCODE_OFFSET', 'SAVE_GCODE_STATE', 'RESTORE_GCODE_STATE', 'M105', 'M112',
-        'M115', 'IGNORE', 'GET_POSITION', 'RESTART', 'FIRMWARE_RESTART', 'ECHO', 'STATUS', 'HELP']
+        'GET_PID_INFO', 'SET_PID_TERMS', 'RESET_PID_TERMS_TO_DEFAULT', 
+        'RESET_PID', 'SET_GCODE_OFFSET', 'SAVE_GCODE_STATE', 
+        'RESTORE_GCODE_STATE', 'M105', 'M112', 'M115', 'IGNORE', 
+        'GET_POSITION', 'RESTART', 'FIRMWARE_RESTART', 'ECHO', 
+        'STATUS', 'HELP']
     # G-Code movement commands
     cmd_G1_aliases = ['G0']
     def cmd_G1(self, params):
@@ -562,7 +564,7 @@ class GCodeParser:
                               % (heater_name, Kp, Ki, Kd))
         except Exception as e:
             self.respond_info(str(e))
-    cmd_RESET_PID_TERMS_TO_DEFAULT_help = "Reset HEATER_NAME to default config-loaded PID terms"
+    cmd_RESET_PID_TERMS_TO_DEFAULT_help = "Reset PID terms to default values"
     def cmd_RESET_PID_TERMS_TO_DEFAULT(self, params):
         heater_name = self.get_str('HEATER_NAME', params, 'extruder')
         try:
@@ -581,10 +583,16 @@ class GCodeParser:
         heater_name = self.get_str('HEATER_NAME', params, 'extruder')
         try:
             heater = self.heaters.lookup_heater(heater_name)
-            active_Kp, active_Ki, active_Kd = heater.control.get_tuning()
-            default_Kp, default_Ki, default_Kd = heater.control.get_default_tuning()
+            active_Kp, 
+            active_Ki, 
+            active_Kd = heater.control.get_tuning()
+            default_Kp, 
+            default_Ki, 
+            default_Kd = heater.control.get_default_tuning()
             PonM = heater.control.get_proportional_on_measurement()
-            p_minus, i_minus, d_minus = heater.control.get_components()
+            p_minus, 
+            i_minus, 
+            d_minus = heater.control.get_components()
             output = heater.control.get_output()
             auto_mode = heater.control.get_auto_mode()
             out_limits = heater.control.get_output_limits()
@@ -605,8 +613,11 @@ class GCodeParser:
                               "output_low: %s\n"
                               "proportional on measurement: %s\n"
                               "setpoint: %s\n"
-                              % (heater_name, active_Kp, active_Ki, active_Kd, auto_mode, p_minus, i_minus, d_minus,
-                                 default_Kp, default_Ki, default_Kd, output, out_limits[1], out_limits[0], PonM,
+                              % (heater_name, active_Kp, active_Ki, 
+                                 active_Kd, auto_mode, p_minus, 
+                                 i_minus, d_minus, default_Kp, 
+                                 default_Ki, default_Kd, output, 
+                                 out_limits[1], out_limits[0], PonM,
                                  setpoint))
         except Exception as e:
             self.respond_info(str(e))

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -444,10 +444,10 @@ class GCodeParser:
     all_handlers = [
         'G1', 'G4', 'G28', 'M400',
         'G20', 'M82', 'M83', 'G90', 'G91', 'G92', 'M114', 'M220', 'M221',
-        'GET_PID_INFO', 'SET_PID_TERMS', 'RESET_PID_TERMS_TO_DEFAULT', 
-        'RESET_PID', 'SET_GCODE_OFFSET', 'SAVE_GCODE_STATE', 
-        'RESTORE_GCODE_STATE', 'M105', 'M112', 'M115', 'IGNORE', 
-        'GET_POSITION', 'RESTART', 'FIRMWARE_RESTART', 'ECHO', 
+        'GET_PID_INFO', 'SET_PID_TERMS', 'RESET_PID_TERMS_TO_DEFAULT',
+        'RESET_PID', 'SET_GCODE_OFFSET', 'SAVE_GCODE_STATE',
+        'RESTORE_GCODE_STATE', 'M105', 'M112', 'M115', 'IGNORE',
+        'GET_POSITION', 'RESTART', 'FIRMWARE_RESTART', 'ECHO',
         'STATUS', 'HELP']
     # G-Code movement commands
     cmd_G1_aliases = ['G0']
@@ -583,15 +583,15 @@ class GCodeParser:
         heater_name = self.get_str('HEATER_NAME', params, 'extruder')
         try:
             heater = self.heaters.lookup_heater(heater_name)
-            active_Kp, 
-            active_Ki, 
+            active_Kp,
+            active_Ki,
             active_Kd = heater.control.get_tuning()
-            default_Kp, 
-            default_Ki, 
+            default_Kp,
+            default_Ki,
             default_Kd = heater.control.get_default_tuning()
             PonM = heater.control.get_proportional_on_measurement()
-            p_minus, 
-            i_minus, 
+            p_minus,
+            i_minus,
             d_minus = heater.control.get_components()
             output = heater.control.get_output()
             auto_mode = heater.control.get_auto_mode()
@@ -613,10 +613,10 @@ class GCodeParser:
                               "output_low: %s\n"
                               "proportional on measurement: %s\n"
                               "setpoint: %s\n"
-                              % (heater_name, active_Kp, active_Ki, 
-                                 active_Kd, auto_mode, p_minus, 
-                                 i_minus, d_minus, default_Kp, 
-                                 default_Ki, default_Kd, output, 
+                              % (heater_name, active_Kp, active_Ki,
+                                 active_Kd, auto_mode, p_minus,
+                                 i_minus, d_minus, default_Kp,
+                                 default_Ki, default_Kd, output,
                                  out_limits[1], out_limits[0], PonM,
                                  setpoint))
         except Exception as e:

--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -6,3 +6,4 @@ cffi==1.12.2
 pyserial==3.4
 greenlet==0.4.15
 Jinja2==2.10.1
+simple-pid==0.2.4


### PR DESCRIPTION
replacing custom PID control algorithm in favor of simple-pid
library.  also adding additional extended gcode commands
for on-the-fly PID tuning and PID debugging.

Signed-off-by: Brandon Jones <bjones14@gmail.com>

---

These commands allow updating PID terms "on-the-fly".  This allows anyone to script different terms for different portions of their print.  It also allows for more advanced PID tuning for those of us interested in doing so.

Fixes #1167 
Fixes #2324 
Fixes #2331 
Fixes #1215 