### PR TITLE
Added axis homing order for X and Y in Safe Z Homing module

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -330,7 +330,11 @@
 #move_to_previous: False
 #   When set to True, xy are reset to their previous positions after z homing.
 #   The default is False.
-
+#xy_order: XY
+#   The order in which to home the X and Y axes if required before moving them
+#   to the Z homing position. Some printers may experience collisions if X is
+#   homed before Y.
+#   The default is X then Y.
 
 # Homing override. One may use this mechanism to run a series of
 # g-code commands in place of a G28 found in the normal g-code input.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -328,13 +328,20 @@
 #z_hop_speed: 20.0
 #   Speed at which the Z axis is lifted prior to homing. The default is 20mm/s.
 #move_to_previous: False
-#   When set to True, xy are reset to their previous positions after z homing.
+#   When set to True, xy are reset to their previous positions after homing.
 #   The default is False.
-#xy_order: XY
+#xy_order: xy
 #   The order in which to home the X and Y axes if required before moving them
 #   to the Z homing position. Some printers may experience collisions if X is
 #   homed before Y.
 #   The default is X then Y.
+#park_position:             0,0,0
+#   x, y, z coordinates to park the nozzle after a initial homing.
+#   If specified, after homing an axis for the first time, the toolhead
+#   will park at the designated coordinate. If an axis is already homed
+#   and move_to_previous = true, the axis will return to that spot.
+#   If neither option is provided, the axis will remain at its homing location
+#   The default is not to park the toolhead after homing.
 
 # Homing override. One may use this mechanism to run a series of
 # g-code commands in place of a G28 found in the normal g-code input.

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -17,6 +17,7 @@ class SafeZHoming:
 
         self.move_to_previous = config.getboolean('move_to_previous', False)
 
+        self.park_position = None;
         park = config.get('park_position', None)
 
         if park:

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -19,8 +19,8 @@ class SafeZHoming:
 
         park = config.get('park_position', None)
 
-        if park:    
-        
+        if park:
+
             try:
                 self.park_position = [float(i) for i in park.split(',')]
 
@@ -35,7 +35,7 @@ class SafeZHoming:
 
         xy_orders = { "xy" : "xy", "yx" : "yx" }
         self.xy_order = config.getchoice("xy_order", xy_orders, "xy")
-        
+
         self.gcode = self.printer.lookup_object('gcode')
         self.prev_G28 = self.gcode.register_command("G28", None)
         self.gcode.register_command("G28", self.cmd_G28)
@@ -52,7 +52,7 @@ class SafeZHoming:
         # Perform Z Hop if necessary
         if self.z_hop != 0.0:
             pos = toolhead.get_position()
-          
+
             # Check if Z axis is homed or has a known position
             if 'z' in kin_status['homed_axes']:
                 # Check if the zhop would exceed the printer limits
@@ -75,7 +75,7 @@ class SafeZHoming:
             need_x, need_y, need_z = tuple(axis in params
                                            for axis in ['X', 'Y', 'Z'])
 
-       
+
         prev_pos = toolhead.get_position()
 
         # Home XY axes if necessary
@@ -83,15 +83,15 @@ class SafeZHoming:
 
             if axis == 'x' and need_x:
                self.prev_G28('X0')
-        
+
             if axis == 'y' and need_y:
                self.prev_G28('Y0')
 
         # Home Z axis if necessary
         if need_z:
-            
+
             # Move to safe XY homing position
-            pos = toolhead.get_position()    
+            pos = toolhead.get_position()
             pos[0] = self.home_x_pos
             pos[1] = self.home_y_pos
             toolhead.move(pos, self.speed)
@@ -100,12 +100,12 @@ class SafeZHoming:
             # Home Z
             self.prev_G28({'Z': '0'})
             pos = toolhead.get_position()
-            
+
             if self.park_position:
                 pos[2] = self.park_position[2]
 
-            if 'z' in kin_status['homed_axes']: 
-                
+            if 'z' in kin_status['homed_axes']:
+
                 #return z to prev position if previously homed
                 #or re-hop it for pressure based probes
                 if self.move_to_previous:
@@ -123,8 +123,8 @@ class SafeZHoming:
                 pos[0] = prev_pos[0]
         elif self.park_position:
                 pos[0] = self.park_position[0]
-                
-        if 'y' in kin_status['homed_axes'] and self.move_to_previous:  
+
+        if 'y' in kin_status['homed_axes'] and self.move_to_previous:
                 pos[1] = prev_pos[1]
         elif self.park_position:
                 pos[1] = self.park_position[1]

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -19,6 +19,7 @@ class SafeZHoming:
         self.z_hop_speed = config.getfloat('z_hop_speed', 15., above=0.)
         self.max_z = config.getsection('stepper_z').getfloat('position_max')
         self.speed = config.getfloat('speed', 50.0, above=0.)
+        self.xy_order = config.get("xy_order", "xy").strip().lower()
         self.move_to_previous = config.getboolean('move_to_previous', False)
         self.gcode = self.printer.lookup_object('gcode')
         self.prev_G28 = self.gcode.register_command("G28", None)
@@ -60,12 +61,15 @@ class SafeZHoming:
 
         # Home XY axes if necessary
         new_params = {}
-        if need_x:
-            new_params['X'] = '0'
-        if need_y:
-            new_params['Y'] = '0'
-        if new_params:
-            self.prev_G28(new_params)
+
+        for axis in self.xy_order:
+
+            if axis == 'x' and need_x:
+               self.prev_G28('X0')
+        
+            if axis == 'y' and need_y:
+               self.prev_G28('Y0')
+
         # Home Z axis if necessary
         if need_z:
             # Move to safe XY homing position


### PR DESCRIPTION
Some printers have issues where X can't home before Y without a collision. 
This adds an option to specify the order in which the X and Y axes are homed
when Safe Z Homing is used.

Signed-off-by: Paul McGowan <mental405@gmail.com>