### PR TITLE
Add configuration options for OLED displays

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1831,8 +1831,16 @@
 #   optional. The cs_pin and a0_pin parameters must be provided when
 #   using an uc1701 display.
 #contrast: 40
-#   The contrast to set when using a uc1701 type display.  The value may
-#   range from 0 to 63.  Default is 40.
+#   The contrast to set when using a uc1701 or SSD1306/SH1106 type display
+#   For UC1701 the value may range from 0 to 63.  Default is 40.
+#   For SSD1306/SH1106 the value may range from 0 to 256.  Default is 239.
+#vcomh: 0
+#   Set the Vcomh value on SSD1306/SH1106 displays. This value is
+#   associated with a "smearing" effect on some OLED displays.
+#   The value may range from 0 to 63. Default is 0.
+#invert: FALSE
+#   TRUE inverts the pixels on certain OLED (SSD1306/SH1106) displays
+#   The default is FALSE
 #cs_pin:
 #dc_pin:
 #spi_bus:

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -223,7 +223,7 @@ class SSD1306(DisplayBase):
             0xDB, self.vcomh, # Set VCOMH deselect level
             0x2E,       # Deactivate scroll
             0xA4,       # Output ram to display
-            0xA6 if self.invert else 0xA7, # Normal display
+            0xA7 if self.invert else 0xA6, # Set normal/invert
             0xAF,       # Display on
         ]
         self.send(init_cmds)

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -202,6 +202,9 @@ class SSD1306(DisplayBase):
             io_bus = io.spi
         self.reset = ResetHelper(config.get("reset_pin", None), io_bus)
         DisplayBase.__init__(self, io, columns)
+        self.contrast = config.getint('contrast', 239, minval=0, maxval=255)
+        self.vcomh = config.getint('vcomh', 0, minval=0, maxval=63)
+        self.invert = config.getboolean('invert', False)
     def init(self):
         self.reset.init()
         init_cmds = [
@@ -215,12 +218,12 @@ class SSD1306(DisplayBase):
             0xA1,       # Set Segment re-map
             0xC8,       # Set COM output scan direction
             0xDA, 0x12, # Set COM pins hardware configuration
-            0x81, 0xEF, # Set contrast control
+            0x81, self.contrast, # Set contrast control
             0xD9, 0xA1, # Set pre-charge period
-            0xDB, 0x00, # Set VCOMH deselect level
+            0xDB, self.vcomh, # Set VCOMH deselect level
             0x2E,       # Deactivate scroll
             0xA4,       # Output ram to display
-            0xA6,       # Normal display
+            0xA6 if self.invert else 0xA7, # Normal display
             0xAF,       # Display on
         ]
         self.send(init_cmds)


### PR DESCRIPTION
This adds configuration options for a few of the initialization commands on SSD1306/SH1106 type displays.
Contrast is self-explanatory. Vcomh is used to adjust what appears as a sort of "smearing" that certain cheap OLEDs exhibit (seems to be most prevalent on the 1.3" SH1106 type displays). Invert allows the user to invert the display for black text on lit background.
This is my first time contributing so apologies if I missed anything

-James