### PR TITLE
[Linux_MCU] Add shutdown on DTR in virtual serial.

### DIFF
--- a/src/linux/console.c
+++ b/src/linux/console.c
@@ -138,6 +138,12 @@ console_task(void)
     if (!sched_check_wake(&console_wake))
         return;
 
+    // Check DTR status (arduino reset)
+    int serial;
+    ioctl(main_pfd[MP_TTY_IDX].fd, TIOCMGET, &serial);
+    if( serial & TIOCM_DTR)
+        shutdown("DTR shutdown command");
+
     // Read data
     int ret = read(main_pfd[MP_TTY_IDX].fd, &receive_buf[receive_pos]
                    , sizeof(receive_buf) - receive_pos);


### PR DESCRIPTION
This PR normalizes the behavior of the linux MCU to FIRMWARE_RESET.

### Background:
The linux MCU is not responding correctly to FIRMWARE_RESET command. In fact, it always needs two FIRMWARE_RESET commands to function. The first always goes into error because the "config_reset" command  does not find the MCU in shutdown state ( consequently puts it in shutdown because there was an error: I'm not in shutdown. LOL ) the second actually resets (the mcu is in shutdown state).

### Symptoms:
In the case of a single MCU it causes the autoreset in connection not to function and you need manually reset the firmware (Which also happens on other types of MCU) but it is particularly annoying if you are using the MCU as a secondary one because you have to reset the primary MCU twice.

### Solution:
Since shutdown of the MCU before restarting the process is necessary (as explained by Kevin while commented  PR [#2781](https://github.com/KevinOConnor/klipper/pull/2781#issuecomment-621767090) ) the best method (in my opinion)  is to simulate what happens on an arduino.

_The "arduino" reset flow called by default by the GCODE "FIRMWARE_RESET" first do a disconnect () and then arduino_reset () which in fact does reopen the serial at 2400 and raise the DTR for 100ms. With this signal the arduino makes a reset and restart. After a new connection and "config_reset" command is send._

This PR adds control of the DTR signal within the virtual serial reading task. If the signal is raised, the MCU is put in the shutdown state which is the state that the MCU expects at the following command which is the reset_config. The real restart is done by the config_reset which creates a new process and replaces it with the old one.


Signed-off-by: Lucio Tarantino <lucio.tarantino@gmail.com>