### PR TITLE
Fix for SKR Mini-e3 v2.0 UART addresses

### DIFF
--- a/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
@@ -43,7 +43,7 @@ homing_speed: 50
 [tmc2209 stepper_y]
 uart_pin: PC11
 tx_pin: PC10
-uart_address: 1
+uart_address: 2
 microsteps: 16
 run_current: 0.580
 hold_current: 0.500
@@ -61,7 +61,7 @@ position_max: 250
 [tmc2209 stepper_z]
 uart_pin: PC11
 tx_pin: PC10
-uart_address: 2
+uart_address: 1
 microsteps: 16
 run_current: 0.580
 hold_current: 0.500


### PR DESCRIPTION
Y and Z were flipped as per: https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/blob/master/firmware/V2.0/Marlin-2.0.x-SKR-mini-E3-V2.0/Marlin/Configuration_adv.h#L2204-L2212

thanks to Vael#9090 on Discord for pointing this out

Signed-off-by: Paul Greidanus <paul@majestik.org>