### PR TITLE
gcode: Make homed information appear in GET_POSITION response

### DIFF
--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -34,8 +34,7 @@ class SafeZHoming:
         # Perform Z Hop if necessary
         if self.z_hop != 0.0:
             pos = toolhead.get_position()
-            curtime = self.printer.get_reactor().monotonic()
-            kin_status = toolhead.get_kinematics().get_status(curtime)
+            kin_status = toolhead.get_kinematics().get_status()
             # Check if Z axis is homed or has a known position
             if 'z' in kin_status['homed_axes']:
                 # Check if the zhop would exceed the printer limits

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -637,8 +637,7 @@ class GCodeParser:
             s.set_tag_position(s.get_commanded_position())
         stepper_pos = " ".join(["%s:%.6f" % (s.get_name(), s.get_tag_position())
                                 for s in steppers])
-        kin_status = kin.get_status(self.reactor.monotonic())
-        kin_homed = [a in kin_status['homed_axes'] for a in 'xyz']
+        kin_homed = [a in kin.get_status()['homed_axes'] for a in 'xyz']
         kin_pos = " ".join(["%s:%s" % (a, v)
             for a, v in zip("XYZ", [str(p) if h else 'Unhomed'
             for (p, h) in zip(kin.calc_tag_position(), kin_homed)])])

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -637,8 +637,11 @@ class GCodeParser:
             s.set_tag_position(s.get_commanded_position())
         stepper_pos = " ".join(["%s:%.6f" % (s.get_name(), s.get_tag_position())
                                 for s in steppers])
-        kin_pos = " ".join(["%s:%.6f" % (a, v)
-                            for a, v in zip("XYZ", kin.calc_tag_position())])
+        kin_status = kin.get_status(self.reactor.monotonic())
+        kin_homed = [a in kin_status['homed_axes'] for a in 'xyz']
+        kin_pos = " ".join(["%s:%s" % (a, v)
+            for a, v in zip("XYZ", [str(p) if h else 'Unhomed'
+            for (p, h) in zip(kin.calc_tag_position(), kin_homed)])])
         toolhead_pos = " ".join(["%s:%.6f" % (a, v) for a, v in zip(
             "XYZE", self.toolhead.get_position())])
         gcode_pos = " ".join(["%s:%.6f"  % (a, v)

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -117,7 +117,7 @@ class CartKinematics:
         z_ratio = move.move_d / abs(move.axes_d[2])
         move.limit_speed(
             self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
-    def get_status(self, eventtime):
+    def get_status(self):
         axes = [a for a, (l, h) in zip("xyz", self.limits) if l <= h]
         return { 'homed_axes': "".join(axes) }
     # Dual carriage support

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -94,7 +94,7 @@ class CoreXYKinematics:
         z_ratio = move.move_d / abs(move.axes_d[2])
         move.limit_speed(
             self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
-    def get_status(self, eventtime):
+    def get_status(self):
         axes = [a for a, (l, h) in zip("xyz", self.limits) if l <= h]
         return {'homed_axes': "".join(axes)}
 

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -145,7 +145,7 @@ class DeltaKinematics:
             move.limit_speed(max_velocity * r, self.max_accel * r)
             limit_xy2 = -1.
         self.limit_xy2 = min(limit_xy2, self.slow_xy2)
-    def get_status(self, eventtime):
+    def get_status(self):
         return {'homed_axes': '' if self.need_home else 'xyz'}
     def get_calibration(self):
         endstops = [rail.get_homing_info().position_endstop

--- a/klippy/kinematics/none.py
+++ b/klippy/kinematics/none.py
@@ -17,7 +17,7 @@ class NoneKinematics:
         pass
     def check_move(self, move):
         pass
-    def get_status(self, eventtime):
+    def get_status(self):
         return {'homed_axes': ''}
 
 def load_kinematics(toolhead, config):

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -106,7 +106,7 @@ class PolarKinematics:
             z_ratio = move.move_d / abs(move.axes_d[2])
             move.limit_speed(
                 self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
-    def get_status(self, eventtime):
+    def get_status(self):
         xy_home = "xy" if self.limit_xy2 >= 0. else ""
         z_home = "z" if self.limit_z[0] <= self.limit_z[1] else ""
         return {'homed_axes': xy_home + z_home}

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -45,7 +45,7 @@ class WinchKinematics:
     def check_move(self, move):
         # XXX - boundary checks and speed limits not implemented
         pass
-    def get_status(self, eventtime):
+    def get_status(self):
         # XXX - homed_checks and rail limits not implemented
         return {'homed_axes': 'xyz'}
 

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -490,7 +490,7 @@ class ToolHead:
             status = "Printing"
         else:
             status = "Ready"
-        res = dict(self.kin.get_status(eventtime))
+        res = dict(self.kin.get_status())
         res.update({ 'status': status, 'print_time': print_time,
                      'estimated_print_time': estimated_print_time,
                      'extruder': self.extruder.get_name(),


### PR DESCRIPTION
AFAIK the only way to know if a stepper is homed is to try a G1 and to see if it get an error.
I propose to add this information to GET_POSITION.
In GET_POSITION reponse, kinematic fields will be set as 'Unhomed' until the corresponding axis is homed.