### PR TITLE
Replicape config updates with pin aliases

### DIFF
--- a/config/generic-replicape.cfg
+++ b/config/generic-replicape.cfg
@@ -135,7 +135,38 @@ pin: replicape:power_fan0
 #   provided.
 #...
 
+# Providing a sample config for switch filament sensor using the Linux MCU for replicape, instead of the PRU which does not have enough memory:
+#[filament_switch_sensor sentinel_sensor]
+#pause_on_runout: True
+#   When set to True, a PAUSE will execute immediately after a runout
+#   is detected. Note that if pause_on_runout is False and the
+#   runout_gcode is omitted then runout detection is disabled. Default
+#   is True.
+#runout_gcode: outoffilament
+#   A list of G-Code commands to execute after a filament runout is
+#   detected. See docs/Command_Templates.md for G-Code format. If
+#   pause_on_runout is set to True this G-Code will run after the
+#   PAUSE is complete. The default is not to run any G-Code commands.
+#insert_gcode:
+#   A list of G-Code commands to execute after a filament insert is
+#   detected. See docs/Command_Templates.md for G-Code format. The
+#   default is not to run any G-Code commands, which disables insert
+#   detection.
+#event_delay: 3.0
+#   The minimum amount of time in seconds to delay between events.
+#   Events triggered during this time period will be silently
+#   ignored. The default is 3 seconds.
+#pause_delay: 0.5
+#   The amount of time to delay, in seconds, between the pause command
+#   dispatch and execution of the runout_gcode.  It may be useful to
+#   increase this delay if Octoprint exhibits strange pause behavior.
+#   Default is 0.5 seconds.
+#switch_pin: HOST_X2_STOP
+#   The pin on which the switch is connected. This parameter must be
+#   provided
 
+
+# providing board pin aliases
 [board_pins]
 aliases:
    # step/dir pins
@@ -152,5 +183,7 @@ aliases:
    # Thermistors
    THERM_E=P9_33, THERM_H=P9_36, THERM_BED=P9_35,
    # D1W pin
-   DALLAS=P9_22
+   DALLAS=P9_22,
+   # Host aliases for Linux MCU
+   HOST_X2_STOP=host:gpio30, HOST_Y2_STOP=host:gpio113, HOST_Z2_STOP=host:gpio4
    

--- a/config/generic-replicape.cfg
+++ b/config/generic-replicape.cfg
@@ -186,4 +186,3 @@ aliases:
    DALLAS=P9_22,
    # Host aliases for Linux MCU
    HOST_X2_STOP=host:gpio30, HOST_Y2_STOP=host:gpio113, HOST_Z2_STOP=host:gpio4
-   

--- a/config/generic-replicape.cfg
+++ b/config/generic-replicape.cfg
@@ -134,3 +134,23 @@ pin: replicape:power_fan0
 #   PWM output pin controlling the servo. This parameter must be
 #   provided.
 #...
+
+
+[board_pins]
+aliases:
+   # step/dir pins
+   X_DIR=P8_26, X_STEP=P8_17, Y_DIR=P8_19, Y_STEP=P8_12, Z_DIR=P8_14, Z_STEP=P8_13,
+   E_DIR=P8_15, E_STEP=P9_12, H_DIR=P8_16, H_STEP=P8_11,
+   # stepper fault pins
+   FAULT_X=P8_10, FAULT_Y=P8_9, FAULT_Z=P9_24, FAULT_E=P8_18, FAULT_H=P8_8,
+   # endstops
+   STOP_X1=P9_25, STOP_X2=P9_11, STOP_Y1=P9_23, STOP_Y2=P9_28, STOP_Z1=P9_13, STOP_Z2=P9_18,
+   # enable steppers (all on one pin)
+   STEPPER_ENABLE=P9_41,
+   # servos
+   SERVO_0=P9_14, SERVO_1=P9_16,
+   # Thermistors
+   THERM_E=P9_33, THERM_H=P9_36, THERM_BED=P9_35,
+   # D1W pin
+   DALLAS=P9_22
+   

--- a/config/generic-replicape.cfg
+++ b/config/generic-replicape.cfg
@@ -135,36 +135,9 @@ pin: replicape:power_fan0
 #   provided.
 #...
 
-# Providing a sample config for switch filament sensor using the Linux MCU for replicape, instead of the PRU which does not have enough memory:
-#[filament_switch_sensor sentinel_sensor]
-#pause_on_runout: True
-#   When set to True, a PAUSE will execute immediately after a runout
-#   is detected. Note that if pause_on_runout is False and the
-#   runout_gcode is omitted then runout detection is disabled. Default
-#   is True.
-#runout_gcode: outoffilament
-#   A list of G-Code commands to execute after a filament runout is
-#   detected. See docs/Command_Templates.md for G-Code format. If
-#   pause_on_runout is set to True this G-Code will run after the
-#   PAUSE is complete. The default is not to run any G-Code commands.
-#insert_gcode:
-#   A list of G-Code commands to execute after a filament insert is
-#   detected. See docs/Command_Templates.md for G-Code format. The
-#   default is not to run any G-Code commands, which disables insert
-#   detection.
-#event_delay: 3.0
-#   The minimum amount of time in seconds to delay between events.
-#   Events triggered during this time period will be silently
-#   ignored. The default is 3 seconds.
-#pause_delay: 0.5
-#   The amount of time to delay, in seconds, between the pause command
-#   dispatch and execution of the runout_gcode.  It may be useful to
-#   increase this delay if Octoprint exhibits strange pause behavior.
-#   Default is 0.5 seconds.
+# Providing an example of a switch filament sensor using the Linux MCU for replicape, instead of the PRU which does not have enough memory:
+#[filament_switch_sensor switch_sensor]
 #switch_pin: HOST_X2_STOP
-#   The pin on which the switch is connected. This parameter must be
-#   provided
-
 
 # providing board pin aliases
 [board_pins]
@@ -183,6 +156,10 @@ aliases:
    # Thermistors
    THERM_E=P9_33, THERM_H=P9_36, THERM_BED=P9_35,
    # D1W pin
-   DALLAS=P9_22,
+   DALLAS=P9_22
+   
+
+[board_pins host]
+aliases:
    # Host aliases for Linux MCU
-   HOST_X2_STOP=host:gpio30, HOST_Y2_STOP=host:gpio113, HOST_Z2_STOP=host:gpio4
+   HOST_X2_STOP=gpio30, HOST_Y2_STOP=gpio113, HOST_Z2_STOP=gpio4

--- a/config/generic-replicape.cfg
+++ b/config/generic-replicape.cfg
@@ -157,7 +157,6 @@ aliases:
    THERM_E=P9_33, THERM_H=P9_36, THERM_BED=P9_35,
    # D1W pin
    DALLAS=P9_22
-   
 
 [board_pins host]
 aliases:


### PR DESCRIPTION
As was discussed in #3128 the board_pins section for gpio access by the linux host is being provided here.

Also a sample filament switch sensor section that makes use of it.