### PR TITLE
aux_display:  support for multiple auxiliary LCD displays

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1812,6 +1812,36 @@
 #   The resistance range for a 'kill' button. Range minimum and maximum
 #   comma-separated values must be provided when using analog button.
 
+# If a primary [display] section has been defined in printer.cfg as shown
+# above it is possible to define multiple auxilary displays.  Note that
+# auxilary displays do not currently support menu functionality, thus they
+# do not support the "menu" options or button configuration.
+#[display my_display]
+#lcd_type:
+#rs_pin:
+#e_pin:
+#d4_pin:
+#d5_pin:
+#d6_pin:
+#d7_pin:
+#cs_pin:
+#sclk_pin:
+#sid_pin:
+#cs_pin:
+#a0_pin:
+#rst_pin:
+#contrast: 40
+#cs_pin:
+#dc_pin:
+#spi_bus:
+#spi_speed:
+#spi_software_sclk_pin:
+#spi_software_mosi_pin:
+#spi_software_miso_pin:
+#reset_pin:
+#   See the [display] section above for details on each configuration
+#   option above.
+
 
 ######################################################################
 # Filament sensors

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -77,8 +77,13 @@ The following standard G-Code commands are available if a
 
 The following standard G-Code commands are available if a "display"
 config section is enabled:
-- Display Message: `M117 <message>`
-- Set build percentage: `M73 P<percent>`
+- Display Message (on all displays): `M117 <message>`
+- Set build percentage (on all displays): `M73 P<percent>`
+- `SHOW_MESSAGE DISPLAY=<name> MESSAGE=<message> TIMEOUT=<timeout>`:  Shows
+  a message on the specified display.  If `MESSAGE` is not provided the
+  display will be cleared.  If a `TIMEOUT` is specified, the message will
+  be cleared after the specified number of seconds.  Note that the primary
+  display's name is `display`.
 
 ## Other available G-Code commands
 

--- a/klippy/extras/display/__init__.py
+++ b/klippy/extras/display/__init__.py
@@ -7,3 +7,15 @@ import display
 
 def load_config(config):
     return display.load_config(config)
+
+def load_config_prefix(config):
+    if not config.has_section('display'):
+        raise config.error(
+            "A primary [display] section must be defined in printer.cfg "
+            "to use auxilary displays")
+    name = config.get_name().split()[-1]
+    if name == "display":
+        raise config.error(
+            "Section name [display display] is not valid. "
+            "Please choose a different postfix.")
+    return display.load_config(config)

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -41,10 +41,14 @@ class PrinterLCD:
             self.screen_update_event)
         # Register commands
         self.gcode = self.printer.lookup_object('gcode')
-        name = config.get_name()
+        name = config.get_name().split()[-1]
         # Only register if no previous display object has been instantiated
         if name == "display":
             DisplayCommands(config)
+        self.gcode.register_mux_command(
+            "SHOW_MESSAGE", "DISPLAY", name,
+            self.cmd_SHOW_MESSAGE,
+            desc=self.cmd_SHOW_MESSAGE_help)
     # Initialization
     def handle_ready(self):
         self.lcd_chip.init()
@@ -253,6 +257,11 @@ class PrinterLCD:
     def set_progress(self, progress, prg_time):
         self.progress = progress
         self.prg_time = prg_time
+    cmd_SHOW_MESSAGE_help = "Show a message on a display"
+    def cmd_SHOW_MESSAGE(self, params):
+        msg = self.gcode.get_str("MESSAGE", params, None)
+        timeout = self.gcode.get_float("TIMEOUT", params, None)
+        self.set_message(msg, timeout)
 
 class DisplayCommands:
     def __init__(self, config):

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -21,6 +21,11 @@ class PrinterLCD:
         self.reactor = self.printer.get_reactor()
         self.lcd_chip = config.getchoice('lcd_type', LCD_chips)(config)
         self.lcd_type = config.get('lcd_type')
+        # init attributes
+        self.prg_time = .0
+        self.progress = None
+        self.msg_time = None
+        self.message = None
         # menu
         self.menu = menu.MenuManager(config, self.lcd_chip)
         # printer objects
@@ -44,10 +49,6 @@ class PrinterLCD:
         self.extruder = self.printer.lookup_object('extruder', None)
         self.extruder1 = self.printer.lookup_object('extruder1', None)
         self.heater_bed = self.printer.lookup_object('heater_bed', None)
-        self.prg_time = .0
-        self.progress = None
-        self.msg_time = None
-        self.message = None
         # Start screen update timer
         self.reactor.update_timer(self.screen_update_timer, self.reactor.NOW)
     def get_status(self, eventtime):


### PR DESCRIPTION
This PR implements the ability to define and use multiple displays for a single host.  Each display has its own menu that can be customized per display.

The M117 and M73 gcodes have been moved into their own class, instantiated once when the primary [display] section is loaded.   Both gcodes broadcast a printer event that is captured by the all defined displays.  Additionally, a "SHOW_MESSAGE" gcode has been added that can update the message per display.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>