### PR TITLE
Possible fix for glyph rendering on uc1701 display variants

### DIFF
--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -54,8 +54,8 @@ class DisplayBase:
         bits_bot = [0] * 8
         for row in range(8):
             for col in range(8):
-                bits_top[col] |= ((data[row] >> (8 - col)) & 1) << row
-                bits_bot[col] |= ((data[row + 8] >> (8 - col)) & 1) << row
+                bits_top[col] |= ((data[row] >> (7 - col)) & 1) << row
+                bits_bot[col] |= ((data[row + 8] >> (7 - col)) & 1) << row
         return (bits_top, bits_bot)
     def write_text(self, x, y, data):
         if x + len(data) > 16:


### PR DESCRIPTION
The current code always renders the final column of the glyph black, causing gaps between glyphs that are placed right next to each other:
![current master](https://media.discordapp.net/attachments/460172848565190667/719843956682260550/20200609_112217.jpg?width=902&height=677)

This change makes the glyphs be displayed properly on uc1701 based displays.

![this PR](https://media.discordapp.net/attachments/460172848565190667/719847377045028884/20200609_113610.jpg?width=902&height=677)