### PR TITLE
Example.cfg: Show heater_bed config options previously missing.

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -224,6 +224,14 @@ control: watermark
 #   Celsius above the target temperature before disabling the heater
 #   as well as the number of degrees below the target before
 #   re-enabling the heater. The default is 2 degrees Celsius.
+#pid_Kp: 22.2
+#pid_Ki: 1.08
+#pid_Kd: 114
+#   On PID control heaters the above need to be defined
+#pid_integral_max:
+#max_power: 1.0
+#smooth_time: 2.0
+#pwm_cycle_time: 0.100
 min_temp: 0
 max_temp: 110
 


### PR DESCRIPTION
The example.cfg section for heater_bed is missing some attributes that are available.

Please let me know if I missed any or added any that are actually not available.

signed-off-by: David Smith <davidosmith@gmail.com>