### PR TITLE
virtual_sdcard: pre-spooling gcode file

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -470,6 +470,16 @@
 #   are not supported). One may point this to OctoPrint's upload
 #   directory (generally ~/.octoprint/uploads/ ). This parameter must
 #   be provided.
+#pre_spool: True
+#   Use a spooled temporary file to process gcode. This is useful
+#   when your virtual sdcard path is a slow or unreliable data source
+#   such as an NFS mount or external hard drive.
+#   Optional parameter. The default is false.
+#max_spool_size: 64
+#   The max file size in megabytes to allow in RAM. Anything larger will
+#   be written to a temporary file on disk. This value has no effect when
+#   pre_spool is False.
+#   Optional parameter. The default is 64
 
 # Support manually moving stepper motors for diagnostic purposes.
 # Note, using this feature may place the printer in an invalid state -


### PR DESCRIPTION
This change helps make the input source of the gcode files both in path and medium less sensitive.

**Spooling behavior use case:**
In my home setup I have multiple machines running klipper on a typical raspbian 3b+ setup, each instance utilizes a virtual_sdcard path that is actually an NFS volume mount that is hosted from a separate file server. While this typically works well it introduces network as an element of the critical path. At times this prohibits me from doing server maintenance while prints are running. Additionally I believe a series of recent `no next step` failures are due to network or server issues of some sort (gcode file read stalling I am assuming).

**Select/Clear extraction use case:**
For the spooling work it allowed a bit less code duplication and separating the gcode param unpacking from the file operations.

It is also an enabler for improvements in the DWC2-for-klipper extra.
1. The DWC2-for-klipper extra has reimplemented a part of the `M23` logic [as part of its `M32` command](https://github.com/Stephan3/dwc2-for-klipper/blob/master/web_dwc2.py#L1074).  By extracting the select logic the integration can be improved in that module to allow virtual_sdcard.py to own the file operations, equally making DWC2-for-klipper not need to replicate the spooling behavior introduced here. 

2. Once a few small changes are made within the DWC2-for-klipper repo as well as a small adjustment to the sd card menu configuration in a users printer.cfg, DWC2-for-klipper can be made to gracefully handle the situation where a print is started via the printer LCD.

3. Due to the code duplication in DWC2-for-klipper file descriptors seemed to be leaked since clear logic was not executed when appropriate. Again having virtual_sdcard expose the select logic ensures files are closed with appropriate timing.