### PR TITLE
link LCD menu control move input_min/max linked to axis config min/max

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -261,8 +261,8 @@ name: Move 10mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_x.position_min|float}
+input_max: {printer.configfile.config.stepper_x.position_max|float}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -274,8 +274,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_y.position_min|float}
+input_max: {printer.configfile.config.stepper_y.position_max|float}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -288,8 +288,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_z.position_min|float}
+input_max: {printer.configfile.config.stepper_z.position_max|float}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -321,8 +321,8 @@ name: Move 1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_x.position_min|float}
+input_max: {printer.configfile.config.stepper_x.position_max|float}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -334,8 +334,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_y.position_min|float}
+input_max: {printer.configfile.config.stepper_y.position_max|float}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -348,8 +348,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_z.position_min|float}
+input_max: {printer.configfile.config.stepper_z.position_max|float}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -381,8 +381,8 @@ name: Move 0.1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_x.position_min|float}
+input_max: {printer.configfile.config.stepper_x.position_max|float}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -394,8 +394,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_y.position_min|float}
+input_max: {printer.configfile.config.stepper_y.position_max|float}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -408,8 +408,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_z.position_min|float}
+input_max: {printer.configfile.config.stepper_z.position_max|float}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis


### PR DESCRIPTION
Use `printer.cfg` axis position_min/max for LCD control move limits

`input_min` and `input_max` limits in the LCD control move menu
evaluate to corresponding `stepper_<axis>` config section
`position_min` and `position_max` parameters. Replacing
defaults of 0 and 200 respectively.

Signed-off-by: Robert Pazdzior robertp@norbital.com