### PR TITLE
Support for 20KiB bootloader offset.

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -101,6 +101,8 @@ choice
         bool "8KiB bootloader (stm32duino)" if MACH_STM32F103 || MACH_STM32F070
     config STM32_FLASH_START_4000
         bool "16KiB bootloader (HID Bootloader)" if MACH_STM32F405 || MACH_STM32F407
+    config STM32_FLASH_START_5000
+        bool "20KiB bootloader" if MACH_STM32F103
     config STM32_FLASH_START_7000
         bool "28KiB bootloader" if MACH_STM32F103
     config STM32_FLASH_START_8000
@@ -115,6 +117,7 @@ config FLASH_START
     default 0x8000800 if STM32_FLASH_START_800
     default 0x8002000 if STM32_FLASH_START_2000
     default 0x8004000 if STM32_FLASH_START_4000
+    default 0x8005000 if STM32_FLASH_START_5000
     default 0x8007000 if STM32_FLASH_START_7000
     default 0x8008000 if STM32_FLASH_START_8000
     default 0x8010000 if STM32_FLASH_START_10000


### PR DESCRIPTION
This change will allow Klipper to run on **MKS Robin E3D** and **E3** boards.

Micro-controller Architecture: **STMicroelectronics STM32**
Processor model: **STM32F103**
Bootloader offset: **20KiB bootloader**
Clock Reference: **8 MHz crystal**
Serial Port: **USART1**
Baud rate: **250000**

The compiled firmware has still to be "signed" with the **update_mks_robin.py** script before uploading to the board. 

Signed-off-by: Kianusch Sayah Karadji <kianusch@gmail.com>