### PR TITLE
printer-creality-ender5pro+3dTouch.cfg

### DIFF
--- a/config/printer-creality-ender5-2019.cfg
+++ b/config/printer-creality-ender5-2019.cfg
@@ -13,32 +13,34 @@
 
 [stepper_x]
 step_pin: PD7
-dir_pin: PC5
+dir_pin: !PC5
+#Reverse the logic to work correctly on the octoprint control preview
 enable_pin: !PD6
 step_distance: .0125
 endstop_pin: ^PC2
-position_endstop: 0
+position_endstop: 235
 position_max: 235
-homing_speed: 30
+homing_speed: 50
 
 [stepper_y]
 step_pin: PC6
-dir_pin: PC7
+dir_pin: !PC7
+Reverse the logic to work correctly on the octoprint control preview
 enable_pin: !PD6
 step_distance: .0125
 endstop_pin: ^PC3
-position_endstop: 0
+position_endstop: 235
 position_max: 235
-homing_speed: 30
+homing_speed: 50
 
 [stepper_z]
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
 step_distance: .0025
-endstop_pin: ^PC4
-position_endstop: 0.0
+endstop_pin:probe:z_virtual_endstop
 position_max: 300
+position_min: -1
 
 [extruder]
 max_extrude_only_distance: 100.0
@@ -91,3 +93,34 @@ sclk_pin: PA1
 sid_pin: PC1
 encoder_pins: ^PD2, ^PD3
 click_pin: ^!PC0
+
+[bltouch]
+sensor_pin: ^PC4
+control_pin: PA4
+x_offset: -45
+y_offset: -10
+z_offset: 4.7
+pin_move_time: 0.4
+pin_up_touch_mode_reports_triggered: False
+pin_up_reports_not_triggered: False
+
+ 
+
+[bed_mesh]
+speed: 80
+horizontal_move_z: 10
+mesh_min: 30,30
+mesh_max: 180,225
+probe_count: 5,5
+fade_start: 1.0
+mesh_pps: 2,2
+
+[gcode_macro G29]
+gcode:
+    BED_MESH_CALIBRATE
+ 
+[safe_z_home]
+home_xy_position: 160,138
+speed: 80.0
+z_hop: 10.0
+z_hop_speed: 10.0


### PR DESCRIPTION
This config is based on the existing Ender 5.config, created by xel prep. For better control with OctoPrint some directions for the steppers have been reversed and 3dTouch was configured.