### PR TITLE
config: Added missing pin declarations on SKR 1.4 example

### DIFF
--- a/config/generic-bigtreetech-skr-v1.4.cfg
+++ b/config/generic-bigtreetech-skr-v1.4.cfg
@@ -74,6 +74,9 @@ pin: P2.3
 
 [mcu]
 serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00
+#serial: /dev/ttyAMA0 # 3 wire connection Pi <> Klipper
+#baud: 250000
+#restart_method: command
 
 [printer]
 kinematics: cartesian
@@ -81,6 +84,15 @@ max_velocity: 400
 max_accel: 500
 max_z_velocity: 10
 max_z_accel: 100
+
+#[neopixel my_neopixel]
+#pin: P1.24
+#chain_count: 27
+#color_order_GRB: True
+#initial_RED: 0.0
+#initial_GREEN: 0.0
+#initial_BLUE: 0.0
+
 
 
 ########################################
@@ -136,6 +148,8 @@ max_z_accel: 100
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
+#diag1_pin: 1.29
+#driver_SGT: 0
 
 #[tmc2130 stepper_y]
 #cs_pin: P1.9
@@ -146,6 +160,8 @@ max_z_accel: 100
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
+#diag1_pin: 1.28
+#driver_SGT: 0
 
 #[tmc2130 stepper_z]
 #cs_pin: P1.8
@@ -156,6 +172,8 @@ max_z_accel: 100
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
+#diag1_pin: 1.27
+#driver_SGT: 0
 
 #[tmc2130 extruder]
 #cs_pin: P1.4
@@ -166,6 +184,8 @@ max_z_accel: 100
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
+#diag1_pin: 1.26
+#driver_SGT: 0
 
 #[tmc2130 extruder1]
 #cs_pin: P1.1
@@ -176,6 +196,8 @@ max_z_accel: 100
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
+#diag1_pin: 1.25
+#driver_SGT: 0
 
 
 ########################################


### PR DESCRIPTION
A few pins required for stallguard / sensorless homing for the SKR 1.4 (Turbo) were missing. They're officially documented over here:

- [BIGTREETECH-SKR-V1.3/BTT SKR V1.4/Hardware/SKR-V1.4-pinout.jpg](https://github.com/bigtreetech/BIGTREETECH-SKR-V1.3/blob/master/BTT%20SKR%20V1.4/Hardware/SKR-V1.4-pinout.jpg)
- [BIGTREETECH-SKR-V1.3/BTT SKR V1.4/Hardware/SKR-V1.4-Turbo-pinout.jpg](https://github.com/bigtreetech/BIGTREETECH-SKR-V1.3/blob/master/BTT%20SKR%20V1.4/Hardware/SKR-V1.4-Turbo-pinout.jpg)

Furthermore the official manual gives a hint on using three wire serial connection, instead of an USB cable for SKR 1.3 and 1.4 ([BTT SKR V1.4 Instruction Manual.pdf](https://github.com/bigtreetech/BIGTREETECH-SKR-V1.3/blob/master/BTT%20SKR%20V1.4/BTT%20SKR%20V1.4%20Instruction%20Manual.pdf)). For this reason I added it the example config.

Signed-off-by: Kim Nikulski < k.nikulski@gmail.com >