### PR TITLE
bed_mesh:  make sure the toolhead is available in get_position()

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -133,6 +133,8 @@ class BedMesh:
         else:
             return 1.
     def get_position(self):
+        if self.toolhead is None:
+            return [0., 0., 0., 0.]
         # Return last, non-transformed position
         if self.z_mesh is None:
             # No mesh calibrated, so send toolhead position

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -23,6 +23,8 @@ class BedTilt:
     def handle_connect(self):
         self.toolhead = self.printer.lookup_object('toolhead')
     def get_position(self):
+        if self.toolhead is None:
+            return [0., 0., 0., 0.]
         x, y, z, e = self.toolhead.get_position()
         return [x, y, z - x*self.x_adjust - y*self.y_adjust - self.z_adjust, e]
     def move(self, newpos, speed):


### PR DESCRIPTION
This should resolve #2811, where it appears that a gcode error was raised before the printer is ready.  I also applied this patch to bed_tilt.py.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>