### PR TITLE
Fix UART Addresses

### DIFF
--- a/config/generic-bigtreetech-skr-mini-e3-v1.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v1.0.cfg
@@ -43,7 +43,7 @@ homing_speed: 50
 [tmc2209 stepper_y]
 uart_pin: PC11
 tx_pin: PC10
-uart_address: 1
+uart_address: 2
 microsteps: 16
 run_current: 0.580
 hold_current: 0.500
@@ -61,7 +61,7 @@ position_max: 250
 [tmc2209 stepper_z]
 uart_pin: PC11
 tx_pin: PC10
-uart_address: 2
+uart_address: 1
 microsteps: 16
 run_current: 0.580
 hold_current: 0.500


### PR DESCRIPTION
Although it looks incorrect, this is actually the correct mapping of UART addresses on SKR Mini E3 V1.0. Consider the schematics for the board, specifically the hardwired connections of MS0 and MS1 on each of the stepper drivers. Also, this configuration change made my UART connections work correctly for sensorless homing, and I have double checked that the steppers were not swtiched by accident ;)