### PR TITLE
virtual_sdcard module menu

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3342,14 +3342,14 @@ Read-only attributes for menu element:
 
 List of actions for menu element:
 * menu.back(force, update): will execute menu back command, optional
-  boolean parameters <force> and <update>.
-  * When <force> is set True then it will also stop editing. Default
+  boolean parameters \<force\> and \<update\>
+  * When \<force\> is set True then it will also stop editing. Default
     value is False
-  * When <update> is set False then parent container items are not
+  * When \<update\> is set False then parent container items are not
     updated. Default value is True
 * menu.exit(force) - will execute menu exit command, optional boolean
-  parameter <force> default value False
-  * When <force> is set True then it will also stop editing. Default
+  parameter \<force\>
+  * When \<force\> is set True then it will also stop editing. Default
     value is False
 
 ```
@@ -3369,8 +3369,6 @@ List of actions for menu element:
 #                 scrollable list.  Add to the list by creating menu
 #                 configurations using "some_list" as a prefix - for
 #                 example: [menu some_list some_item_in_the_list]
-#       vsdlist - same as 'list' but will append files from virtual sdcard
-#                 (will be removed in the future)
 #name:
 #   Name of menu item - evaluated as a template.
 #enable:
@@ -3378,6 +3376,11 @@ List of actions for menu element:
 #index:
 #   Position where an item needs to be inserted in list. By default
 #   the item is added at the end.
+#event_sender:
+#   The menu item emits the event only if the sender name of the event
+#   is specified. Events are used internally to interact with event listeners.
+#   The default is empty. This parameter is optional.
+
 
 #[menu some_list]
 #type: list

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -159,7 +159,8 @@ gcode:
 
 ### menu virtual sdcard ###
 [menu __main __sdcard]
-type: vsdlist
+type: list
+event_sender: __vsdfiles
 enable: {('virtual_sdcard' in printer)}
 name: SD Card
 

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -11,6 +11,9 @@ class VirtualSD:
     def __init__(self, config):
         printer = config.get_printer()
         printer.register_event_handler("klippy:shutdown", self.handle_shutdown)
+        # Register menu handlers
+        printer.register_event_handler(
+            "menu:populate:__vsdfiles", self.handle_sdcard_populate)
         # sdcard state
         sd = config.get('path')
         self.sdcard_dirname = os.path.normpath(os.path.expanduser(sd))
@@ -48,6 +51,14 @@ class VirtualSD:
             logging.info("Virtual sdcard (%d): %s\nUpcoming (%d): %s",
                          readpos, repr(data[:readcount]),
                          self.file_position, repr(data[readcount:]))
+    # menu handlers
+    def handle_sdcard_populate(self, item):
+        if item is not None:
+            files = self.get_file_list()
+            for fname, fsize in files:
+                sdfile = item.manager.menuitem_from(
+                    'command', name=repr(fname), gcode='M23 /%s' % str(fname))
+                item.insert_item(sdfile)
     def stats(self, eventtime):
         if self.work_timer is None:
             return False, ""


### PR DESCRIPTION
Transfer SD Card menu parts to the `virtual_sdcard` module.
The element `vsdlist` is removed from the menu.
Module `virtual_sdcard` will extend the existing default menu
by loading and injecting its own menu items. 
It's a loose reference with menu via menu events.

NB! The module must appear in the printer config before the menu section otherwise it will not catch `menu:init` event!