### PR TITLE
HallFilamentWidthSensor: Use current width instead of nomal width while delay is not over

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -2013,7 +2013,7 @@
 #Virtual filament_switch_sensor support. Create sensor named hall_filament_width_sensor.
 #min_diameter:1.0
 #Minimal diameter for trigger virtual filament_switch_sensor.
-#use_current_dia_while_delay: True
+#use_current_dia_while_delay: False
 #   Use the current diameter instead of the nominal diamenter while the measurement delay has not run through.
 #Values from filament_switch_sensor.
 #See [filament_switch_sensor] for a description of these parameters.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -2013,6 +2013,8 @@
 #Virtual filament_switch_sensor support. Create sensor named hall_filament_width_sensor.
 #min_diameter:1.0
 #Minimal diameter for trigger virtual filament_switch_sensor.
+#use_current_dia_while_delay: True
+#   Use the current diameter instead of the nominal diamenter while the measurement delay has not run through.
 #Values from filament_switch_sensor.
 #See [filament_switch_sensor] for a description of these parameters.
 #pause_on_runout: True

--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -52,6 +52,8 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
     #
     #min_diameter:1.0
     #Minimal diameter for trigger virtual filament_switch_sensor.
+    #use_current_dia_while_delay: True
+    #   Use the current diameter instead of the nominal diamenter while the measurement delay has not run through.
     #
     #Values from filament_switch_sensor. See the "filament_switch_sensor" section for information on these parameters.
     #

--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -52,7 +52,7 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
     #
     #min_diameter:1.0
     #Minimal diameter for trigger virtual filament_switch_sensor.
-    #use_current_dia_while_delay: True
+    #use_current_dia_while_delay: False
     #   Use the current diameter instead of the nominal diamenter while the measurement delay has not run through.
     #
     #Values from filament_switch_sensor. See the "filament_switch_sensor" section for information on these parameters.

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -31,6 +31,8 @@ class HallFilamentWidthSensor:
         self.diameter =self.nominal_filament_dia
         self.is_active =config.getboolean('enable', False)
         self.runout_dia=config.getfloat('min_diameter', 1.0)
+        # Use the current diameter instead of nominal while the first measurement isn't in place
+        self.use_current_dia_while_delay = config.getboolean('use_current_dia_while_delay', False)
         # filament array [position, filamentWidth]
         self.filament_array = []
         self.lastFilamentWidthReading = 0
@@ -116,13 +118,18 @@ class HallFilamentWidthSensor:
                     # Get first item in filament_array queue
                     item = self.filament_array.pop(0)
                     filament_width = item[1]
-                    if ((filament_width <= self.max_diameter)
-                        and (filament_width >= self.min_diameter)):
-                        percentage = round(self.nominal_filament_dia**2
-                                           / filament_width**2 * 100)
-                        self.gcode.run_script("M221 S" + str(percentage))
-                    else:
-                        self.gcode.run_script("M221 S100")
+                elif self.use_current_dia_while_delay:
+                    filament_width = self.diameter
+                else:
+                    filament_width = self.nominal_filament_dia
+                
+                if ((filament_width <= self.max_diameter)
+                    and (filament_width >= self.min_diameter)):
+                    percentage = round(self.nominal_filament_dia**2
+                                       / filament_width**2 * 100)
+                    self.gcode.run_script("M221 S" + str(percentage))
+                else:
+                    self.gcode.run_script("M221 S100")
         else:
             self.gcode.run_script("M221 S100")
             self.filament_array = []


### PR DESCRIPTION
I have a very long Bowden after the sensor (about 700mm) and I am using filament which isn't varying very much but every spool is different. 
So for me, the more exact guess of the current width in the melting area is the current reading of the sensor, therefore I added an option that enables the use of the current width while the first reading isn't in place.