### PR TITLE
Correct TMC2130 diag1_pin logic

### DIFF
--- a/config/generic-mks-sgenl.cfg
+++ b/config/generic-mks-sgenl.cfg
@@ -128,7 +128,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.29
+##diag1_pin: ^!P1.29
 #microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
@@ -139,7 +139,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.27
+##diag1_pin: ^!P1.27
 #microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
@@ -150,7 +150,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.25
+##diag1_pin: ^!P1.25
 #microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
@@ -161,7 +161,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.28
+##diag1_pin: ^!P1.28
 #microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
@@ -172,7 +172,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.26
+##diag1_pin: ^!P1.26
 #microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500


### PR DESCRIPTION
The diag1_pin logic should be inverted and pulled up. (At least on this board)