### PR TITLE
Adding example configuration for a SKR Mini E3 v2.0

### DIFF
--- a/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
@@ -114,50 +114,6 @@ pin: PC6
 [mcu]
 serial: /dev/serial/by-id/usb-Klipper_stm32f103xe_35FFD6054246303216590757-if00
 
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 5
-max_z_accel: 100
-
-[bed_screws]
-screw1: 30, 40
-screw2: 30, 210
-screw3: 200, 40
-screw4: 200, 210
-
-[static_digital_output usb_pullup_enable]
-pins: !PA14
-
-[board_pins]
-aliases:
-
-[heater_fan extruder]
-pin: PC7
-heater: extruder
-heater_temp: 50.0
-fan_speed: 0.5
-
-[fan]
-pin: PC6
-
-[mcu]
-serial: /dev/serial/by-id/usb-Klipper_stm32f103xe_35FFD6054246303216590757-if00
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 5
-max_z_accel: 100
-
-[bed_screws]
-screw1: 30, 40
-screw2: 30, 210
-screw3: 200, 40
-screw4: 200, 210
-
 [static_digital_output usb_pullup_enable]
 pins: !PA14
 

--- a/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
@@ -175,4 +175,3 @@ sid_pin: EXP1_8
 encoder_pins: ^EXP1_5, ^EXP1_3
 click_pin: ^!EXP1_2
 #kill_pin: ^!EXP2_8
-

--- a/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
@@ -1,0 +1,178 @@
+# This file contains common pin mappings for the BIGTREETECH SKR mini
+# E3 v2.0. To use this config, the firmware should be compiled for the
+# STM32F103 with a "28KiB bootloader". Also, select "Enable extra
+# low-level configuration options" and configure "GPIO pins to set at
+# micro-controller startup" to "!PA14".
+
+# The "make flash" command does not work on the SKR mini E3. Instead,
+# after running "make", copy the generated "out/klipper.bin" file to a
+# file named "firmware.bin" on an SD card and then restart the SKR
+# mini E3 with that SD card.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: PB13
+dir_pin: !PB12
+enable_pin: !PB14
+step_distance: .0125
+endstop_pin: ^PC0
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[tmc2209 stepper_x]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 0
+microsteps: 16
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[stepper_y]
+step_pin: PB10
+dir_pin: !PB2
+enable_pin: !PB11
+step_distance: .0125
+endstop_pin: ^PC1
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[tmc2209 stepper_y]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 1
+microsteps: 16
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[stepper_z]
+step_pin: PB0
+dir_pin: PC5
+enable_pin: !PB1
+step_distance: .0025
+endstop_pin: ^PC2
+position_endstop: 0.0
+position_max: 220
+
+[tmc2209 stepper_z]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 2
+microsteps: 16
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 5
+
+[extruder]
+step_pin: PB3
+dir_pin: PB4
+enable_pin: !PD2
+step_distance:  0.010526
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA0
+#control: pid
+min_temp: 0
+max_temp: 280
+max_extrude_only_distance: 150.0
+
+[tmc2209 extruder]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 3
+microsteps: 16
+run_current: 0.650
+hold_current: 0.500
+stealthchop_threshold: 5
+
+[heater_bed]
+heater_pin: PC9
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC3
+control: pid
+min_temp: 0
+max_temp: 110
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+
+[heater_fan extruder]
+pin: PC7
+heater: extruder
+heater_temp: 50.0
+fan_speed: 0.5
+
+[fan]
+pin: PC6
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_stm32f103xe_35FFD6054246303216590757-if00
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[bed_screws]
+screw1: 30, 40
+screw2: 30, 210
+screw3: 200, 40
+screw4: 200, 210
+
+[static_digital_output usb_pullup_enable]
+pins: !PA14
+
+[board_pins]
+aliases:
+
+[heater_fan extruder]
+pin: PC7
+heater: extruder
+heater_temp: 50.0
+fan_speed: 0.5
+
+[fan]
+pin: PC6
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_stm32f103xe_35FFD6054246303216590757-if00
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[bed_screws]
+screw1: 30, 40
+screw2: 30, 210
+screw3: 200, 40
+screw4: 200, 210
+
+[static_digital_output usb_pullup_enable]
+pins: !PA14
+
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=PB5, EXP1_3=PA9,   EXP1_5=PA10, EXP1_7=PB8, EXP1_9=<GND>,
+    EXP1_2=PA15, EXP1_4=<RST>, EXP1_6=PB9,  EXP1_8=PB15, EXP1_10=<5V>
+
+[display]
+lcd_type: st7920
+cs_pin: EXP1_7
+sclk_pin: EXP1_6
+sid_pin: EXP1_8
+encoder_pins: ^EXP1_5, ^EXP1_3
+click_pin: ^!EXP1_2
+#kill_pin: ^!EXP2_8
+


### PR DESCRIPTION
module: Config example for a SKR Mini E3 v2.0

This is a basic config example for a SKR Mini E3 v2.0, the pinouts are different than the 1.2 and requires different compile options, so worth having an example

Signed-off-by: Paul Greidanus paul@majestik.org
