### PR TITLE
Extruder: Add g-codes for get and set extruder step_distance

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -161,15 +161,12 @@ The following standard commands are supported:
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active
   extruder.
-- `GET_EXTRUDER_STEP_DISTANCE [EXTRUDER=<config_name>]`: Print to the
-  terminal the current step_distance value for the provided extruder.
 - `SET_EXTRUDER_STEP_DISTANCE [EXTRUDER=<config_name>] [DISTANCE=<distance>]`:
-  Set a new value for the provided extruder's step_distance. Useful
-  for tuning calibration and updatig value to compensate for
-  filament softness. Value is not retained on Klipper reset. Use with
-  caution, small changes can result in excessive pressure between
-  extruder and hot end. Do proper calibration steps with filament
-  before use.
+  Set a new value for the provided extruder's step_distance. Value is
+  not retained on Klipper reset. Use with caution, small changes can
+  result in excessive pressure between extruder and hot end. Do proper
+  calibration steps with filament before use. If 'DISTANCE' value is
+  not included command will return current step distance.
 - `SET_STEPPER_ENABLE STEPPER=<config_name> ENABLE=[0|1]`: Enable or
   disable only the given stepper. This is a diagnostic and debugging
   tool and must be used with care. Disabling an axis motor does not

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -161,6 +161,15 @@ The following standard commands are supported:
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active
   extruder.
+- `GET_E_STEP_DISTANCE [EXTRUDER=<config_name>]`: Print to the
+  terminal the current step_distance value for the provided extruder.
+- `SET_E_STEP_DISTANCE [EXTRUDER=<config_name>] [DISTANCE=<distance>]`:
+  Set a new value for the provided extruder's step_distance. Useful
+  for tuning calibration and updatig value to compensate for
+  filament softness. Value is not retained on Klipper reset. Use with
+  caution, small changes can result in excessive pressure between
+  extruder and hot end. Do proper calibration steps with filament
+  before use.
 - `SET_STEPPER_ENABLE STEPPER=<config_name> ENABLE=[0|1]`: Enable or
   disable only the given stepper. This is a diagnostic and debugging
   tool and must be used with care. Disabling an axis motor does not

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -161,9 +161,9 @@ The following standard commands are supported:
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active
   extruder.
-- `GET_E_STEP_DISTANCE [EXTRUDER=<config_name>]`: Print to the
+- `GET_EXTRUDER_STEP_DISTANCE [EXTRUDER=<config_name>]`: Print to the
   terminal the current step_distance value for the provided extruder.
-- `SET_E_STEP_DISTANCE [EXTRUDER=<config_name>] [DISTANCE=<distance>]`:
+- `SET_EXTRUDER_STEP_DISTANCE [EXTRUDER=<config_name>] [DISTANCE=<distance>]`:
   Set a new value for the provided extruder's step_distance. Useful
   for tuning calibration and updatig value to compensate for
   filament softness. Value is not retained on Klipper reset. Use with

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -197,20 +197,16 @@ class PrinterExtruder:
     def cmd_SET_E_STEP_DISTANCE(self, params):
         gcode = self.printer.lookup_object('gcode')
         toolhead = self.printer.lookup_object('toolhead')
-        dist = gcode.get_float('DISTANCE', params, 0.)
-        old_step_dist = self.stepper.get_step_dist()
-        if abs((dist - old_step_dist)/old_step_dist) > 0.25:
-            gcode.respond_info("Failed: step change is outside of"
-                               " safe margin. %f -> %f" %
-                                            (old_step_dist, dist))
+        if 'DISTANCE' not in params:
+            step_dist = self.stepper.get_step_dist()
+            gcode.respond_info("%s E step distance: %f" % (self.name, step_dist))
         else:
-            self.stepper.set_step_dist(dist)
+            dist = gcode.get_float('DISTANCE', params, 0.)
+            toolhead.flush_step_generation()
+            self.stepper.set_step_dist(self.sk_extruder, dist)
             step_dist = self.stepper.get_step_dist()
             gcode.respond_info("%s E step distance set: %f" %
                                                 (self.name, step_dist))
-            self.stepper.set_max_jerk(9999999.9, 9999999.9)
-            self.stepper.set_stepper_kinematics(self.sk_extruder)
-            self.stepper.set_trapq(self.trapq)
     cmd_ACTIVATE_EXTRUDER_help = "Change the active extruder"
     def cmd_ACTIVATE_EXTRUDER(self, params):
         gcode = self.printer.lookup_object('gcode')

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -72,9 +72,6 @@ class PrinterExtruder:
         gcode.register_mux_command("ACTIVATE_EXTRUDER", "EXTRUDER",
                                    self.name, self.cmd_ACTIVATE_EXTRUDER,
                                    desc=self.cmd_ACTIVATE_EXTRUDER_help)
-        gcode.register_mux_command("GET_EXTRUDER_STEP_DISTANCE", "EXTRUDER",
-                                   self.name, self.cmd_GET_E_STEP_DISTANCE,
-                                   desc=self.cmd_GET_E_STEP_DISTANCE_help)
         gcode.register_mux_command("SET_EXTRUDER_STEP_DISTANCE", "EXTRUDER",
                                    self.name, self.cmd_SET_E_STEP_DISTANCE,
                                    desc=self.cmd_SET_E_STEP_DISTANCE_help)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -188,11 +188,6 @@ class PrinterExtruder:
                    pressure_advance, smooth_time))
         self.printer.set_rollover_info(self.name, "%s: %s" % (self.name, msg))
         gcode.respond_info(msg, log=False)
-    cmd_GET_E_STEP_DISTANCE_help = "Get extruder step distance"
-    def cmd_GET_E_STEP_DISTANCE(self, params):
-        gcode = self.printer.lookup_object('gcode')
-        step_dist = self.stepper.get_step_dist()
-        gcode.respond_info("%s E step distance: %f" % (self.name, step_dist))
     cmd_SET_E_STEP_DISTANCE_help = "Set extruder step distance"
     def cmd_SET_E_STEP_DISTANCE(self, params):
         gcode = self.printer.lookup_object('gcode')
@@ -200,12 +195,12 @@ class PrinterExtruder:
         if 'DISTANCE' not in params:
             step_dist = self.stepper.get_step_dist()
             gcode.respond_info("%s E step distance: %f" % (self.name, step_dist))
-        else:
-            dist = gcode.get_float('DISTANCE', params, 0.)
-            toolhead.flush_step_generation()
-            self.stepper.set_step_dist(self.sk_extruder, dist)
-            step_dist = self.stepper.get_step_dist()
-            gcode.respond_info("%s E step distance set: %f" %
+            return
+        dist = gcode.get_float('DISTANCE', params, 0.)
+        toolhead.flush_step_generation()
+        self.stepper.set_step_dist(self.sk_extruder, dist)
+        step_dist = self.stepper.get_step_dist()
+        gcode.respond_info("%s E step distance set: %f" %
                                                 (self.name, step_dist))
     cmd_ACTIVATE_EXTRUDER_help = "Change the active extruder"
     def cmd_ACTIVATE_EXTRUDER(self, params):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -72,10 +72,10 @@ class PrinterExtruder:
         gcode.register_mux_command("ACTIVATE_EXTRUDER", "EXTRUDER",
                                    self.name, self.cmd_ACTIVATE_EXTRUDER,
                                    desc=self.cmd_ACTIVATE_EXTRUDER_help)
-        gcode.register_mux_command("GET_E_STEP_DISTANCE", "EXTRUDER",
+        gcode.register_mux_command("GET_EXTRUDER_STEP_DISTANCE", "EXTRUDER",
                                    self.name, self.cmd_GET_E_STEP_DISTANCE,
                                    desc=self.cmd_GET_E_STEP_DISTANCE_help)
-        gcode.register_mux_command("SET_E_STEP_DISTANCE", "EXTRUDER",
+        gcode.register_mux_command("SET_EXTRUDER_STEP_DISTANCE", "EXTRUDER",
                                    self.name, self.cmd_SET_E_STEP_DISTANCE,
                                    desc=self.cmd_SET_E_STEP_DISTANCE_help)
     def update_move_time(self, flush_time):
@@ -214,7 +214,6 @@ class PrinterExtruder:
             self.stepper.set_max_jerk(9999999.9, 9999999.9)
             self.stepper.set_stepper_kinematics(self.sk_extruder)
             self.stepper.set_trapq(self.trapq)
-            toolhead.register_step_generator(self.stepper.generate_steps)
     cmd_ACTIVATE_EXTRUDER_help = "Change the active extruder"
     def cmd_ACTIVATE_EXTRUDER(self, params):
         gcode = self.printer.lookup_object('gcode')

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -201,14 +201,20 @@ class PrinterExtruder:
         gcode = self.printer.lookup_object('gcode')
         toolhead = self.printer.lookup_object('toolhead')
         dist = gcode.get_float('DISTANCE', params, 0.)
-        self.stepper.set_step_dist(dist)
-        step_dist = self.stepper.get_step_dist()
-        gcode.respond_info("%s E step distance set: %f" %
-                                            (self.name, step_dist))
-        self.stepper.set_max_jerk(9999999.9, 9999999.9)
-        self.stepper.set_stepper_kinematics(self.sk_extruder)
-        self.stepper.set_trapq(self.trapq)
-        toolhead.register_step_generator(self.stepper.generate_steps)
+        old_step_dist = self.stepper.get_step_dist()
+        if abs((dist - old_step_dist)/old_step_dist) > 0.25:
+            gcode.respond_info("Failed: step change is outside of"
+                               " safe margin. %f -> %f" %
+                                            (old_step_dist, dist))
+        else:
+            self.stepper.set_step_dist(dist)
+            step_dist = self.stepper.get_step_dist()
+            gcode.respond_info("%s E step distance set: %f" %
+                                                (self.name, step_dist))
+            self.stepper.set_max_jerk(9999999.9, 9999999.9)
+            self.stepper.set_stepper_kinematics(self.sk_extruder)
+            self.stepper.set_trapq(self.trapq)
+            toolhead.register_step_generator(self.stepper.generate_steps)
     cmd_ACTIVATE_EXTRUDER_help = "Change the active extruder"
     def cmd_ACTIVATE_EXTRUDER(self, params):
         gcode = self.printer.lookup_object('gcode')

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -94,6 +94,10 @@ class MCU_stepper:
         return self._oid
     def get_step_dist(self):
         return self._step_dist
+    def set_step_dist(self, dist):
+        self._step_dist = dist
+        logging.info("%s manually set to =%.6f", (self._name, dist))
+        return self._step_dist
     def is_dir_inverted(self):
         return self._invert_dir
     def calc_position_from_coord(self, coord):

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -94,10 +94,10 @@ class MCU_stepper:
         return self._oid
     def get_step_dist(self):
         return self._step_dist
-    def set_step_dist(self, dist):
+    def set_step_dist(self, sk, dist):
         self._step_dist = dist
+        self.set_stepper_kinematics(sk)
         logging.info("%s manually set to =%.6f", (self._name, dist))
-        return self._step_dist
     def is_dir_inverted(self):
         return self._invert_dir
     def calc_position_from_coord(self, coord):


### PR DESCRIPTION
Add GET_E_STEP_DISTANCE and SET_E_STEP_DISTANCE to available g-codes. Implemented in response to request for a tunable step_distance to account for difference in hardness levels of filament materials.

Signed off by: David Smith <davidosmith@gmail.com>