### PR TITLE
bed_mesh:  add support for runtime configuration

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -295,12 +295,29 @@ the coordinates listed under the "Probe" header to find the correct index.
 
 ### Calibration
 
-`BED_MESH_CALIBRATE METHOD=[manual | automatic]`\
+`BED_MESH_CALIBRATE METHOD=[manual | automatic] [<probe_parameter>=<value>]
+ [<mesh_parameter>=<value>]`\
 _Default Method:  automatic if a probe is detected, otherwise manual_
 
 Initiates the probing procedure for Bed Mesh Calibration.  If `METHOD=manual`
 is selected then manual probing will occur.  When switching between automatic
 and manual probing the generated mesh points will automatically be adjusted.
+
+It is possible to specify mesh parameters to modify the probed area.  The
+following parameters are available:
+- Rectangular beds (cartesian):
+  - `MESH_MIN`
+  - `MESH_MAX`
+  - `PROBE_COUNT`
+- Round beds (delta):
+  - `MESH_RADIUS`
+  - `MESH_ORIGIN`
+  - `ROUND_PROBE_COUNT`
+- All beds:
+  - `RELATIVE_REFERNCE_INDEX`
+  - `ALGORITHM`
+See the configuration documentation above for details on how each parameter
+applies to the mesh.
 
 ### Profiles
 
@@ -357,3 +374,9 @@ set, the generated probed points will be output to the terminal:
 The "Tool Adjusted" points refer to the nozzle location for each point, and
 the "Probe" points refer to the probe location.  Note that when manually
 probing the "Probe" points will refer to both the tool and nozzle locations.
+
+### Clear Mesh State
+
+`BED_MESH_CLEAR`
+
+This gcode may be used to clear the internal mesh state.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -382,7 +382,8 @@ section is enabled:
 
 The following commands are available when the "bed_mesh" config
 section is enabled:
-- `BED_MESH_CALIBRATE [METHOD=manual] [<probe_parameter>=<value>]`:
+- `BED_MESH_CALIBRATE [METHOD=manual] [<probe_parameter>=<value>]
+  [<mesh_parameter>=<value>]`:
   This command probes the bed using generated points specified by the
   parameters in the config. After probing, a mesh is generated and
   z-movement is adjusted according to the mesh. See the PROBE command

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -342,6 +342,9 @@ class ProbePointsHelper:
         if len(self.probe_points) < n:
             raise self.printer.config_error(
                 "Need at least %d probe points for %s" % (n, self.name))
+    def update_probe_points(self, points, min_points):
+        self.probe_points = points
+        self.minimum_points(min_points)
     def use_xy_offsets(self, use_offsets):
         self.use_offsets = use_offsets
     def get_lift_speed(self):


### PR DESCRIPTION
This adds a `BED_MESH_CONFIG` gcode, which allows users to modify the configuration at runtime.  The gcode can accept parameters matching all available config options, sans `speed` and `horizontal_move_z`. This did require a modification to the ProbePointsHelper so that its "probe_points" attribute could be changed.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>