### PR TITLE
Simplify handling of BL-Touch command timing

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -626,9 +626,8 @@
 #stow_on_each_sample: True
 #   This determines if Klipper should command the pin to move up
 #   between each probe attempt when performing a multiple probe
-#   sequence. Setting this to False can allow for faster probing, but
-#   using this mode requires careful tuning of probing speed
-#   parameters. The default is True.
+#   sequence. Read the directions in docs/BLTouch.md before setting
+#   this to False. The default is True.
 #probe_with_touch_mode: False
 #   If this is set to True then Klipper will probe with the device in
 #   "touch_mode". The default is False (probing in "pin_down" mode).

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -630,8 +630,8 @@
 #   using this mode requires careful tuning of probing speed
 #   parameters. The default is True.
 #probe_with_touch_mode: False
-#   You can elect to probe in touch mode if you want. Note that this
-#   is not supported by all probe types.
+#   If this is set to True then Klipper will probe with the device in
+#   "touch_mode". The default is False (probing in "pin_down" mode).
 #pin_up_reports_not_triggered: True
 #   Set if the BLTouch consistently reports the probe in a "not
 #   triggered" state after a successful "pin_up" command. This should

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -629,6 +629,9 @@
 #   sequence. Setting this to False can allow for faster probing, but
 #   using this mode requires careful tuning of probing speed
 #   parameters. The default is True.
+#probe_with_touch_mode: False
+#   You can elect to probe in touch mode if you want. Note that this
+#   is not supported by all probe types.
 #pin_up_reports_not_triggered: True
 #   Set if the BLTouch consistently reports the probe in a "not
 #   triggered" state after a successful "pin_up" command. This should

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -620,9 +620,9 @@
 #control_pin:
 #   Pin connected to the BLTouch control pin. This parameter must be
 #   provided.
-#pin_move_time: 0.675
+#pin_move_time: 0.680
 #   The amount of time (in seconds) to wait for the BLTouch pin to
-#   move up or down. The default is 0.675 seconds.
+#   move up or down. The default is 0.680 seconds.
 #stow_on_each_sample: True
 #   This determines if Klipper should command the pin to move up
 #   between each probe attempt when performing a multiple probe

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -48,13 +48,13 @@ the probe should be lit. If there are any errors, for example the
 probe is flashing red or the pin is down instead of up, please turn
 off the printer and check the wiring and configuration.
 
-If the above is looking good, it's time to test that the probe
-responds to commands from the firmware. First run `BLTOUCH_DEBUG
-COMMAND=pin_down` in your printer terminal. Verify that the pin moves
-down and that the red LED on the probe turns off. If not, check your
-wiring and configuration again. Next issue a `BLTOUCH_DEBUG
-COMMAND=pin_up`, verify that the pin moves up, and that the red light
-turns on again. If it's flashing then there's some problem.
+If the above is looking good, it's time to test that the control pin
+is working correctly. First run `BLTOUCH_DEBUG COMMAND=pin_down` in
+your printer terminal. Verify that the pin moves down and that the red
+LED on the probe turns off. If not, check your wiring and
+configuration again. Next issue a `BLTOUCH_DEBUG COMMAND=pin_up`,
+verify that the pin moves up, and that the red light turns on
+again. If it's flashing then there's some problem.
 
 The next step is to confirm that the sensor pin is working correctly.
 Run `BLTOUCH_DEBUG COMMAND=pin_down`, verify that the pin moves down,
@@ -66,15 +66,15 @@ not report the correct message then check your wiring and
 configuration again. At the completion of this test run `BLTOUCH_DEBUG
 COMMAND=pin_up` and verify that the pin moves up.
 
-After completing the BL-Touch command and sensor tests, it is now time
-to test probing, but with a twist. Instead of letting the probe pin
-touch the print bed, let it touch the nail on your finger. Position
-the toolhead far from the bed, issue a `G28` (or `PROBE` if not using
-probe:z_virtual_endstop), wait until the toolhead starts to move down,
-and stop the movement by very gently touching the pin with your nail.
-You may have to do it twice, since the default homing configuration
-probes twice. Be prepared to turn off the printer, to avoid damage, if
-it doesn't stop when you touch the pin.
+After completing the BL-Touch control pin and sensor pin tests, it is
+now time to test probing, but with a twist. Instead of letting the
+probe pin touch the print bed, let it touch the nail on your finger.
+Position the toolhead far from the bed, issue a `G28` (or `PROBE` if
+not using probe:z_virtual_endstop), wait until the toolhead starts to
+move down, and stop the movement by very gently touching the pin with
+your nail. You may have to do it twice, since the default homing
+configuration probes twice. Be prepared to turn off the printer if it
+doesn't stop when you touch the pin.
 
 If that was successful, do another `G28` (or `PROBE`) but this time
 let it touch the bed as it should.
@@ -140,6 +140,34 @@ the second query reports "probe: TRIGGERED" then it indicates that
 `pin_up_reports_not_triggered` should be set to False in the Klipper
 config file.
 
+BL-Touch v3
+===========
+
+Some BL-Touch v3.0 and BL-Touch 3.1 devices may require configuring
+`probe_with_touch_mode` in the printer config file.
+
+If the BL-Touch v3.0 has its signal wire connected to an endstop pin
+(with a noise filtering capacitor), then the BL-Touch v3.0 may not be
+able to consistently send a signal during homing and probing. If the
+`QUERY_PROBE` commands in the [initial tests section](#initial-tests)
+always produce the expected results, but the toolhead does not always
+stop during G28/PROBE commands, then it is indicative of this issue. A
+workaround is to set `probe_with_touch_mode: True` in the config file.
+
+The BL-Touch v3.1 may incorrectly enter an error state after a
+successful probe attempt. The symptoms are an occasional flashing
+light on the BL-Touch v3.1 that lasts for a couple of seconds after it
+successfully contacts the bed. Klipper should clear this error
+automatically and it is generally harmless. However, one may set
+`probe_with_touch_mode` in the config file to avoid this issue.
+
+Important! Some "clone" devices and the BL-Touch v2.0 (and earlier)
+may have reduced accuracy when `probe_with_touch_mode` is set to True.
+Setting this to True also increases the time it takes to deploy the
+probe. If configuring this value on a "clone" or older BL-Touch
+device, be sure to test the probe accuracy before and after setting
+this value (use the `PROBE_ACCURACY` command to test).
+
 Calibrating the BL-Touch offsets
 ================================
 
@@ -193,21 +221,3 @@ BL-Touch output mode
   default being a safe OPEN DRAIN mode) and is not suited to be repeatedly
   issued by any slicer, macro or anything else, it is preferably only to be
   used when first integrating the probe into a printers electronics.
-
-Troubleshooting
-===============
-
-* A BL-Touch v3 may not work correctly when its signal wire is
-  connected to the Z end-stop pin on some printer boards. The symptoms
-  of this problem are: the BL-Touch probe deploys, the printer
-  descends, the probe contacts a surface, the BL-Touch raises the
-  probe, the BL-Touch does not successfully notify the
-  micro-controller, and the printer continues to descend. The Z
-  end-stop pin on some printer boards have a capacitor to filter the
-  signal which the BL-Touch v3 may not support. The simplest solution
-  is to connect the BL-Touch v3 sensor wire to an available pin on the
-  printer board that is not associated with an end-stop (and thus is
-  unlikely to have a capacitor). An alternative solution is to
-  physically alter the printer board to disable the given end-stop
-  capacitor or to add a hardware "pull up resistor" to the BL-Touch v3
-  sensor wire.

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -168,6 +168,37 @@ probe. If configuring this value on a "clone" or older BL-Touch
 device, be sure to test the probe accuracy before and after setting
 this value (use the `PROBE_ACCURACY` command to test).
 
+Multi-probing without stowing
+=============================
+
+By default, Klipper will deploy the probe at the start of each probe
+attempt and then stow the probe afterwards. This repetitive deploying
+and stowing of the probe may increase the total time of calibration
+sequences that involve many probe measurements. Klipper supports
+leaving the probe deployed between consecutive probes, which can
+reduce the total time of probing. This mode is enabled by configuring
+`stow_on_each_sample` to False in the config file.
+
+Important! Setting `stow_on_each_sample` to False can lead to Klipper
+making horizontal toolhead movements while the probe is deployed. Be
+sure to verify all probing operations have sufficient Z clearance
+prior to setting this value to False. If there is insufficient
+clearance then a horizontal move may cause the pin to catch on an
+obstruction and result in damage to the printer.
+
+Important! It is recommended to use `probe_with_touch_mode` configured
+to True when using `stow_on_each_sample` configured to False. Some
+"clone" devices may not detect a subsequent bed contact if
+`probe_with_touch_mode` is not set. On all devices, using the
+combination of these two settings simplifies the device signaling,
+which can improve overall stability.
+
+Note, however, that some "clone" devices and the BL-Touch v2.0 (and
+earlier) may have reduced accuracy when `probe_with_touch_mode` is set
+to True. On these devices it is a good idea to test the probe accuracy
+before and after setting `probe_with_touch_mode` (use the
+`PROBE_ACCURACY` command to test).
+
 Calibrating the BL-Touch offsets
 ================================
 

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -31,6 +31,8 @@ class BLTouchEndstopWrapper:
         self.position_endstop = config.getfloat('z_offset')
         self.stow_on_each_sample = config.getboolean('stow_on_each_sample',
                                                      True)
+        self.probe_touch_mode = config.getboolean('probe_with_touch_mode',
+                                                  False)
         # Create a pwm object to handle the control pin
         ppins = self.printer.lookup_object('pins')
         self.mcu_pwm = ppins.setup_pin('pwm', config.get('control_pin'))
@@ -134,6 +136,8 @@ class BLTouchEndstopWrapper:
         self.test_sensor()
         self.sync_print_time()
         self.send_cmd('pin_down', duration=self.pin_move_time)
+        if self.probe_touch_mode:
+            self.send_cmd('touch_mode')
     def test_sensor(self):
         if not self.pin_up_touch_triggered:
             # Nothing to test

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -1,9 +1,9 @@
 # BLTouch support
 #
-# Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import math, logging
+import logging
 import homing, probe
 
 SIGNAL_PERIOD = 0.020
@@ -16,7 +16,7 @@ ENDSTOP_SAMPLE_TIME = .000015
 ENDSTOP_SAMPLE_COUNT = 4
 
 Commands = {
-    None: 0.0, 'pin_down': 0.000650, 'touch_mode': 0.001165,
+    'pin_down': 0.000650, 'touch_mode': 0.001165,
     'pin_up': 0.001475, 'self_test': 0.001780, 'reset': 0.002190,
     'set_5V_output_mode' : 0.001988, 'set_OD_output_mode' : 0.002091,
     'output_mode_store' : 0.001884,
@@ -36,7 +36,7 @@ class BLTouchEndstopWrapper:
         self.mcu_pwm = ppins.setup_pin('pwm', config.get('control_pin'))
         self.mcu_pwm.setup_max_duration(0.)
         self.mcu_pwm.setup_cycle_time(SIGNAL_PERIOD)
-        self.next_cmd_time = 0.
+        self.next_cmd_time = self.action_end_time = 0.
         # Create an "endstop" object to handle the sensor pin
         pin = config.get('sensor_pin')
         pin_params = ppins.lookup_pin(pin, can_invert=True, can_pullup=True)
@@ -55,8 +55,7 @@ class BLTouchEndstopWrapper:
             'pin_up_touch_mode_reports_triggered', True)
         self.start_mcu_pos = []
         # Calculate pin move time
-        pmt = max(config.getfloat('pin_move_time', 0.675), MIN_CMD_TIME)
-        self.pin_move_time = math.ceil(pmt / SIGNAL_PERIOD) * SIGNAL_PERIOD
+        self.pin_move_time = config.getfloat('pin_move_time', 0.680, above=0.)
         # Wrappers
         self.get_mcu = self.mcu_endstop.get_mcu
         self.add_stepper = self.mcu_endstop.add_stepper
@@ -94,32 +93,34 @@ class BLTouchEndstopWrapper:
         else:
             self.next_cmd_time = print_time
     def send_cmd(self, cmd, duration=MIN_CMD_TIME):
-        self.mcu_pwm.set_pwm(self.next_cmd_time, Commands[cmd] / SIGNAL_PERIOD)
         # Translate duration to ticks to avoid any secondary mcu clock skew
         mcu = self.mcu_pwm.get_mcu()
         cmd_clock = mcu.print_time_to_clock(self.next_cmd_time)
-        cmd_clock += mcu.seconds_to_clock(max(duration, MIN_CMD_TIME))
-        self.next_cmd_time = mcu.clock_to_print_time(cmd_clock)
-        return self.next_cmd_time
-    def verify_state(self, check_start_time, check_end_time, triggered):
+        pulse = int((duration - MIN_CMD_TIME) / SIGNAL_PERIOD) * SIGNAL_PERIOD
+        cmd_clock += mcu.seconds_to_clock(max(MIN_CMD_TIME, pulse))
+        end_time = mcu.clock_to_print_time(cmd_clock)
+        # Schedule command followed by PWM disable
+        self.mcu_pwm.set_pwm(self.next_cmd_time, Commands[cmd] / SIGNAL_PERIOD)
+        self.mcu_pwm.set_pwm(end_time, 0.)
+        # Update time tracking
+        self.action_end_time = self.next_cmd_time + duration
+        self.next_cmd_time = max(self.action_end_time, end_time + MIN_CMD_TIME)
+    def verify_state(self, triggered):
         # Perform endstop check to verify bltouch reports desired state
-        self.mcu_endstop.home_start(check_start_time, ENDSTOP_SAMPLE_TIME,
+        self.mcu_endstop.home_start(self.action_end_time, ENDSTOP_SAMPLE_TIME,
                                     ENDSTOP_SAMPLE_COUNT, ENDSTOP_REST_TIME,
                                     triggered=triggered)
-        return self.mcu_endstop.home_wait(check_end_time)
+        return self.mcu_endstop.home_wait(self.action_end_time + 0.100)
     def raise_probe(self):
         self.sync_mcu_print_time()
         if not self.pin_up_not_triggered:
             # No way to verify raise attempt - just issue commands
             self.send_cmd('reset')
             self.send_cmd('pin_up', duration=self.pin_move_time)
-            self.send_cmd(None)
             return
         for retry in range(3):
-            check_start_time = self.send_cmd('pin_up',
-                                             duration=self.pin_move_time)
-            check_end_time = self.send_cmd(None)
-            success = self.verify_state(check_start_time, check_end_time, False)
+            self.send_cmd('pin_up', duration=self.pin_move_time)
+            success = self.verify_state(False)
             if success:
                 # The "probe raised" test completed successfully
                 break
@@ -132,9 +133,7 @@ class BLTouchEndstopWrapper:
     def lower_probe(self):
         self.test_sensor()
         self.sync_print_time()
-        duration = max(MIN_CMD_TIME, self.pin_move_time - MIN_CMD_TIME)
-        self.send_cmd('pin_down', duration=duration)
-        self.send_cmd(None)
+        self.send_cmd('pin_down', duration=self.pin_move_time)
     def test_sensor(self):
         if not self.pin_up_touch_triggered:
             # Nothing to test
@@ -147,15 +146,13 @@ class BLTouchEndstopWrapper:
         # Raise the bltouch probe and test if probe is raised
         self.sync_print_time()
         for retry in range(3):
-            check_start_time = self.send_cmd('pin_up',
-                                             duration=self.pin_move_time)
+            self.send_cmd('pin_up', duration=self.pin_move_time)
             self.send_cmd('touch_mode')
-            check_end_time = self.send_cmd(None)
-            success = self.verify_state(check_start_time, check_end_time, True)
+            success = self.verify_state(True)
             self.sync_print_time()
             if success:
                 # The "bltouch connection" test completed successfully
-                self.next_test_time = check_end_time + TEST_TIME
+                self.next_test_time = print_time + TEST_TIME
                 return
             msg = "BLTouch failed to verify sensor state"
             if retry >= 2:
@@ -233,7 +230,6 @@ class BLTouchEndstopWrapper:
         else:
             self.send_cmd('set_OD_output_mode')
         self.send_cmd('pin_up')
-        self.send_cmd(None)
     cmd_BLTOUCH_DEBUG_help = "Send a command to the bltouch for debugging"
     def cmd_BLTOUCH_DEBUG(self, gcmd):
         cmd = gcmd.get('COMMAND', None)
@@ -244,7 +240,6 @@ class BLTouchEndstopWrapper:
         gcmd.respond_info("Sending BLTOUCH_DEBUG COMMAND=%s" % (cmd,))
         self.sync_print_time()
         self.send_cmd(cmd, duration=self.pin_move_time)
-        self.send_cmd(None)
         self.sync_print_time()
     cmd_BLTOUCH_STORE_help = "Store an output mode in the BLTouch EEPROM"
     def cmd_BLTOUCH_STORE(self, gcmd):


### PR DESCRIPTION
The BL-Touch timing optimization in commit 5c8d15bb had to be reverted (as of commit a028aeaf).  Here's another attempt at it, which also tries to simplify the overall handling of command timing.  Unfortunately, I don't have a good way to test this, so consider it a bit risky.

@FanDjango - FYI.

-Kevin