### PR TITLE
menu improvements 20200824

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -94,6 +94,8 @@ class PrinterGCodeMacro:
             'action_respond_info': self._action_respond_info,
             'action_raise_error': self._action_raise_error,
         }
+    def create_template(self, name, script):
+        return TemplateWrapper(self.printer, self.env, name, script)
 
 def load_config(config):
     return PrinterGCodeMacro(config)


### PR DESCRIPTION
- only render visible items
- fix issue #3231
- hopefully will improve #3176
- improve `asbool` method
- new gcode_macro `create_template` method,
  allows creating a template from a string
- improve item enable value evaluation, in case of a static boolean value/default value 
  don't use template rendering.
- new item type `disabled` for overwriting and disabling a default menu item
  only `type` attribute is required. This item has been permanently disabled. #3221
```ini
  [menu __main __octoprint]
  type: disabled
```