### PR TITLE
linux: change clock frequency

### DIFF
--- a/src/linux/Kconfig
+++ b/src/linux/Kconfig
@@ -17,6 +17,6 @@ config BOARD_DIRECTORY
 
 config CLOCK_FREQ
     int
-    default 20000000
+    default 50000000
 
 endif


### PR DESCRIPTION
Allow configure timer resolution for linux mcu.
With gpio implementation need more precise timings for some hardware.