### PR TITLE
input_shaper: Fixed C module compilation on older gnu90 compilers

### DIFF
--- a/klippy/chelper/kin_shaper.c
+++ b/klippy/chelper/kin_shaper.c
@@ -50,7 +50,8 @@ calc_position(struct move *m, int axis, double move_time
               , struct shaper_pulse *pulses, int n)
 {
     double res = 0.;
-    for (int i = 0; i < n; ++i)
+    int i;
+    for (i = 0; i < n; ++i)
         res += pulses[i].a * get_axis_position_across_moves(
                 m, axis, move_time + pulses[i].t);
     return res;


### PR DESCRIPTION
For example, Raspbian GNU/Linux 8 (jessie) uses an old GCC version 4.9.2
which uses -std=gnu90 by default.

Signed-off-by: Dmitry Butyugin <dmbutyugin@google.com>