### PR TITLE
bed_mesh: Fix typo in the error

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -339,7 +339,7 @@ class BedMeshCalibrate:
             # than 6 samples
             raise config.error(
                 "bed_mesh: cannot exceed a probe_count of 6 when using "
-                "langrange interpolation. Configured Probe Count: %d, %d" %
+                "lagrange interpolation. Configured Probe Count: %d, %d" %
                 (self.mesh_params['x_count'], self.mesh_params['y_count']))
         elif params['algo'] == 'bicubic' and min_probe_cnt < 4:
             if max_probe_cnt > 6:


### PR DESCRIPTION
This PR fixes the typo in the error message.

Signed-off-by: Piotr Usewicz <piotr@layer22.com>

/cc @KevinOConnor 