### PR TITLE
Rename try_load_module() to load_object()

### DIFF
--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -22,7 +22,7 @@ class PrinterADCtoTemperature:
         ppins = config.get_printer().lookup_object('pins')
         self.mcu_adc = ppins.setup_pin('adc', config.get('sensor_pin'))
         self.mcu_adc.setup_adc_callback(REPORT_TIME, self.adc_callback)
-        query_adc = config.get_printer().try_load_module(config, 'query_adc')
+        query_adc = config.get_printer().load_object(config, 'query_adc')
         query_adc.register_adc(config.get_name(), self.mcu_adc)
     def setup_callback(self, temperature_callback):
         self.temperature_callback = temperature_callback
@@ -273,7 +273,7 @@ PT1000 = [
 
 def load_config(config):
     # Register default sensors
-    pheaters = config.get_printer().try_load_module(config, "heaters")
+    pheaters = config.get_printer().load_object(config, "heaters")
     for sensor_type, params in [("AD595", AD595),
                                 ("AD8494", AD8494),
                                 ("AD8495", AD8495),
@@ -294,5 +294,5 @@ def load_config_prefix(config):
         custom_sensor = CustomLinearVoltage(config)
     else:
         custom_sensor = CustomLinearResistance(config)
-    pheaters = config.get_printer().try_load_module(config, "heaters")
+    pheaters = config.get_printer().load_object(config, "heaters")
     pheaters.add_sensor_factory(custom_sensor.name, custom_sensor.create)

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -198,5 +198,5 @@ class BME280:
 
 def load_config(config):
     # Register sensor
-    pheaters = config.get_printer().try_load_module(config, "heaters")
+    pheaters = config.get_printer().load_object(config, "heaters")
     pheaters.add_sensor_factory("BME280", BME280)

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -207,7 +207,7 @@ class RotaryEncoder:
 class PrinterButtons:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.printer.try_load_module(config, 'query_adc')
+        self.printer.load_object(config, 'query_adc')
         self.mcu_buttons = {}
         self.adc_buttons = {}
     def register_adc_button(self, pin, min_val, max_val, pullup, callback):

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -12,9 +12,8 @@ class ControllerFan:
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.stepper_names = []
-        self.stepper_enable = self.printer.try_load_module(config,
-                                                           'stepper_enable')
-        self.printer.try_load_module(config, 'heaters')
+        self.stepper_enable = self.printer.load_object(config, 'stepper_enable')
+        self.printer.load_object(config, 'heaters')
         self.heaters = []
         self.fan = fan.PrinterFan(config)
         self.mcu = self.fan.mcu_fan.get_mcu()

--- a/klippy/extras/delayed_gcode.py
+++ b/klippy/extras/delayed_gcode.py
@@ -12,7 +12,7 @@ class DelayedGcode:
         self.reactor = self.printer.get_reactor()
         self.name = config.get_name().split()[1]
         self.gcode = self.printer.lookup_object('gcode')
-        gcode_macro = self.printer.try_load_module(config, 'gcode_macro')
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.timer_gcode = gcode_macro.load_template(config, 'gcode')
         self.duration = config.getfloat('initial_duration', 0., minval=0.)
         self.timer_handler = None

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -30,7 +30,7 @@ class DisplayTemplate:
                 raise config.error(
                     "Option '%s' in section '%s' is not a valid literal" % (
                         option, config.get_name()))
-        gcode_macro = self.printer.try_load_module(config, 'gcode_macro')
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.template = gcode_macro.load_template(config, 'text')
     def render(self, context, **kwargs):
         params = dict(self.params)
@@ -58,7 +58,7 @@ class DisplayGroup:
         # Load all templates and store sorted by display position
         configs_by_name = {c.get_name(): c for c in data_configs}
         printer = config.get_printer()
-        gcode_macro = printer.try_load_module(config, 'gcode_macro')
+        gcode_macro = printer.load_object(config, 'gcode_macro')
         self.data_items = []
         for row, col, name in sorted(items):
             c = configs_by_name[name]
@@ -88,7 +88,7 @@ class PrinterLCD:
         if name == 'display':
             # only load menu for primary display
             self.menu = menu.MenuManager(config, self.lcd_chip)
-        self.printer.try_load_module(config, "display_status")
+        self.printer.load_object(config, "display_status")
         # Configurable display
         self.display_templates = {}
         self.display_data_groups = {}

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -1019,7 +1019,7 @@ class MenuManager:
         self._last_encoder_cw_eventtime = 0
         self._last_encoder_ccw_eventtime = 0
         # printer objects
-        self.buttons = self.printer.try_load_module(config, "buttons")
+        self.buttons = self.printer.load_object(config, "buttons")
         # register itself for printer callbacks
         self.printer.add_object('menu', self)
         self.printer.register_event_handler("klippy:ready", self.handle_ready)

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -17,8 +17,8 @@ class EndstopPhase:
                                             self.handle_connect)
         self.printer.register_event_handler("homing:home_rails_end",
                                             self.handle_home_rails_end)
-        self.printer.try_load_module(config, "endstop_phase")
-        self.printer.try_load_module(config, "force_move")
+        self.printer.load_object(config, "endstop_phase")
+        self.printer.load_object(config, "force_move")
         # Read config
         self.phases = config.getint('phases', None, minval=1)
         self.endstop_phase = config.getint('endstop_phase', None, minval=0)

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -14,9 +14,9 @@ class RunoutHelper:
         # Read config
         self.runout_pause = config.getboolean('pause_on_runout', True)
         if self.runout_pause:
-            self.printer.try_load_module(config, 'pause_resume')
+            self.printer.load_object(config, 'pause_resume')
         self.runout_gcode = self.insert_gcode = None
-        gcode_macro = self.printer.try_load_module(config, 'gcode_macro')
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
         if self.runout_pause or config.get('runout_gcode', None) is not None:
             self.runout_gcode = gcode_macro.load_template(
                 config, 'runout_gcode', '')
@@ -104,7 +104,7 @@ class RunoutHelper:
 class SwitchSensor:
     def __init__(self, config):
         printer = config.get_printer()
-        buttons = printer.try_load_module(config, 'buttons')
+        buttons = printer.load_object(config, 'buttons')
         switch_pin = config.get('switch_pin')
         buttons.register_buttons([switch_pin], self._button_handler)
         self.runout_helper = RunoutHelper(config)

--- a/klippy/extras/gcode_button.py
+++ b/klippy/extras/gcode_button.py
@@ -11,9 +11,9 @@ class GCodeButton:
         self.name = config.get_name().split(' ')[-1]
         self.pin = config.get('pin')
         self.last_state = 0
-        buttons = self.printer.try_load_module(config, "buttons")
+        buttons = self.printer.load_object(config, "buttons")
         buttons.register_buttons([self.pin], self.button_callback)
-        gcode_macro = self.printer.try_load_module(config, 'gcode_macro')
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.press_template = gcode_macro.load_template(config, 'press_gcode')
         self.release_template = gcode_macro.load_template(config,
                                                           'release_gcode', '')

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -93,7 +93,7 @@ class GCodeMacro:
         name = config.get_name().split()[1]
         self.alias = name.upper()
         self.printer = printer = config.get_printer()
-        gcode_macro = printer.try_load_module(config, 'gcode_macro')
+        gcode_macro = printer.load_object(config, 'gcode_macro')
         self.template = gcode_macro.load_template(config, 'gcode')
         self.gcode = printer.lookup_object('gcode')
         self.rename_existing = config.get("rename_existing", None)

--- a/klippy/extras/heater_bed.py
+++ b/klippy/extras/heater_bed.py
@@ -7,7 +7,7 @@
 class PrinterHeaterBed:
     def __init__(self, config):
         self.printer = config.get_printer()
-        pheaters = self.printer.try_load_module(config, 'heaters')
+        pheaters = self.printer.load_object(config, 'heaters')
         self.heater = pheaters.setup_heater(config, 'B')
         self.get_status = self.heater.get_status
         self.stats = self.heater.stats

--- a/klippy/extras/heater_fan.py
+++ b/klippy/extras/heater_fan.py
@@ -10,7 +10,7 @@ PIN_MIN_TIME = 0.100
 class PrinterHeaterFan:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.printer.try_load_module(config, 'heaters')
+        self.printer.load_object(config, 'heaters')
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.heater_name = config.get("heater", "extruder")
         self.heater_temp = config.getfloat("heater_temp", 50.0)

--- a/klippy/extras/heater_generic.py
+++ b/klippy/extras/heater_generic.py
@@ -5,5 +5,5 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 def load_config_prefix(config):
-    pheaters = config.get_printer().try_load_module(config, 'heaters')
+    pheaters = config.get_printer().load_object(config, 'heaters')
     return pheaters.setup_heater(config)

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -58,8 +58,8 @@ class Heater:
             self.mcu_pwm.setup_cycle_time(pwm_cycle_time)
         self.mcu_pwm.setup_max_duration(MAX_HEAT_TIME)
         # Load additional modules
-        self.printer.try_load_module(config, "verify_heater %s" % (self.name,))
-        self.printer.try_load_module(config, "pid_calibrate")
+        self.printer.load_object(config, "verify_heater %s" % (self.name,))
+        self.printer.load_object(config, "pid_calibrate")
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command("SET_HEATER_TEMPERATURE", "HEATER",
                                    self.name, self.cmd_SET_HEATER_TEMPERATURE,
@@ -260,11 +260,10 @@ class PrinterHeaters:
                 "Unknown heater '%s'" % (heater_name,))
         return self.heaters[heater_name]
     def setup_sensor(self, config):
-        self.printer.try_load_module(config, "thermistor")
-        self.printer.try_load_module(config, "adc_temperature")
-        self.printer.try_load_module(config, "spi_temperature")
-        self.printer.try_load_module(config, "bme280")
-        self.printer.try_load_module(config, "htu21d")
+        modules = ["thermistor", "adc_temperature", "spi_temperature",
+                   "bme280", "htu21d"]
+        for module_name in modules:
+            self.printer.load_object(config, module_name)
         sensor_type = config.get('sensor_type')
         if sensor_type not in self.sensor_factories:
             raise self.printer.config_error(

--- a/klippy/extras/homing_heaters.py
+++ b/klippy/extras/homing_heaters.py
@@ -19,7 +19,7 @@ class HomingHeaters:
         self.disable_heaters = []
         self.steppers_needing_quiet = config.get("steppers", "")
         self.flaky_steppers = []
-        self.pheaters = self.printer.try_load_module(config, 'heaters')
+        self.pheaters = self.printer.load_object(config, 'heaters')
         self.target_save = {}
 
     def handle_connect(self):

--- a/klippy/extras/homing_override.py
+++ b/klippy/extras/homing_override.py
@@ -10,7 +10,7 @@ class HomingOverride:
         self.start_pos = [config.getfloat('set_position_' + a, None)
                           for a in 'xyz']
         self.axes = config.get('axes', 'XYZ').upper()
-        gcode_macro = self.printer.try_load_module(config, 'gcode_macro')
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.template = gcode_macro.load_template(config, 'gcode')
         self.in_script = False
         self.gcode = self.printer.lookup_object('gcode')

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -21,11 +21,11 @@ class IdleTimeout:
         self.toolhead = self.timeout_timer = None
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.idle_timeout = config.getfloat('timeout', 600., above=0.)
-        gcode_macro = self.printer.try_load_module(config, 'gcode_macro')
-        self.idle_gcode = gcode_macro.load_template(
-            config, 'gcode', DEFAULT_IDLE_GCODE)
-        self.gcode.register_command(
-            'SET_IDLE_TIMEOUT', self.cmd_SET_IDLE_TIMEOUT)
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        self.idle_gcode = gcode_macro.load_template(config, 'gcode',
+                                                    DEFAULT_IDLE_GCODE)
+        self.gcode.register_command('SET_IDLE_TIMEOUT',
+                                    self.cmd_SET_IDLE_TIMEOUT)
         self.state = "Idle"
         self.last_print_start_systime = 0.
     def get_status(self, eventtime):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -268,7 +268,7 @@ class ProbeEndstopWrapper:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.position_endstop = config.getfloat('z_offset')
-        gcode_macro = self.printer.try_load_module(config, 'gcode_macro')
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.activate_gcode = gcode_macro.load_template(
             config, 'activate_gcode', '')
         self.deactivate_gcode = gcode_macro.load_template(

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -336,6 +336,6 @@ Sensors = {
 
 def load_config(config):
     # Register sensors
-    pheaters = config.get_printer().try_load_module(config, "heaters")
+    pheaters = config.get_printer().load_object(config, "heaters")
     for name, klass in Sensors.items():
         pheaters.add_sensor_factory(name, klass)

--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -17,7 +17,7 @@ class TemperatureFan:
         self.fan = fan.PrinterFan(config, default_shutdown_speed=1.)
         self.min_temp = config.getfloat('min_temp', minval=KELVIN_TO_CELSIUS)
         self.max_temp = config.getfloat('max_temp', above=self.min_temp)
-        pheaters = self.printer.try_load_module(config, 'heaters')
+        pheaters = self.printer.load_object(config, 'heaters')
         self.sensor = pheaters.setup_sensor(config)
         self.sensor.setup_minmax(self.min_temp, self.max_temp)
         self.sensor.setup_callback(self.temperature_callback)

--- a/klippy/extras/temperature_sensor.py
+++ b/klippy/extras/temperature_sensor.py
@@ -9,7 +9,7 @@ KELVIN_TO_CELSIUS = -273.15
 class PrinterSensorGeneric:
     def __init__(self, config):
         self.printer = config.get_printer()
-        pheaters = self.printer.try_load_module(config, 'heaters')
+        pheaters = self.printer.load_object(config, 'heaters')
         self.sensor = pheaters.setup_sensor(config)
         self.min_temp = config.getfloat('min_temp', KELVIN_TO_CELSIUS,
                                         minval=KELVIN_TO_CELSIUS)

--- a/klippy/extras/thermistor.py
+++ b/klippy/extras/thermistor.py
@@ -116,12 +116,12 @@ Sensors = {
 
 def load_config(config):
     # Register default thermistor types
-    pheaters = config.get_printer().try_load_module(config, "heaters")
+    pheaters = config.get_printer().load_object(config, "heaters")
     for sensor_type, params in Sensors.items():
         func = (lambda config, params=params: PrinterThermistor(config, params))
         pheaters.add_sensor_factory(sensor_type, func)
 
 def load_config_prefix(config):
     thermistor = CustomThermistor(config)
-    pheaters = config.get_printer().try_load_module(config, "heaters")
+    pheaters = config.get_printer().load_object(config, "heaters")
     pheaters.add_sensor_factory(thermistor.name, thermistor.create)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -11,7 +11,7 @@ class PrinterExtruder:
         self.printer = config.get_printer()
         self.name = config.get_name()
         shared_heater = config.get('shared_heater', None)
-        pheaters = self.printer.try_load_module(config, 'heaters')
+        pheaters = self.printer.load_object(config, 'heaters')
         gcode_id = 'T%d' % (extruder_num,)
         if shared_heater is None:
             self.heater = pheaters.setup_heater(config, gcode_id)

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -93,11 +93,6 @@ class Printer:
         if module in self.objects:
             return [(module, self.objects[module])] + objs
         return objs
-    def set_rollover_info(self, name, info, log=True):
-        if log:
-            logging.info(info)
-        if self.bglogger is not None:
-            self.bglogger.set_rollover_info(name, info)
     def try_load_module(self, config, section):
         if section in self.objects:
             return self.objects[section]
@@ -189,6 +184,11 @@ class Printer:
         except:
             logging.exception("Unhandled exception during post run")
         return run_result
+    def set_rollover_info(self, name, info, log=True):
+        if log:
+            logging.info(info)
+        if self.bglogger is not None:
+            self.bglogger.set_rollover_info(name, info)
     def invoke_shutdown(self, msg):
         if self.in_shutdown_state:
             return

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -93,7 +93,7 @@ class Printer:
         if module in self.objects:
             return [(module, self.objects[module])] + objs
         return objs
-    def try_load_module(self, config, section):
+    def load_object(self, config, section, default=configfile.sentinel):
         if section in self.objects:
             return self.objects[section]
         module_parts = section.split()
@@ -103,15 +103,20 @@ class Printer:
         py_dirname = os.path.join(os.path.dirname(__file__),
                                   'extras', module_name, '__init__.py')
         if not os.path.exists(py_name) and not os.path.exists(py_dirname):
-            return None
+            if default is not configfile.sentinel:
+                return default
+            raise self.config_error("Unable to load module '%s'" % (section,))
         mod = importlib.import_module('extras.' + module_name)
         init_func = 'load_config'
         if len(module_parts) > 1:
             init_func = 'load_config_prefix'
         init_func = getattr(mod, init_func, None)
-        if init_func is not None:
-            self.objects[section] = init_func(config.getsection(section))
-            return self.objects[section]
+        if init_func is None:
+            if default is not configfile.sentinel:
+                return default
+            raise self.config_error("Unable to load module '%s'" % (section,))
+        self.objects[section] = init_func(config.getsection(section))
+        return self.objects[section]
     def _read_config(self):
         self.objects['configfile'] = pconfig = configfile.PrinterConfig(self)
         config = pconfig.read_main_config()
@@ -121,7 +126,7 @@ class Printer:
         for m in [pins, mcu]:
             m.add_printer_objects(config)
         for section_config in config.get_prefix_sections(''):
-            self.try_load_module(config, section_config.get_name())
+            self.load_object(config, section_config.get_name(), None)
         for m in [toolhead]:
             m.add_printer_objects(config)
         # Validate that there are no undefined parameters in the config file

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -186,10 +186,10 @@ def PrinterStepper(config, units_in_radians=False):
     mcu_stepper = MCU_stepper(name, step_pin_params, dir_pin_params, step_dist,
                               units_in_radians)
     # Support for stepper enable pin handling
-    stepper_enable = printer.try_load_module(config, 'stepper_enable')
+    stepper_enable = printer.load_object(config, 'stepper_enable')
     stepper_enable.register_stepper(mcu_stepper, config.get('enable_pin', None))
     # Register STEPPER_BUZZ command
-    force_move = printer.try_load_module(config, 'force_move')
+    force_move = printer.load_object(config, 'force_move')
     force_move.register_stepper(mcu_stepper)
     return mcu_stepper
 
@@ -289,7 +289,7 @@ class PrinterRail:
         mcu_endstop.add_stepper(stepper)
         name = stepper.get_name(short=True)
         self.endstops.append((mcu_endstop, name))
-        query_endstops = printer.try_load_module(config, 'query_endstops')
+        query_endstops = printer.load_object(config, 'query_endstops')
         query_endstops.register_endstop(mcu_endstop, name)
     def setup_itersolve(self, alloc_func, *params):
         for stepper in self.steppers:

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -267,10 +267,9 @@ class ToolHead:
                                desc=self.cmd_SET_VELOCITY_LIMIT_help)
         gcode.register_command('M204', self.cmd_M204)
         # Load some default modules
-        self.printer.try_load_module(config, "idle_timeout")
-        self.printer.try_load_module(config, "statistics")
-        self.printer.try_load_module(config, "manual_probe")
-        self.printer.try_load_module(config, "tuning_tower")
+        modules = ["idle_timeout", "statistics", "manual_probe", "tuning_tower"]
+        for module_name in modules:
+            self.printer.load_object(config, module_name)
     # Print time tracking
     def _update_move_time(self, next_print_time):
         batch_time = MOVE_BATCH_TIME


### PR DESCRIPTION
This is an internal function renaming change.  There should be no user visible impact to this.  It fixes a minor development issue where an incorrect try_load_module() call does not properly raise an error.

-Kevin