### PR TITLE
Pin logic on MKS SGEN L generic config

### DIFF
--- a/config/generic-mks-sgenl.cfg
+++ b/config/generic-mks-sgenl.cfg
@@ -8,7 +8,7 @@ step_pin: P2.2
 dir_pin: !P2.3
 enable_pin: !P2.1
 step_distance: .0125
-endstop_pin: P1.29  # P1.28 for X-max
+endstop_pin: ^P1.29  # ^P1.28 for X-max
 position_endstop: 0
 position_max: 320
 homing_speed: 50
@@ -18,7 +18,7 @@ step_pin: P0.19
 dir_pin: !P0.20
 enable_pin: !P2.8
 step_distance: .0125
-endstop_pin: P1.27  # P1.26 for Y-max
+endstop_pin: ^P1.27  # ^P1.26 for Y-max
 position_endstop: 0
 position_max: 300
 homing_speed: 50
@@ -28,7 +28,7 @@ step_pin: P0.22
 dir_pin: P2.11
 enable_pin: !P0.21
 step_distance: .0025
-endstop_pin: P1.25  # P1.24 for Z-max
+endstop_pin: ^P1.25  # ^P1.24 for Z-max
 position_endstop: 0.5
 position_max: 400
 

--- a/config/generic-mks-sgenl.cfg
+++ b/config/generic-mks-sgenl.cfg
@@ -128,7 +128,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.29
+##diag1_pin: ^!P1.29
 #microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
@@ -139,7 +139,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.27
+##diag1_pin: ^!P1.27
 #microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
@@ -150,7 +150,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.25
+##diag1_pin: ^!P1.25
 #microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
@@ -161,7 +161,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.28
+##diag1_pin: ^!P1.28
 #microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
@@ -172,7 +172,7 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
-##diag1_pin: P1.26
+##diag1_pin: ^!P1.26
 #microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500


### PR DESCRIPTION
Hi, I corrected the diag1_pin logic (using pullups and invert) for the config template for MKS SGEN L board, and also used pull up for the endstops. This is a reopen PR since I didn't include `Signed-off-by` section in my original commit. #2601