### PR TITLE
BED_MESH_TILT implementation

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -357,3 +357,19 @@ set, the generated probed points will be output to the terminal:
 The "Tool Adjusted" points refer to the nozzle location for each point, and
 the "Probe" points refer to the probe location.  Note that when manually
 probing the "Probe" points will refer to both the tool and nozzle locations.
+
+### Tilt
+
+`BED_MESH_TILT`
+
+Probes three points on the bed to gauge the bed's current height and tilt,
+then updates the active bed mesh to reflect this information. BED_MESH_TILT 
+allows the use of a high-resolution bed map without sacrificing the use of
+bed leveling screws or preventing the adjustment of axes. It's fast enough
+to use before every print.
+
+You can run BED_MESH_TILT repeatedly without degrading the quality of the 
+mesh. Each invocation starts with a fresh copy of the original bed mesh.
+
+Tilted meshes cannot be saved. BED_MESH_PROFILE SAVE=xxx always saves the 
+original, untilted probe data.

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -9,13 +9,16 @@ import math
 import json
 import probe
 import collections
+import copy
 
 PROFILE_VERSION = 1
-PROFILE_OPTIONS = {
-    'min_x': float, 'max_x': float, 'min_y': float, 'max_y': float,
-    'x_count': int, 'y_count': int, 'mesh_x_pps': int, 'mesh_y_pps': int,
-    'algo': str, 'tension': float
-}
+PROFILE_OPTIONS = collections.OrderedDict([
+    ('x_count', int), ('y_count', int), 
+    ('mesh_x_pps', int), ('mesh_y_pps', int),
+    ('algo', str), ('tension', float),
+    ('min_x', float), ('max_x', float),
+    ('min_y', float), ('max_y', float),
+])
 
 class BedMeshError(Exception):
     pass
@@ -215,13 +218,23 @@ class BedMeshCalibrate:
             'relative_reference_index', None)
         self.bedmesh = bedmesh
         self.probed_matrix = None
+        self.probed_matrix_backup = None
+        self.build_map = False
+        self.tilt_points = []
         self.mesh_params = collections.OrderedDict()
         self.points = self._generate_points(config)
         self._init_mesh_params(config, self.points)
         self.probe_helper = probe.ProbePointsHelper(
             config, self.probe_finalize, self.points)
+        self.tilt_probe_helper = probe.ProbePointsHelper(
+            config, self.tilt_probe_finalize, self.tilt_points)
+        logging.info("Tilt points:")
+        for point in self.tilt_points:
+            logging.info("%f, %f" % point)
         self.probe_helper.minimum_points(3)
+        self.tilt_probe_helper.minimum_points(3)
         self.probe_helper.use_xy_offsets(True)
+        self.tilt_probe_helper.use_xy_offsets(True)
         # setup persistent storage
         self.profiles = {}
         self.incompatible_profiles = []
@@ -230,6 +243,9 @@ class BedMeshCalibrate:
         self.gcode.register_command(
             'BED_MESH_CALIBRATE', self.cmd_BED_MESH_CALIBRATE,
             desc=self.cmd_BED_MESH_CALIBRATE_help)
+        self.gcode.register_command(
+            'BED_MESH_TILT', self.cmd_BED_MESH_TILT,
+            desc=self.cmd_BED_MESH_TILT_help)
         self.gcode.register_command(
             'BED_MESH_PROFILE', self.cmd_BED_MESH_PROFILE,
             desc=self.cmd_BED_MESH_PROFILE_help)
@@ -251,14 +267,23 @@ class BedMeshCalibrate:
             self.radius = math.floor(self.radius * 10) / 10
             min_x = min_y = -self.radius
             max_x = max_y = self.radius
+            mpi = atan(1.0) * 4.0;
+            rcmpi, rsmpi = r * cos(mpi / 6.0), r * sin(mpi / 6.0)
+            r = self.radius
+            self.tilt_points.append((0.0, r))
+            self.tilt_points.append((-rcmpi, -rsmpi))
+            self.tilt_points.append((rcmpi, rsmpi))
         else:
             # rectangular
-            x_cnt, y_cnt = parse_pair(
-                config, ('probe_count', '3'), check=False, cast=int, minval=3)
+            x_cnt, y_cnt = parse_pair(config, ('probe_count', '3'), 
+                check=False, cast=int, minval=3)
             min_x, min_y = parse_pair(config, ('mesh_min',))
             max_x, max_y = parse_pair(config, ('mesh_max',))
             if max_x <= min_x or max_y <= min_y:
                 raise config.error('bed_mesh: invalid min/max points')
+            self.tilt_points.append((min_x, min_y))
+            self.tilt_points.append((max_x, min_y))
+            self.tilt_points.append((0.5 * (max_x + min_x), max_y))
 
         self.mesh_params['x_count'] = x_cnt
         self.mesh_params['y_count'] = y_cnt
@@ -404,23 +429,30 @@ class BedMeshCalibrate:
                 "Unable to save to profile [%s], the bed has not been probed"
                 % (prof_name))
             return
+        if self.probed_matrix_backup is not None:
+            self.gcode.respond_info(
+                "NOTE: mesh has been tilted, saving untilted mesh data...")
+            matrix = self.probed_matrix_backup
+        else:
+            matrix = self.probed_matrix
         configfile = self.printer.lookup_object('configfile')
         cfg_name = self.name + " " + prof_name
         # set params
         z_values = ""
-        for line in self.probed_matrix:
+        for line in matrix:
             z_values += "\n  "
             for p in line:
                 z_values += "%.6f, " % p
             z_values = z_values[:-2]
         configfile.set(cfg_name, 'version', PROFILE_VERSION)
         configfile.set(cfg_name, 'points', z_values)
-        for key, value in self.mesh_params.iteritems():
+        params = self.bedmesh.z_mesh.mesh_params
+        for key, value in params.iteritems():
             configfile.set(cfg_name, key, value)
         # save copy in local storage
         self.profiles[prof_name] = profile = {}
-        profile['points'] = list(self.probed_matrix)
-        profile['mesh_params'] = collections.OrderedDict(self.mesh_params)
+        profile['points'] = list(matrix)
+        profile['mesh_params'] = collections.OrderedDict(params)
         self.gcode.respond_info(
             "Bed Mesh state has been saved to profile [%s]\n"
             "for the current session.  The SAVE_CONFIG command will\n"
@@ -432,6 +464,7 @@ class BedMeshCalibrate:
             raise self.gcode.error(
                 "bed_mesh: Unknown profile [%s]" % prof_name)
         self.probed_matrix = profile['points']
+        self.probed_matrix_backup = None
         zmesh = ZMesh(profile['mesh_params'])
         try:
             zmesh.build_mesh(self.probed_matrix)
@@ -473,7 +506,15 @@ class BedMeshCalibrate:
     def cmd_BED_MESH_CALIBRATE(self, params):
         self.build_map = False
         self.bedmesh.set_mesh(None)
+        self.probed_matrix_backup = None
         self.probe_helper.start_probe(params)
+    cmd_BED_MESH_TILT_help = "Tilt active mesh to match current attitude of bed"
+    def cmd_BED_MESH_TILT(self, params):
+        if self.bedmesh.z_mesh is None:
+            self.gcode.respond_info("No mesh! Nothing to tilt!");
+        else:
+            self.tilt_probe_helper.start_probe(params)
+
     def print_probed_positions(self, print_func):
         if self.probed_matrix is not None:
             msg = "Mesh Leveling Probed Z positions:\n"
@@ -484,6 +525,71 @@ class BedMeshCalibrate:
             print_func(msg)
         else:
             print_func("bed_mesh: bed has not been probed")
+
+    # Look up z position according to the active mesh and 
+    # compare with probed height
+    def _calculate_delta_z(self, pos, z_offset):
+        z_in_mesh = self.bedmesh.z_mesh.calc_z(*pos[0:2]) + z_offset
+        delta_z = pos[2] - z_in_mesh;
+        return [pos[0], pos[1], delta_z]
+
+    def tilt_probe_finalize(self, offsets, positions):
+        x_offset, y_offset, z_offset = offsets
+        self.gcode.respond_info("offsets: %f %f %f" % tuple(offsets));
+
+        if self.relative_reference_index is not None:
+            rri = self.relative_reference_index
+            z_offset = self.bedmesh.z_mesh.calc_z(*self.points[rri][0:2])
+
+        if self.probed_matrix_backup is None:
+            self.probed_matrix_backup = copy.deepcopy(self.probed_matrix)
+
+        t_probed_matrix = copy.deepcopy(self.probed_matrix_backup)
+        self.bedmesh.z_mesh.build_mesh(t_probed_matrix)
+        pts = [self._calculate_delta_z(pos, z_offset) for pos in positions]
+
+        # cross product of vectors defined by 3 probed points
+        cx = pts[1][2]*(pts[0][1] - pts[2][1]) + \
+                pts[0][2]*(-pts[1][1] + pts[2][1]) + \
+                (-pts[0][1] + pts[1][1])*pts[2][2]
+        cy = pts[0][2]*(pts[1][0] - pts[2][0]) +\
+                pts[1][2]*(-pts[0][0] + pts[2][0]) + \
+                ( pts[0][0] - pts[1][0])*pts[2][2]
+        cz = pts[1][1]*(pts[0][0] - pts[2][0]) + \
+                pts[0][1]*(-pts[1][0] + pts[2][0]) + \
+                (-pts[0][0] + pts[1][0])*pts[2][1]
+        # self.gcode.respond_info("Normal to plane is [%f,%f,%f]" % (cx,cy,cz))
+        # calcuate d in the equation of plane cx*X+cy*Y+cz*Zd==d
+        d = cx*pts[0][0]+cy*pts[0][1]+cz*pts[0][2]
+
+        # now for any (x,y) z defines as (d-cx*X-cy*Y)/cz
+        zcorr = [-cx/cz, -cy/cz, d/cz]
+
+        params = self.bedmesh.z_mesh.mesh_params
+
+        x_cnt = params['x_count']
+        y_cnt = params['y_count']
+        min_x = params['min_x']
+        min_y = params['min_y']
+        x_dist = (params['max_x'] -params['min_x']) / (x_cnt - 1)
+        y_dist = (params['max_y'] -params['min_y']) / (y_cnt - 1)
+        for i in range(x_cnt):
+            for j in range(y_cnt):
+                xx = min_x + i * x_dist
+                yy = min_y + j * y_dist
+                adj = zcorr[0] * xx + zcorr[1] * yy + zcorr[2]
+                t_probed_matrix[j][i] += adj
+
+        mesh = ZMesh(params)
+        try:
+            mesh.build_mesh(t_probed_matrix)
+        except BedMeshError as e:
+            self.probed_matrix = copy.deepcopy(self.probed_matrix_backup)
+            raise self.gcode.error(e.message)
+        self.bedmesh.set_mesh(mesh)
+        self.probed_matrix = t_probed_matrix
+        self.gcode.respond_info("Mesh Bed Tilting Complete")
+
     def probe_finalize(self, offsets, positions):
         x_offset, y_offset, z_offset = offsets
         params = self.mesh_params


### PR DESCRIPTION
This PR is intended to supersede PRs #2107 by @antst and #2018 by @jperrin72 (at jperrin72's request). All credit for this goes to @antst (Anton Starikov) - I just ported it to the current code base and added a few finishing touches.

This command probes three points on the bed to determine its current attitude and then adjusts
the currently-active bed leveling mesh to conform it to the actual state of the bed.

Pursuant to comments from @Arksine on PR #2107, meshes that have been tilted cannot be saved. Or rather, they can be saved, but it is the original, untilted probe values that go into the config file. I think this compromise will help to ensure that saved configurations include the highest quality data while preventing people from backing themselves into a corner (e.g., by making a complex map, testing it under a slicer profile that does a BED_MESH_TILT, and then discovering that the mesh can no longer be saved).

This patch fixes what I believe is likely an issue in the original master code which applies the bed_mesh settings from printer.cfg to every saved bed mesh. The params now come from the active mesh and are ordered canonically.

Includes docs.

This version continues to support `relative_reference_index`, but I believe it's now doing so correctly. 🤞

I have been testing this code for a while on my Sidewinder X1, and it has been working fine for me. Unfortunately, there are some delta-specific code paths that I'm unable to test. 

Open issues:

* Need to test on delta.

* Limited to 3 probe points, so probing error is potentially on the order of three times the error of one probe (which on my printer seems to be about 0.01). That seems like enough to affect mesh quality, although just barely.

* Is there any chance numpy could be added as a dependency? It's easily installed without compilation on all the platforms that have a Klipper install- script with the possible exception of beaglebone, although that's Linux too. There seems to be quite a bit of linear algebra in Klipper, and this feature is just one case in point. The [Kabsch algorithm](https://en.wikipedia.org/wiki/Kabsch_algorithm) would allow the current 3-point algorithm to be generalized to N points, and with numpy this is about [10 lines of code](https://math.stackexchange.com/questions/99299/best-fitting-plane-given-a-set-of-points) - shorter, in fact, than the current code.