### PR TITLE
TMC5160 diag0 support

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1430,14 +1430,16 @@
 #   chip. This may be used to set custom motor parameters. The
 #   defaults for each parameter are next to the parameter name in the
 #   above list.
+#diag0_pin:
 #diag1_pin:
-#   The micro-controller pin attached to the DIAG1 line of the TMC2130
-#   chip. Setting this creates a "tmc2130_stepper_x:virtual_endstop"
-#   virtual pin which may be used as the stepper's endstop_pin. Doing
-#   this enables "sensorless homing". (Be sure to also set driver_SGT
-#   to an appropriate sensitivity value.) The default is to not enable
-#   sensorless homing. See docs/Sensorless_Homing.md for details on how
-#   to configure this.
+#   The micro-controller pin attached to one of the DIAG lines of the
+#   TMC2130 chip. Only a single diag pin should be specified.
+#   Setting this creates a "tmc2130_stepper_x:virtual_endstop" virtual
+#   pin which may be used as the stepper's endstop_pin. Doing this
+#   enables "sensorless homing". (Be sure to also set driver_SGT to an
+#   appropriate sensitivity value.) The default is to not enable
+#   sensorless homing. See docs/Sensorless_Homing.md for details on
+#   how to configure this.
 
 # Configure a TMC2208 (or TMC2224) stepper motor driver via single
 # wire UART. To use this feature, define a config section with a
@@ -1685,14 +1687,16 @@
 #   chip. This may be used to set custom motor parameters. The
 #   defaults for each parameter are next to the parameter name in the
 #   above list.
+#diag0_pin:
 #diag1_pin:
-#   The micro-controller pin attached to the DIAG1 line of the TMC5160
-#   chip. Setting this creates a "tmc5160_stepper_x:virtual_endstop"
-#   virtual pin which may be used as the stepper's endstop_pin. Doing
-#   this enables "sensorless homing". (Be sure to also set driver_SGT
-#   to an appropriate sensitivity value.) The default is to not enable
-#   sensorless homing. See docs/Sensorless_Homing.md for details on how
-#   to configure this.
+#   The micro-controller pin attached to one of the DIAG lines of the
+#   TMC5160 chip. Only a single diag pin should be specified.
+#   Setting this creates a "tmc5160_stepper_x:virtual_endstop" virtual
+#   pin which may be used as the stepper's endstop_pin. Doing this
+#   enables "sensorless homing". (Be sure to also set driver_SGT to an
+#   appropriate sensitivity value.) The default is to not enable
+#   sensorless homing. See docs/Sensorless_Homing.md for details on
+#   how to configure this.
 
 
 ######################################################################

--- a/docs/Sensorless_Homing.md
+++ b/docs/Sensorless_Homing.md
@@ -59,6 +59,8 @@ homing_retract_dist: 0
 
 The name of the virtual end stop pin is derived from the name of the TMC2130 section. The `homing_retract_dist` setting should be set to zero to disable the second homing move as a second pass is not needed, and attempts to do so are error prone.
 
+The TMC2130 and TMC5160 have both a `diag0_pin` and `diag1_pin` in most known hardware the `diag1_pin` is appropriate. In order for klipper to correctly configure the driver for sensorless homing, the correct configuration property name `diag0_pin` or `diag1_pin` must be used. Which is used is determined by which driver pin is connected to the MCU pin.
+
 ATTENTION: This guide only mentions the mandatory parameters and the ones needed to set up sensorless homing. There are many other options to configure on a TMC2130, make sure to take a look at `config/example-extras.cfg` for all the available options.
 
 ## Testing of SPI/UART communication

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -186,7 +186,16 @@ class TMCVirtualPinHelper:
         self.printer = config.get_printer()
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
-        self.diag_pin = mcu_tmc.get_diag_pin()
+        if self.fields.lookup_register('diag0_stall') is not None:
+            if config.get('diag0_pin', None) is not None:
+                self.diag_pin = config.get('diag0_pin')
+                self.diag_pin_field = 'diag0_stall'
+            else:
+                self.diag_pin = config.get('diag1_pin', None)
+                self.diag_pin_field = 'diag1_stall'
+        else:
+            self.diag_pin = config.get('diag_pin', None)
+            self.diag_pin_field = None
         self.mcu_endstop = None
         self.en_pwm = False
         self.pwmthrs = 0
@@ -228,7 +237,7 @@ class TMCVirtualPinHelper:
         else:
             # On earlier drivers, "stealthchop" must be disabled
             self.fields.set_field("en_pwm_mode", 0)
-            val = self.fields.set_field(self.mcu_tmc.get_diag_field(), 1)
+            val = self.fields.set_field(self.diag_pin_field, 1)
         self.mcu_tmc.set_register("GCONF", val)
         self.mcu_tmc.set_register("TCOOLTHRS", 0xfffff)
     def handle_homing_move_end(self, endstops):
@@ -240,7 +249,7 @@ class TMCVirtualPinHelper:
             val = self.fields.set_field("en_spreadCycle", not self.en_pwm)
         else:
             self.fields.set_field("en_pwm_mode", self.en_pwm)
-            val = self.fields.set_field(self.mcu_tmc.get_diag_field(), 0)
+            val = self.fields.set_field(self.diag_pin_field, 0)
         self.mcu_tmc.set_register("GCONF", val)
         self.mcu_tmc.set_register("TCOOLTHRS", 0)
 

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -182,11 +182,11 @@ class TMCCommandHelper:
 
 # Helper class for "sensorless homing"
 class TMCVirtualPinHelper:
-    def __init__(self, config, mcu_tmc, diag_pin):
+    def __init__(self, config, mcu_tmc):
         self.printer = config.get_printer()
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
-        self.diag_pin = diag_pin
+        self.diag_pin = mcu_tmc.get_diag_pin()
         self.mcu_endstop = None
         self.en_pwm = False
         self.pwmthrs = 0
@@ -228,7 +228,7 @@ class TMCVirtualPinHelper:
         else:
             # On earlier drivers, "stealthchop" must be disabled
             self.fields.set_field("en_pwm_mode", 0)
-            val = self.fields.set_field("diag1_stall", 1)
+            val = self.fields.set_field(self.mcu_tmc.get_diag_field(), 1)
         self.mcu_tmc.set_register("GCONF", val)
         self.mcu_tmc.set_register("TCOOLTHRS", 0xfffff)
     def handle_homing_move_end(self, endstops):
@@ -240,7 +240,7 @@ class TMCVirtualPinHelper:
             val = self.fields.set_field("en_spreadCycle", not self.en_pwm)
         else:
             self.fields.set_field("en_pwm_mode", self.en_pwm)
-            val = self.fields.set_field("diag1_stall", 0)
+            val = self.fields.set_field(self.mcu_tmc.get_diag_field(), 0)
         self.mcu_tmc.set_register("GCONF", val)
         self.mcu_tmc.set_register("TCOOLTHRS", 0)
 

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -178,20 +178,6 @@ class MCU_TMC_SPI:
         self.spi = bus.MCU_SPI_from_config(config, 3, default_speed=4000000)
         self.name_to_reg = name_to_reg
         self.fields = fields
-        diag0_pin = config.get('diag0_pin', None)
-        diag1_pin = config.get('diag1_pin', None)
-        if diag0_pin is not None and diag1_pin is not None:
-            raise config.error(
-                "TMC_SPI: only diag0_pin or diag1_pin should be specified")
-        elif diag0_pin is not None:
-            self.diag_pin = diag0_pin
-            self.diag_field = "diag0_stall"
-        elif diag1_pin is not None:
-            self.diag_pin = diag1_pin
-            self.diag_field = "diag1_stall"
-        else:
-            self.diag_pin = None
-            self.diag_field = None
     def get_fields(self):
         return self.fields
     def get_register(self, reg_name):
@@ -212,10 +198,6 @@ class MCU_TMC_SPI:
                 (val >> 8) & 0xff, val & 0xff]
         with self.mutex:
             self.spi.spi_send(data, minclock)
-    def get_diag_pin(self):
-        return self.diag_pin
-    def get_diag_field(self):
-        return self.diag_field
 
 
 ######################################################################

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -178,6 +178,20 @@ class MCU_TMC_SPI:
         self.spi = bus.MCU_SPI_from_config(config, 3, default_speed=4000000)
         self.name_to_reg = name_to_reg
         self.fields = fields
+        diag0_pin = config.get('diag0_pin', None)
+        diag1_pin = config.get('diag1_pin', None)
+        if diag0_pin is not None and diag1_pin is not None:
+            raise config.error(
+                "TMC_SPI: only diag0_pin or diag1_pin should be specified")
+        elif diag0_pin is not None:
+            self.diag_pin = diag0_pin
+            self.diag_field = "diag0_stall"
+        elif diag1_pin is not None:
+            self.diag_pin = diag1_pin
+            self.diag_field = "diag1_stall"
+        else:
+            self.diag_pin = None
+            self.diag_field = None
     def get_fields(self):
         return self.fields
     def get_register(self, reg_name):
@@ -198,6 +212,10 @@ class MCU_TMC_SPI:
                 (val >> 8) & 0xff, val & 0xff]
         with self.mutex:
             self.spi.spi_send(data, minclock)
+    def get_diag_pin(self):
+        return self.diag_pin
+    def get_diag_field(self):
+        return self.diag_field
 
 
 ######################################################################
@@ -210,8 +228,7 @@ class TMC2130:
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = MCU_TMC_SPI(config, Registers, self.fields)
         # Allow virtual pins to be created
-        diag1_pin = config.get('diag1_pin', None)
-        tmc.TMCVirtualPinHelper(config, self.mcu_tmc, diag1_pin)
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc)
         cmdhelper.setup_register_dump(ReadRegisters)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -60,8 +60,7 @@ class TMC2209:
                                       FieldFormatters)
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields, 3)
         # Allow virtual pins to be created
-        diag_pin = config.get('diag_pin', None)
-        tmc.TMCVirtualPinHelper(config, self.mcu_tmc, diag_pin)
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc)
         cmdhelper.setup_register_dump(ReadRegisters)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -309,8 +309,7 @@ class TMC5160:
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields)
         # Allow virtual pins to be created
-        diag1_pin = config.get('diag1_pin', None)
-        tmc.TMCVirtualPinHelper(config, self.mcu_tmc, diag1_pin)
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc)
         cmdhelper.setup_register_dump(ReadRegisters)

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -195,7 +195,6 @@ class MCU_TMC_uart:
         self.instance_id, self.addr, self.mcu_uart = lookup_tmc_uart_bitbang(
             config, max_addr)
         self.mutex = self.mcu_uart.mutex
-        self.diag_pin = config.get('diag_pin', None)
     def get_fields(self):
         return self.fields
     def _do_get_register(self, reg_name):
@@ -227,5 +226,3 @@ class MCU_TMC_uart:
                     return
         raise self.printer.command_error(
             "Unable to write tmc uart '%s' register %s" % (self.name, reg_name))
-    def get_diag_pin(self):
-        return self.diag_pin

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -195,6 +195,7 @@ class MCU_TMC_uart:
         self.instance_id, self.addr, self.mcu_uart = lookup_tmc_uart_bitbang(
             config, max_addr)
         self.mutex = self.mcu_uart.mutex
+        self.diag_pin = config.get('diag_pin', None)
     def get_fields(self):
         return self.fields
     def _do_get_register(self, reg_name):
@@ -226,3 +227,5 @@ class MCU_TMC_uart:
                     return
         raise self.printer.command_error(
             "Unable to write tmc uart '%s' register %s" % (self.name, reg_name))
+    def get_diag_pin(self):
+        return self.diag_pin


### PR DESCRIPTION
Follow up to and closes #3150 

Here is my first pass at it. I figured pushing the diag_pin lookup into the tmc_spi is a reasonable place to limit duplication and minimize impact on the 2209/uart code.

I wasn't sure what the best place to document was so I just added that small note to the sensorless homing page. If the
 assumption holds, that the diag0 only hardware is uncommon I don't expect much more would be necessary?

~My machine with with the 5160's just finished as I was typing this PR up, so I am headed to test it now.~
One silly mistake on my part and it seems to be working as expected.