### PR TITLE
display: add SET_DISPLAY_GROUP command

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -202,12 +202,13 @@ The following standard commands are supported:
   adjustment will only be made every BAND millimeters of z height - in
   that case the formula used is `value = start + factor *
   ((floor(z_height / band) + .5) * band)`.
+- `SET_DISPLAY_GROUP DISPLAY=<display> GROUP=<group>`: Set the active
+  display group of the display. This allows to define multiple display
+  data groups in the config, e.g.`[display_data <group> <elementname>]`
+  and switch between them using this extended gcode command. use
+  `DISPLAY=display` to change the display group of the default display.
 - `SET_IDLE_TIMEOUT [TIMEOUT=<timeout>]`:  Allows the user to set the
   idle timeout (in seconds).
-- `SET_DISPLAY_GROUP GROUP=<group>`: Set the active display group of the
-  display. This allows to define multiple display data groups in the
-  config, e.g.`[display_data <group> <elementname>]` and switch between
-  them using this extended gcode command.
 - `RESTART`: This will cause the host software to reload its config
   and perform an internal reset. This command will not clear error
   state from the micro-controller (see FIRMWARE_RESTART) nor will it

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -204,6 +204,10 @@ The following standard commands are supported:
   ((floor(z_height / band) + .5) * band)`.
 - `SET_IDLE_TIMEOUT [TIMEOUT=<timeout>]`:  Allows the user to set the
   idle timeout (in seconds).
+- `SET_DISPLAY_GROUP GROUP=<group>`: Set the active display group of the
+  display. This allows to define multiple display data groups in the
+  config, e.g.`[display_data <group> <elementname>]` and switch between
+  them using this extended gcode command.
 - `RESTART`: This will cause the host software to reload its config
   and perform an internal reset. This command will not clear error
   state from the micro-controller (see FIRMWARE_RESTART) nor will it

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -103,6 +103,10 @@ class PrinterLCD:
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.screen_update_timer = self.reactor.register_timer(
             self.screen_update_event)
+        gcode = self.printer.lookup_object("gcode")
+        gcode.register_command(
+            'SET_DISPLAY_GROUP', self.cmd_SET_DISPLAY_GROUP,
+            desc=self.cmd_SET_DISPLAY_GROUP_help)
     # Configurable display
     def _parse_glyph(self, config, glyph_name, data, width, height):
         glyph_data = []
@@ -215,6 +219,13 @@ class PrinterLCD:
             self.lcd_chip.write_graphics(col, row, i, data)
         self.lcd_chip.write_graphics(col, row, 15, [0xff]*width)
         return ""
+    cmd_SET_DISPLAY_GROUP_help = "Set the active display group"
+    def cmd_SET_DISPLAY_GROUP(self, gcmd):
+        group = gcmd.get('GROUP')
+        new_dg = self.display_data_groups.get(group)
+        if new_dg is None:
+            raise gcmd.error("Unknown display_data group '%s'" % (group,))
+        self.show_data_group = new_dg
 
 def load_config(config):
     return PrinterLCD(config)

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -104,8 +104,8 @@ class PrinterLCD:
         self.screen_update_timer = self.reactor.register_timer(
             self.screen_update_event)
         gcode = self.printer.lookup_object("gcode")
-        gcode.register_command(
-            'SET_DISPLAY_GROUP', self.cmd_SET_DISPLAY_GROUP,
+        gcode.register_mux_command(
+            'SET_DISPLAY_GROUP', 'DISPLAY', name, self.cmd_SET_DISPLAY_GROUP,
             desc=self.cmd_SET_DISPLAY_GROUP_help)
     # Configurable display
     def _parse_glyph(self, config, glyph_name, data, width, height):


### PR DESCRIPTION
Add a new extended gcode to change the active display group of the display.

This allows switching between multiple display groups (e.g. to show a splashscreen, or move between different overview displays)

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>