### PR TITLE
Disable some minor timing optimizations on the Linux mcu that are not valid there

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -121,6 +121,9 @@ config HAVE_GPIO_HARD_PWM
 config HAVE_GPIO_BITBANGING
     bool
     default n
+config HAVE_STRICT_TIMING
+    bool
+    default n
 config HAVE_CHIPID
     bool
     default n

--- a/src/atsam/Kconfig
+++ b/src/atsam/Kconfig
@@ -11,6 +11,7 @@ config ATSAM_SELECT
     select HAVE_GPIO_SPI
     select HAVE_GPIO_HARD_PWM
     select HAVE_GPIO_BITBANGING
+    select HAVE_STRICT_TIMING
     select HAVE_CHIPID
 
 config BOARD_DIRECTORY

--- a/src/atsamd/Kconfig
+++ b/src/atsamd/Kconfig
@@ -11,6 +11,7 @@ config ATSAMD_SELECT
     select HAVE_GPIO_SPI
     select HAVE_GPIO_HARD_PWM if MACH_SAMD21
     select HAVE_GPIO_BITBANGING
+    select HAVE_STRICT_TIMING
     select HAVE_CHIPID
 
 config BOARD_DIRECTORY

--- a/src/avr/Kconfig
+++ b/src/avr/Kconfig
@@ -11,6 +11,7 @@ config AVR_SELECT
     select HAVE_GPIO_I2C
     select HAVE_GPIO_HARD_PWM
     select HAVE_GPIO_BITBANGING if !MACH_atmega168
+    select HAVE_STRICT_TIMING
 
 config STEP_DELAY
     default -1

--- a/src/lcd_hd44780.c
+++ b/src/lcd_hd44780.c
@@ -100,6 +100,11 @@ command_config_hd44780(uint32_t *args)
     h->d6 = gpio_out_setup(args[5], 0);
     h->d7 = gpio_out_setup(args[6], 0);
 
+    if (!CONFIG_HAVE_STRICT_TIMING) {
+        h->cmd_wait_ticks = args[7];
+        return;
+    }
+
     // Calibrate cmd_wait_ticks
     irq_disable();
     uint32_t start = timer_read_time();

--- a/src/lcd_st7920.c
+++ b/src/lcd_st7920.c
@@ -106,6 +106,12 @@ command_config_st7920(uint32_t *args)
     s->sid = gpio_out_setup(args[3], 0);
     gpio_out_setup(args[1], 1);
 
+    if (!CONFIG_HAVE_STRICT_TIMING) {
+        s->sync_wait_ticks = args[4];
+        s->cmd_wait_ticks = args[5];
+        return;
+    }
+
     // Calibrate cmd_wait_ticks
     st7920_xmit_byte(s, SYNC_CMD);
     st7920_xmit_byte(s, 0x20);

--- a/src/lpc176x/Kconfig
+++ b/src/lpc176x/Kconfig
@@ -10,6 +10,7 @@ config LPC_SELECT
     select HAVE_GPIO_I2C
     select HAVE_GPIO_SPI
     select HAVE_GPIO_BITBANGING
+    select HAVE_STRICT_TIMING
     select HAVE_CHIPID
 
 config BOARD_DIRECTORY

--- a/src/pru/Kconfig
+++ b/src/pru/Kconfig
@@ -7,6 +7,7 @@ config PRU_SELECT
     default y
     select HAVE_GPIO
     #select HAVE_GPIO_ADC
+    select HAVE_STRICT_TIMING
 
 config BOARD_DIRECTORY
     string

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -154,9 +154,13 @@ stepper_event(struct timer *t)
         return stepper_event_nodelay(s);
 
     // Normal step code - schedule the unstep event
+    if (!CONFIG_HAVE_STRICT_TIMING)
+        gpio_out_toggle_noirq(s->step_pin);
     uint32_t step_delay = timer_from_us(CONFIG_STEP_DELAY);
     uint32_t min_next_time = timer_read_time() + step_delay;
-    gpio_out_toggle_noirq(s->step_pin);
+    if (CONFIG_HAVE_STRICT_TIMING)
+        // Toggling gpio after reading the time is a micro-optimization
+        gpio_out_toggle_noirq(s->step_pin);
     s->count--;
     if (likely(s->count & 1))
         // Schedule unstep event

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -10,6 +10,7 @@ config STM32_SELECT
     select HAVE_GPIO_I2C
     select HAVE_GPIO_SPI
     select HAVE_GPIO_BITBANGING
+    select HAVE_STRICT_TIMING
     select HAVE_CHIPID
 
 config BOARD_DIRECTORY


### PR DESCRIPTION
The Linux mcu code does not have "strict timing".  That is, the same code executed twice may have very different execution time.  That makes a few minor optimizations in the code not valid on the Linux mcu.  This series adds a new HAVE_STRICT_TIMING build symbol and it uses that to disable these optimizations for Linux mcu builds (at least for the code I'm aware of).

@dianlight , @andryblack - FYI.

-Kevin