### PR TITLE
This is a proposal for updates to the "webhooks" interface

### DIFF
--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -19,27 +19,20 @@ class PauseResume:
         self.gcode.register_command("CLEAR_PAUSE", self.cmd_CLEAR_PAUSE)
         self.gcode.register_command("CANCEL_PRINT", self.cmd_CANCEL_PRINT)
         webhooks = self.printer.lookup_object('webhooks')
-        webhooks.register_endpoint(
-            "pause_resume/cancel", self._handle_web_request)
-        webhooks.register_endpoint(
-            "pause_resume/pause", self._handle_web_request)
-        webhooks.register_endpoint(
-            "pause_resume/resume", self._handle_web_request)
+        webhooks.register_endpoint("pause_resume/cancel",
+                                   self._handle_cancel_request)
+        webhooks.register_endpoint("pause_resume/pause",
+                                   self._handle_pause_request)
+        webhooks.register_endpoint("pause_resume/resume",
+                                   self._handle_resume_request)
     def handle_ready(self):
         self.v_sd = self.printer.lookup_object('virtual_sdcard', None)
-    def _handle_web_request(self, web_request):
-        if web_request.get_method() != 'POST':
-            raise web_request.error("Invalid Request Method")
-        path = web_request.get_path()
-        if path == "pause_resume/cancel":
-            script = "CANCEL_PRINT"
-        elif path == "pause_resume/pause":
-            script = "PAUSE"
-        elif path == "pause_resume/resume":
-            script = "RESUME"
-        else:
-            raise web_request.error("Invalid Path")
-        self.gcode.run_script(script)
+    def _handle_cancel_request(self, web_request):
+        self.gcode.run_script("CANCEL_PRINT")
+    def _handle_pause_request(self, web_request):
+        self.gcode.run_script("PAUSE")
+    def _handle_resume_request(self, web_request):
+        self.gcode.run_script("RESUME")
     def get_status(self, eventtime):
         return {
             'is_paused': self.is_paused

--- a/klippy/extras/query_endstops.py
+++ b/klippy/extras/query_endstops.py
@@ -22,8 +22,6 @@ class QueryEndstops:
     def get_status(self, eventtime):
         return {'last_query': {name: value for name, value in self.last_state}}
     def _handle_web_request(self, web_request):
-        if web_request.get_method() != 'GET':
-            raise web_request.error("Invalid Request Method")
         gc_mutex = self.printer.lookup_object('gcode').get_mutex()
         toolhead = self.printer.lookup_object('toolhead')
         with gc_mutex:

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -35,9 +35,6 @@ class VirtualSD:
         self.gcode.register_command(
             "SDCARD_PRINT_FILE", self.cmd_SDCARD_PRINT_FILE,
             desc=self.cmd_SDCARD_PRINT_FILE_help)
-        # Register sd path
-        webhooks = printer.lookup_object('webhooks')
-        webhooks.register_static_path("sd_path", self.sdcard_dirname)
     def handle_shutdown(self):
         if self.work_timer is not None:
             self.must_pause_work = True

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -78,16 +78,6 @@ class GCodeParser:
                                        self._handle_disconnect)
         printer.register_event_handler("extruder:activate_extruder",
                                        self._handle_activate_extruder)
-        # Register webhooks
-        webhooks = self.printer.lookup_object('webhooks')
-        webhooks.register_endpoint(
-            "gcode/help", self._handle_remote_help)
-        webhooks.register_endpoint(
-            "gcode/script", self._handle_remote_script)
-        webhooks.register_endpoint(
-            "gcode/restart", self._handle_remote_restart)
-        webhooks.register_endpoint(
-            "gcode/firmware_restart", self._handle_remote_firmware_restart)
         # Command handling
         self.is_printer_ready = False
         self.mutex = printer.get_reactor().mutex()
@@ -158,6 +148,8 @@ class GCodeParser:
                 "mux command %s %s %s already registered (%s)" % (
                     cmd, key, value, prev_values))
         prev_values[value] = func
+    def get_command_help(self):
+        return dict(self.gcode_help)
     def register_output_handler(self, cb):
         self.output_callbacks.append(cb)
     def set_move_transform(self, transform, force=False):
@@ -617,15 +609,6 @@ class GCodeParser:
             if cmd in self.gcode_help:
                 cmdhelp.append("%-10s: %s" % (cmd, self.gcode_help[cmd]))
         gcmd.respond_info("\n".join(cmdhelp), log=False)
-    # Webhooks
-    def _handle_remote_help(self, web_request):
-        web_request.send(dict(self.gcode_help))
-    def _handle_remote_restart(self, web_request):
-        self.run_script('restart')
-    def _handle_remote_firmware_restart(self, web_request):
-        self.run_script('firmware_restart')
-    def _handle_remote_script(self, web_request):
-        self.run_script(web_request.get('script'))
 
 # Support reading gcode from a pseudo-tty interface
 class GCodeIO:

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -87,7 +87,7 @@ class GCodeParser:
         webhooks.register_endpoint(
             "gcode/restart", self._handle_remote_restart)
         webhooks.register_endpoint(
-            "gcode/firmware_restart", self._handle_remote_restart)
+            "gcode/firmware_restart", self._handle_remote_firmware_restart)
         # Command handling
         self.is_printer_ready = False
         self.mutex = printer.get_reactor().mutex()
@@ -619,22 +619,13 @@ class GCodeParser:
         gcmd.respond_info("\n".join(cmdhelp), log=False)
     # Webhooks
     def _handle_remote_help(self, web_request):
-        if web_request.get_method() != 'GET':
-            raise web_request.error("Invalid Request Method")
         web_request.send(dict(self.gcode_help))
     def _handle_remote_restart(self, web_request):
-        if web_request.get_method() != 'POST':
-            raise web_request.error("Invalid Request Method")
-        path = web_request.get_path()
-        if path == "gcode/restart":
-            self.run_script('restart')
-        elif path == "gcode/firmware_restart":
-            self.run_script('firmware_restart')
+        self.run_script('restart')
+    def _handle_remote_firmware_restart(self, web_request):
+        self.run_script('firmware_restart')
     def _handle_remote_script(self, web_request):
-        if web_request.get_method() != 'POST':
-            raise web_request.error("Invalid Request Method")
-        script = web_request.get('script')
-        self.run_script(script)
+        self.run_script(web_request.get('script'))
 
 # Support reading gcode from a pseudo-tty interface
 class GCodeIO:

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -59,7 +59,7 @@ class Printer:
         self.event_handlers = {}
         self.objects = collections.OrderedDict()
         # Init printer components that must be setup prior to config
-        for m in [webhooks, gcode]:
+        for m in [gcode, webhooks]:
             m.add_early_printer_objects(self)
     def get_start_args(self):
         return self.start_args

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -247,6 +247,8 @@ def main():
     opts.add_option("-I", "--input-tty", dest="inputtty",
                     default='/tmp/printer',
                     help="input tty name (default is /tmp/printer)")
+    opts.add_option("-a", "--api-server", dest="apiserver",
+                    help="api server unix domain socket filename")
     opts.add_option("-l", "--logfile", dest="logfile",
                     help="write log to file instead of stderr")
     opts.add_option("-v", action="store_true", dest="verbose",
@@ -259,7 +261,8 @@ def main():
     options, args = opts.parse_args()
     if len(args) != 1:
         opts.error("Incorrect number of arguments")
-    start_args = {'config_file': args[0], 'start_reason': 'startup'}
+    start_args = {'config_file': args[0], 'apiserver': options.apiserver,
+                  'start_reason': 'startup'}
 
     debuglevel = logging.INFO
     if options.verbose:

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -262,13 +262,6 @@ class WebHooks:
         self.register_endpoint("emergency_stop", self._handle_estop_request)
         self.sconn = ServerSocket(self, printer)
 
-        # Register Events
-        printer.register_event_handler(
-            "klippy:shutdown", self._notify_shutdown)
-
-    def _notify_shutdown(self):
-        self.call_remote_method("set_klippy_shutdown")
-
     def register_endpoint(self, path, callback):
         if path in self._endpoints:
             raise WebRequestError("Path already registered to an endpoint")
@@ -310,10 +303,10 @@ class WebHooks:
         self.call_remote_method(method, **kwargs)
         return ""
 
-    def get_status(self, eventtime=0.):
-        return {
-            "action_call_remote_method": self._action_call_remote_method
-        }
+    def get_status(self, eventtime):
+        state_message, state = self.printer.get_state_message()
+        return {'state': state, 'state_message': state_message,
+                "action_call_remote_method": self._action_call_remote_method}
 
 class GCodeHelper:
     def __init__(self, printer):

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -258,7 +258,6 @@ class WebHooks:
         self.register_endpoint("info", self._handle_info_request)
         self.register_endpoint("emergency_stop", self._handle_estop_request)
         self.sconn = ServerSocket(self, printer)
-        StatusHandler(self)
 
         # Register Events
         printer.register_event_handler(
@@ -330,9 +329,9 @@ class WebHooks:
 SUBSCRIPTION_REFRESH_TIME = .25
 
 class StatusHandler:
-    def __init__(self, webhooks):
-        self.printer = webhooks.printer
-        self.webhooks = webhooks
+    def __init__(self, printer):
+        self.printer = printer
+        self.webhooks = webhooks = printer.lookup_object('webhooks')
         self.ready = self.timer_started = False
         self.reactor = self.printer.get_reactor()
         self.available_objects = {}
@@ -462,3 +461,4 @@ class StatusHandler:
 
 def add_early_printer_objects(printer):
     printer.add_object('webhooks', WebHooks(printer))
+    StatusHandler(printer)

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -45,11 +45,15 @@ class Sentinel:
 
 class WebRequest:
     error = WebRequestError
-    def __init__(self, base_request):
+    def __init__(self, client_conn, base_request):
+        self.client_conn = client_conn
         self.id = base_request['id']
         self.path = base_request['path']
         self.args = base_request['args']
         self.response = None
+
+    def get_client_connection(self):
+        return self.client_conn
 
     def get(self, item, default=Sentinel):
         if item not in self.args:
@@ -170,6 +174,9 @@ class ClientConnection:
                 pass
             self.server.pop_client(self.uid)
 
+    def is_closed(self):
+        return self.fd_handle is None
+
     def process_received(self, eventtime):
         try:
             data = self.sock.recv(4096)
@@ -191,7 +198,7 @@ class ClientConnection:
             logging.debug(
                 "webhooks: Request received: %s" % (req))
             try:
-                web_request = WebRequest(json_loads_byteified(req))
+                web_request = WebRequest(self, json_loads_byteified(req))
             except Exception:
                 logging.exception(
                     "webhooks: Error decoding Server Request %s"
@@ -257,20 +264,10 @@ class WebHooks:
 
         # Register Events
         printer.register_event_handler(
-            "klippy:connect", self._handle_connect)
-        printer.register_event_handler(
             "klippy:shutdown", self._notify_shutdown)
-
-    def _handle_connect(self):
-        gcode = self.printer.lookup_object('gcode')
-        gcode.register_output_handler(self._process_gcode_response)
 
     def _notify_shutdown(self):
         self.call_remote_method("set_klippy_shutdown")
-
-    def _process_gcode_response(self, gc_response):
-        self.call_remote_method(
-            "process_gcode_response", response=gc_response)
 
     def register_endpoint(self, path, callback):
         if path in self._endpoints:
@@ -317,6 +314,46 @@ class WebHooks:
         return {
             "action_call_remote_method": self._action_call_remote_method
         }
+
+class GCodeHelper:
+    def __init__(self, printer):
+        self.printer = printer
+        self.gcode = printer.lookup_object("gcode")
+        # Output subscription tracking
+        self.is_output_registered = False
+        self.clients = {}
+        # Register webhooks
+        wh = printer.lookup_object('webhooks')
+        wh.register_endpoint("gcode/help", self._handle_help)
+        wh.register_endpoint("gcode/script", self._handle_script)
+        wh.register_endpoint("gcode/restart", self._handle_restart)
+        wh.register_endpoint("gcode/firmware_restart",
+                             self._handle_firmware_restart)
+        wh.register_endpoint("gcode/subscribe_output",
+                             self._handle_subscribe_output)
+    def _handle_help(self, web_request):
+        web_request.send(self.gcode.get_command_help())
+    def _handle_script(self, web_request):
+        self.gcode.run_script(web_request.get('script'))
+    def _handle_restart(self, web_request):
+        self.gcode.run_script('restart')
+    def _handle_firmware_restart(self, web_request):
+        self.gcode.run_script('firmware_restart')
+    def _output_callback(self, msg):
+        for cconn, template in list(self.clients.items()):
+            if cconn.is_closed():
+                del self.clients[cconn]
+                continue
+            tmp = dict(template)
+            tmp['params'] = {'response': msg}
+            cconn.send(tmp)
+    def _handle_subscribe_output(self, web_request):
+        cconn = web_request.get_client_connection()
+        template = web_request.get('response_template', {})
+        self.clients[cconn] = template
+        if not self.is_output_registered:
+            self.gcode.register_output_handler(self._output_callback)
+            self.is_output_registered = True
 
 SUBSCRIPTION_REFRESH_TIME = .25
 
@@ -443,4 +480,5 @@ class StatusHandler:
 
 def add_early_printer_objects(printer):
     printer.add_object('webhooks', WebHooks(printer))
+    GCodeHelper(printer)
     StatusHandler(printer)

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -144,10 +144,6 @@ class ServerSocket:
     def pop_client(self, client_id):
         self.clients.pop(client_id, None)
 
-    def send_all_clients(self, data):
-        for client in self.clients.values():
-            client.send(data)
-
 class ClientConnection:
     def __init__(self, server, sock):
         self.printer = server.printer
@@ -296,17 +292,9 @@ class WebHooks:
             raise WebRequestError(msg)
         return cb
 
-    def call_remote_method(self, method, **kwargs):
-        self.sconn.send_all_clients({'method': method, 'params': kwargs})
-
-    def _action_call_remote_method(self, method, **kwargs):
-        self.call_remote_method(method, **kwargs)
-        return ""
-
     def get_status(self, eventtime):
         state_message, state = self.printer.get_state_message()
-        return {'state': state, 'state_message': state_message,
-                "action_call_remote_method": self._action_call_remote_method}
+        return {'state': state, 'state_message': state_message}
 
 class GCodeHelper:
     def __init__(self, printer):

--- a/scripts/whconsole.py
+++ b/scripts/whconsole.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python2
+# Test console for webhooks interface
+#
+# Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import sys, os, optparse, socket, fcntl, select, json, errno, time
+
+# Set a file-descriptor as non-blocking
+def set_nonblock(fd):
+    fcntl.fcntl(fd, fcntl.F_SETFL
+                , fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
+
+def webhook_socket_create(uds_filename):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.setblocking(0)
+    sys.stderr.write("Waiting for connect to %s\n" % (uds_filename,))
+    while 1:
+        try:
+            sock.connect(uds_filename)
+        except socket.error as e:
+            if e.errno == errno.ECONNREFUSED:
+                time.sleep(0.1)
+                continue
+            sys.stderr.write("Unable to connect socket %s [%d,%s]\n"
+                             % (uds_filename, e.errno,
+                                errno.errorcode[e.errno]))
+            sys.exit(-1)
+        break
+    sys.stderr.write("Connection.\n")
+    return sock
+
+class KeyboardReader:
+    def __init__(self, uds_filename):
+        self.kbd_fd = sys.stdin.fileno()
+        set_nonblock(self.kbd_fd)
+        self.webhook_socket = webhook_socket_create(uds_filename)
+        self.poll = select.poll()
+        self.poll.register(sys.stdin, select.POLLIN | select.POLLHUP)
+        self.poll.register(self.webhook_socket, select.POLLIN | select.POLLHUP)
+        self.kbd_data = self.socket_data = ""
+    def process_socket(self):
+        data = self.webhook_socket.recv(4096)
+        if not data:
+            sys.stderr.write("Socket closed\n")
+            sys.exit(0)
+        parts = data.split('\x03')
+        parts[0] = self.socket_data + parts[0]
+        self.socket_data = parts.pop()
+        for line in parts:
+            sys.stdout.write("GOT: %s\n" % (line,))
+    def process_kbd(self):
+        data = os.read(self.kbd_fd, 4096)
+        parts = data.split('\n')
+        parts[0] = self.kbd_data + parts[0]
+        self.kbd_data = parts.pop()
+        for line in parts:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            try:
+                m = json.loads(line)
+            except:
+                sys.stderr.write("ERROR: Unable to parse line\n")
+                continue
+            cm = json.dumps(m, separators=(',', ':'))
+            sys.stdout.write("SEND: %s\n" % (cm,))
+            self.webhook_socket.send("%s\x03" % (cm,))
+    def run(self):
+        while 1:
+            res = self.poll.poll(1000.)
+            for fd, event in res:
+                if fd == self.kbd_fd:
+                    self.process_kbd()
+                else:
+                    self.process_socket()
+
+def main():
+    usage = "%prog [options] <socket filename>"
+    opts = optparse.OptionParser(usage)
+    options, args = opts.parse_args()
+    if len(args) != 1:
+        opts.error("Incorrect number of arguments")
+
+    ml = KeyboardReader(args[0])
+    ml.run()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
@Arksine - as discussed, I'm putting together a proposal for some changes to the "webhooks" interface.

The primary change is to convert the interface to a format that is more similar to json-rpc (though it does not stringently follow json-rpc).  So, requests now look like: `{"id":14, "method": "api_server/info", "params": {}}`.  The `id` and `params` fields are optional.  Responses now look like `{"id": 14, "result": {}}`.

This branch also adds a new `./scripts/whconsole.py` script that one can use to send in queries to the klippy server.  So, one can send in the above command and see the response.

Another notable change is that the server never sends unsolicited messages to the client.  The client must subscribe to get_status() updates and/or gcode output messages.  Such a subscription might look like: `{"id":101, "method": "subscribe_gcode_output", "params": {"response_template": {"method": "process_gcode_response"}}}`.  On each subscription, one can specify a "response_template" - that template is used to format the message ultimately sent to the client.  For example, after the above, the client might receive: `{"method": "process_gcode_response", "params": {"response": "// ECHO hello=world"}}`

Along with this change, the register_static_path() method was removed - instead, most of that info is now available via the "api_server/info" endpoint.

Also, I propose that we rename "webhooks.py" to "api_server.py" and prefix all endpoints defined in api_server.py with an "api_server/" prefix.

As above, this is just a proposal.  Let me know what you think.

Separately, I think it would be useful to update the get_status() subscription mechanism to support per-client subscriptions.  I also think it would be nice if only deltas were sent after the first update.  That is, if a field like gcode.gcode_position hasn't changed, then no need to send it every update.  If there's interest in that, I can put together a prototype.

-Kevin