### PR TITLE
config: Add x_offset (Used to add horizontal offset on SSD1306/SH1106 displays)

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1967,7 +1967,7 @@
 #analog_range_kill_pin:
 #   The resistance range for a 'kill' button. Range minimum and maximum
 #   comma-separated values must be provided when using analog button.
-#
+
 # Support for displaying custom data on an lcd screen. One may create
 # any number of display groups and any number of data items under
 # those groups. The display will show all the data items for a given

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1965,7 +1965,9 @@
 #analog_range_kill_pin:
 #   The resistance range for a 'kill' button. Range minimum and maximum
 #   comma-separated values must be provided when using analog button.
-
+#x_offset:
+#   Set the horizontal offset value on SSD1306/SH1106 displays.
+#
 # Support for displaying custom data on an lcd screen. One may create
 # any number of display groups and any number of data items under
 # those groups. The display will show all the data items for a given

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1893,6 +1893,8 @@
 #   Set the Vcomh value on SSD1306/SH1106 displays. This value is
 #   associated with a "smearing" effect on some OLED displays.
 #   The value may range from 0 to 63. Default is 0.
+#x_offset: 0
+#   Set the horizontal offset value on SSD1306/SH1106 displays. Default is 0.
 #invert: FALSE
 #   TRUE inverts the pixels on certain OLED (SSD1306/SH1106) displays
 #   The default is FALSE
@@ -1965,8 +1967,6 @@
 #analog_range_kill_pin:
 #   The resistance range for a 'kill' button. Range minimum and maximum
 #   comma-separated values must be provided when using analog button.
-#x_offset:
-#   Set the horizontal offset value on SSD1306/SH1106 displays.
 #
 # Support for displaying custom data on an lcd screen. One may create
 # any number of display groups and any number of data items under

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -13,6 +13,7 @@ BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 TextGlyphs = { 'right_arrow': '\x1a', 'degrees': '\xf8' }
 
 class DisplayBase:
+    x_offset = 0
     def __init__(self, io, columns=128):
         self.send = io.send
         # framebuffers
@@ -71,6 +72,7 @@ class DisplayBase:
         if x + len(data) > 16:
             data = data[:16 - min(x, 16)]
         pix_x = x * 8
+        pix_x += self.x_offset
         page_top = self.vram[y * 2]
         page_bot = self.vram[y * 2 + 1]
         for c in bytearray(data):
@@ -83,6 +85,7 @@ class DisplayBase:
             return
         bits_top, bits_bot = self._swizzle_bits(data)
         pix_x = x * 8
+        pix_x += self.x_offset
         page_top = self.vram[y * 2]
         page_bot = self.vram[y * 2 + 1]
         for i in range(8):
@@ -93,6 +96,7 @@ class DisplayBase:
         if icon is not None and x < 15:
             # Draw icon in graphics mode
             pix_x = x * 8
+            pix_x += self.x_offset
             page_idx = y * 2
             self.vram[page_idx][pix_x:pix_x+16] = icon[0]
             self.vram[page_idx + 1][pix_x:pix_x+16] = icon[1]
@@ -164,6 +168,7 @@ class UC1701(DisplayBase):
     def __init__(self, config):
         io = SPI4wire(config, "a0_pin")
         DisplayBase.__init__(self, io)
+        self.x_offset = config.getint('x_offset')
         self.contrast = config.getint('contrast', 40, minval=0, maxval=63)
         self.reset = ResetHelper(config.get("rst_pin", None), io.spi)
     def init(self):

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -13,11 +13,11 @@ BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 TextGlyphs = { 'right_arrow': '\x1a', 'degrees': '\xf8' }
 
 class DisplayBase:
-    x_offset = 0
-    def __init__(self, io, columns=128):
+    def __init__(self, io, columns=128, x_offset=0):
         self.send = io.send
         # framebuffers
         self.columns = columns
+        self.x_offset = x_offset
         self.vram = [bytearray(self.columns) for i in range(8)]
         self.all_framebuffers = [(self.vram[i], bytearray('~'*self.columns), i)
                                  for i in range(8)]
@@ -168,7 +168,6 @@ class UC1701(DisplayBase):
     def __init__(self, config):
         io = SPI4wire(config, "a0_pin")
         DisplayBase.__init__(self, io)
-        self.x_offset = config.getint('x_offset', 0)
         self.contrast = config.getint('contrast', 40, minval=0, maxval=63)
         self.reset = ResetHelper(config.get("rst_pin", None), io.spi)
     def init(self):
@@ -197,7 +196,7 @@ class UC1701(DisplayBase):
 
 # The SSD1306 supports both i2c and "4-wire" spi
 class SSD1306(DisplayBase):
-    def __init__(self, config, columns=128):
+    def __init__(self, config, columns=128, x_offset=0):
         cs_pin = config.get("cs_pin", None)
         if cs_pin is None:
             io = I2C(config, 60)
@@ -206,7 +205,7 @@ class SSD1306(DisplayBase):
             io = SPI4wire(config, "dc_pin")
             io_bus = io.spi
         self.reset = ResetHelper(config.get("reset_pin", None), io_bus)
-        DisplayBase.__init__(self, io, columns)
+        DisplayBase.__init__(self, io, columns, x_offset)
         self.contrast = config.getint('contrast', 239, minval=0, maxval=255)
         self.vcomh = config.getint('vcomh', 0, minval=0, maxval=63)
         self.invert = config.getboolean('invert', False)
@@ -237,4 +236,5 @@ class SSD1306(DisplayBase):
 # the SH1106 is SSD1306 compatible with up to 132 columns
 class SH1106(SSD1306):
     def __init__(self, config):
-        SSD1306.__init__(self, config, 132)
+        x_offset = config.getint('x_offset', 0, minval=0, maxval=3)
+        SSD1306.__init__(self, config, 132, x_offset=x_offset)

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -168,7 +168,7 @@ class UC1701(DisplayBase):
     def __init__(self, config):
         io = SPI4wire(config, "a0_pin")
         DisplayBase.__init__(self, io)
-        self.x_offset = config.getint('x_offset')
+        self.x_offset = config.getint('x_offset', 0)
         self.contrast = config.getint('contrast', 40, minval=0, maxval=63)
         self.reset = ResetHelper(config.get("rst_pin", None), io.spi)
     def init(self):


### PR DESCRIPTION
module: Display, add x_offset config

Fix for https://github.com/KevinOConnor/klipper/issues/3091

Adds a horizontal offset config for fixing displays that are cutoff
in Voron v0 printers.

Detail explanation here:
https://github.com/KevinOConnor/klipper/issues/3091#issuecomment-657923777

Signed-off-by: RJ Patawaran <rjpatawaran@me.com>