### PR TITLE
moonraker:  API server configuration and interface module

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -2178,3 +2178,73 @@
 # Replicape support - see the generic-replicape.cfg file for further
 # details.
 #[replicape]
+
+
+######################################################################
+# Moonraker API Server Configuration
+######################################################################
+
+# Primary Server Configuration.
+#[moonraker]
+#require_auth: True
+#   Enables authorization.  When set to true, requests must either contain
+#   a valid API key or originate from a trusted client. Default is True.
+#enable_cors: False
+#   Enables CORS support.  This may be enabled if one wishes to serve
+#   static files from a different origin than that of Moonraker.  This
+#   is useful for debugging web clients.  Default is False.
+#trusted_clients:
+# 192.168.1.30
+# 192.168.1.0/24
+#   A list of newline separated ip addresses and/or ip ranges that are
+#   trusted. Trusted clients are given full access to the API.  Both IPv4
+#   and IPv6 addresses and ranges are supported. Ranges must be expressed
+#   in CIDR notation (see http://ip.sb/cidr for more info).  For example, an
+#   entry of 192.168.1.0/24 will authorize IPs in the range of 192.168.1.1 -
+#   192.168.1.254.  Note that when specifying IPv4 ranges the last segment
+#   of the ip address must be 0. The default is no clients or ranges are
+#   trusted.
+#config_path: ~/klipper_config
+#   An optional path where configuration files are located. If specified,
+#   Moonraker will serve this path allowing file and directory manipulation
+#   within it. The default is no path, which results in no configuration files
+#   being served.
+
+# PanelDue Plugin Configuration
+#[moonraker_plugin paneldue]
+#serial:
+#   The serial port in which the PanelDue is connected.  This parameter
+#   must be provided.
+#baud: 57600
+#   The baud rate to connect at.  The default is 57600 baud.
+#machine_name: Klipper
+#   An optional unique machine name which displays on the PanelDue's
+#   Header.  The default is "Klipper".
+#macros:
+# LOAD_FILAMENT
+# UNLOAD_FILAMENT
+# PANELDUE_BEEP FREQUENCY=500 DURATION=1
+#   A list of newline separated "macros" that are displayed in the
+#   PanelDue's "macros" tab.  These can be gcode macros or simple
+#   gcodes.  A macro may contain parameters.  The default is no
+#   macros will be displayed by the PanelDue.
+
+# Power Plugin Configuration.  One may use this module to toggle the
+# state of a relay using a linux GPIO, enabling the ability to power
+# a printer on/off regardless of Klippy's state.  GPIOs are toggled
+# using linux sysfs.
+#[moonraker_plugin power]
+#devices: printer, led
+#  A comma separated list of devices you wish to control. Device names may not
+#  contain whitespace.  This parameter must be provided.
+#
+# Each device specified in "devices" should define its own set of the below
+# options:
+#<device>_name: Friendly Name
+#  An optional alias for the device. The default is the name specifed in
+#  "devices".
+#<device>_pin: 23
+#  The sysfs GPIO pin number you wish to control.  This parameter must be
+#  provided.
+#<device>_active_low: False
+#  When set to true the pin signal is inverted.  Default is False.

--- a/klippy/extras/moonraker.py
+++ b/klippy/extras/moonraker.py
@@ -1,37 +1,16 @@
-# Moonraker - Moonraker API server configuation and event relay
+# Moonraker - Moonraker API server event relay
 #
 # Copyright (C) 2020 Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license
 import os
-import socket
+import logging
+import sys
 
-class MoonrakerConfig:
+class MoonrakerEnable:
     def __init__(self, config):
-        self.printer = config.get_printer()
-        self.webhooks = self.printer.lookup_object('webhooks')
-
-        # Register webhooks
-        self.webhooks.register_endpoint(
-            "moonraker/get_configuration", self._handle_config_request)
-
-        # Load Server Config
-        self.server_config = None
-        self._load_server_config(config)
-
-        # Attempt to load the pause_resume and display_status objects
-        self.printer.load_object(config, "pause_resume")
-        self.printer.load_object(config, "display_status")
-
-        # Register Events
-        self.printer.register_event_handler(
-            "klippy:shutdown", self._handle_shutdown)
-
-        gcode = self.printer.lookup_object('gcode')
-        gcode.register_output_handler(self._handle_gcode_response)
-
-    def _load_server_config(self, config):
-        server_config = {}
+        printer = config.get_printer()
+        self.webhooks = printer.lookup_object('webhooks')
 
         # Check Virtual SDCard is loaded
         if not config.has_section('virtual_sdcard'):
@@ -39,63 +18,30 @@ class MoonrakerConfig:
                 "moonraker: The [virtual_sdcard] section "
                 "must be present and configured in printer.cfg")
         vsd_cfg = config.getsection('virtual_sdcard')
-        server_config['sd_path'] = vsd_cfg.get('path')
-
-        # Authorization Config
-        server_config['require_auth'] = config.getboolean('require_auth', True)
-        server_config['enable_cors'] = config.getboolean('enable_cors', False)
-        trusted_clients = config.get("trusted_clients", "")
-        trusted_clients = [c.strip() for c in trusted_clients.split('\n')
-                           if c.strip()]
-        trusted_ips = []
-        trusted_ranges = []
-        for ip in trusted_clients:
-            ip_parts = ip.rsplit('/', 1)
-            is_range = len(ip_parts) == 2
-            is_v4 = True
-            # Check IPv4
-            try:
-                socket.inet_pton(socket.AF_INET, ip_parts[0])
-            except socket.error:
-                is_v4 = False
-            if not is_v4:
-                # Check IPv6
-                try:
-                    socket.inet_pton(socket.AF_INET6, ip_parts[0])
-                except socket.error:
-                    raise config.error(
-                        "moonraker: Invalid value in trusted_clients: %s"
-                        % (ip))
-            if is_range:
-                if not ip_parts[1].isdigit() or \
-                        ip_parts[0][-2:] not in [".0", "::"]:
-                    raise config.error(
-                        "moonraker: Invalid range in trusted_clients: %s"
-                        % (ip))
-                trusted_ranges.append(ip)
-            else:
-                trusted_ips.append(ip)
-        server_config['trusted_ips'] = trusted_ips
-        server_config['trusted_ranges'] = trusted_ranges
-
-        # Printer config file
-        start_args = self.printer.get_start_args()
-        server_config['printer_config_main'] = start_args['config_file']
-        server_config['printer_config_path'] = config.get('config_path', None)
-        server_config['klipper_path'] = os.path.normpath(os.path.join(
+        start_args = printer.get_start_args()
+        sd_path = vsd_cfg.get('path')
+        cfg_file = start_args.get('config_file')
+        klipper_path = os.path.normpath(os.path.join(
             os.path.dirname(__file__), "../.."))
 
-        # Plugin Configuration.
-        plugin_sections = config.get_prefix_sections('moonraker_plugin')
-        for section in plugin_sections:
-            plugin_config = {}
-            name = "plugin_" + section.get_name().lower().split()[-1]
-            options = section.get_prefix_options('')
-            for opt in options:
-                plugin_config[opt] = section.get(opt)
-            server_config[name] = plugin_config
+        # Attempt to load the pause_resume and display_status objects
+        printer.load_object(config, "pause_resume")
+        printer.load_object(config, "display_status")
 
-        self.server_config = server_config
+        # Register Events
+        printer.register_event_handler(
+            "klippy:shutdown", self._handle_shutdown)
+
+        # Register webhooks
+        self.webhooks.register_static_path("sd_path", sd_path)
+        self.webhooks.register_static_path("printer.cfg", cfg_file)
+        self.webhooks.register_static_path("klippy_env", sys.executable)
+        self.webhooks.register_static_path("klipper_path", klipper_path)
+        self.webhooks.register_endpoint(
+            "moonraker/check_available", self._handle_check_available)
+
+        gcode = printer.lookup_object('gcode')
+        gcode.register_output_handler(self._handle_gcode_response)
 
     def _handle_shutdown(self):
         self.webhooks.call_remote_method("set_klippy_shutdown")
@@ -104,11 +50,9 @@ class MoonrakerConfig:
         self.webhooks.call_remote_method(
             "process_gcode_response", response=gc_response)
 
-    def _handle_config_request(self, web_request):
-        if self.server_config is None:
-            raise web_request.error("Config not available")
-        web_request.send(self.server_config)
+    def _handle_check_available(self, web_request):
+        logging.info("moonraker:  Connection Established")
 
 
 def load_config(config):
-    return MoonrakerConfig(config)
+    return MoonrakerEnable(config)

--- a/klippy/extras/moonraker.py
+++ b/klippy/extras/moonraker.py
@@ -1,0 +1,114 @@
+# Moonraker - Moonraker API server configuation and event relay
+#
+# Copyright (C) 2020 Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license
+import os
+import socket
+
+class MoonrakerConfig:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.webhooks = self.printer.lookup_object('webhooks')
+
+        # Register webhooks
+        self.webhooks.register_endpoint(
+            "moonraker/get_configuration", self._handle_config_request)
+
+        # Load Server Config
+        self.server_config = None
+        self._load_server_config(config)
+
+        # Attempt to load the pause_resume and display_status objects
+        self.printer.load_object(config, "pause_resume")
+        self.printer.load_object(config, "display_status")
+
+        # Register Events
+        self.printer.register_event_handler(
+            "klippy:shutdown", self._handle_shutdown)
+
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_output_handler(self._handle_gcode_response)
+
+    def _load_server_config(self, config):
+        server_config = {}
+
+        # Check Virtual SDCard is loaded
+        if not config.has_section('virtual_sdcard'):
+            raise config.error(
+                "moonraker: The [virtual_sdcard] section "
+                "must be present and configured in printer.cfg")
+        vsd_cfg = config.getsection('virtual_sdcard')
+        server_config['sd_path'] = vsd_cfg.get('path')
+
+        # Authorization Config
+        server_config['require_auth'] = config.getboolean('require_auth', True)
+        server_config['enable_cors'] = config.getboolean('enable_cors', False)
+        trusted_clients = config.get("trusted_clients", "")
+        trusted_clients = [c.strip() for c in trusted_clients.split('\n')
+                           if c.strip()]
+        trusted_ips = []
+        trusted_ranges = []
+        for ip in trusted_clients:
+            ip_parts = ip.rsplit('/', 1)
+            is_range = len(ip_parts) == 2
+            is_v4 = True
+            # Check IPv4
+            try:
+                socket.inet_pton(socket.AF_INET, ip_parts[0])
+            except socket.error:
+                is_v4 = False
+            if not is_v4:
+                # Check IPv6
+                try:
+                    socket.inet_pton(socket.AF_INET6, ip_parts[0])
+                except socket.error:
+                    raise config.error(
+                        "moonraker: Invalid value in trusted_clients: %s"
+                        % (ip))
+            if is_range:
+                if not ip_parts[1].isdigit() or \
+                        ip_parts[0][-2:] not in [".0", "::"]:
+                    raise config.error(
+                        "moonraker: Invalid range in trusted_clients: %s"
+                        % (ip))
+                trusted_ranges.append(ip)
+            else:
+                trusted_ips.append(ip)
+        server_config['trusted_ips'] = trusted_ips
+        server_config['trusted_ranges'] = trusted_ranges
+
+        # Printer config file
+        start_args = self.printer.get_start_args()
+        server_config['printer_config_main'] = start_args['config_file']
+        server_config['printer_config_path'] = config.get('config_path', None)
+        server_config['klipper_path'] = os.path.normpath(os.path.join(
+            os.path.dirname(__file__), "../.."))
+
+        # Plugin Configuration.
+        plugin_sections = config.get_prefix_sections('moonraker_plugin')
+        for section in plugin_sections:
+            plugin_config = {}
+            name = "plugin_" + section.get_name().lower().split()[-1]
+            options = section.get_prefix_options('')
+            for opt in options:
+                plugin_config[opt] = section.get(opt)
+            server_config[name] = plugin_config
+
+        self.server_config = server_config
+
+    def _handle_shutdown(self):
+        self.webhooks.call_remote_method("set_klippy_shutdown")
+
+    def _handle_gcode_response(self, gc_response):
+        self.webhooks.call_remote_method(
+            "process_gcode_response", response=gc_response)
+
+    def _handle_config_request(self, web_request):
+        if self.server_config is None:
+            raise web_request.error("Config not available")
+        web_request.send(self.server_config)
+
+
+def load_config(config):
+    return MoonrakerConfig(config)


### PR DESCRIPTION
This adds the moonraker.py extras module, which parses Moonraker's configuration, handles printer object "status" requests, and pushes notifications from Klippy to Moonraker (ie: gcode responses, klippy shutdown).   Also included are the following changes to gcode.py:
- A `gcode:respond` event has been added.  The moonraker extra registers this event and forwards gcode responses to the server.
- The pty output buffer is flushed when the OSError raised  in `gcode.respond_raw()` matches `EAGAIN`.   In my testing the pty becomes unstable after repeated attempts at writing when the buffer is full.  This  also prevents the error from spamming klippy.log each time `respond_raw()` is called. 

Below is a brief explanation on how the StatusHandler deals with subscriptions:
- The server makes a request to subscribe to specified printer objects.  A subscription request may look like `{gcode: ["gcode_position", "speed"], toolhead: []}`.  In this example, a client has requested the `gcode_position`  and `speed` items of `gcode`, and all items of the `toolhead`.  For all subsequent requests the StatusHandler will add additional subscriptions if they do not already exist. 
-  The timer in StatusHandler batches together subscription notifications based on the number of "ticks" a printer object is assigned during configuration.  The StatusHandler provides defaults that should be adequate in most situations.  For example, "gcode", and "toolhead" are assigned 1 tick, so their status will be fetched and pushed to Moonraker on each cycle of the timer.  The status of an object assigned 4 ticks is fetched and pushed every 4 cycles of the timer.

Moonraker has a plugin system similar to Klippy's "extras".  Core plugins get their configuration from the `[moonraker]` section, however optional plugins are defined in printer.cfg as `[moonraker_plugin plugin_name]`.  Currently there are two optional a plugins, a PanelDue plugin and a power plugin which was user contributed.

The power plugin toggles a Linux GPIO using sysfs to trigger a relay serving as a switch for the printer.     I thought that the use case made sense, as Klipper cannot toggle a GPIO if the printer is powered down.  I do think I would like to refactor the pin configuration to match Klipper's pin naming convention.  If you prefer, I can remove that section in examples-extras.cfg until this is done.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>

