### PR TITLE
webhooks:  register remote API hooks

### DIFF
--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -17,8 +17,29 @@ class PauseResume:
         self.gcode.register_command("PAUSE", self.cmd_PAUSE)
         self.gcode.register_command("RESUME", self.cmd_RESUME)
         self.gcode.register_command("CLEAR_PAUSE", self.cmd_CLEAR_PAUSE)
+        self.gcode.register_command("CANCEL_PRINT", self.cmd_CANCEL_PRINT)
+        webhooks = self.printer.lookup_object('webhooks')
+        webhooks.register_endpoint(
+            "pause_resume/cancel", self._handle_web_request)
+        webhooks.register_endpoint(
+            "pause_resume/pause", self._handle_web_request)
+        webhooks.register_endpoint(
+            "pause_resume/resume", self._handle_web_request)
     def handle_ready(self):
         self.v_sd = self.printer.lookup_object('virtual_sdcard', None)
+    def _handle_web_request(self, web_request):
+        if web_request.get_method() != 'POST':
+            raise web_request.error("Invalid Request Method")
+        path = web_request.get_path()
+        if path == "pause_resume/cancel":
+            script = "CANCEL_PRINT"
+        elif path == "pause_resume/pause":
+            script = "PAUSE"
+        elif path == "pause_resume/resume":
+            script = "RESUME"
+        else:
+            raise web_request.error("Invalid Path")
+        self.gcode.run_script(script)
     def get_status(self, eventtime):
         return {
             'is_paused': self.is_paused
@@ -60,6 +81,11 @@ class PauseResume:
             gcmd.respond_info("action:resumed")
     def cmd_CLEAR_PAUSE(self, gcmd):
         self.is_paused = self.pause_command_sent = False
+    def cmd_CANCEL_PRINT(self, gcmd):
+        self.cmd_PAUSE(gcmd)
+        if not self.sd_paused:
+            gcmd.respond_info("action:cancel")
+        self.cmd_CLEAR_PAUSE(gcmd)
 
 def load_config(config):
     return PauseResume(config)

--- a/klippy/extras/query_endstops.py
+++ b/klippy/extras/query_endstops.py
@@ -9,6 +9,10 @@ class QueryEndstops:
         self.printer = config.get_printer()
         self.endstops = []
         self.last_state = {}
+        # Register webhook if server is available
+        webhooks = self.printer.lookup_object('webhooks')
+        webhooks.register_endpoint(
+            "query_endstops/status", self._handle_web_request)
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command("QUERY_ENDSTOPS", self.cmd_QUERY_ENDSTOPS,
                                desc=self.cmd_QUERY_ENDSTOPS_help)
@@ -17,6 +21,17 @@ class QueryEndstops:
         self.endstops.append((mcu_endstop, name))
     def get_status(self, eventtime):
         return {'last_query': {name: value for name, value in self.last_state}}
+    def _handle_web_request(self, web_request):
+        if web_request.get_method() != 'GET':
+            raise web_request.error("Invalid Request Method")
+        gc_mutex = self.printer.lookup_object('gcode').get_mutex()
+        toolhead = self.printer.lookup_object('toolhead')
+        with gc_mutex:
+            print_time = toolhead.get_last_move_time()
+            self.last_state = [(name, mcu_endstop.query_endstop(print_time))
+                               for mcu_endstop, name in self.endstops]
+        web_request.send({name: ["open", "TRIGGERED"][not not t]
+                          for name, t in self.last_state})
     cmd_QUERY_ENDSTOPS_help = "Report on the status of each endstop"
     def cmd_QUERY_ENDSTOPS(self, gcmd):
         # Query the endstops

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -437,7 +437,7 @@ class GCodeParser:
             gcmd.ack("T:0")
             return
         if not self.is_printer_ready:
-            raise gcmd.error(self.printer.get_state_message())
+            raise gcmd.error(self.printer.get_state_message()[0])
             return
         if not cmd:
             logging.debug(gcmd.get_commandline())
@@ -696,7 +696,7 @@ class GCodeParser:
         if self.is_printer_ready:
             self._respond_state("Ready")
             return
-        msg = self.printer.get_state_message()
+        msg = self.printer.get_state_message()[0]
         msg = msg.rstrip() + "\nKlipper state: Not ready"
         raise gcmd.error(msg)
     cmd_HELP_when_not_ready = True

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -91,6 +91,16 @@ class GCodeParser:
         self.pending_commands = []
         self.bytes_read = 0
         self.input_log = collections.deque([], 50)
+        # Register webhooks
+        webhooks = self.printer.lookup_object('webhooks')
+        webhooks.register_endpoint(
+            "gcode/help", self._handle_remote_help)
+        webhooks.register_endpoint(
+            "gcode/script", self._handle_remote_script)
+        webhooks.register_endpoint(
+            "gcode/restart", self._handle_remote_restart)
+        webhooks.register_endpoint(
+            "gcode/firmware_restart", self._handle_remote_restart)
         # Command handling
         self.is_printer_ready = False
         self.mutex = self.reactor.mutex()
@@ -349,6 +359,23 @@ class GCodeParser:
         if self.fd_handle is None:
             self.fd_handle = self.reactor.register_fd(self.fd,
                                                       self._process_data)
+    def _handle_remote_help(self, web_request):
+        if web_request.get_method() != 'GET':
+            raise web_request.error("Invalid Request Method")
+        web_request.send(dict(self.gcode_help))
+    def _handle_remote_restart(self, web_request):
+        if web_request.get_method() != 'POST':
+            raise web_request.error("Invalid Request Method")
+        path = web_request.get_path()
+        if path == "gcode/restart":
+            self.run_script('restart')
+        elif path == "gcode/firmware_restart":
+            self.run_script('firmware_restart')
+    def _handle_remote_script(self, web_request):
+        if web_request.get_method() != 'POST':
+            raise web_request.error("Invalid Request Method")
+        script = web_request.get('script')
+        self.run_script(script)
     def run_script_from_command(self, script):
         self._process_commands(script.split('\n'), need_ack=False)
     def run_script(self, script):

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -65,7 +65,13 @@ class Printer:
     def get_reactor(self):
         return self.reactor
     def get_state_message(self):
-        return self.state_message
+        if self.state_message == message_ready:
+            category = "ready"
+        elif self.state_message == message_startup:
+            category = "startup"
+        else:
+            category = "error"
+        return self.state_message, category
     def is_shutdown(self):
         return self.in_shutdown_state
     def _set_state(self, msg):

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -1,0 +1,270 @@
+# Klippy WebHooks registration and server connection
+#
+# Copyright (C) 2020 Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license
+import logging
+import socket
+import errno
+import json
+import homing
+from klippy import message_startup, message_ready
+
+SOCKET_LOCATION = "/tmp/moonraker"
+
+# Json decodes strings as unicode types in Python 2.x.  This doesn't
+# play well with some parts of Klipper (particuarly displays), so we
+# need to create an object hook. This solution borrowed from:
+#
+# https://stackoverflow.com/questions/956867/
+#
+def byteify(data, ignore_dicts=False):
+    if isinstance(data, unicode):
+        return data.encode('utf-8')
+    if isinstance(data, list):
+        return [byteify(i, True) for i in data]
+    if isinstance(data, dict) and not ignore_dicts:
+        return {byteify(k, True): byteify(v, True)
+                for k, v in data.items()}
+    return data
+
+def json_loads_byteified(data):
+    return byteify(
+        json.loads(data, object_hook=byteify), True)
+
+class WebRequestError(homing.CommandError):
+    def __init__(self, message,):
+        Exception.__init__(self, message)
+
+    def to_dict(self):
+        return {
+            'error': 'WebRequestError',
+            'message': self.message}
+
+class Sentinel:
+    pass
+
+class WebRequest:
+    error = WebRequestError
+    def __init__(self, base_request):
+        self.id = base_request['id']
+        self.path = base_request['path']
+        self.method = base_request['method']
+        self.args = base_request['args']
+        self.response = None
+
+    def get(self, item, default=Sentinel):
+        if item not in self.args:
+            if default == Sentinel:
+                raise WebRequestError("Invalid Argument [%s]" % item)
+            return default
+        return self.args[item]
+
+    def get_int(self, item):
+        return int(self.get(item))
+
+    def get_float(self, item):
+        return float(self.get(item))
+
+    def get_args(self):
+        return self.args
+
+    def get_path(self):
+        return self.path
+
+    def get_method(self):
+        return self.method
+
+    def set_error(self, error):
+        self.response = error.to_dict()
+
+    def send(self, data):
+        if self.response is not None:
+            raise WebRequestError("Multiple calls to send not allowed")
+        self.response = data
+
+    def finish(self):
+        if self.response is None:
+            # No error was set and the user never executed
+            # send, default response is "ok"
+            self.response = "ok"
+        return {"request_id": self.id, "response": self.response}
+
+class ServerConnection:
+    def __init__(self, webhooks, printer):
+        self.printer = printer
+        self.webhooks = webhooks
+        self.reactor = printer.get_reactor()
+
+        # Klippy Connection
+        self.fd_handler = self.mutex = None
+        self.is_server_connected = False
+        self.partial_data = ""
+        is_fileoutput = (printer.get_start_args().get('debugoutput')
+                         is not None)
+        if is_fileoutput:
+            # Do not try to connect in klippy batch mode
+            return
+        self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.socket.setblocking(0)
+        try:
+            self.socket.connect(SOCKET_LOCATION)
+        except socket.error:
+            logging.debug(
+                "ServerConnection: Moonraker server not detected")
+            return
+        logging.debug("ServerConnection: Moonraker connection established")
+        self.is_server_connected = True
+        self.fd_handler = self.reactor.register_fd(
+            self.socket.fileno(), self.process_received)
+        self.mutex = self.reactor.mutex()
+        printer.register_event_handler('klippy:disconnect', self.close_socket)
+
+    def close_socket(self):
+        if self.is_server_connected:
+            logging.info("ServerConnection: lost connection to Moonraker")
+            self.is_server_connected = False
+            self.reactor.unregister_fd(self.fd_handler)
+            try:
+                self.socket.close()
+            except socket.error:
+                pass
+
+    def is_connected(self):
+        return self.is_server_connected
+
+    def process_received(self, eventtime):
+        try:
+            data = self.socket.recv(4096)
+        except socket.error as e:
+            # If bad file descriptor allow connection to be
+            # closed by the data check
+            if e.errno == errno.EBADF:
+                data = ''
+            else:
+                return
+        if data == '':
+            # Socket Closed
+            self.close_socket()
+            return
+        requests = data.split('\x03')
+        requests[0] = self.partial_data + requests[0]
+        self.partial_data = requests.pop()
+        for req in requests:
+            logging.debug(
+                "ServerConnection: Request received from Moonraker %s" % (req))
+            try:
+                decoded_req = json_loads_byteified(req)
+                self._process_request(decoded_req)
+            except Exception:
+                logging.exception(
+                    "ServerConnection: Error processing Server Request %s"
+                    % (req))
+
+    def _process_request(self, req):
+        web_request = WebRequest(req)
+        try:
+            func = self.webhooks.get_callback(
+                web_request.get_path())
+            func(web_request)
+        except homing.CommandError as e:
+            web_request.set_error(WebRequestError(e.message))
+        except Exception as e:
+            msg = "Internal Error on WebRequest: %s" % (web_request.get_path())
+            logging.exception(msg)
+            web_request.set_error(WebRequestError(e.message))
+            self.printer.invoke_shutdown(msg)
+        result = web_request.finish()
+        logging.debug(
+            "ServerConnection: Sending response - %s" % (str(result)))
+        self.send({'method': "response", 'params': result})
+
+    def send(self, data):
+        if not self.is_server_connected:
+            return
+        with self.mutex:
+            retries = 10
+            data = json.dumps(data) + "\x03"
+            while data:
+                try:
+                    sent = self.socket.send(data)
+                except socket.error as e:
+                    if e.errno == errno.EBADF or e.errno == errno.EPIPE \
+                            or not retries:
+                        sent = 0
+                    else:
+                        retries -= 1
+                        waketime = self.reactor.monotonic() + .001
+                        self.reactor.pause(waketime)
+                        continue
+                retries = 10
+                if sent > 0:
+                    data = data[sent:]
+                else:
+                    logging.info(
+                        "ServerConnection: Error sending server data,"
+                        " closing socket")
+                    self.close_socket()
+                    break
+
+class WebHooks:
+    def __init__(self, printer):
+        self.printer = printer
+        self._endpoints = {"list_endpoints": self._handle_list_endpoints}
+        self._static_paths = []
+        self.register_endpoint("info", self._handle_info_request)
+        self.register_endpoint("emergency_stop", self._handle_estop_request)
+        start_args = printer.get_start_args()
+        log_file = start_args.get('log_file')
+        if log_file is not None:
+            self.register_static_path("klippy.log", log_file)
+        self.sconn = ServerConnection(self, printer)
+
+    def register_endpoint(self, path, callback):
+        if path in self._endpoints:
+            raise WebRequestError("Path already registered to an endpoint")
+        self._endpoints[path] = callback
+
+
+    def register_static_path(self, resource_id, file_path):
+        static_path_info = {
+            'resource_id': resource_id, 'file_path': file_path}
+        self._static_paths.append(static_path_info)
+
+    def _handle_list_endpoints(self, web_request):
+        web_request.send({
+            'hooks': self._endpoints.keys(),
+            'static_paths': self._static_paths})
+
+    def _handle_info_request(self, web_request):
+        if web_request.get_method() != 'GET':
+            raise web_request.error("Invalid Request Method")
+        start_args = self.printer.get_start_args()
+        state_message = self.printer.get_state_message()
+        version = start_args['software_version']
+        cpu_info = start_args['cpu_info']
+        error = state_message != message_startup and \
+            state_message != message_ready
+        web_request.send(
+            {'cpu': cpu_info, 'version': version,
+             'hostname': socket.gethostname(),
+             'is_ready': state_message == message_ready,
+             'error_detected': error,
+             'message': state_message})
+
+    def _handle_estop_request(self, web_request):
+        if web_request.get_method() != 'POST':
+            raise web_request.error("Invalid Request Method")
+        gcode = self.printer.lookup_object('gcode')
+        gcode.cmd_M112(None)
+
+    def get_connection(self):
+        return self.sconn
+
+    def get_callback(self, path):
+        cb = self._endpoints.get(path, None)
+        if cb is None:
+            msg = "webhooks: No registered callback for path '%s'" % (path)
+            logging.info(msg)
+            raise WebRequestError(msg)
+        return cb

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -8,7 +8,6 @@ import socket
 import errno
 import json
 import homing
-from klippy import message_startup, message_ready
 
 SOCKET_LOCATION = "/tmp/moonraker"
 
@@ -252,15 +251,14 @@ class WebHooks:
         if web_request.get_method() != 'GET':
             raise web_request.error("Invalid Request Method")
         start_args = self.printer.get_start_args()
-        state_message = self.printer.get_state_message()
+        state_message, msg_type = self.printer.get_state_message()
         version = start_args['software_version']
         cpu_info = start_args['cpu_info']
-        error = state_message != message_startup and \
-            state_message != message_ready
+        error = msg_type == "error"
         web_request.send(
             {'cpu': cpu_info, 'version': version,
              'hostname': socket.gethostname(),
-             'is_ready': state_message == message_ready,
+             'is_ready': msg_type == "ready",
              'error_detected': error,
              'message': state_message})
 


### PR DESCRIPTION
This is the initial implementation of the webhooks module.  The module handles endpoint registration and communication with the Moonraker API server over a Unix Domain Socket.  If the server is not available then the module will not attempt to register endpoints with the server or communicate with it in any way.

Endpoints should be registered in the format `<module_name>/<action>`.  In most cases a callback should be provided, however it is valid to provide `None` in some instances (such as registering an endpoint to serve a file where no intervention from Klippy is necessary).  The "methods" argument takes a list of methods that the server will accept for the given endpoint, the default being ['GET'].   'GET' , 'POST', and 'DELETE' methods are available.   The optional "params" argument is a dict that may be necessary to configure the endpoint's handler on the server.  For example, the endpoint registered to serve "klippy.log" must specify that that the handler be a `FileRequestHandler` and the path to the log file.  Most endpoints registered will not need to provide a "params" argument.  A future pull request will provide detailed developer documentation on how to register an endpoint and all options available.

The webhooks module is instantiated in klippy.py, where the "klippy/info" and "klippy/klippy.log" endpoints are registered.  It then passes the module to gcode.py so that it may register "gcode/script", "gcode/help", "gcoce/restart", and "gcode/firmware_restart".  Registering these endpoints before the config file is parsed provides connected clients basic functionality in the event that there is a config error.

Also included in this request is endpoint registration for query_endstops and pause_resume.  The pause_resume module also adds a basic "CANCEL_PRINT" gcode, so that the "pause_resume/cancel" endpoint is guaranteed to execute.  It is assumed that advanced users will override the PAUSE, RESUME, and CANCEL_PRINT gcodes using gcode_macro's "rename_existing" functionality, allowing the user to customize the action taken when these requests are made.

Endpoint registration for the virtual_sdcard, file_manger, and the api_server configuration modules were not included.  Each of these are accompanied by larger changes which would be better served with their own pull request.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>