### PR TITLE
delta_calibrate: Show statistic info about delta_calibrate process

### DIFF
--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -227,6 +227,10 @@ class DeltaCalibrate:
 
         sum = 0
         count = len(self.probe_helper.results)
+
+        if count <= 0:
+          return
+
         for i in range(count):
             x = self.probe_helper.results[i][0]
             y = self.probe_helper.results[i][1]

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -224,6 +224,26 @@ class DeltaCalibrate:
     cmd_DELTA_CALIBRATE_help = "Delta calibration script"
     def cmd_DELTA_CALIBRATE(self, gcmd):
         self.probe_helper.start_probe(gcmd)
+
+        sum = 0
+        count = len(self.probe_helper.results)
+        for i in range(count):
+            x = self.probe_helper.results[i][0]
+            y = self.probe_helper.results[i][1]
+            z = self.probe_helper.results[i][2]
+            self.gcode.respond_info("%2d. x:%.2f, y:%.2f, z : %.6f" % (i, x, y, z))
+            sum += z
+        avg = sum / count
+        
+        sd_sum = 0
+        for i in range(count):
+            z = self.probe_helper.results[i][2]
+            sd_sum += pow(z - avg, 2.)
+        sd = (sd_sum / count) ** 0.5
+        
+        self.gcode.respond_info("probe count : %d" % (count))
+        self.gcode.respond_info("average : %.6f" % (avg))
+        self.gcode.respond_info("stdev : %.6f" % (sd))
     def add_manual_height(self, height):
         # Determine current location of toolhead
         toolhead = self.printer.lookup_object('toolhead')

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -231,16 +231,17 @@ class DeltaCalibrate:
             x = self.probe_helper.results[i][0]
             y = self.probe_helper.results[i][1]
             z = self.probe_helper.results[i][2]
-            self.gcode.respond_info("%2d. x:%.2f, y:%.2f, z : %.6f" % (i, x, y, z))
+            self.gcode.respond_info\
+              ("%2d. x:%.2f, y:%.2f, z : %.6f" % (i, x, y, z))
             sum += z
         avg = sum / count
-        
+
         sd_sum = 0
         for i in range(count):
             z = self.probe_helper.results[i][2]
             sd_sum += pow(z - avg, 2.)
         sd = (sd_sum / count) ** 0.5
-        
+
         self.gcode.respond_info("probe count : %d" % (count))
         self.gcode.respond_info("average : %.6f" % (avg))
         self.gcode.respond_info("stdev : %.6f" % (sd))


### PR DESCRIPTION
After running delta_calibrate, it will show these additional info :
- x, y, and z coordinates of each probe location
- count of probing points
- the average of z probe position (could be useful to approximate the z-probe offset)
- standard deviation of z position (useful to have some clue about the calibration quality), a perfect calibration would have stdev == 0

Signed-off-by: Andri YS <andri.ys.st@gmail.com>