### PR TITLE
webhooks:  Fix reentrant protection

### DIFF
--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -99,9 +99,9 @@ class ServerConnection:
         self.fd = self.fd_handle = self.mutex = None
         self.is_server_connected = False
         self.partial_data = ""
-        is_fileoutput = (printer.get_start_args().get('debugoutput')
-                         is not None)
-        if is_fileoutput:
+        is_fileinput = (printer.get_start_args().get('debuginput')
+                        is not None)
+        if is_fileinput:
             # Do not try to connect in klippy batch mode
             return
         self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)


### PR DESCRIPTION
This fixes a bug where pending requests would be dropped when the ServerConnection is "busy".  The "emergency_stop" request is now checked out of order and will be processed if it is properly decoded and validated.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>