### PR TITLE
hall_filament_width_sensor.py: Fix Flow update before next pending_position #3184

### DIFF
--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -97,7 +97,7 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
     enable: {'hall_filament_width_sensor' in printer}
     name: Dia: {'%.2F' % printer.hall_filament_width_sensor.Diameter}
     index: 0
-    
+
     [menu __main __filament __raw_width_current]
     type: command
     enable: {'hall_filament_width_sensor' in printer}

--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -92,26 +92,17 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
 **hall_filament_width_sensor.is_active** Sensor on or off
 
 ## Template for menu variables
-    [menu __filament_width_current]
-    type: item
-    name: "Dia:{0:4.2f} mm"
-    parameter:  hall_filament_width_sensor.Diameter
-
-    [menu __filament_raw_width_current]
-    type: item
-    name: "RAW:{0:4.0f}"
-    parameter:  hall_filament_width_sensor.Raw
-
-    [menu __filament]
-    type: list
-    name: Filament
-    items:
-     __temp __hotend0_current, __temp __hotend0_target
-     .__unload
-     .__load
-     .__feed
-     __filament_width_current
-     __filament_raw_width_current
+    [menu __main __filament __width_current]
+    type: command
+    enable: {'hall_filament_width_sensor' in printer}
+    name: Dia: {'%.2F' % printer.hall_filament_width_sensor.Diameter}
+    index: 0
+    
+    [menu __main __filament __raw_width_current]
+    type: command
+    enable: {'hall_filament_width_sensor' in printer}
+    name: Raw: {'%4.0F' % printer.hall_filament_width_sensor.Raw}
+    index: 1
 
 ## Calibration procedure
 Insert first  calibration rod (1.5 mm size) get first  raw sensor value

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -114,7 +114,8 @@ class HallFilamentWidthSensor:
             # add first item to array
             self.filament_array.append([self.measurement_delay + last_epos,
                                         self.diameter])
-            self.firstExtruderUpdatePosition = self.measurement_delay + last_epos
+            self.firstExtruderUpdatePosition = (self.measurement_delay 
+                                                + last_epos)
 
     def extrude_factor_update_event(self, eventtime):
         # Update extrude factor
@@ -135,7 +136,8 @@ class HallFilamentWidthSensor:
                     item = self.filament_array.pop(0)
                     self.filament_width = item[1]
                 else:
-                    if self.use_current_dia_while_delay and self.firstExtruderUpdatePosition == pending_position:
+                    if (self.use_current_dia_while_delay
+                        and (self.firstExtruderUpdatePosition == pending_position)):
                         self.filament_width = self.diameter
                     elif  self.firstExtruderUpdatePosition == pending_position:
                         self.filament_width = self.nominal_filament_dia

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -114,7 +114,7 @@ class HallFilamentWidthSensor:
             # add first item to array
             self.filament_array.append([self.measurement_delay + last_epos,
                                         self.diameter])
-            self.firstExtruderUpdatePosition = (self.measurement_delay 
+            self.firstExtruderUpdatePosition = (self.measurement_delay
                                                 + last_epos)
 
     def extrude_factor_update_event(self, eventtime):
@@ -136,8 +136,9 @@ class HallFilamentWidthSensor:
                     item = self.filament_array.pop(0)
                     self.filament_width = item[1]
                 else:
-                    if (self.use_current_dia_while_delay
-                        and (self.firstExtruderUpdatePosition == pending_position)):
+                    if ((self.use_current_dia_while_delay)
+                        and (self.firstExtruderUpdatePosition
+                             == pending_position)):
                         self.filament_width = self.diameter
                     elif  self.firstExtruderUpdatePosition == pending_position:
                         self.filament_width = self.nominal_filament_dia

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -40,6 +40,8 @@ class HallFilamentWidthSensor:
         self.filament_array = []
         self.lastFilamentWidthReading = 0
         self.lastFilamentWidthReading2 = 0
+        self.firstExtruderUpdatePosition = 0
+        self.filament_width = self.nominal_filament_dia
         # printer objects
         self.toolhead = self.ppins = self.mcu_adc = None
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
@@ -112,6 +114,7 @@ class HallFilamentWidthSensor:
             # add first item to array
             self.filament_array.append([self.measurement_delay + last_epos,
                                         self.diameter])
+            self.firstExtruderUpdatePosition = self.measurement_delay + last_epos
 
     def extrude_factor_update_event(self, eventtime):
         # Update extrude factor
@@ -130,15 +133,16 @@ class HallFilamentWidthSensor:
                 if pending_position <= last_epos:
                     # Get first item in filament_array queue
                     item = self.filament_array.pop(0)
-                    filament_width = item[1]
-                elif self.use_current_dia_while_delay:
-                    filament_width = self.diameter
+                    self.filament_width = item[1]
                 else:
-                    filament_width = self.nominal_filament_dia
-                if ((filament_width <= self.max_diameter)
-                    and (filament_width >= self.min_diameter)):
+                    if self.use_current_dia_while_delay and self.firstExtruderUpdatePosition == pending_position:
+                        self.filament_width = self.diameter
+                    elif  self.firstExtruderUpdatePosition == pending_position:
+                        self.filament_width = self.nominal_filament_dia
+                if ((self.filament_width <= self.max_diameter)
+                    and (self.filament_width >= self.min_diameter)):
                     percentage = round(self.nominal_filament_dia**2
-                                       / filament_width**2 * 100)
+                                       / self.filament_width**2 * 100)
                     self.gcode.run_script("M221 S" + str(percentage))
                 else:
                     self.gcode.run_script("M221 S100")


### PR DESCRIPTION
After reading the first item of self.filament_array, filament_width is updated back to self.nominal_filament_dia or self.diameter instead of keeping the value until the next pending_position.

Signed-off-by: Nicola Falciani <nicola.fal@gmail.com>