### PR TITLE
fan: Scale fan speed between off_below and max_power

### DIFF
--- a/config/example.cfg
+++ b/config/example.cfg
@@ -276,7 +276,7 @@ pin: ar9
 #   example, 12% -> 0.12) or slightly higher.
 #relative_power: False
 #   If this set to True then fan speed requests will be scaled between
-#   off_below and max_power (for example, if off_below is .3 and 
+#   off_below and max_power (for example, if off_below is .3 and
 #   max_power is .9 and a fan speed of 20% is requested, then the fan
 #   power will be set to 42%). The default is False.
 #

--- a/config/example.cfg
+++ b/config/example.cfg
@@ -267,13 +267,23 @@ pin: ar9
 #   requested the fan will instead be turned off. This setting may be
 #   used to prevent fan stalls and to ensure kick starts are
 #   effective. The default is 0.0.
-#
+# 
 #   This setting should be recalibrated whenever max_power is adjusted.
 #   To calibrate this setting, start with off_below set to 0.0 and the
 #   fan spinning. Gradually lower the fan speed to determine the lowest
 #   input speed which reliably drives the fan without stalls. Set
 #   off_below to the duty cycle corresponding to this value (for
 #   example, 12% -> 0.12) or slightly higher.
+#relative_power: False
+#   If this set to True then fan speed requests will be scaled between
+#   off_below and max_power (for example, if off_below is .3 and 
+#   max_power is .9 and a fan speed of 20% is requested, then the fan
+#   power will be set to 42%). The default is False.
+# 
+#   With this setting enabled, once you have off_below and max_power
+#   properly cailbrated, it is much easier to request fan speeds between
+#   0-1 and have the fan behave as intended without having to be mindful
+#   of what speed the fan will be under or over powered.
 
 # Micro-controller information.
 [mcu]

--- a/config/example.cfg
+++ b/config/example.cfg
@@ -267,7 +267,7 @@ pin: ar9
 #   requested the fan will instead be turned off. This setting may be
 #   used to prevent fan stalls and to ensure kick starts are
 #   effective. The default is 0.0.
-# 
+#
 #   This setting should be recalibrated whenever max_power is adjusted.
 #   To calibrate this setting, start with off_below set to 0.0 and the
 #   fan spinning. Gradually lower the fan speed to determine the lowest
@@ -279,7 +279,7 @@ pin: ar9
 #   off_below and max_power (for example, if off_below is .3 and 
 #   max_power is .9 and a fan speed of 20% is requested, then the fan
 #   power will be set to 42%). The default is False.
-# 
+#
 #   With this setting enabled, once you have off_below and max_power
 #   properly cailbrated, it is much easier to request fan speeds between
 #   0-1 and have the fan behave as intended without having to be mindful

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -39,13 +39,13 @@ class Fan:
             value = 0.
         elif self.relative_power == True:
             # adjust value proportionately between off_below to max_power
-            value = max(0., (value * (self.max_power - self.off_below)) + self.off_below)
+            value = max(0., (value * (self.max_power - 
+                        self.off_below)) + self.off_below)
             if value <= self.off_below:
                 value = 0.
         else:
             # adjust value proportionately between 0 and max_power
             value = max(0., min(self.max_power, value * self.max_power))
-        
         if value == self.last_fan_value:
             return
         print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)
@@ -66,7 +66,8 @@ class Fan:
     def get_status(self, eventtime):
         if self.relative_power == True:
             # return the relative value between off_below and max_power
-            return {'speed': (self.last_fan_value - self.off_below) / self.max_power}
+            return {'speed': (self.last_fan_value - 
+                                self.off_below) / self.max_power}
         return {'speed': self.last_fan_value}
 
 class PrinterFan:

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -39,7 +39,7 @@ class Fan:
             value = 0.
         elif self.relative_power == True:
             # adjust value proportionately between off_below to max_power
-            value = max(0., (value * (self.max_power - 
+            value = max(0., (value * (self.max_power -
                         self.off_below)) + self.off_below)
             if value <= self.off_below:
                 value = 0.
@@ -66,7 +66,7 @@ class Fan:
     def get_status(self, eventtime):
         if self.relative_power == True:
             # return the relative value between off_below and max_power
-            return {'speed': (self.last_fan_value - 
+            return {'speed': (self.last_fan_value -
                                 self.off_below) / self.max_power}
         return {'speed': self.last_fan_value}
 


### PR DESCRIPTION
New relative_power fan setting will allow the scaling of fan speed requests
between  off_below and max_power. For example, if off_below is .3 and
max_power is .9 and a fan speed of 20% is requested, then the fan power
will be set to 42%). 

With this setting enabled, once you have off_below and
max_power properly calibrated, it is much easier to request fan speeds
between 0% and 100% (or 0-255) via slicer for example and have the fan
behave as intended without having to be mindful of what speed the fan
will be under (ie not started) or over powered.

Signed-off-by: Peter Femiani <peter@femiani.com>