### PR TITLE
Extruder: Prevent  "Extrude only move too long (100.000mm vs 100.000mm)"

### DIFF
--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -107,7 +107,7 @@ class PrinterExtruder:
                 "See the 'min_extrude_temp' config option for details")
         if (not move.axes_d[0] and not move.axes_d[1]) or axis_r < 0.:
             # Extrude only move (or retraction move) - limit accel and velocity
-            if abs(move.axes_d[3]) > self.max_e_dist:
+            if round(abs(move.axes_d[3]),3) > self.max_e_dist:
                 raise homing.EndstopError(
                     "Extrude only move too long (%.3fmm vs %.3fmm)\n"
                     "See the 'max_extrude_only_distance' config"


### PR DESCRIPTION
forces rounding to 3 decimal places for comparison between the commanded extrude value and the value present in the config file.  Should eliminate most move too long errors, or at least show a difference in value in the error.

Signed off by: David Smith <davidosmith@gmail.com>