### PR TITLE
Improve Python version compatibility

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -3,15 +3,15 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import os, glob, re, time, logging, ConfigParser, StringIO
+import os, glob, re, time, logging, ConfigParser as configparser, StringIO
 
-error = ConfigParser.Error
+error = configparser.Error
 
 class sentinel:
     pass
 
 class ConfigWrapper:
-    error = ConfigParser.Error
+    error = configparser.Error
     def __init__(self, printer, fileconfig, access_tracking, section):
         self.printer = printer
         self.fileconfig = fileconfig
@@ -194,7 +194,7 @@ class PrinterConfig:
             if pos >= 0:
                 line = line[:pos]
             # Process include or buffer line
-            mo = ConfigParser.RawConfigParser.SECTCRE.match(line)
+            mo = configparser.RawConfigParser.SECTCRE.match(line)
             header = mo and mo.group('header')
             if header and header.startswith('include '):
                 self._parse_config_buffer(buffer, filename, fileconfig)
@@ -206,7 +206,7 @@ class PrinterConfig:
         self._parse_config_buffer(buffer, filename, fileconfig)
         visited.remove(path)
     def _build_config_wrapper(self, data, filename):
-        fileconfig = ConfigParser.RawConfigParser()
+        fileconfig = configparser.RawConfigParser()
         self._parse_config(data, filename, fileconfig, set())
         return ConfigWrapper(self.printer, fileconfig, {}, 'printer')
     def _build_config_string(self, config):

--- a/klippy/extras/ad5206.py
+++ b/klippy/extras/ad5206.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2017,2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import bus
+from . import bus
 
 class ad5206:
     def __init__(self, config):

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -4,11 +4,8 @@
 # Copyright (C) 2018-2019 Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging
-import math
-import json
-import probe
-import collections
+import logging, math, json, collections
+from . import probe
 
 PROFILE_VERSION = 1
 PROFILE_OPTIONS = {

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -390,7 +390,7 @@ class BedMeshCalibrate:
                     for line in z_values if line.strip()]
             self.profiles[name]['mesh_params'] = params = \
                 collections.OrderedDict()
-            for key, t in PROFILE_OPTIONS.iteritems():
+            for key, t in PROFILE_OPTIONS.items():
                 if t is int:
                     params[key] = profile.getint(key)
                 elif t is float:
@@ -414,7 +414,7 @@ class BedMeshCalibrate:
             z_values = z_values[:-2]
         configfile.set(cfg_name, 'version', PROFILE_VERSION)
         configfile.set(cfg_name, 'points', z_values)
-        for key, value in self.mesh_params.iteritems():
+        for key, value in self.mesh_params.items():
             configfile.set(cfg_name, key, value)
         # save copy in local storage
         self.profiles[prof_name] = profile = {}
@@ -532,7 +532,7 @@ class BedMeshCalibrate:
                     msg += "Probed Table:\n"
                     msg += str(self.probed_matrix)
                     raise self.gcode.error(msg)
-                buf_cnt = (x_cnt - row_size) / 2
+                buf_cnt = (x_cnt - row_size) // 2
                 if buf_cnt == 0:
                     continue
                 left_buffer = [row[0]] * buf_cnt
@@ -626,7 +626,7 @@ class ZMesh:
         self.avg_z = 0.
         self.mesh_offset = 0.
         logging.debug('bed_mesh: probe/mesh parameters:')
-        for key, value in self.mesh_params.iteritems():
+        for key, value in self.mesh_params.items():
             logging.debug("%s :  %s" % (key, value))
         self.mesh_x_min = params['min_x']
         self.mesh_x_max = params['max_x']
@@ -738,7 +738,7 @@ class ZMesh:
         y_mult = self.y_mult
         self.mesh_matrix = \
             [[0. if ((i % x_mult) or (j % y_mult))
-             else z_matrix[j/y_mult][i/x_mult]
+             else z_matrix[j//y_mult][i//x_mult]
              for i in range(self.mesh_x_count)]
              for j in range(self.mesh_y_count)]
         xpts, ypts = self._get_lagrange_coords()
@@ -793,7 +793,7 @@ class ZMesh:
         c = self.mesh_params['tension']
         self.mesh_matrix = \
             [[0. if ((i % x_mult) or (j % y_mult))
-             else z_matrix[j/y_mult][i/x_mult]
+             else z_matrix[j//y_mult][i//x_mult]
              for i in range(self.mesh_x_count)]
              for j in range(self.mesh_y_count)]
         # Interpolate X values

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -4,7 +4,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import probe, mathutil
+import mathutil
+from . import probe
 
 class BedTilt:
     def __init__(self, config):

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -4,7 +4,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import homing, probe
+import homing
+from . import probe
 
 SIGNAL_PERIOD = 0.020
 MIN_CMD_TIME = 5 * SIGNAL_PERIOD

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -3,9 +3,8 @@
 # Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-
-import bus
 import logging
+from . import bus
 
 REPORT_TIME = .8
 BME280_CHIP_ADDR = 0x76

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019  Nils Friedchen <nils.friedchen@googlemail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import fan
+from . import fan
 
 PIN_MIN_TIME = 0.100
 

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -52,7 +52,7 @@ def measurements_to_distances(measured_params, delta_params):
         for od, opw in zip(mp['OUTER_DISTS'], mp['OUTER_PILLAR_WIDTHS']) ]
     # Convert angles in degrees to an XY multiplier
     obj_angles = map(math.radians, MeasureAngles)
-    xy_angles = zip(map(math.cos, obj_angles), map(math.sin, obj_angles))
+    xy_angles = list(zip(map(math.cos, obj_angles), map(math.sin, obj_angles)))
     # Calculate stable positions for center measurements
     inner_ridge = MeasureRidgeRadius * scale
     inner_pos = [(ax * inner_ridge, ay * inner_ridge, 0.)
@@ -270,7 +270,7 @@ class DeltaCalibrate:
             if data is None:
                 continue
             try:
-                parts = map(float, data.split(','))
+                parts = list(map(float, data.split(',')))
             except:
                 raise gcmd.error("Unable to parse parameter '%s'" % (name,))
             if len(parts) != count:

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -4,7 +4,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging, collections
-import probe, mathutil
+import mathutil
+from . import probe
 
 # A "stable position" is a 3-tuple containing the number of steps
 # taken since hitting the endstop on each delta tower.  Delta

--- a/klippy/extras/display/__init__.py
+++ b/klippy/extras/display/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import display
+from . import display
 
 def load_config(config):
     return display.load_config(config)

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -6,7 +6,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, os, ast
-import hd44780, st7920, uc1701, menu
+from . import hd44780, st7920, uc1701, menu
 
 LCD_chips = {
     'st7920': st7920.ST7920, 'hd44780': hd44780.HD44780,

--- a/klippy/extras/display/st7920.py
+++ b/klippy/extras/display/st7920.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import font8x14
+from . import font8x14
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import extras.bus
+from .. import bus
 from . import font8x14
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
@@ -113,11 +113,10 @@ class DisplayBase:
 # IO wrapper for "4 wire" spi bus (spi bus with an extra data/control line)
 class SPI4wire:
     def __init__(self, config, data_pin_name):
-        self.spi = extras.bus.MCU_SPI_from_config(config, 0,
-                                                  default_speed=10000000)
+        self.spi = bus.MCU_SPI_from_config(config, 0, default_speed=10000000)
         dc_pin = config.get(data_pin_name)
-        self.mcu_dc = extras.bus.MCU_bus_digital_out(
-            self.spi.get_mcu(), dc_pin, self.spi.get_command_queue())
+        self.mcu_dc = bus.MCU_bus_digital_out(self.spi.get_mcu(), dc_pin,
+                                              self.spi.get_command_queue())
     def send(self, cmds, is_data=False):
         self.mcu_dc.update_digital_out(is_data,
                                        reqclock=BACKGROUND_PRIORITY_CLOCK)
@@ -126,8 +125,8 @@ class SPI4wire:
 # IO wrapper for i2c bus
 class I2C:
     def __init__(self, config, default_addr):
-        self.i2c = extras.bus.MCU_I2C_from_config(
-            config, default_addr=default_addr, default_speed=400000)
+        self.i2c = bus.MCU_I2C_from_config(config, default_addr=default_addr,
+                                           default_speed=400000)
     def send(self, cmds, is_data=False):
         if is_data:
             hdr = 0x40
@@ -143,8 +142,8 @@ class ResetHelper:
         self.mcu_reset = None
         if pin_desc is None:
             return
-        self.mcu_reset = extras.bus.MCU_bus_digital_out(
-            io_bus.get_mcu(), pin_desc, io_bus.get_command_queue())
+        self.mcu_reset = bus.MCU_bus_digital_out(io_bus.get_mcu(), pin_desc,
+                                                 io_bus.get_command_queue())
     def init(self):
         if self.mcu_reset is None:
             return

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -5,7 +5,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import font8x14, extras.bus
+import extras.bus
+from . import font8x14
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 

--- a/klippy/extras/dotstar.py
+++ b/klippy/extras/dotstar.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import bus
+from . import bus
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019  Mustafa YILDIZ <mydiz@hotmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import filament_switch_sensor
+from . import filament_switch_sensor
 
 ADC_REPORT_TIME = 0.500
 ADC_SAMPLE_TIME = 0.03

--- a/klippy/extras/heater_fan.py
+++ b/klippy/extras/heater_fan.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import fan
+from . import fan
 
 PIN_MIN_TIME = 0.100
 

--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2020  Lucio Tarantino <lucio.tarantino@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+from . import bus
 
 ######################################################################
 # NOTE: The implementation requires write support of length 0
@@ -16,9 +18,6 @@
 #       SHT21  - Untested
 #
 ######################################################################
-
-import bus
-import logging
 
 HTU21D_I2C_ADDR= 0x40
 

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -3,7 +3,8 @@
 # Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import stepper, homing, force_move, chelper
+import stepper, homing, chelper
+from . import force_move
 
 ENDSTOP_SAMPLE_TIME = .000015
 ENDSTOP_SAMPLE_COUNT = 4

--- a/klippy/extras/mcp4451.py
+++ b/klippy/extras/mcp4451.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import bus
+from . import bus
 
 WiperRegisters = [0x00, 0x01, 0x06, 0x07]
 

--- a/klippy/extras/mcp4728.py
+++ b/klippy/extras/mcp4728.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import bus
+from . import bus
 
 class mcp4728:
     def __init__(self, config):

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-import heaters
+from . import heaters
 
 class PIDCalibrate:
     def __init__(self, config):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -4,7 +4,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import pins, homing, manual_probe
+import pins, homing
+from . import manual_probe
 
 HINT_TIMEOUT = """
 Make sure to home the printer before probing. If the probe

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import probe, z_tilt
+from . import probe, z_tilt
 
 class QuadGantryLevel:
     def __init__(self, config):

--- a/klippy/extras/replicape.py
+++ b/klippy/extras/replicape.py
@@ -4,7 +4,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, os
-import pins, mcu, bus
+import pins, mcu
+from . import bus
 
 REPLICAPE_MAX_CURRENT = 3.84
 REPLICAPE_PCA9685_BUS = 2

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math
-import probe
+from . import probe
 
 def parse_coord(config, param):
     pair = config.get(param).strip().split(',', 1)

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math
-import bus
+from . import bus
 
 
 ######################################################################

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import pins
-import bus
+from . import bus
 
 # Word registers
 REG_RESET = 0x7D

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -52,7 +52,7 @@ class SX1509(object):
                                  " clear_set_bits=%02x%02x" % (
                                      self._oid, REG_MISC, 0, (1 << 4)))
         # Transfer all regs with their initial cached state
-        for _reg, _data in self.reg_dict.iteritems():
+        for _reg, _data in self.reg_dict.items():
             self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%04x" % (
                 self._oid, _reg, _data), is_init=True)
     def setup_pin(self, pin_type, pin_params):

--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import fan
+from . import fan
 
 KELVIN_TO_CELSIUS = -273.15
 MAX_FAN_TIME = 5.0

--- a/klippy/extras/thermistor.py
+++ b/klippy/extras/thermistor.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-import adc_temperature
+from . import adc_temperature
 
 KELVIN_TO_CELSIUS = -273.15
 

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-import bus, tmc
+from . import bus, tmc
 
 TMC_FREQUENCY=13200000.
 

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import tmc, tmc_uart, tmc2130
+from . import tmc, tmc_uart, tmc2130
 
 TMC_FREQUENCY=12000000.
 

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019  Stephan Oelze <stephan.oelze@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import tmc2208, tmc2130, tmc, tmc_uart
+from . import tmc2208, tmc2130, tmc, tmc_uart
 
 TMC_FREQUENCY=12000000.
 

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-import bus, tmc
+from . import bus, tmc
 
 Registers = {
     "DRVCONF": 0xE, "SGCSCONF": 0xC, "SMARTEN": 0xA,

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-import bus, tmc, tmc2130
+from . import bus, tmc, tmc2130
 
 TMC_FREQUENCY=12000000.
 

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -78,7 +78,7 @@ class MCU_TMC_uart_bitbang:
         self.tmcuart_send_cmd = self.mcu.lookup_query_command(
             "tmcuart_send oid=%c write=%*s read=%c",
             "tmcuart_response oid=%c read=%*s", oid=self.oid,
-            cq=self.cmd_queue, async=True)
+            cq=self.cmd_queue, is_async=True)
     def register_instance(self, rx_pin_params, tx_pin_params,
                           select_pins_desc, addr):
         if (rx_pin_params['pin'] != self.rx_pin

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -4,7 +4,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import probe, mathutil
+import mathutil
+from . import probe
 
 class ZAdjustHelper:
     def __init__(self, config, z_count):

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -337,14 +337,14 @@ class RetryAsyncCommand:
 # Wrapper around query commands
 class CommandQueryWrapper:
     def __init__(self, serial, msgformat, respformat, oid=None,
-                 cmd_queue=None, async=False):
+                 cmd_queue=None, is_async=False):
         self._serial = serial
         self._cmd = serial.get_msgparser().lookup_command(msgformat)
         serial.get_msgparser().lookup_command(respformat)
         self._response = respformat.split()[0]
         self._oid = oid
         self._xmit_helper = serialhdl.SerialRetryCommand
-        if async:
+        if is_async:
             self._xmit_helper = RetryAsyncCommand
         if cmd_queue is None:
             cmd_queue = serial.get_default_command_queue()
@@ -650,9 +650,9 @@ class MCU:
     def lookup_command(self, msgformat, cq=None):
         return CommandWrapper(self._serial, msgformat, cq)
     def lookup_query_command(self, msgformat, respformat, oid=None,
-                             cq=None, async=False):
+                             cq=None, is_async=False):
         return CommandQueryWrapper(self._serial, msgformat, respformat, oid,
-                                   cq, async)
+                                   cq, is_async)
     def try_lookup_command(self, msgformat):
         try:
             return self.lookup_command(msgformat)

--- a/klippy/msgproto.py
+++ b/klippy/msgproto.py
@@ -80,7 +80,7 @@ class PT_string:
         out.extend(bytearray(v))
     def parse(self, s, pos):
         l = s[pos]
-        return str(bytearray(s[pos+1:pos+l+1])), pos+l+1
+        return bytes(bytearray(s[pos+1:pos+l+1])), pos+l+1
 class PT_progmem_buffer(PT_string):
     pass
 class PT_buffer(PT_string):
@@ -209,7 +209,7 @@ class UnknownFormat:
     name = '#unknown'
     def parse(self, s, pos):
         msgid = s[pos]
-        msg = str(bytearray(s))
+        msg = bytes(bytearray(s))
         return {'#msgid': msgid, '#msg': msg}, len(s)-MESSAGE_TRAILER_SIZE
     def format_params(self, params):
         return "#unknown %s" % (repr(params['#msg']),)

--- a/klippy/queuelogger.py
+++ b/klippy/queuelogger.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging, logging.handlers, threading, Queue, time
+import logging, logging.handlers, threading, Queue as queue, time
 
 # Class to forward all messages through a queue to a background thread
 class QueueHandler(logging.Handler):
@@ -25,7 +25,7 @@ class QueueListener(logging.handlers.TimedRotatingFileHandler):
     def __init__(self, filename):
         logging.handlers.TimedRotatingFileHandler.__init__(
             self, filename, when='midnight', backupCount=5)
-        self.bg_queue = Queue.Queue()
+        self.bg_queue = queue.Queue()
         self.bg_thread = threading.Thread(target=self._bg_thread)
         self.bg_thread.start()
         self.rollover_info = {}

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import os, select, math, time, Queue
+import os, select, math, time, Queue as queue
 import greenlet
 import chelper, util
 
@@ -102,7 +102,7 @@ class SelectReactor:
         self._next_timer = self.NEVER
         # Callbacks
         self._pipe_fds = None
-        self._async_queue = Queue.Queue()
+        self._async_queue = queue.Queue()
         # File descriptors
         self._fds = []
         # Greenlets
@@ -170,7 +170,7 @@ class SelectReactor:
         while 1:
             try:
                 func, args = self._async_queue.get_nowait()
-            except Queue.Empty:
+            except queue.Empty:
                 break
             func(*args)
     def _setup_async_callbacks(self):

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -38,7 +38,7 @@ def create_pty(ptyname):
     except os.error:
         pass
     filename = os.ttyname(sfd)
-    os.chmod(filename, 0660)
+    os.chmod(filename, 0o660)
     os.symlink(filename, ptyname)
     set_nonblock(mfd)
     old = termios.tcgetattr(mfd)
@@ -99,7 +99,7 @@ def get_cpu_info():
         f = open('/proc/cpuinfo', 'rb')
         data = f.read()
         f.close()
-    except IOError, OSError:
+    except (IOError, OSError) as e:
         logging.debug("Exception on read /proc/cpuinfo: %s",
                       traceback.format_exc())
         return "?"


### PR DESCRIPTION
This change improves the Python2/Python3 code compatibility.  It appears a handful of incompatibilities have crept into the code over the last couple years.

Most of these changes are simple and non-invasive.  @Arksine - FYI, I made a couple of minor changes to bed_mesh.py .

Note, I don't have any immediate plans to convert Klipper to python3.  (I remain in a "wait and see" mode.)  I do have another branch (work-python3-20200613) available that makes additional (more invasive) code changes.  It is able to run the test cases and some benchmarks with Python3.  It is not an exhaustive search of incompatibilities, but if other developers wish to track down these types of issues they can try that branch.  That branch will not be supported beyond the purpose of identifying incompatibilities.  Interestingly, the python3 code is now slightly faster than the python2 code for the quick benchmarks I've run (on a desktop class machine).

-Kevin