### PR TITLE
safe_z_home: Make sure X and Y are homed before homing Z

### DIFF
--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019 Florian Heilmann <Florian.Heilmann@gmx.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import homing
 
 class SafeZHoming:
     def __init__(self, config):
@@ -30,12 +31,12 @@ class SafeZHoming:
 
     def cmd_G28(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')
+        curtime = self.printer.get_reactor().monotonic()
+        kin_status = toolhead.get_kinematics().get_status(curtime)
 
         # Perform Z Hop if necessary
         if self.z_hop != 0.0:
             pos = toolhead.get_position()
-            curtime = self.printer.get_reactor().monotonic()
-            kin_status = toolhead.get_kinematics().get_status(curtime)
             # Check if Z axis is homed or has a known position
             if 'z' in kin_status['homed_axes']:
                 # Check if the zhop would exceed the printer limits
@@ -65,14 +66,24 @@ class SafeZHoming:
         if new_params:
             g28_gcmd = self.gcode.create_gcode_command("G28", "G28", new_params)
             self.prev_G28(g28_gcmd)
+
+        # Update the currently homed axes
+        curtime = self.printer.get_reactor().monotonic()
+        kin_status = toolhead.get_kinematics().get_status(curtime)
+
         # Home Z axis if necessary
         if need_z:
-            # Move to safe XY homing position
             pos = toolhead.get_position()
             prev_x = pos[0]
             prev_y = pos[1]
             pos[0] = self.home_x_pos
             pos[1] = self.home_y_pos
+            # Throw an error if X or Y are not homed
+            if ('x' not in kin_status['homed_axes'] or
+                'y' not in kin_status['homed_axes']):
+                raise homing.EndstopMoveError(
+                        pos, "Must home axis first")
+            # Move to safe XY homing position
             toolhead.move(pos, self.speed)
             self.gcode.reset_last_position()
             # Home Z

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2019 Florian Heilmann <Florian.Heilmann@gmx.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import homing
 
 class SafeZHoming:
     def __init__(self, config):
@@ -81,8 +80,7 @@ class SafeZHoming:
             # Throw an error if X or Y are not homed
             if ('x' not in kin_status['homed_axes'] or
                 'y' not in kin_status['homed_axes']):
-                raise homing.EndstopMoveError(
-                        pos, "Must home axis first")
+                raise gcmd.error("Must home X and Y axes first")
             # Move to safe XY homing position
             toolhead.move(pos, self.speed)
             self.gcode.reset_last_position()


### PR DESCRIPTION
In it's current behavior, safe_z_home will attempt to home Z if it thinks the toolhead is above the z endstop even if the motors have since been disabled and the toolhead was moved to another position.

To fix this, the homed status of X and Y is checked immediately before Z is homed. If either of the axes is not homed, an Exception is raised.

The reason this check is done so late, is to cover cases such as:

```
G28 X0
G28 Y0 Z0
```
or
```
G28 Y0
G28 X0 Z0
```

which (with an earily check) would raise the exception even though this sequence of gcodes would yield correct behavior. This does mean, however, that the zlift will always be executed.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>