### PR TITLE
makefile: fix cross build

### DIFF
--- a/scripts/check-gcc.sh
+++ b/scripts/check-gcc.sh
@@ -4,8 +4,8 @@
 f1="$1"
 f2="$2"
 
-s1=`readelf -A "$f1" | grep "Tag_ARM_ISA_use"`
-s2=`readelf -A "$f2" | grep "Tag_ARM_ISA_use"`
+s1=`$READELF -A "$f1" | grep "Tag_ARM_ISA_use"`
+s2=`$READELF -A "$f2" | grep "Tag_ARM_ISA_use"`
 
 if [ "$s1" != "$s2" ]; then
     echo ""

--- a/src/linux/gpio.c
+++ b/src/linux/gpio.c
@@ -15,7 +15,7 @@
 
 #include "internal.h" // report_errno
 
-#include </usr/include/linux/gpio.h>
+#include <linux/gpio.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 

--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -4,7 +4,7 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
-#include </usr/include/sched.h> // sched_setscheduler
+#include <sched.h> // sched_setscheduler
 #include <stdio.h> // fprintf
 #include <string.h> // memset
 #include <unistd.h> // getopt


### PR DESCRIPTION
Allow cross-build Klipper and linux mcu. As example I build openwrt based packages for raspberry-pi.
