### PR TITLE
DISPLAY: Menu control from gcode macros

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -197,6 +197,23 @@ The following standard commands are supported:
   ((floor(z_height / band) + .5) * band)`.
 - `SET_IDLE_TIMEOUT [TIMEOUT=<timeout>]`:  Allows the user to set the
   idle timeout (in seconds).
+- `GOTO_MENU [MENU=<menu_item>]`:  Allows setting the printer display
+  to a specific list page on the printer display. If a specific list
+  item is also included the cursor will move to preset on that item.
+  You must use the entire menu name as declared in the menu file. For
+  example when pausing a print, to have the menu open to the Octoprint
+  list and highlight the resume print item the syntax would be
+  GOTO_MENU MENU="__octoprint __resume". It is not necessary to
+  specify a specific item within a list. Quotes must be used around
+  any list or item calls containing spaces. Calling 'GOTO_MENU'
+  without any arguments will return to the main display.
+- `MENU_TIMEOUT [ENABLE=0,1] [TIME=<seconds>]`:  Allows disabling
+  or changing the time of the display menu timeout. Can be used with
+  GOTO_MENU to wait for user interaction. Setting ENABLE=0 will
+  disable the menu timeout. Calling MENU_TIMEOUT without any
+  parameters or with ENABLE=1 will restore the menu timeout time to
+  the value declared in the config file. Using the TIME parameter
+  allows setting to a value other than declared in the config file.
 - `RESTART`: This will cause the host software to reload its config
   and perform an internal reset. This command will not clear error
   state from the micro-controller (see FIRMWARE_RESTART) nor will it

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -1635,8 +1635,8 @@ class MenuManager:
                             self.selected = 0
                             self.top_row = 0
                             searching = False
-                            self.gcode.respond_info('"%s" not currently available on page'
-                                                    % (m_item))
+                            self.gcode.respond_info('"%s" not currently
+                                            available on page' % (m_item))
                         elif self.selected < self.top_row + self.rows - 1:
                             self.selected += 1
                         else:

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -1635,8 +1635,9 @@ class MenuManager:
                             self.selected = 0
                             self.top_row = 0
                             searching = False
-                            self.gcode.respond_info('"%s" not currently
-                                            available on page' % (m_item))
+                            self.gcode.respond_info(
+                                '"%s" not currently available on page'
+                                % (m_item))
                         elif self.selected < self.top_row + self.rows - 1:
                             self.selected += 1
                         else:

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -1110,6 +1110,9 @@ class MenuManager:
                                         desc=self.cmd_DO_help)
         self.gcode.register_command("GOTO_MENU", self.cmd_GOTO_MENU,
                                         desc=self.cmd_GOTO_MENU_help)
+        self.gcode.register_command("DISPLAY_TIMEOUT", self.cmd_DISP_TIMEOUT,
+                                        desc=self.cmd_DISP_TIMEOUT_help)
+
         # Load local config file in same directory as current module
         self.load_config(os.path.dirname(__file__), 'menu.cfg')
         # Load items from main config
@@ -1639,6 +1642,25 @@ class MenuManager:
                         else:
                             self.top_row += 1
                             self.selected += 1
+
+    cmd_DISP_TIMEOUT_help = "Enable or Disable the display timeout"
+
+    def cmd_DISP_TIMEOUT(self, params):
+        time_enable = self.gcode.get_int('ENABLE', params, 1)
+        if time_enable == 0:
+            self.timeout_store()
+            self.timeout = 0
+        elif 'TIME' in params:
+            self.timeout = self.gcode.get_int('TIME', params, 30)
+        else:
+            self.timeout = self.timeout_store()
+        self.gcode.respond_info('Display Timeout set to "%d"'
+                                              % (self.timeout))
+
+    def timeout_store(self):
+        if not hasattr(self, "timeout_backup"):
+            self.timeout_backup = self.timeout
+        return self.timeout_backup
 
     # buttons & encoder callbacks
     def encoder_cw_callback(self, eventtime):

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -1110,8 +1110,8 @@ class MenuManager:
                                         desc=self.cmd_DO_help)
         self.gcode.register_command("GOTO_MENU", self.cmd_GOTO_MENU,
                                         desc=self.cmd_GOTO_MENU_help)
-        self.gcode.register_command("DISPLAY_TIMEOUT", self.cmd_DISP_TIMEOUT,
-                                        desc=self.cmd_DISP_TIMEOUT_help)
+        self.gcode.register_command("MENU_TIMEOUT", self.cmd_MENU_TIMEOUT,
+                                        desc=self.cmd_MENU_TIMEOUT_help)
 
         # Load local config file in same directory as current module
         self.load_config(os.path.dirname(__file__), 'menu.cfg')
@@ -1644,9 +1644,9 @@ class MenuManager:
                             self.top_row += 1
                             self.selected += 1
 
-    cmd_DISP_TIMEOUT_help = "Enable or Disable the display timeout"
+    cmd_MENU_TIMEOUT_help = "Enable, Disable, or change the menu timeout"
 
-    def cmd_DISP_TIMEOUT(self, params):
+    def cmd_MENU_TIMEOUT(self, params):
         time_enable = self.gcode.get_int('ENABLE', params, 1)
         if time_enable == 0:
             self.timeout_store()
@@ -1655,7 +1655,7 @@ class MenuManager:
             self.timeout = self.gcode.get_int('TIME', params, 30)
         else:
             self.timeout = self.timeout_store()
-        self.gcode.respond_info('Display Timeout set to "%d"'
+        self.gcode.respond_info('Menu Timeout set to "%d"'
                                               % (self.timeout))
 
     def timeout_store(self):


### PR DESCRIPTION
Add G-Code commands that allow setting the display to a specific list or moving cursor to specific item in a list to allow for anticipated user interaction.  Ability to disable menu timeout included to make it possible to await for user interaction.

The GOTO_MENU command clears the stack so the [..] back will return to main screen.  If called without any parameters it will return straight to the main screen

The DISPLAY_TIMEOUT command stores the value initially read from the config file and will restore it when timeout is re-enabled.  A "TIME" parameter is also available to set a value other than that in config.

I know menu changes are coming.  In that branch right now it looks like the methods this relies on have changed a little, but not so excessively as to not be possible to bring over.  Let me know your thoughts about committing this to the current master with the expectation that I would adapt it to work with the future menu system as well.

Signed-off-by: David O Smith <davidosmith@gmail.com>