### PR TITLE
Give more time to reset the BL-Touch after a failure to raise the probe

### DIFF
--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -127,9 +127,8 @@ class BLTouchEndstopWrapper:
                 raise homing.EndstopError("BLTouch failed to raise probe")
             msg = "Failed to verify BLTouch probe is raised; retrying."
             self.gcode.respond_info(msg)
-            self.next_cmd_time += RETRY_RESET_TIME
             self.sync_mcu_print_time()
-            self.send_cmd('reset')
+            self.send_cmd('reset', duration=RETRY_RESET_TIME)
     def lower_probe(self):
         self.test_sensor()
         self.sync_print_time()

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -163,6 +163,7 @@ class BLTouchEndstopWrapper:
         if self.stow_on_each_sample:
             return
         self.raise_probe()
+        self.sync_print_time()
         self.multi = 'OFF'
     def probe_prepare(self):
         if self.multi == 'OFF' or self.multi == 'FIRST':


### PR DESCRIPTION
In the event that a "raise probe" operation fails, the current code will issue a "reset" command to attempt to clear the error state.  However, the "reset" command is only sent for 100ms.  It appears a longer time is needed ( see https://github.com/KevinOConnor/klipper/issues/2267#issuecomment-567044957 ).  This update reworks the code so the existing RETRY_RESET_TIME delay time of 1 second is now done while the "reset" command is being issued.  This should hopefully give the BL-Touch more time to update its internal state.

@FanDjango - does this change look okay to you?

-Kevin