### PR TITLE
Mange configuration file backups using git instead of copying the file

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -312,7 +312,8 @@ class PrinterConfig:
             if cfgname.endswith(".cfg"):
                 backup_name = cfgname[:-4] + datestr + ".cfg"
                 temp_name = cfgname[:-4] + "_autosave.cfg"
-                # Create new config file with temporary name and swap with main config
+                # Create new config file with temporary name
+                # and swap with main config
                 logging.info("SAVE_CONFIG to '%s' (backup in '%s')",
                              cfgname, backup_name)
         else:
@@ -327,7 +328,8 @@ class PrinterConfig:
                 if retcode == 0:
                     return ver.strip()
                 else:
-                    logging.info("SAVE_CONFIG saving previous changes: %s %s", ver, err)
+                    logging.info("SAVE_CONFIG saving previous changes: %s %s",
+                                 ver, err)
             except OSError:
                 logging.debug("Exception on run: %s", traceback.format_exc())
             temp_name = cfgname
@@ -353,8 +355,9 @@ class PrinterConfig:
                     else:
                         logging.info("SAVE_CONFIG git saving: %s %s", ver, err)
                 except OSError:
-                    logging.debug("Exception on run: %s", traceback.format_exc())
-                
+                    logging.debug("Exception on run: %s",
+                                  traceback.format_exc())
+
         except:
             msg = "Unable to write config file during SAVE_CONFIG"
             logging.exception(msg)

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -328,20 +328,23 @@ class PrinterConfig:
                 # and swap with main config
                 logging.info("SAVE_CONFIG to '%s' (backup in '%s')",
                              cfgname, backup_name)
-        elif git_have_file_change():
-            # try to protect the user from errors, save his state of the config:
-            prog = ('git', '-C', cfg_wd, 'commit', cfg_file, '-m',
-                    'the config file was modified before, these are your edits')
-            try:
-                process = subprocess.Popen(prog, stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE)
-                msg, err = process.communicate()
-                retcode = process.wait()
-                if retcode != 0:
-                    logging.info("SAVE_CONFIG saving previous changes: %s %s",
-                                 msg, err)
-            except OSError:
-                logging.debug("Exception on run: %s", traceback.format_exc())
+        else:
+            if git_have_file_change():
+                # try to protect the user from errors,
+                # save his state of the config:
+                prog = ('git', '-C', cfg_wd, 'commit', cfg_file, '-m',
+                        'saving your edits')
+                try:
+                    process = subprocess.Popen(prog, stdout=subprocess.PIPE,
+                                               stderr=subprocess.PIPE)
+                    msg, err = process.communicate()
+                    retcode = process.wait()
+                    if retcode != 0:
+                        logging.info("SAVE_CONFIG saving previous changes:"
+                                     "%s %s", msg, err)
+                except OSError:
+                    logging.debug("Exception on run: %s",
+                                  traceback.format_exc())
             temp_name = cfgname
             os.unlink(cfgname)
         try:

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -323,13 +323,14 @@ class PrinterConfig:
             try:
                 process = subprocess.Popen(prog, stdout=subprocess.PIPE,
                                            stderr=subprocess.PIPE)
-                ver, err = process.communicate()
+                msg, err = process.communicate()
                 retcode = process.wait()
                 if retcode == 0:
                     return ver.strip()
                 else:
-                    logging.info("SAVE_CONFIG saving previous changes: %s %s",
-                                 ver, err)
+                    if not msg.find('nothing to commit'):
+                        logging.info("SAVE_CONFIG saving previous changes: %s %s",
+                                     msg, err)
             except OSError:
                 logging.debug("Exception on run: %s", traceback.format_exc())
             temp_name = cfgname
@@ -348,12 +349,13 @@ class PrinterConfig:
                 try:
                     process = subprocess.Popen(prog, stdout=subprocess.PIPE,
                                                stderr=subprocess.PIPE)
-                    ver, err = process.communicate()
+                    msg, err = process.communicate()
                     retcode = process.wait()
                     if retcode == 0:
                         return ver.strip()
                     else:
-                        logging.info("SAVE_CONFIG git saving: %s %s", ver, err)
+                        if not msg.find('nothing to commit'):
+                            logging.info("SAVE_CONFIG git saving: %s %s", msg, err)
                 except OSError:
                     logging.debug("Exception on run: %s",
                                   traceback.format_exc())

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -336,7 +336,7 @@ class PrinterConfig:
             f = open(temp_name, 'wb')
             f.write(data)
             f.close()
-            if not gitconfig:
+            if not git_config:
                 os.rename(cfgname, backup_name)
             else:
                 # now we save what we changed:

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -338,6 +338,7 @@ class PrinterConfig:
             f.close()
             if not git_config:
                 os.rename(cfgname, backup_name)
+                os.rename(temp_name, cfgname)
             else:
                 # now we save what we changed:
                 prog = ('git', '-C', cfg_wd, 'commit', cfg_file, '-m',

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -236,6 +236,8 @@ def main():
                     help="write log to file instead of stderr")
     opts.add_option("-v", action="store_true", dest="verbose",
                     help="enable debug messages")
+    opts.add_option("-g", dest="git_config",
+                    help="manage config backups using git")
     opts.add_option("-o", "--debugoutput", dest="debugoutput",
                     help="write output to file instead of to serial port")
     opts.add_option("-d", "--dictionary", dest="dictionary", type="string",
@@ -264,6 +266,11 @@ def main():
         bglogger = queuelogger.setup_bg_logging(options.logfile, debuglevel)
     else:
         logging.basicConfig(level=debuglevel)
+    if options.git_config:
+        start_args['git_config'] = True
+    else:
+        start_args['git_config'] = False
+        
     logging.info("Starting Klippy...")
     start_args['software_version'] = util.get_git_version()
     if bglogger is not None:

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -270,7 +270,7 @@ def main():
         start_args['git_config'] = True
     else:
         start_args['git_config'] = False
-        
+
     logging.info("Starting Klippy...")
     start_args['software_version'] = util.get_git_version()
     if bglogger is not None:


### PR DESCRIPTION
If you prefer to keep your klippy config file git versioned, klippys timestamped backup config file approach doesn't play well. 
This PR adds a commandline switch `-g True` which assumes that your config file is in a git repository, and hence changes to it can be versioned using `git commit`. 

Signed-off-by: Wilfried Goesgens <willi@arangodb.com>