### PR TITLE
Add term to the heater power, proportional to the extruder speed

### DIFF
--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -83,7 +83,10 @@ class Heater:
             time_diff = read_time - self.last_temp_time
             self.last_temp = temp
             self.last_temp_time = read_time
-            self.control.temperature_update(read_time, temp, self.target_temp)
+            extruder_velocity = \
+                self.printer.lookup_object("extruder").get_velocity(read_time)
+            self.control.temperature_update(read_time, temp, self.target_temp,
+                extruder_velocity)
             temp_diff = temp - self.smoothed_temp
             adj_time = min(time_diff * self.inv_smooth_time, 1.)
             self.smoothed_temp += temp_diff * adj_time
@@ -152,7 +155,8 @@ class ControlBangBang:
         self.heater_max_power = heater.get_max_power()
         self.max_delta = config.getfloat('max_delta', 2.0, above=0.)
         self.heating = False
-    def temperature_update(self, read_time, temp, target_temp):
+    def temperature_update(self, read_time, temp, target_temp,
+        extruder_velocity):
         if self.heating and temp >= target_temp+self.max_delta:
             self.heating = False
         elif not self.heating and temp <= target_temp-self.max_delta:
@@ -179,6 +183,7 @@ class ControlPID:
         self.Kp = config.getfloat('pid_Kp') / PID_PARAM_BASE
         self.Ki = config.getfloat('pid_Ki') / PID_PARAM_BASE
         self.Kd = config.getfloat('pid_Kd') / PID_PARAM_BASE
+        self.Kc = config.getfloat('pid_Kc', default = 0.) / PID_PARAM_BASE
         self.min_deriv_time = heater.get_smooth_time()
         imax = config.getfloat('pid_integral_max', self.heater_max_power,
                                minval=0.)
@@ -187,7 +192,8 @@ class ControlPID:
         self.prev_temp_time = 0.
         self.prev_temp_deriv = 0.
         self.prev_temp_integ = 0.
-    def temperature_update(self, read_time, temp, target_temp):
+    def temperature_update(self, read_time, temp, target_temp, extruder_velocity
+        ):
         time_diff = read_time - self.prev_temp_time
         # Calculate change of temperature
         temp_diff = temp - self.prev_temp
@@ -201,9 +207,12 @@ class ControlPID:
         temp_integ = self.prev_temp_integ + temp_err * time_diff
         temp_integ = max(0., min(self.temp_integ_max, temp_integ))
         # Calculate output
-        co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd*temp_deriv
-        #logging.debug("pid: %f@%.3f -> diff=%f deriv=%f err=%f integ=%f co=%d",
-        #    temp, read_time, temp_diff, temp_deriv, temp_err, temp_integ, co)
+        co = self.Kp*temp_err + \
+            self.Ki*temp_integ - self.Kd*temp_deriv + self.Kc*extruder_velocity
+        # logging.debug("pid: %f@%.3f -> diff=%f deriv=%f err=%f integ=%f "
+        #     "extruder_velocity=%f co=%f",
+        #     temp, read_time, temp_diff, temp_deriv, temp_err, temp_integ,
+        #     extruder_velocity, co)
         bounded_co = max(0., min(self.heater_max_power, co))
         self.heater.set_pwm(read_time, bounded_co)
         # Store state for next measurement

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -74,7 +74,8 @@ class ControlAutoTune:
                 (read_time + self.heater.get_pwm_delay(), value))
             self.last_pwm = value
         self.heater.set_pwm(read_time, value)
-    def temperature_update(self, read_time, temp, target_temp):
+    def temperature_update(self, read_time, temp, target_temp, extruder_velocity
+        ):
         self.temp_samples.append((read_time, temp))
         # Check if the temperature has crossed the target and
         # enable/disable the heater if so.


### PR DESCRIPTION
I added a Kc factor to the PID. This increases the duty cycle of the heater to compensate for the cooldown caused by the plastic melting.
In my case, a value of 9 reduces the dip and then overshoot of the temperature after a fast, mid-air, extrusion-only move. In real prints though I didn't notice a significant difference. Maybe a slight look-ahead will work better (compensate for future moves).

It was previously requested in these issues: #573 #2175