### PR TITLE
extras: Tuning tower compensate z-offset

### DIFF
--- a/klippy/extras/tuning_tower.py
+++ b/klippy/extras/tuning_tower.py
@@ -45,6 +45,10 @@ class TuningTower:
         self.last_position = list(pos)
         return pos
     def calc_value(self, z):
+        # Compensate Z-Offset
+        gcode = self.printer.lookup_object("gcode")
+        z_offset = gcode.get_status(None)['base_zpos']
+        z = max(0, z - z_offset)
         if self.band:
             z = (math.floor(z / self.band) + .5) * self.band
         return self.start + z * self.factor


### PR DESCRIPTION
Tuning tower helper now takes care of printer z-offset.
This pull request fixes #2511