### PR TITLE
virtual_sdcard:  various additions

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,12 @@ All dates in this document are approximate.
 
 # Changes
 
+20200731:  The behavior of the `progress` attribute reported by
+the `virtual_sdcard` printer object has changed.  Progress is no
+longer reset to 0 when a print is paused.  It will now always report
+progress based on the internal file position, or 0 if no file is
+currently loaded.
+
 20200725: The servo `enable` config parameter and the SET_SERVO
 `ENABLE` parameter have been removed.  Update any macros to use
 `SET_SERVO SERVO=my_servo WIDTH=0` to disable a servo.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -60,6 +60,11 @@ Klipper also supports the following standard G-Code commands if the
 - Set SD position: `M26 S<offset>`
 - Report SD print status: `M27`
 
+In addition, the following extended commands are availble when the
+"virtual_sdcard" config section is enabled.
+- Load a file and start SD print: `SDCARD_PRINT_FILE FILENAME=<filename>`
+- Unload file and clear SD state:  `SDCARD_RESET_FILE`
+
 ## G-Code arcs
 
 The following standard G-Code commands are available if a "gcode_arcs"

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -1,0 +1,64 @@
+# Virtual SDCard print stat tracking
+#
+# Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+class PrintStats:
+    def __init__(self, config):
+        printer = config.get_printer()
+        self.gcode = printer.lookup_object('gcode')
+        self.reactor = printer.get_reactor()
+        self.reset()
+    def _update_filament_usage(self, eventtime):
+        gc_status = self.gcode.get_status(eventtime)
+        cur_epos = gc_status['last_epos']
+        self.filament_used += (cur_epos - self.last_epos) \
+            / gc_status['extrude_factor']
+        self.last_epos = cur_epos
+    def set_current_file(self, filename):
+        self.reset()
+        self.filename = filename
+    def note_start(self):
+        curtime = self.reactor.monotonic()
+        if self.print_start_time is None:
+            self.print_start_time = curtime
+        elif self.last_pause_time is not None:
+            # Update pause time duration
+            pause_duration = curtime - self.last_pause_time
+            self.prev_pause_duration += pause_duration
+            self.last_pause_time = None
+        # Reset last e-position
+        gc_status = self.gcode.get_status(curtime)
+        self.last_epos = gc_status['last_epos']
+    def note_pause(self):
+        if self.last_pause_time is None:
+            curtime = self.reactor.monotonic()
+            self.last_pause_time = curtime
+            # update filament usage
+            self._update_filament_usage(curtime)
+    def reset(self):
+        self.filename = ""
+        self.prev_pause_duration = self.last_epos = 0.
+        self.filament_used = 0.
+        self.print_start_time = self.last_pause_time = None
+    def get_status(self, eventtime):
+        total_duration = 0.
+        time_paused = self.prev_pause_duration
+        if self.print_start_time is not None:
+            if self.last_pause_time is not None:
+                # Calculate the total time spent paused during the print
+                time_paused += eventtime - self.last_pause_time
+            else:
+                # Accumulate filament if not paused
+                self._update_filament_usage(eventtime)
+            total_duration = eventtime - self.print_start_time
+        return {
+            'filename': self.filename,
+            'total_duration': total_duration,
+            'print_duration': total_duration - time_paused,
+            'filament_used': self.filament_used
+        }
+
+def load_config(config):
+    return PrintStats(config)

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -231,6 +231,7 @@ class VirtualSD:
             try:
                 self.gcode.run_script(lines[-1])
             except self.gcode.error as e:
+                self.print_stats.note_error(str(e))
                 break
             except:
                 logging.exception("virtual_sdcard dispatch")
@@ -243,7 +244,7 @@ class VirtualSD:
         if self.current_file is not None:
             self.print_stats.note_pause()
         else:
-            self._reset_file()
+            self.print_stats.note_complete()
         return self.reactor.NEVER
 
 def load_config(config):

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -78,9 +78,11 @@ class VirtualSD:
                 raise self.gcode.error("Unable to get file list")
     def get_status(self, eventtime):
         progress = 0.
-        if self.work_timer is not None and self.file_size:
+        if self.file_size:
             progress = float(self.file_position) / self.file_size
-        return {'progress': progress}
+        is_active = self.is_active()
+        return {'progress': progress, 'is_active': is_active,
+                'file_position': self.file_position}
     def is_active(self):
         return self.work_timer is not None
     def do_pause(self):


### PR DESCRIPTION
This request proposes the following changes to the virtual_sdcard module:
- Add a RESET_SD gcode.  This allows users to clear the virtual_sdcard's state in the event that they want to cancel a print.
- Walk through subdirectories when populating the file list, allowing Klipper to load these files via `M23 subdir/myfile.gcode` or  `M23 /subdir/myfile.gcode`
- Report print progress while the virtual_sdcard is paused.  The current behavior resets progress to 0.  In addition, report "is_active" and "file_position"  via get_status()
-  Add a PrintStats class that tracks the total time elapsed since the print has started, the total time spent printing  (not paused), and the total filament used based based on the gcode position.  These stats, along with the currently loaded file's name, are reported via get_status(). 

This functionality is currently used by Moonraker/Mainsail, however it may also be useful for displays or gcode_macros.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>