### PR TITLE
add get_status wrapper to probe for last_query from query_probe command

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -182,7 +182,7 @@ The following are common printer attributes:
   containing this reference.
 - `printer.probe.last_query`: Returns True if the probe was reported
   as "triggered" during the last QUERY_PROBE command. Note, due to the
-  order of template expansion (see above), the QUERY_STATUS command 
+  order of template expansion (see above), the QUERY_STATUS command
   must be run prior to the macro containing this reference.
 - `printer.configfile.config["<section>"]["<option>"]`: Returns the
   given config file setting as read by Klipper during the last

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -180,6 +180,10 @@ The following are common printer attributes:
   QUERY_ENDSTOP command. Note, due to the order of template expansion
   (see above), the QUERY_STATUS command must be run prior to the macro
   containing this reference.
+- `printer.probe.last_query`: Returns True if the probe was reported
+  as "triggered" during the last QUERY_PROBE command. Note, due to the
+  order of template expansion (see above), the QUERY_STATUS command 
+  must be run prior to the macro containing this reference.
 - `printer.configfile.config["<section>"]["<option>"]`: Returns the
   given config file setting as read by Klipper during the last
   software start or restart. (Any settings changed at run-time will

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -26,6 +26,7 @@ class PrinterProbe:
         self.z_offset = config.getfloat('z_offset')
         self.probe_calibrate_z = 0.
         self.multi_probe_pending = False
+        self.last_state = ''
         # Infer Z position to move to during a probe
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')
@@ -193,7 +194,10 @@ class PrinterProbe:
         toolhead = self.printer.lookup_object('toolhead')
         print_time = toolhead.get_last_move_time()
         res = self.mcu_probe.query_endstop(print_time)
+        self.last_state = res
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
+    def get_status(self, eventtime):
+        return {'last_query': self.last_state}
     cmd_PROBE_ACCURACY_help = "Probe Z-height accuracy at current XY position"
     def cmd_PROBE_ACCURACY(self, gcmd):
         speed = gcmd.get_float("PROBE_SPEED", self.speed, above=0.)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -26,7 +26,7 @@ class PrinterProbe:
         self.z_offset = config.getfloat('z_offset')
         self.probe_calibrate_z = 0.
         self.multi_probe_pending = False
-        self.last_state = ''
+        self.last_state = False
         # Infer Z position to move to during a probe
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')


### PR DESCRIPTION
module: Probe - Add get_status wrapper with last_query status for macros

It is sometimes useful to determine the state of the probe from a macro. If
the probe is connected to an endstop pin, the results can be obtained via
QUERY_ENDSTOPS but if a physical endstop is in use in addition to the probe
the probe state cannot be obtained. This change allows one to use QUERY_PROBE 
and then access the printer.probe.last_query object to obtain the state.

Signed-off-by: Paul McGowan <mental405@gmail.com>