### PR TITLE
Fix sample macros that use old action_respond_info syntax

### DIFF
--- a/config/sample-macros.cfg
+++ b/config/sample-macros.cfg
@@ -140,7 +140,7 @@ gcode:
 [gcode_macro QUERY_BME280]
 default_parameter_SENSOR: bme280 my_sensor
 gcode:
-    {printer.gcode.action_respond_info(
+    {action_respond_info(
         "Temperature: %.2f C\n"
         "Pressure: %.2f hPa\n"
         "Humidity: %.2f%%" % (
@@ -171,7 +171,7 @@ gcode:
 [gcode_macro QUERY_HTU21D]
 default_parameter_SENSOR: htu21d my_sensor
 gcode:
-    {printer.gcode.action_respond_info(
+    {action_respond_info(
         "Temperature: %.2f C\n"
         "Humidity: %.2f%%" % (
             printer[SENSOR].temperature,

--- a/config/sample-raspberry-pi.cfg
+++ b/config/sample-raspberry-pi.cfg
@@ -33,7 +33,7 @@ htu21d_hold_master: False
 [gcode_macro QUERY_ENCLOSURE]
 default_parameter_SENSOR: htu21d enclosure_temp
 gcode:
-    {printer.gcode.action_respond_info(
+    {action_respond_info(
         "Temperature: %.2f C\n"
         "Humidity: %.2f%%" % (
             printer[SENSOR].temperature,


### PR DESCRIPTION
Two sample config files still had the old syntax.

-Florian