### PR TITLE
Start the process of migrating to python 3

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -3,7 +3,8 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import os, glob, re, time, logging, ConfigParser as configparser, StringIO
+import os, glob, re, time, logging, configparser
+from io import StringIO
 
 error = configparser.Error
 
@@ -102,7 +103,7 @@ class PrinterConfig:
     def _read_config_file(self, filename):
         try:
             f = open(filename, 'rb')
-            data = f.read()
+            data = f.read().decode('utf-8')
             f.close()
         except:
             msg = "Unable to open config file %s" % (filename,)
@@ -162,7 +163,8 @@ class PrinterConfig:
             return
         data = '\n'.join(buffer)
         del buffer[:]
-        sbuffer = StringIO.StringIO(data)
+        logging.info(f"Configuration string:\n\n{data}")
+        sbuffer = StringIO(data)
         fileconfig.readfp(sbuffer, filename)
     def _resolve_include(self, source_filename, include_spec, fileconfig,
                          visited):
@@ -210,7 +212,7 @@ class PrinterConfig:
         self._parse_config(data, filename, fileconfig, set())
         return ConfigWrapper(self.printer, fileconfig, {}, 'printer')
     def _build_config_string(self, config):
-        sfile = StringIO.StringIO()
+        sfile = StringIO()
         config.fileconfig.write(sfile)
         return sfile.getvalue().strip()
     def read_config(self, filename):

--- a/klippy/extras/display/display.cfg
+++ b/klippy/extras/display/display.cfg
@@ -335,8 +335,8 @@ data:
 ######################################################################
 # NOTE: The following section commented, because it causes:
 ######################################################################
-# configparser.DuplicateSectionError: While reading from 
-# '/home/pi/klipper/klippy/extras/display/display.cfg' [line 335]: 
+# configparser.DuplicateSectionError: While reading from
+# '/home/pi/klipper/klippy/extras/display/display.cfg' [line 335]:
 # section 'display_glyph extruder' already exists
 ######################################################################
 #[display_glyph extruder]

--- a/klippy/extras/display/display.cfg
+++ b/klippy/extras/display/display.cfg
@@ -332,125 +332,132 @@ data:
 # Default 20x4 glyphs
 ######################################################################
 
-[display_glyph extruder]
-hd44780_slot: 0
-hd44780_data:
-  ..*..
-  .*.*.
-  .*.*.
-  .*.*.
-  .*.*.
-  *...*
-  *...*
-  .***.
+######################################################################
+# NOTE: The following section commented, because it causes:
+######################################################################
+# configparser.DuplicateSectionError: While reading from 
+# '/home/pi/klipper/klippy/extras/display/display.cfg' [line 335]: 
+# section 'display_glyph extruder' already exists
+######################################################################
+#[display_glyph extruder]
+#hd44780_slot: 0
+#hd44780_data:
+#  ..*..
+#  .*.*.
+#  .*.*.
+#  .*.*.
+#  .*.*.
+#  *...*
+#  *...*
+#  .***.
 
-[display_glyph bed]
-hd44780_slot: 1
-hd44780_data:
-  .....
-  *****
-  *.*.*
-  *...*
-  *.*.*
-  *****
-  .....
-  .....
+#[display_glyph bed]
+#hd44780_slot: 1
+#hd44780_data:
+#  .....
+#  *****
+#  *.*.*
+#  *...*
+#  *.*.*
+#  *****
+#  .....
+#  .....
 
-[display_glyph bed_heat1]
-hd44780_slot: 1
-hd44780_data:
-  .*..*
-  *..*.
-  .*..*
-  *..*.
-  .....
-  *****
-  .....
-  .....
+#[display_glyph bed_heat1]
+#hd44780_slot: 1
+#hd44780_data:
+#  .*..*
+#  *..*.
+#  .*..*
+#  *..*.
+#  .....
+#  *****
+#  .....
+#  .....
 
-[display_glyph bed_heat2]
-hd44780_slot: 1
-hd44780_data:
-  *..*.
-  .*..*
-  *..*.
-  .*..*
-  .....
-  *****
-  .....
-  .....
+#[display_glyph bed_heat2]
+#hd44780_slot: 1
+#hd44780_data:
+#  *..*.
+#  .*..*
+#  *..*.
+#  .*..*
+#  .....
+#  *****
+#  .....
+#  .....
 
-[display_glyph fan]
-hd44780_slot: 2
-hd44780_data:
-  .....
-  *..**
-  **.*.
-  ..*..
-  .*.**
-  **..*
-  .....
-  .....
+#[display_glyph fan]
+#hd44780_slot: 2
+#hd44780_data:
+#  .....
+#  *..**
+#  **.*.
+#  ..*..
+#  .*.**
+#  **..*
+#  .....
+#  .....
 
-[display_glyph feedrate]
-hd44780_slot: 3
-hd44780_data:
-  ***..
-  *....
-  **...
-  *.***
-  ..*.*
-  ..**.
-  ..*.*
-  .....
+#[display_glyph feedrate]
+#hd44780_slot: 3
+#hd44780_data:
+#  ***..
+#  *....
+#  **...
+#  *.***
+#  ..*.*
+#  ..**.
+#  ..*.*
+#  .....
 
-[display_glyph clock]
-hd44780_slot: 4
-hd44780_data:
-  .....
-  .***.
-  *..**
-  *.*.*
-  *...*
-  .***.
-  .....
-  .....
+#[display_glyph clock]
+#hd44780_slot: 4
+#hd44780_data:
+#  .....
+#  .***.
+#  *..**
+#  *.*.*
+#  *...*
+#  .***.
+#  .....
+#  .....
 
-[display_glyph degrees]
-hd44780_slot: 5
-hd44780_data:
-  .**..
-  *..*.
-  *..*.
-  .**..
-  .....
-  .....
-  .....
-  .....
+#[display_glyph degrees]
+#hd44780_slot: 5
+#hd44780_data:
+#  .**..
+#  *..*.
+#  *..*.
+#  .**..
+#  .....
+#  .....
+#  .....
+#  .....
 
-[display_glyph usb]
-hd44780_slot: 6
-hd44780_data:
-  .***.
-  .***.
-  .***.
-  *****
-  *****
-  *****
-  ..*..
-  ..*..
+#[display_glyph usb]
+#hd44780_slot: 6
+#hd44780_data:
+#  .***.
+#  .***.
+#  .***.
+#  *****
+#  *****
+#  *****
+#  ..*..
+#  ..*..
 
-[display_glyph sd]
-hd44780_slot: 6
-hd44780_data:
-  .....
-  ..***
-  .****
-  *****
-  *****
-  *****
-  *****
-  .....
+#[display_glyph sd]
+#hd44780_slot: 6
+#hd44780_data:
+#  .....
+#  ..***
+#  .****
+#  *****
+#  *****
+#  *****
+#  *****
+#  .....
 
 # In addition to the above glyphs, 20x4 displays also have the
 # following hard-coded glyphs: right_arrow.

--- a/klippy/extras/display/hd44780.py
+++ b/klippy/extras/display/hd44780.py
@@ -31,7 +31,9 @@ class HD44780:
         self.send_data_cmd = self.send_cmds_cmd = None
         self.icons = {}
         # framebuffers
-        self.text_framebuffers = [bytearray(' '*40, 'utf-8'), bytearray(' '*40, 'utf-8')]
+        self.text_framebuffers = [
+            bytearray(' '*40, 'utf-8'), 
+            bytearray(' '*40, 'utf-8') ]
         self.glyph_framebuffer = bytearray(64)
         self.all_framebuffers = [
             # Text framebuffers

--- a/klippy/extras/display/hd44780.py
+++ b/klippy/extras/display/hd44780.py
@@ -31,14 +31,14 @@ class HD44780:
         self.send_data_cmd = self.send_cmds_cmd = None
         self.icons = {}
         # framebuffers
-        self.text_framebuffers = [bytearray(' '*40), bytearray(' '*40)]
+        self.text_framebuffers = [bytearray(' '*40, 'utf-8'), bytearray(' '*40, 'utf-8')]
         self.glyph_framebuffer = bytearray(64)
         self.all_framebuffers = [
             # Text framebuffers
-            (self.text_framebuffers[0], bytearray('~'*40), 0x80),
-            (self.text_framebuffers[1], bytearray('~'*40), 0xc0),
+            (self.text_framebuffers[0], bytearray('~'*40, 'utf-8'), 0x80),
+            (self.text_framebuffers[1], bytearray('~'*40, 'utf-8'), 0xc0),
             # Glyph framebuffer
-            (self.glyph_framebuffer, bytearray('~'*64), 0x40) ]
+            (self.glyph_framebuffer, bytearray('~'*64, 'utf-8'), 0x40) ]
     def build_config(self):
         self.mcu.add_config_cmd(
             "config_hd44780 oid=%d rs_pin=%s e_pin=%s"

--- a/klippy/extras/display/hd44780.py
+++ b/klippy/extras/display/hd44780.py
@@ -32,7 +32,7 @@ class HD44780:
         self.icons = {}
         # framebuffers
         self.text_framebuffers = [
-            bytearray(' '*40, 'utf-8'), 
+            bytearray(' '*40, 'utf-8'),
             bytearray(' '*40, 'utf-8') ]
         self.glyph_framebuffer = bytearray(64)
         self.all_framebuffers = [

--- a/klippy/extras/display/st7920.py
+++ b/klippy/extras/display/st7920.py
@@ -13,7 +13,7 @@ ST7920_CMD_DELAY  = .000020
 ST7920_SYNC_DELAY = .000045
 
 TextGlyphs = { 'right_arrow': '\x1a' }
-CharGlyphs = { 'degrees': bytearray(font8x14.VGA_FONT[0xf8]) }
+CharGlyphs = { 'degrees': bytearray(font8x14.VGA_FONT[0xf8], 'utf-8') }
 
 class ST7920:
     def __init__(self, config):
@@ -34,16 +34,16 @@ class ST7920:
         self.send_data_cmd = self.send_cmds_cmd = None
         self.is_extended = False
         # framebuffers
-        self.text_framebuffer = bytearray(' '*64)
+        self.text_framebuffer = bytearray(' '*64, 'utf-8')
         self.glyph_framebuffer = bytearray(128)
         self.graphics_framebuffers = [bytearray(32) for i in range(32)]
         self.all_framebuffers = [
             # Text framebuffer
-            (self.text_framebuffer, bytearray('~'*64), 0x80),
+            (self.text_framebuffer, bytearray('~'*64, 'utf-8'), 0x80),
             # Glyph framebuffer
-            (self.glyph_framebuffer, bytearray('~'*128), 0x40),
+            (self.glyph_framebuffer, bytearray('~'*128, 'utf-8'), 0x40),
             # Graphics framebuffers
-            ] + [(self.graphics_framebuffers[i], bytearray('~'*32), i)
+            ] + [(self.graphics_framebuffers[i], bytearray('~'*32, 'utf-8'), i)
                  for i in range(32)]
         self.cached_glyphs = {}
         self.icons = {}

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -21,7 +21,7 @@ class DisplayBase:
         self.all_framebuffers = [(self.vram[i], bytearray('~'*self.columns), i)
                                  for i in range(8)]
         # Cache fonts and icons in display byte order
-        self.font = [self._swizzle_bits(bytearray(c))
+        self.font = [self._swizzle_bits(bytearray(c, 'utf-8'))
                      for c in font8x14.VGA_FONT]
         self.icons = {}
     def flush(self):
@@ -132,7 +132,7 @@ class I2C:
             hdr = 0x40
         else:
             hdr = 0x00
-        cmds = bytearray(cmds)
+        cmds = bytearray(cmds, 'utf-8')
         cmds.insert(0, hdr)
         self.i2c.i2c_write(cmds, reqclock=BACKGROUND_PRIORITY_CLOCK)
 

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -38,7 +38,7 @@ class ForceMove:
         self.trapq_append = ffi_lib.trapq_append
         self.trapq_free_moves = ffi_lib.trapq_free_moves
         self.stepper_kinematics = ffi_main.gc(
-            ffi_lib.cartesian_stepper_alloc('x'), ffi_lib.free)
+            ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
         # Register commands
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('STEPPER_BUZZ', self.cmd_STEPPER_BUZZ,

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -657,7 +657,7 @@ class GCodeIO:
     def _process_data(self, eventtime):
         # Read input, separate by newline, and add to pending_commands
         try:
-            data = os.read(self.fd, 4096)
+            data = os.read(self.fd, 4096).decode('utf-8')
         except os.error:
             logging.exception("Read g-code")
             return
@@ -703,7 +703,7 @@ class GCodeIO:
     def _respond_raw(self, msg):
         if self.pipe_is_active:
             try:
-                os.write(self.fd, msg+"\n")
+                os.write(self.fd, bytes(msg+"\n", 'utf-8'))
             except os.error:
                 logging.exception("Write g-code response")
                 self.pipe_is_active = False

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -15,7 +15,7 @@ class CartKinematics:
         self.rails = [stepper.LookupMultiRail(config.getsection('stepper_' + n))
                       for n in 'xyz']
         for rail, axis in zip(self.rails, 'xyz'):
-            rail.setup_itersolve('cartesian_stepper_alloc', axis)
+            rail.setup_itersolve('cartesian_stepper_alloc', bytes(axis, 'utf-8'))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
@@ -37,7 +37,7 @@ class CartKinematics:
         # Check for dual carriage support
         if config.has_section('dual_carriage'):
             dc_config = config.getsection('dual_carriage')
-            dc_axis = dc_config.getchoice('axis', {'x': 'x', 'y': 'y'})
+            dc_axis = dc_config.getchoice('axis', {'x': b'x', 'y': b'y'})
             self.dual_carriage_axis = {'x': 0, 'y': 1}[dc_axis]
             dc_rail = stepper.LookupMultiRail(dc_config)
             dc_rail.setup_itersolve('cartesian_stepper_alloc', dc_axis)

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -15,7 +15,8 @@ class CartKinematics:
         self.rails = [stepper.LookupMultiRail(config.getsection('stepper_' + n))
                       for n in 'xyz']
         for rail, axis in zip(self.rails, 'xyz'):
-            rail.setup_itersolve('cartesian_stepper_alloc', bytes(axis, 'utf-8'))
+            rail.setup_itersolve(
+              'cartesian_stepper_alloc', bytes(axis, 'utf-8') )
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)

--- a/klippy/msgproto.py
+++ b/klippy/msgproto.py
@@ -80,7 +80,7 @@ class PT_string:
         out.extend(bytearray(v))
     def parse(self, s, pos):
         l = s[pos]
-        return bytes(bytearray(s[pos+1:pos+l+1])), pos+l+1
+        return bytes(bytearray(s[pos+1:pos+l+1], 'utf-8')), pos+l+1
 class PT_progmem_buffer(PT_string):
     pass
 class PT_buffer(PT_string):
@@ -209,7 +209,7 @@ class UnknownFormat:
     name = '#unknown'
     def parse(self, s, pos):
         msgid = s[pos]
-        msg = bytes(bytearray(s))
+        msg = bytes(bytearray(s, 'utf-8'))
         return {'#msgid': msgid, '#msg': msg}, len(s)-MESSAGE_TRAILER_SIZE
     def format_params(self, params):
         return "#unknown %s" % (repr(params['#msg']),)

--- a/klippy/parsedump.py
+++ b/klippy/parsedump.py
@@ -37,7 +37,7 @@ def main():
                 logging.error("Invalid data")
                 data = data[-l:]
                 continue
-            msgs = mp.dump(bytearray(data[:l]))
+            msgs = mp.dump(bytearray(data[:l], 'utf-8'))
             sys.stdout.write('\n'.join(msgs[1:]) + '\n')
             data = data[l:]
 

--- a/klippy/queuelogger.py
+++ b/klippy/queuelogger.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging, logging.handlers, threading, Queue as queue, time
+import logging, logging.handlers, threading, queue, time
 
 # Class to forward all messages through a queue to a background thread
 class QueueHandler(logging.Handler):

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import os, select, math, time, Queue as queue
+import os, select, math, time, queue
 import greenlet
 import chelper, util
 

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -264,7 +264,7 @@ def stk500v2_leave(ser, reactor):
     ser.baudrate = 115200
     reactor.pause(reactor.monotonic() + 0.100)
     ser.read(4096)
-    ser.write('\x1b\x01\x00\x01\x0e\x11\x04')
+    ser.write(b'\x1b\x01\x00\x01\x0e\x11\x04')
     reactor.pause(reactor.monotonic() + 0.050)
     res = ser.read(4096)
     logging.debug("Got %s from stk500v2", repr(res))

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -97,7 +97,7 @@ def dump_mcu_build():
 def get_cpu_info():
     try:
         f = open('/proc/cpuinfo', 'rb')
-        data = f.read()
+        data = f.read().decode('utf-8')
         f.close()
     except (IOError, OSError) as e:
         logging.debug("Exception on read /proc/cpuinfo: %s",

--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -34,7 +34,7 @@ create_virtualenv()
     report_status "Updating python virtual environment..."
 
     # Create virtualenv if it doesn't already exist
-    [ ! -d ${PYTHONDIR} ] && virtualenv ${PYTHONDIR}
+    [ ! -d ${PYTHONDIR} ] && virtualenv --python=$(which python3) ${PYTHONDIR}
 
     # Install/update dependencies
     ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt


### PR DESCRIPTION
This patch is mostly about adding in encoding/decoding handling for UTF-8 / bytes and the like. I also had to map some imports for things like Queue, StringIO, and ConfigParser.

**This pull request has two main problems, from what I can tell so far:**

1. I don't know how the python 2 code ever supported the duplicate config sections.

I've disabled several duplicate sections in display.cfg to work around errors, but I suspect I'm doing something wrong with the new configparser, since it seems that the configuration strategy for Klipper depends on overlapping/additive duplicate sections.

2. Serial communication to the MCU appears to timeout, but if I shift back to a python 2 virtualenv it works again.

I believe this is probably an error in the encoding/decoding logic I've added, and could be in some area where I've made semi-educated guesses about the datatype involved. I know just enough MCU coding to know that serial communication can be pretty brittle, and I'm guessing this would be an easy fix if I knew more about where to look.

In any case, I know the 2020 Python 3 deadline is looming, and I **really** don't want to switch my Enders back to Marlin. Hopefully this work can be tweaked, or some other effort is underway to convert. I'm a big fan of the project.