### PR TITLE
Use default layout for 16x4 lcd screens even with multiple extruders

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,12 @@ All dates in this document are approximate.
 
 # Changes
 
+20200313: The default lcd layout for multi-extruder printers with a
+16x4 screen has changed.  The single extruder screen layout is now the
+default and it will show the currently active extruder.  To use the
+previous display layout set "display_group: _multiextruder_16x4" in
+the [display] section of the printer.cfg file.
+
 20200308: The menu "deck" and "card" options were removed. To
 customize the layout of an lcd screen use the new display_data config
 sections (see config/example-extras.cfg for the details).

--- a/klippy/extras/display/display.cfg
+++ b/klippy/extras/display/display.cfg
@@ -73,7 +73,9 @@ text:
 
 [display_data _default_16x4 extruder]
 position: 0, 0
-text: { render("_heater_temperature", param_heater_name="extruder") }
+text:
+  {% set active_extruder = printer.toolhead.extruder %}
+  { render("_heater_temperature", param_heater_name=active_extruder) }
 
 [display_data _default_16x4 fan]
 position: 0, 10

--- a/klippy/extras/display/display.cfg
+++ b/klippy/extras/display/display.cfg
@@ -2,7 +2,7 @@
 
 
 ######################################################################
-# Display templates
+# Helper macros for showing common screen values
 ######################################################################
 
 [display_template _heater_temperature]
@@ -30,6 +30,31 @@ text:
     ~degrees~
   {% endif %}
 
+[display_template _fan_speed]
+text:
+  {% if 'fan' in printer %}
+    {% set speed = printer.fan.speed %}
+    {% if speed %}
+      ~animated_fan~
+    {% else %}
+      ~fan~
+    {% endif %}
+    { "{:>4.0%}".format(speed) }
+  {% endif %}
+
+[display_template _printing_time]
+text:
+  {% set ptime = printer.idle_timeout.printing_time %}
+  {% set progress = printer.display_status.progress %}
+  {% if progress >= 0.05 and ptime % 12 >= 6 %}
+    # Periodically show time remaining
+    {% set rtime = (ptime / progress) - ptime %}
+    { "-%02d:%02d" % (rtime // (60 * 60), (rtime // 60) % 60) }
+  {% else %}
+    {% set msg = "%02d:%02d" % (ptime // (60 * 60), (ptime // 60) % 60) %}
+    { "%6s" % (msg,) }
+  {% endif %}
+
 [display_template _print_status]
 text:
   {% if printer.display_status.message %}
@@ -52,77 +77,68 @@ text: { render("_heater_temperature", param_heater_name="extruder") }
 
 [display_data _default_16x4 fan]
 position: 0, 10
-text:
-  {% if 'fan' in printer %}
-    {% set speed = printer.fan.speed %}
-    {% if speed %}
-      ~animated_fan~
-    {% else %}
-      ~fan~
-    {% endif %}
-    { "{:>4.0%}".format(speed) }
-  {% endif %}
+text: { render("_fan_speed") }
 
-[display_data _default_16x4 row1col0]
+[display_data _default_16x4 heater_bed]
 position: 1, 0
-text:
-  {% if 'extruder1' in printer %}
-    # A multi-extruder setup uses an alternate screen layout
-    { render("_heater_temperature", param_heater_name="extruder1") }
-  {% else %}
-    { render("_heater_temperature", param_heater_name="heater_bed") }
-  {% endif %}
+text: { render("_heater_temperature", param_heater_name="heater_bed") }
 
-[display_data _default_16x4 ro1col10]
+[display_data _default_16x4 speed_factor]
 position: 1, 10
 text:
-  {% if 'extruder1' in printer %}
-    # A multi-extruder setup uses an alternate screen layout
-    {% set progress = printer.display_status.progress %}
-    { "{:^6.0%}".format(progress) }
-  {% else %}
-    ~feedrate~
-    { "{:>4.0%}".format(printer.gcode.speed_factor) }
-  {% endif %}
+  ~feedrate~
+  { "{:>4.0%}".format(printer.gcode.speed_factor) }
 
-[display_data _default_16x4 row2col0]
+[display_data _default_16x4 print_progress]
 position: 2, 0
-text:
-  {% if 'extruder1' in printer %}
-    # A multi-extruder setup uses an alternate screen layout
-    { render("_heater_temperature", param_heater_name="heater_bed") }
-  {% else %}
-    {% set progress = printer.display_status.progress %}
-    { "{:^10.0%}".format(progress) }
-  {% endif %}
+text: { "{:^10.0%}".format(printer.display_status.progress) }
+[display_data _default_16x4 progress_bar]
+position: 2, 1 # Draw graphical progress bar after text is written
+text: { draw_progress_bar(2, 0, 10, printer.display_status.progress) }
 
 [display_data _default_16x4 printing_time]
 position: 2, 10
-text:
-  {% set ptime = printer.idle_timeout.printing_time %}
-  {% set progress = printer.display_status.progress %}
-  {% if progress >= 0.05 and ptime % 12 >= 6 %}
-    {% set rtime = (ptime / progress) - ptime %}
-    { "-%02d:%02d" % (rtime // (60 * 60), (rtime // 60) % 60) }
-  {% else %}
-    {% set msg = "%02d:%02d" % (ptime // (60 * 60), (ptime // 60) % 60) %}
-    { "%6s" % (msg,) }
-  {% endif %}
+text: { render("_printing_time") }
 
 [display_data _default_16x4 print_status]
 position: 3, 0
 text: { render("_print_status") }
 
-[display_data _default_16x4 progress_bar]
-position: 3, 16 # Render graphical progress bar after text is written
-text:
-  {% set progress = printer.display_status.progress %}
-  {% if 'extruder1' in printer %}
-    # A multi-extruder setup uses an alternate screen layout
-    { draw_progress_bar(1, 10, 6, progress) }
-  {% else %}
-    { draw_progress_bar(2, 0, 10, progress) }
-  {% endif %}
+
+######################################################################
+# Alternative 16x4 layout for multi-extruders
+######################################################################
+
+[display_data _multiextruder_16x4 extruder]
+position: 0, 0
+text: { render("_heater_temperature", param_heater_name="extruder") }
+
+[display_data _multiextruder_16x4 fan]
+position: 0, 10
+text: { render("_fan_speed") }
+
+[display_data _multiextruder_16x4 extruder1]
+position: 1, 0
+text: { render("_heater_temperature", param_heater_name="extruder1") }
+
+[display_data _multiextruder_16x4 print_progress]
+position: 1, 10
+text: { "{:^6.0%}".format(printer.display_status.progress) }
+[display_data _multiextruder_16x4 progress_bar]
+position: 1, 11 # Draw graphical progress bar after text is written
+text: { draw_progress_bar(1, 10, 6, printer.display_status.progress) }
+
+[display_data _multiextruder_16x4 heater_bed]
+position: 2, 0
+text: { render("_heater_temperature", param_heater_name="heater_bed") }
+
+[display_data _multiextruder_16x4 printing_time]
+position: 2, 10
+text: { render("_printing_time") }
+
+[display_data _multiextruder_16x4 print_status]
+position: 3, 0
+text: { render("_print_status") }
 
 
 ######################################################################


### PR DESCRIPTION
In PR #2581 the layout of lcd screens was made configurable.  The default layout was unchanged, however.  The 16x4 default screen layout actually included the two different screen layouts - one for single extruder printers and one for multiple extruders.

I'm not sure it is a good idea to automatically use a different lcd screen layout just because the printer has multiple extruders.  This PR changes Klipper to use the same default layout for all 16x4 screens.  The default extruder shown, however, is changed to be the currently active extruder.

For those users that wish to continue using the alternate "multi-extruder" screen layout, they can enable it by adding `display_group: _multiextruder_16x4` to their printer.cfg file.  Or, of course, one can build a completely custom screen layout using the mechanism introduced in PR #2581 .

-Kevin