### PR TITLE
Implement tmc2208 step+dir+step filter

### DIFF
--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -16,6 +16,9 @@ struct stepper_kinematics {
     double step_dist, commanded_pos;
     struct stepcompress *sc;
 
+    double next_move_print_time, next_step_time;
+    int next_step_dir;
+
     double last_flush_time, last_move_time;
     struct trapq *tq;
     int active_flags;

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -12,20 +12,10 @@ void stepcompress_fill(struct stepcompress *sc, uint32_t max_error
 void stepcompress_free(struct stepcompress *sc);
 int stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock);
 int stepcompress_queue_msg(struct stepcompress *sc, uint32_t *data, int len);
-double stepcompress_get_mcu_freq(struct stepcompress *sc);
 uint32_t stepcompress_get_oid(struct stepcompress *sc);
 int stepcompress_get_step_dir(struct stepcompress *sc);
-
-struct queue_append {
-    struct stepcompress *sc;
-    uint32_t *qnext, *qend, last_step_clock_32;
-    double clock_offset;
-};
-struct queue_append queue_append_start(
-    struct stepcompress *sc, double print_time, double adjust);
-void queue_append_finish(struct queue_append qa);
-int queue_append(struct queue_append *qa, double step_clock);
-int queue_append_set_next_step_dir(struct queue_append *qa, int sdir);
+int stepcompress_append(struct stepcompress *sc, int sdir
+                        , double print_time, double step_time);
 
 struct serialqueue;
 struct steppersync *steppersync_alloc(

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -1,6 +1,6 @@
 # Code for coordinating events on the printer toolhead
 #
-# Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging, importlib
@@ -183,6 +183,7 @@ class MoveQueue:
 
 MIN_KIN_TIME = 0.100
 MOVE_BATCH_TIME = 0.500
+SDS_CHECK_TIME = 0.001 # step+dir+step filter in itersolve.c
 
 DRIP_SEGMENT_TIME = 0.050
 DRIP_TIME = 0.100
@@ -236,7 +237,7 @@ class ToolHead:
         self.print_stall = 0
         self.drip_completion = None
         # Kinematic step generation scan window time tracking
-        self.kin_flush_delay = 0.
+        self.kin_flush_delay = SDS_CHECK_TIME
         self.kin_flush_times = []
         self.last_kin_flush_time = self.last_kin_move_time = 0.
         # Setup iterative solver
@@ -512,7 +513,7 @@ class ToolHead:
             self.kin_flush_times.pop(self.kin_flush_times.index(old_delay))
         if delay:
             self.kin_flush_times.append(delay)
-        new_delay = max(self.kin_flush_times + [0.])
+        new_delay = max(self.kin_flush_times + [SDS_CHECK_TIME])
         self.kin_flush_delay = new_delay
     def register_lookahead_callback(self, callback):
         last_move = self.move_queue.get_last()


### PR DESCRIPTION
It is not currently valid to run the tmc2208 drivers in "standalone mode" with Klipper due to what appears to be an issue in how the tmc2208 handles direction changes.  It is believed that a step followed by a direction change followed by a step in the opposite direction can cause it to experience an "over current" event if the two step pulses occur in a small time period.  This is described in the FAQ at https://www.klipper3d.org/FAQ.html#my-tmc-motor-driver-turns-off-in-the-middle-of-a-print .

This PR adds code to filter out rapid step+dir+step sequences.  This should, ideally, prevent issues with the tmc2208 - both when they are in standalone mode and in a "stealthchop" mode configured via the uart interface.  Some other stepper drivers have been observed to not handle rapid direction changes particularly well and there should be no harm in filtering these events, so this support is enabled for all steppers.

-Kevin