### PR TITLE
Improvements to CAN bus ID generation. And added a small fast hash library

### DIFF
--- a/lib/README
+++ b/lib/README
@@ -74,3 +74,7 @@ revision 425a42d82006cf0aa24be27b483d2f6a41607489. The code is taken
 from the repo's hc-sr04-range-sensor directory. It has been modified
 so that the IEP definitions compile correctly. See pru_rpmsg.patch for
 the modifications.
+
+The fast-hash directory contains code from:
+  https://github.com/ztanml/fast-hash
+revision ae3bb53c199fe75619e940b5b6a3584ede99c5fc

--- a/lib/fast-hash/fasthash.c
+++ b/lib/fast-hash/fasthash.c
@@ -1,0 +1,75 @@
+/* The MIT License
+
+   Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#include "fasthash.h"
+
+// Compression function for Merkle-Damgard construction.
+// This function is generated using the framework provided.
+#define mix(h) ({					\
+			(h) ^= (h) >> 23;		\
+			(h) *= 0x2127599bf4325c37ULL;	\
+			(h) ^= (h) >> 47; })
+
+uint64_t fasthash64(const void *buf, size_t len, uint64_t seed)
+{
+	const uint64_t    m = 0x880355f21e6d1965ULL;
+	const uint64_t *pos = (const uint64_t *)buf;
+	const uint64_t *end = pos + (len / 8);
+	const unsigned char *pos2;
+	uint64_t h = seed ^ (len * m);
+	uint64_t v;
+
+	while (pos != end) {
+		v  = *pos++;
+		h ^= mix(v);
+		h *= m;
+	}
+
+	pos2 = (const unsigned char*)pos;
+	v = 0;
+
+	switch (len & 7) {
+	case 7: v ^= (uint64_t)pos2[6] << 48;
+	case 6: v ^= (uint64_t)pos2[5] << 40;
+	case 5: v ^= (uint64_t)pos2[4] << 32;
+	case 4: v ^= (uint64_t)pos2[3] << 24;
+	case 3: v ^= (uint64_t)pos2[2] << 16;
+	case 2: v ^= (uint64_t)pos2[1] << 8;
+	case 1: v ^= (uint64_t)pos2[0];
+		h ^= mix(v);
+		h *= m;
+	}
+
+	return mix(h);
+} 
+
+uint32_t fasthash32(const void *buf, size_t len, uint32_t seed)
+{
+	// the following trick converts the 64-bit hashcode to Fermat
+	// residue, which shall retain information from both the higher
+	// and lower parts of hashcode.
+        uint64_t h = fasthash64(buf, len, seed);
+	return h - (h >> 32);
+}

--- a/lib/fast-hash/fasthash.h
+++ b/lib/fast-hash/fasthash.h
@@ -1,0 +1,56 @@
+/* The MIT License
+
+   Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#ifndef _FASTHASH_H
+#define _FASTHASH_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * fasthash32 - 32-bit implementation of fasthash
+ * @buf:  data buffer
+ * @len:  data size
+ * @seed: the seed
+ */
+	uint32_t fasthash32(const void *buf, size_t len, uint32_t seed);
+
+/**
+ * fasthash64 - 64-bit implementation of fasthash
+ * @buf:  data buffer
+ * @len:  data size
+ * @seed: the seed
+ */
+	uint64_t fasthash64(const void *buf, size_t len, uint64_t seed);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -17,7 +17,7 @@ CFLAGS-$(CONFIG_MACH_STM32F1) += -mcpu=cortex-m3 -Ilib/stm32f1/include
 CFLAGS-$(CONFIG_MACH_STM32F2) += -mcpu=cortex-m3 -Ilib/stm32f2/include
 CFLAGS-$(CONFIG_MACH_STM32F4) += -mcpu=cortex-m4 -Ilib/stm32f4/include
 CFLAGS-$(CONFIG_MACH_STM32F4) += -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-CFLAGS += $(CFLAGS-y) -D$(MCU_UPPER) -mthumb -Ilib/cmsis-core
+CFLAGS += $(CFLAGS-y) -D$(MCU_UPPER) -mthumb -Ilib/cmsis-core -Ilib/fast-hash
 
 CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
@@ -46,8 +46,10 @@ src-$(CONFIG_USBSERIAL) += $(usb-src-y) stm32/chipid.c generic/usb_cdc.c
 serial-src-y := stm32/serial.c
 serial-src-$(CONFIG_MACH_STM32F0) := stm32/stm32f0_serial.c
 src-$(CONFIG_SERIAL) += $(serial-src-y) generic/serial_irq.c
-can-src-$(CONFIG_CANSERIAL) += stm32/can.c
+can-src-$(CONFIG_CANSERIAL) += stm32/can.c ../lib/fast-hash/fasthash.c
 src-$(CONFIG_CANSERIAL) += $(can-src-y) generic/serial_irq.c
+
+dirs-$(CONFIG_CANSERIAL) += lib/fast-hash
 
 # Binary output file rules
 target-y += $(OUT)klipper.bin

--- a/src/stm32/can.c
+++ b/src/stm32/can.c
@@ -154,11 +154,6 @@ static void pack_uuid(uint8_t* u)
 {
     uint64_t hash = fasthash64((uint8_t*)UID_BASE, 12, 0xA16231A7);
     memcpy(u, &hash, SHORT_UUID_LEN);
-    /*for(int i=0; i<SHORT_UUID_LEN; i++) {
-        u[i] = *((uint8_t*)(UID_BASE+i)) ^
-                *((uint8_t*)(UID_BASE+i+SHORT_UUID_LEN));
-    }
-    */
 }
 
 static void can_uuid_resp(void)

--- a/src/stm32/can.c
+++ b/src/stm32/can.c
@@ -15,6 +15,7 @@
 #include "sched.h" // DECL_INIT
 #include <string.h>
 #include "can.h"
+#include <fasthash.h>
 
 #if (CONFIG_CAN_PINS_PA11_PA12)
 DECL_CONSTANT_STR("RESERVE_PINS_CAN", "PA11,PA12");
@@ -151,10 +152,13 @@ static void can_transmit(uint32_t id, uint32_t dlc, uint8_t *pkt)
 // Convert Unique 96-bit value into 48 bit representation
 static void pack_uuid(uint8_t* u)
 {
-    for(int i=0; i<SHORT_UUID_LEN; i++) {
+    uint64_t hash = fasthash64((uint8_t*)UID_BASE, 12, 0xA16231A7);
+    memcpy(u, &hash, SHORT_UUID_LEN);
+    /*for(int i=0; i<SHORT_UUID_LEN; i++) {
         u[i] = *((uint8_t*)(UID_BASE+i)) ^
                 *((uint8_t*)(UID_BASE+i+SHORT_UUID_LEN));
     }
+    */
 }
 
 static void can_uuid_resp(void)


### PR DESCRIPTION
There were ID collision in the CAN bus unique ID generation. 
I found a small and fast little hash library that solved that problem.