### PR TITLE
Use command restartt on Creality v4.2.2 board

### DIFF
--- a/config/printer-creality-ender3-v2-2020.cfg
+++ b/config/printer-creality-ender3-v2-2020.cfg
@@ -81,6 +81,7 @@ pin: PA0
 
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
 
 [printer]
 kinematics: cartesian

--- a/config/printer-creality-ender3pro-2020.cfg
+++ b/config/printer-creality-ender3pro-2020.cfg
@@ -81,6 +81,7 @@ pin: PA0
 
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
 
 [printer]
 kinematics: cartesian


### PR DESCRIPTION
This fixes #3348 
The v4.2.2 board is used in the Ender3 V2 and some Ender3 Pro printers. The default arduino restart does not work.

Signed-off-by: JasonTTech <jasonttech@gmail.com>