### PR TITLE
Multiple MCU makefile and Linux shell script [old: Linux mcu extension for digital gpi]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 out
+out_*
 *.so
 *.pyc
 .config
 .config.old
+.config_*
+.config_*.old
 klippy/.version

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,19 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 # Output directory
-OUT=out/
+MCU?=1
+ifeq "$(MCU)"  "1"
+  OUT?=out/
+  export KCONFIG_CONFIG?=$(CURDIR)/.config
+else
+  OUT?=out_$(MCU)/
+  export KCONFIG_CONFIG?=$(CURDIR)/.config_$(MCU)
+endif
 
 # Kconfig includes
 export HOSTCC             := $(CC)
 export CONFIG_SHELL       := sh
 export KCONFIG_AUTOHEADER := autoconf.h
-export KCONFIG_CONFIG     := $(CURDIR)/.config
 -include $(KCONFIG_CONFIG)
 
 # Common command definitions

--- a/config/sample-multi-mcu.cfg
+++ b/config/sample-multi-mcu.cfg
@@ -1,6 +1,13 @@
 # This file contains an example configuration with three
 # micro-controllers simultaneously controlling a single printer.
 
+# You can pass the MCU parameter to the 'make' command to
+# separate the configurations.
+# This way you can give the 'make manuconfig', 'make' and 'make flash'
+# commands for the primary mcu and 'make MCU=<number> menuconfig',
+# 'make MCU=<number>' and 'make MCU=<number> flash' for the others where
+# <number> goes from 2..n (1 is an alias of the primary mcu)
+
 # See both the example.cfg and example-extras.cfg file for a
 # description of available parameters.
 

--- a/docs/beaglebone.md
+++ b/docs/beaglebone.md
@@ -76,13 +76,13 @@ It is also necessary to compile and install the micro-controller code
 for a Linux host process. Run "make menuconfig" a second time and
 configure it for a "Linux process":
 ```
-make menuconfig
+make MCU=2 menuconfig
 ```
 
 Then install this micro-controller code as well:
 ```
 sudo service klipper stop
-make flash
+make MCU=2 flash
 sudo service klipper start
 ```
 

--- a/scripts/flash-linux.sh
+++ b/scripts/flash-linux.sh
@@ -15,6 +15,12 @@ sync
 
 # Restart (if system install script present)
 if [ -f /etc/init.d/klipper_pru ]; then
-    echo "Attempting host MCU restart..."
+    echo "Attempting host PRU restart..."
     service klipper_pru restart
+fi
+
+# Restart (if system install script present)
+if [ -f /etc/init.d/klipper_mcu ]; then
+    echo "Attempting host MCU restart..."
+    service klipper_mcu restart
 fi

--- a/scripts/flash-linux.sh
+++ b/scripts/flash-linux.sh
@@ -4,7 +4,7 @@
 if [ "$#" -ge 1 ]; then
     OUT=$1
 else
-    OUT=out/
+    OUT=out
 fi
 
 if [ "$EUID" -ne 0 ]; then

--- a/scripts/flash-linux.sh
+++ b/scripts/flash-linux.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # This script installs the Linux MCU code to /usr/local/bin/
 
+if [ "$#" -ge 1 ]; then
+    OUT=$1
+else
+    OUT=out/
+fi
+
 if [ "$EUID" -ne 0 ]; then
     echo "This script must be run as root"
     exit -1
@@ -10,7 +16,7 @@ set -e
 # Install new micro-controller code
 echo "Installing mirco-controller code to /usr/local/bin/"
 rm -f /usr/local/bin/klipper_mcu
-cp out/klipper.elf /usr/local/bin/klipper_mcu
+cp $OUT/klipper.elf /usr/local/bin/klipper_mcu
 sync
 
 # Restart (if system install script present)

--- a/scripts/flash-pru.sh
+++ b/scripts/flash-pru.sh
@@ -4,7 +4,7 @@
 if [ "$#" -ge 1 ]; then
     OUT=$1
 else
-    OUT=out/
+    OUT=out
 fi
 
 if [ "$EUID" -ne 0 ]; then

--- a/scripts/flash-pru.sh
+++ b/scripts/flash-pru.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # This script installs the PRU firmware on a beaglebone machine.
 
+if [ "$#" -ge 1 ]; then
+    OUT=$1
+else
+    OUT=out/
+fi
+
 if [ "$EUID" -ne 0 ]; then
     echo "This script must be run as root"
     exit -1
@@ -9,8 +15,8 @@ set -e
 
 # Install new firmware
 echo "Installing firmware to /lib/firmware/"
-cp out/pru0.elf /lib/firmware/am335x-pru0-fw
-cp out/pru1.elf /lib/firmware/am335x-pru1-fw
+cp $OUT/pru0.elf /lib/firmware/am335x-pru0-fw
+cp $OUT/pru1.elf /lib/firmware/am335x-pru1-fw
 sync
 
 # Restart (if system install script present)

--- a/scripts/klipper-mcu-start.sh
+++ b/scripts/klipper-mcu-start.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# System startup script to start the MCU Linux firmware
+
+### BEGIN INIT INFO
+# Provides:          klipper_mcu
+# Required-Start:    $local_fs
+# Required-Stop:
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Klipper_MCU daemon
+# Description:       Starts the MCU for Klipper.
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+DESC="klipper_mcu startup"
+NAME="klipper_mcu"
+KLIPPER_HOST_MCU=/usr/local/bin/klipper_mcu
+KLIPPER_HOST_ARGS="-w -r"
+PIDFILE=/var/run/klipper_mcu.pid
+
+. /lib/lsb/init-functions
+
+mcu_host_stop()
+{
+    # Shutdown existing Klipper instance (if applicable). The goal is to
+    # put the GPIO pins in a safe state.
+    if [ -c /tmp/klipper_host_mcu ]; then
+        log_daemon_msg "Attempting to shutdown host mcu..."
+        set -e
+        ( echo "FORCE_SHUTDOWN" > /tmp/klipper_host_mcu ) 2> /dev/null || ( log_action_msg "Firmware busy! Please shutdown Klipper and then retry." && exit 1 )
+        sleep 1
+        ( echo "FORCE_SHUTDOWN" > /tmp/klipper_host_mcu ) 2> /dev/null || ( log_action_msg "Firmware busy! Please shutdown Klipper and then retry." && exit 1 )
+        sleep 1
+        set +e
+    fi
+
+    log_daemon_msg "Stopping klipper host mcu" $NAME
+    killproc -p $PIDFILE $KLIPPER_HOST_MCU
+}
+
+mcu_host_start()
+{
+    [ -x $KLIPPER_HOST_MCU ] || return
+
+    if [ -c /tmp/klipper_host_mcu ]; then
+        mcu_host_stop
+    fi
+
+    log_daemon_msg "Starting klipper MCU" $NAME
+    start-stop-daemon --start --quiet --exec $KLIPPER_HOST_MCU \
+                      --background --pidfile $PIDFILE --make-pidfile \
+                      -- $KLIPPER_HOST_ARGS
+    log_end_msg $?
+}
+
+case "$1" in
+start)
+    mcu_host_start
+    ;;
+stop)
+    mcu_host_stop
+    ;;
+restart)
+    $0 stop
+    $0 start
+    ;;
+reload|force-reload)
+    log_daemon_msg "Reloading configuration not supported" $NAME
+    log_end_msg 1
+    ;;
+status)
+    status_of_proc -p $PIDFILE $KLIPPER_HOST_MCU $NAME && exit 0 || exit $?
+    ;;
+*)  log_action_msg "Usage: /etc/init.d/klipper_mcu {start|stop|status|restart|reload|force-reload}"
+    exit 2
+    ;;
+esac
+exit 0

--- a/src/linux/Makefile
+++ b/src/linux/Makefile
@@ -10,4 +10,4 @@ CFLAGS_klipper.elf += -lutil
 
 flash: $(OUT)klipper.elf
 	@echo "  Flashing"
-	$(Q)sudo ./scripts/flash-linux.sh
+	$(Q)sudo ./scripts/flash-linux.sh $(OUT)

--- a/src/pru/Makefile
+++ b/src/pru/Makefile
@@ -35,4 +35,4 @@ $(OUT)pru1.elf: $(OUT)klipper.elf
 
 flash: $(OUT)pru0.elf $(OUT)pru1.elf
 	@echo "  Flashing"
-	$(Q)sudo ./scripts/flash-pru.sh
+	$(Q)sudo ./scripts/flash-pru.sh $(OUT)


### PR DESCRIPTION
- Add new parameter to make to allow multiple config.
  For example the command for the second mcu are:
```
      make MCU=2 menuconfig
      make MCU=2
      make MCU=2 flash
```
- New shell script for start/stop only the linux mcu without pru


Old description:
> This PR implements the GPIO support of the bcm2835 chipset on linux mcu.
> 
> ~~_**ATTENTION** : It is only beta version implementation (see below). I present it to see if it can be useful to others and to get advice.~~
> 
> This makes it possible to configure a second MCU in config and use the host GPIO pins to control elements of the printer.
> 
> ***Possible uses cases:***
> - Enclosure devices and sensors on host GPIO ( door sensors, light, thermal sensor, fan, psu control, air sensors etc etc )
> - You need more GPIO and your MCU board not has more pin.
> - Build a 3DPrinter ontop RPi without extra MCU ( see  [PandaPi extra board](https://github.com/markniu/PandaPi/ ) as example )
> 
> ***My use case:***
> In my configuration I have an Octopi+Klipper config ( RPi3B+ and a SKR v1.3). On the RPI i use the GPIO to control a led strip ( realy on GPIO20 ), a DHT11 for enclosure temp ( GPIO26) , a Cooling PWM Fan ( GPIO13 / PWM2 ) and the PSU for SKR ( relay on GPIO21 ).
> 
> Although the use of Octoprint plugins seemed the simplest solution, it brings several limitations, especially regarding what you can or cannot command from the gcode sent to print.
> 
> ***Configuration Examples:***
> 
> - **Light realy on GPIO20**
> ```
> [mcu host]
> serial: /tmp/klipper_host_mcu
> 
> [output_pin light]
> pin: host:gpio20
> 
> ```
> 
> ***Know Issue:*** (checked are fixed)
> 
> - [x] **NOT BCM2835 HW** I don't know if the gpio export system implemented by RPi is used on other chipset or not. I think your best bet is a configuration for whether or not to enable chipset and GPIO support.
> - [x] **FIRMWARE_RESTART** don't work. ~~I need to understand how need to be implemented.~~ The issue was the ignoring on DTR signal on pseudo tty.
> - [x] ~~**PSU control** From what I understand for how klipper's multi MCU system works, I don't think it's possible to control the ignition of one MCU from the other. If I turn off an MCU or it becomes unreachable, klippy goes wrong (_mcu in shutdown state_) and won't let me send commands to the other.~~ _I am studying a system to make the status of MCUs independent. If it will work and especially if useful I will propose the PR._
> - [x] **KLIPPER_MCU STABILITY** ~~Sporadically but it happens the MCU host process (klipper_mcu) remains hung and you have to restart it manually.~~ The issue was related with FIRMWARE_RESTART issue. Now I can say that after 100 prints I didn't have a problem 
> - [x] ~~**GPIO UNEXPORT ON RESTART** I need to find an hook to implement GPIO unexport and fd close on restart or reset.~~ _It is not necessary. The export / import is mainly used to decide the operation of the pin in cases of shared pins. Doing unexport would only serve to reset the choice on the functionality of the pin but to export for a pin already in use from one function to another automatically cancels the first export._
> 
