### PR TITLE
config: Tarantula Pro - Multiple tweaks and description change

### DIFF
--- a/config/printer-tevo-tarantula-pro-2020.cfg
+++ b/config/printer-tevo-tarantula-pro-2020.cfg
@@ -1,5 +1,9 @@
-# Support for Tevo Tarantula Pro. To use this config, the firmware should be
-# compiled for the AVR atmega2560.
+# Support for the green Tevo Tarantula Pro. To use this config, the firmware
+# should be compiled for the AVR atmega2560.
+# Note that this cofig file is for the "old green" Tarantula pro, with a
+# MKS Gen_l 8-bit board.
+# It _will not_ work out of the box for the "new orange" Tarantula pro with a
+# MKS Sgen_l 32-bit board.
 
 # See the example.cfg file for a description of available parameters.
 
@@ -9,8 +13,9 @@ dir_pin: !ar55
 enable_pin: !ar38
 step_distance: 0.012583
 endstop_pin: ^!ar3
-position_endstop: 0
+position_endstop: -2
 position_max: 220
+position_min: -2
 homing_speed: 25.0
 
 [stepper_y]
@@ -21,7 +26,7 @@ step_distance: 0.01256
 endstop_pin: ^!ar14
 position_endstop: 0
 position_max: 220
-homing_speed: 25
+homing_speed: 25.0
 
 [stepper_z]
 step_pin: ar46
@@ -32,11 +37,12 @@ endstop_pin: ^!ar18
 position_endstop: 0
 position_max: 200
 
-[stepper_z1]
-step_pin: ar36
-dir_pin: ar34
-enable_pin: !ar30
-step_distance: 0.002492
+# Enable for dual-z addon
+#[stepper_z1]
+#step_pin: ar36
+#dir_pin: ar34
+#enable_pin: !ar30
+#step_distance: 0.002492
 
 [extruder]
 step_pin: ar26
@@ -75,13 +81,13 @@ pin_map: arduino
 kinematics: cartesian
 max_velocity: 400
 max_accel: 3000
-#max_accel_to_decel:
 max_z_velocity: 50
 max_z_accel: 100
-#square_corner_velocity: 5.0
 
 [heater_fan nozzle_fan]
 pin: ar7
+heater: extruder
+heater_temp: 50.0
 
 
 [display]

--- a/config/printer-tevo-tarantula-pro-2020.cfg
+++ b/config/printer-tevo-tarantula-pro-2020.cfg
@@ -1,6 +1,6 @@
 # Support for the green Tevo Tarantula Pro. To use this config, the firmware
 # should be compiled for the AVR atmega2560.
-# Note that this cofig file is for the "old green" Tarantula pro, with a
+# Note that this config file is for the "old green" Tarantula pro, with a
 # MKS Gen_l 8-bit board.
 # It _will not_ work out of the box for the "new orange" Tarantula pro with a
 # MKS Sgen_l 32-bit board.

--- a/config/printer-tevo-tarantula-pro-2020.cfg
+++ b/config/printer-tevo-tarantula-pro-2020.cfg
@@ -86,9 +86,6 @@ max_z_accel: 100
 
 [heater_fan nozzle_fan]
 pin: ar7
-heater: extruder
-heater_temp: 50.0
-
 
 [display]
 lcd_type: uc1701


### PR DESCRIPTION
Thanks to @Kollimolli for pointing out the potential for confusion, I totally missed the re-branding of Tevo -> Homers.

The following parameters have been tweaked:
 - X endstop position has been set to -2, as per original marlin cofig
 - Second Z axis disabled by default (this must be purchased as an
   add-on)
 - Enable print-head fan only when extruder reaches 50 degrees

The comment at the top of this file has also been modified to describe
the difference between this (old) model and the new (rebranded) Tevo
Tarantula pro.

Signed-off-by: Oliver Fawcett-Griffiths <olly@ollyfg.com>