### PR TITLE
add virtual_sd gcode_dir option

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -470,6 +470,14 @@
 #   are not supported). One may point this to OctoPrint's upload
 #   directory (generally ~/.octoprint/uploads/ ). This parameter must
 #   be provided.
+#gcode_dir: gcodes
+#   The subdirectory / path relative to the virtual_sdcard path where
+#   your gcode files are located.
+#   This parameter is optional. The default is empty.
+#   This may be useful when using dwc2. Config directories of dwc2
+#   (dwc2/, gcodes/, macros/, sys/) are located at klipper's
+#   virtual_sdcard path. If gcode_dir is unset you will not see
+#   any gcode file in menu "SD Card".
 
 # Support manually moving stepper motors for diagnostic purposes.
 # Note, using this feature may place the printer in an invalid state -

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -11,7 +11,8 @@ class VirtualSD:
         printer.register_event_handler("klippy:shutdown", self.handle_shutdown)
         # sdcard state
         sd = config.get('path')
-        self.sdcard_dirname = os.path.normpath(os.path.expanduser(sd))
+        sd_gcode_dir = config.get('gcode_dir', '')
+        self.sdcard_dirname = os.path.normpath(os.path.expanduser(sd + '/' + sd_gcode_dir))
         self.current_file = None
         self.file_position = self.file_size = 0
         # Work timer

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -12,7 +12,8 @@ class VirtualSD:
         # sdcard state
         sd = config.get('path')
         sd_gcode_dir = config.get('gcode_dir', '')
-        self.sdcard_dirname = os.path.normpath(os.path.expanduser(sd + '/' + sd_gcode_dir))
+        self.sdcard_dirname = os.path.normpath(os.path.expanduser(
+            sd + '/' + sd_gcode_dir))
         self.current_file = None
         self.file_position = self.file_size = 0
         # Work timer


### PR DESCRIPTION
Add the possibility to move gcode to a subfolder of virtual_sdcard path.

This may be required for klipper+dwc2 and gcode listing via printer menu "SD Card".