### PR TITLE
Add .vscode directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ out
 *.pyc
 .config
 .config.old
+.vscode
 klippy/.version


### PR DESCRIPTION
VSCode automatically creates a settings directory at the root of the repo, but most projects don't explicitly provide VSCode settings. So, it's common to add it to the .gitignore file to prevent accidentally committing.