### PR TITLE
webhooks:  fix lambda wrapper around _process_request

### DIFF
--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -161,7 +161,7 @@ class ServerConnection:
                     % (req))
                 continue
             self.reactor.register_callback(
-                lambda e, s=self: s._process_request(web_request))
+                lambda e, s=self, wr=web_request: s._process_request(wr))
 
     def _process_request(self, web_request):
         try:


### PR DESCRIPTION
This fixes a bug where multiple calls to `_process_request()` are passed the same "web_request" if the for loop that decodes and processes incoming requests contains more than one item.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>