### PR TITLE
display_status: fix M117 checksum trimming

### DIFF
--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -41,7 +41,8 @@ class DisplayStatus:
             # Parse out additional info if M117 recd during a print
             start = umsg.find('M117')
             end = msg.rfind('*')
-            msg = msg[start:end]
+	    if end >= 0: msg = msg[:end]
+            msg = msg[start:]
         if len(msg) > 5:
             self.message = msg[5:]
         else:

--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -41,7 +41,7 @@ class DisplayStatus:
             # Parse out additional info if M117 recd during a print
             start = umsg.find('M117')
             end = msg.rfind('*')
-	    if end >= 0: msg = msg[:end]
+            if end >= 0: msg = msg[:end]
             msg = msg[start:]
         if len(msg) > 5:
             self.message = msg[5:]

--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -41,7 +41,8 @@ class DisplayStatus:
             # Parse out additional info if M117 recd during a print
             start = umsg.find('M117')
             end = msg.rfind('*')
-            if end >= 0: msg = msg[:end]
+            if end >= 0:
+                msg = msg[:end]
             msg = msg[start:]
         if len(msg) > 5:
             self.message = msg[5:]


### PR DESCRIPTION
The M117 command parser discards the last character of the message
whenever the M117 command does not begin the line and there is no *xx
checksum, e.g.
`N0 M117 Look at me`
causes the banner area of the printer screen to display "Look at m".
This patch only trims the checksum when one is found to trim.