### PR TITLE
config for creality ender3 v4.2.7 board

### DIFF
--- a/config/printer-creality-ender3-v427.cfg
+++ b/config/printer-creality-ender3-v427.cfg
@@ -1,0 +1,91 @@
+# This file contains pin mappings for the stock 2020 Creality Ender 3
+# V2. To use this config, during "make menuconfig" select the
+# STM32F103 with a "28KiB bootloader" and with "Use USB for
+# communication" disabled.
+
+# If you prefer a direct serial connection, in "make menuconfig"
+# select "Enable extra low-level configuration options" and select the
+# USART3 serial port, which is broken out on the 10 pin IDC cable used
+# for the LCD module as follows:
+# 3: Tx, 4: Rx, 9: GND, 10: VCC
+
+# Flash this firmware by copying "out/klipper.bin" to a SD card and
+# turning on the printer with the card inserted. The firmware
+# filename must end in ".bin" and must not match the last filename
+# that was flashed.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: PB9
+dir_pin: PC2
+enable_pin: !PC3
+step_distance: .0125
+endstop_pin: ^PA5
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_y]
+step_pin: PB7
+dir_pin: PB8
+enable_pin: !PC3
+step_distance: .0125
+endstop_pin: ^PA6
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB5
+dir_pin: !PB6
+enable_pin: !PC3
+step_distance: .0025
+endstop_pin: ^PA7
+position_endstop: 0.0
+position_max: 250
+
+[extruder]
+max_extrude_only_distance: 100.0
+step_pin: PB3
+dir_pin: PB4
+enable_pin: !PC3
+step_distance: 0.010752
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PA1
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC5
+control: pid
+# tuned for stock hardware with 200 degree Celsius target
+pid_Kp: 21.527
+pid_Ki: 1.063
+pid_Kd: 108.982
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PA2
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC4
+control: pid
+# tuned for stock hardware with 50 degree Celsius target
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PA0
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100


### PR DESCRIPTION
creality ships v4.2.7 board for ender3, which
 - compatible with ender3
 - have stm32f1 mcu
 - similar with ender3-v2 but have different pin configuration

Here's a reference thread for the board
https://github.com/MarlinFirmware/Marlin/issues/19029

And reference pinout from Marlin source code
https://github.com/MarlinFirmware/Marlin/blob/2.0.x/Marlin/src/pins/stm32f1/pins_CREALITY_V427.h

