### PR TITLE
config: Fix homing order of Ender 3

### DIFF
--- a/config/printer-creality-ender3-2018.cfg
+++ b/config/printer-creality-ender3-2018.cfg
@@ -91,3 +91,15 @@ sclk_pin: PA1
 sid_pin: PC1
 encoder_pins: ^PD2, ^PD3
 click_pin: ^!PC0
+
+# The print bed can move so far to the front, that the nozzle can reach the
+# plastic cover of the print bed heater cable (only when the bed is moved by
+# hand). By homing the Y axis before the X axis, it is ensured the nozzle will
+# not melt through the plastic part.
+# BEWARE: You will lose the ability to home axes individually. The printer will
+# always home all axes for every G28 command.
+#[homing_override]
+#gcode:
+# G28 Y0
+# G28 X0
+# G28 Z0


### PR DESCRIPTION
By homing the y axis before the x axis, the nozzle will not touch the plastic cover of the bed heater cable.

The printer would not hit the cover during normal operation, but the y axis has a lot of extra travel that allows the nozzle to reach behind the print surface. When it is in a low z height and the x axis is homed first, it will collide with the plastic cover.