### PR TITLE
webhooks: implement a unix domain socket server

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -35,6 +35,9 @@ class VirtualSD:
         self.gcode.register_command(
             "SDCARD_PRINT_FILE", self.cmd_SDCARD_PRINT_FILE,
             desc=self.cmd_SDCARD_PRINT_FILE_help)
+        # Register sd path
+        webhooks = printer.lookup_object('webhooks')
+        webhooks.register_static_path("sd_path", self.sdcard_dirname)
     def handle_shutdown(self):
         if self.work_timer is not None:
             self.must_pause_work = True


### PR DESCRIPTION
This changes Klippy's role from a client to a  uds server.  It is possible for Klippy to host simultaneous clients, where the response to a web request is sent only to the requesting client.  Currently data pushed from Klippy (such as status updates and gcode responses) will be sent to all connected clients.  We may wish to look at that behavior in the future, perhaps though an endpoint that allows clients to register an identity and the methods they accept.  

Also implemented in this PR:
- Calls to `ClientConnection.send()` write to a buffer and do not block, resolving potential reentrancy issues
- webhooks registers a "gcode_respond_callback" that forwards gcode responses to all client sockets
- webhooks calls the "set_klippy_shutdown" remote method when it receives a shutdown event
- webhooks registers the printer.cfg, klippy_env, and klipper static paths.
- virtual_sdcard registers its "sd_path" static path.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>