### PR TITLE
homing: Fix zero division in homing rate calculation

### DIFF
--- a/klippy/homing.py
+++ b/klippy/homing.py
@@ -39,7 +39,10 @@ class Homing:
                               - s.calc_position_from_coord(movepos))
                           / s.get_step_dist())
                          for s in mcu_endstop.get_steppers()])
-        return move_t / max_steps
+        try:
+            return move_t / max_steps
+        except ZeroDivisionError:
+            return 1.0
     def homing_move(self, movepos, endstops, speed,
                     probe_pos=False, verify_movement=False):
         # Notify start of homing/probing move


### PR DESCRIPTION
Refers to issue #2738
When calling PROBE from z=0 with z_offset=0, a division by zero occurs. In that case, rate has no meaning has no move will be done, so a default 1.0 value is returned instead.