### PR TITLE
More Fan options

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -259,8 +259,16 @@ pin: ar9
 #   different than the requested cycle_time. The default is False.
 #kick_start_time: 0.100
 #   Time (in seconds) to run the fan at full speed when either first
-#   enabling or increasing it by more than 50% (helps get the fan spinning).
-#   The default is 0.100 seconds.
+#   enabling or increasing it by more than `kick_start_difference` or fan value is more
+#   than or equal to `kick_start_min_power`
+#   (helps get the fan spinning). The default is 0.100 seconds.
+#kick_start_difference: 0.5
+#   Minimum power difference of fan to trigger a kickstart.
+#   The default is 0.5.
+#kick_start_max_power: 0.0
+#   Maximum power of fan to not require a kickstart. Default setting of
+#   0.0 effectively disables this. Setting of 1.0 will make the fan
+#   kickstart all the time. The default is 0.0.
 #off_below: 0.0
 #   The minimum input speed which will power the fan (expressed as a
 #   value from 0.0 to 1.0). When a speed lower than off_below is

--- a/config/example.cfg
+++ b/config/example.cfg
@@ -259,16 +259,20 @@ pin: ar9
 #   different than the requested cycle_time. The default is False.
 #kick_start_time: 0.100
 #   Time (in seconds) to run the fan at full speed when either first
-#   enabling or increasing it by more than `kick_start_difference` or fan value is more
-#   than or equal to `kick_start_min_power`
+#   enabling or increasing it by more than `kick_start_difference` or
+#   fan value is more than or equal to `kick_start_min_power`
 #   (helps get the fan spinning). The default is 0.100 seconds.
 #kick_start_difference: 0.5
 #   Minimum power difference of fan to trigger a kickstart.
 #   The default is 0.5.
 #kick_start_max_power: 0.0
-#   Maximum power of fan to not require a kickstart. Default setting of
-#   0.0 effectively disables this. Setting of 1.0 will make the fan
-#   kickstart all the time. The default is 0.0.
+#   0.0 to the maximum power of to require a kickstart. Some fans
+#   require a kickstart for low speeds but are fine without a kickstart
+#   at higher speeds.
+#   0.0 effectively disables this.
+#   0.5 will only kickstart the fan if the fan speed is set to 0.5
+#   1.0 will make the fan kickstart all the time.
+#   The default is 0.0.
 #off_below: 0.0
 #   The minimum input speed which will power the fan (expressed as a
 #   value from 0.0 to 1.0). When a speed lower than off_below is

--- a/config/example.cfg
+++ b/config/example.cfg
@@ -259,8 +259,8 @@ pin: ar9
 #   different than the requested cycle_time. The default is False.
 #kick_start_time: 0.100
 #   Time (in seconds) to run the fan at full speed when either first
-#   enabling or increasing it by more than `kick_start_difference` or
-#   fan value is more than or equal to `kick_start_min_power`
+#   enabling or increasing it by more than `kick_start_difference` and
+#   fan value is less than or equal to `kick_start_max_power`
 #   (helps get the fan spinning). The default is 0.100 seconds.
 #kick_start_difference: 0.5
 #   Minimum power difference of fan to trigger a kickstart.
@@ -270,7 +270,7 @@ pin: ar9
 #   require a kickstart for low speeds but are fine without a kickstart
 #   at higher speeds.
 #   0.0 effectively disables this.
-#   0.5 will only kickstart the fan if the fan speed is set to 0.5
+#   0.5 will only kickstart the fan if the fan speed is set to 0.5 or lower
 #   1.0 will make the fan kickstart all the time.
 #   The default is 0.0.
 #off_below: 0.0

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -16,6 +16,10 @@ class PrinterFan:
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
         self.kick_start_time = config.getfloat('kick_start_time', 0.1,
                                                minval=0.)
+        self.kick_start_difference = config.getfloat(
+            'kick_start_difference', default=0.5, minval=0., maxval=1.)
+        self.kick_start_max_power = config.getfloat(
+            'kick_start_max_power', default=0.0, minval=0., maxval=1.)
         self.off_below = config.getfloat(
             'off_below', default=0., minval=0., maxval=1.)
         ppins = self.printer.lookup_object('pins')
@@ -42,8 +46,12 @@ class PrinterFan:
         if value == self.last_fan_value:
             return
         print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)
-        if (value and value < self.max_power and self.kick_start_time
-            and (not self.last_fan_value or value - self.last_fan_value > .5)):
+        if (value
+            and value < self.max_power
+            and value <= self.kick_start_max_power
+            and self.kick_start_time
+            and (not self.last_fan_value
+                 or value - self.last_fan_value > self.kick_start_difference)):
             # Run fan at full speed for specified kick_start_time
             self.mcu_fan.set_pwm(print_time, self.max_power)
             print_time += self.kick_start_time


### PR DESCRIPTION
module: FAN, add kick_start_difference and kick_start_max_power

This pull request replaces the 0.5 hard coded value to `kick_start_difference` to allow tweaking.
This pull request also adds a new option `kick_start_max_power` see config/example.cfg in this pull request for more info.

Default settings are set so that existing installs are not affected by this change.

Signed-off-by: Michael D'Silva <michael.dsilva@outlook.com>