### PR TITLE
Print_Stats: Added 2 new gcodes to manipulate the timer

### DIFF
--- a/config/sample-macros.cfg
+++ b/config/sample-macros.cfg
@@ -16,6 +16,8 @@
 default_parameter_BED_TEMP: 60
 default_parameter_EXTRUDER_TEMP: 190
 gcode:
+    #Pause the print timer - only for use with the virtual SD card.
+    #PAUSE_STATS
     # Start bed heating
     M140 S{BED_TEMP}
     # Use absolute coordinates
@@ -32,6 +34,8 @@ gcode:
     M190 S{BED_TEMP}
     # Set and wait for nozzle to reach temperature
     M109 S{EXTRUDER_TEMP}
+    # resume the print timer - only for use with the virtual SD card.
+    #RESUME_STATS
 
 [gcode_macro END_PRINT]
 gcode:

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -231,7 +231,6 @@ The following standard commands are supported:
   calibration tests.
 - `STATUS`: Report the Klipper host software status.
 - `HELP`: Report the list of available extended G-Code commands.
-- `
 
 ## G-Code Macro Commands
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -653,4 +653,3 @@ enabled:
   named `/tmp/adxl345-<name>.csv` where "<name>" is the optional NAME
   parameter. If NAME is not specified it defaults to the current time
   in "YYYYMMDD_HHMMSS" format.
-

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -64,6 +64,9 @@ In addition, the following extended commands are availble when the
 "virtual_sdcard" config section is enabled.
 - Load a file and start SD print: `SDCARD_PRINT_FILE FILENAME=<filename>`
 - Unload file and clear SD state:  `SDCARD_RESET_FILE`
+- Pause the SD print timer: PAUSE_STATS
+- Resume the SD print timer: RESUME_STATS
+
 
 ## G-Code arcs
 
@@ -228,6 +231,7 @@ The following standard commands are supported:
   calibration tests.
 - `STATUS`: Report the Klipper host software status.
 - `HELP`: Report the list of available extended G-Code commands.
+- `
 
 ## G-Code Macro Commands
 
@@ -649,3 +653,4 @@ enabled:
   named `/tmp/adxl345-<name>.csv` where "<name>" is the optional NAME
   parameter. If NAME is not specified it defaults to the current time
   in "YYYYMMDD_HHMMSS" format.
+

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -14,7 +14,6 @@ class PrintStats:
                                      self.cmd_PAUSE_STATS)
         self.gcode.register_command('RESUME_STATS',
                                      self.cmd_RESUME_STATS)
-        
         self.reset()
     def _update_filament_usage(self, eventtime):
         gc_status = self.gcode_move.get_status(eventtime)
@@ -83,9 +82,7 @@ class PrintStats:
         if self.last_pause_time is None:
             curtime = self.reactor.monotonic()
             self.last_pause_time = curtime
-
     def cmd_RESUME_STATS(self,gcmd):
         self.note_start()
-
 def load_config(config):
     return PrintStats(config)

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -8,7 +8,13 @@ class PrintStats:
     def __init__(self, config):
         printer = config.get_printer()
         self.gcode_move = printer.load_object(config, 'gcode_move')
+        self.gcode = printer.lookup_object('gcode')
         self.reactor = printer.get_reactor()
+        self.gcode.register_command('PAUSE_STATS',
+                                     self.cmd_PAUSE_STATS)
+        self.gcode.register_command('RESUME_STATS',
+                                     self.cmd_RESUME_STATS)
+        
         self.reset()
     def _update_filament_usage(self, eventtime):
         gc_status = self.gcode_move.get_status(eventtime)
@@ -73,6 +79,13 @@ class PrintStats:
             'state': self.state,
             'message': self.error_message
         }
+    def cmd_PAUSE_STATS(self,gcmd):
+        if self.last_pause_time is None:
+            curtime = self.reactor.monotonic()
+            self.last_pause_time = curtime
+
+    def cmd_RESUME_STATS(self,gcmd):
+        self.note_start()
 
 def load_config(config):
     return PrintStats(config)


### PR DESCRIPTION
I've created two new gcodes, PAUSE_STATS and RESUME_STATS.  The idea is to pause the print timer (but not the total time) during long running start-of-print warm ups.  The inspiration of this is to improve the accuracy of the print time estimates used in Mainsail.