### PR TITLE
Reset output pins on a restart and improve initial servo settings

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1254,9 +1254,6 @@
 #   the mcu resets.  Must be between minimum_pulse_width and maximum_pulse_width.
 #   This parameter is optional.  If both initial_angle and initial_pulse_width
 #   are set initial_angle will be used
-#enable: True
-#   Enable or disable servo. It can be enabled or disabled later using
-#   SET_SERVO SERVO=my_servo ENABLE=<0|1> g-command. The default is True (=enabled)
 
 # Neopixel (aka WS2812) LED support (one may define any number of
 # sections with a "neopixel" prefix). One may set the LED color via

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1245,15 +1245,13 @@
 #   The maximum pulse width time (in seconds). This should correspond
 #   with an angle of maximum_servo_angle. The default is 0.002
 #   seconds.
-#initial_angle: 70
-#   Initial angle to set the servo to when the mcu resets.  Must be between
-#   0 and maximum_servo_angle  This parameter is optional.  If both
-#   initial_angle and initial_pulse_width are set initial_angle will be used.
-#initial_pulse_width: 0.0015
-#   Initial pulse width time (in seconds) to set the servo to when
-#   the mcu resets.  Must be between minimum_pulse_width and maximum_pulse_width.
-#   This parameter is optional.  If both initial_angle and initial_pulse_width
-#   are set initial_angle will be used
+#initial_angle:
+#   Initial angle (in degrees) to set the servo to. The default is to
+#   not send any signal at startup.
+#initial_pulse_width:
+#   Initial pulse width time (in seconds) to set the servo to. (This
+#   is only valid if initial_angle is not set.) The default is to not
+#   send any signal at startup.
 
 # Neopixel (aka WS2812) LED support (one may define any number of
 # sections with a "neopixel" prefix). One may set the LED color via

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,10 @@ All dates in this document are approximate.
 
 # Changes
 
+20200725: The servo `enable` config parameter and the SET_SERVO
+`ENABLE` parameter have been removed.  Update any macros to use
+`SET_SERVO SERVO=my_servo WIDTH=0` to disable a servo.
+
 20200608: The LCD display support has changed the name of some
 internal "glyphs".  If a custom display layout was implemented it may
 be necessary to update to the latest glyph names (see

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -258,8 +258,9 @@ sections are enabled:
 
 The following commands are available when a "servo" config section is
 enabled:
-- `SET_SERVO SERVO=config_name [WIDTH=<seconds>] [ENABLE=<0|1>]`
-- `SET_SERVO SERVO=config_name [ANGLE=<degrees>] [ENABLE=<0|1>]`
+- `SET_SERVO SERVO=config_name [ANGLE=<degrees> | WIDTH=<seconds>]`:
+  Set the servo position to the given angle (in degrees) or pulse
+  width (in seconds). Use `WIDTH=0` to disable the servo output.
 
 ## Manual stepper Commands
 

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -76,8 +76,8 @@ class MCU_stepper:
                 self._oid, self._step_pin, self._dir_pin,
                 self._mcu.seconds_to_clock(min_stop_interval),
                 self._invert_step))
-        self._mcu.add_config_cmd(
-            "reset_step_clock oid=%d clock=0" % (self._oid,), is_init=True)
+        self._mcu.add_config_cmd("reset_step_clock oid=%d clock=0"
+                                 % (self._oid,), on_restart=True)
         step_cmd_id = self._mcu.lookup_command_id(
             "queue_step oid=%c interval=%u count=%hu add=%hi")
         dir_cmd_id = self._mcu.lookup_command_id(


### PR DESCRIPTION
This change ensures all digital output pins get reset to their initial values on a host restart (even if the micro-controller is not restarted).  This avoids some rare cases where the host and micro-controller state may get out of sync.

The change also improves the servo initialization so that it directly sets the new state once during startup.  This should help with #2821. (@szeker - FYI.) 

The change also removes the explicit servo ENABLE parameter - one can use `SET_SERVO WIDTH=0` to disable the servo instead.  (@dobryj - FYI.)

-Kevin