### PR TITLE
Support for micro-controller on-chip temperature sensors

### DIFF
--- a/src/atsam/adc.c
+++ b/src/atsam/adc.c
@@ -1,6 +1,6 @@
 // Analog to digital support
 //
-// Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -12,17 +12,20 @@
 #include "internal.h" // GPIO
 #include "sched.h" // sched_shutdown
 
+#define ADC_TEMPERATURE_PIN 0xfe
+DECL_ENUMERATION("pin", "ADC_TEMPERATURE", ADC_TEMPERATURE_PIN);
+
 static const uint8_t adc_pins[] = {
 #if CONFIG_MACH_SAM3X
     GPIO('A', 2), GPIO('A', 3), GPIO('A', 4), GPIO('A', 6),
     GPIO('A', 22), GPIO('A', 23), GPIO('A', 24), GPIO('A', 16),
     GPIO('B', 12), GPIO('B', 13), GPIO('B', 17), GPIO('B', 18),
-    GPIO('B', 19), GPIO('B', 20), GPIO('B', 21)
+    GPIO('B', 19), GPIO('B', 20), GPIO('B', 21), ADC_TEMPERATURE_PIN
 #elif CONFIG_MACH_SAM4S
     GPIO('A', 17), GPIO('A', 18), GPIO('A', 19), GPIO('A', 20),
     GPIO('B', 0), GPIO('B', 1), GPIO('B', 2), GPIO('B', 3),
     GPIO('A', 21), GPIO('A', 22), GPIO('C', 13), GPIO('C', 15),
-    GPIO('C', 12), GPIO('C', 29), GPIO('C', 30)
+    GPIO('C', 12), GPIO('C', 29), GPIO('C', 30), ADC_TEMPERATURE_PIN
 #endif
 };
 
@@ -50,8 +53,13 @@ gpio_adc_setup(uint8_t pin)
                        | ADC_MR_TRANSFER(1));
     }
 
-    // Place pin in input floating mode
-    gpio_in_setup(pin, 0);
+    if (pin == ADC_TEMPERATURE_PIN) {
+        // Enable temperature sensor
+        ADC->ADC_ACR |= ADC_ACR_TSON;
+    } else {
+        // Place pin in input floating mode
+        gpio_in_setup(pin, 0);
+    }
     return (struct gpio_adc){ .chan = 1 << chan };
 }
 

--- a/src/atsam/sam4e_afec.c
+++ b/src/atsam/sam4e_afec.c
@@ -11,18 +11,22 @@
 #include "sam4e.h" // AFEC0
 #include "sched.h" // sched_shutdown
 
+#define ADC_TEMPERATURE_PIN 0xfe
+DECL_ENUMERATION("pin", "ADC_TEMPERATURE", ADC_TEMPERATURE_PIN);
+
 static const uint8_t afec_pins[] = {
     //remove first channel, since it offsets the channel number: GPIO('A', 8),
     GPIO('A', 17), GPIO('A', 18), GPIO('A', 19),
     GPIO('A', 20), GPIO('B', 0),  GPIO('B', 1), GPIO('C', 13),
     GPIO('C', 15), GPIO('C', 12), GPIO('C', 29), GPIO('C', 30),
     GPIO('C', 31), GPIO('C', 26), GPIO('C', 27), GPIO('C',0),
+    ADC_TEMPERATURE_PIN,
     // AFEC1
     GPIO('B', 2), GPIO('B', 3), GPIO('A', 21), GPIO('A', 22),
     GPIO('C', 1), GPIO('C', 2), GPIO('C', 3), GPIO('C', 4),
 };
 
-#define AFEC1_START 15 // The first 15 pins are on afec0
+#define AFEC1_START 16 // The first 16 pins are on afec0
 
 static inline struct gpio_adc
 pin_to_gpio_adc(uint8_t pin)

--- a/src/stm32/adc.c
+++ b/src/stm32/adc.c
@@ -1,6 +1,6 @@
 // ADC functions on STM32
 //
-// Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2019-2020  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -15,11 +15,23 @@
 
 DECL_CONSTANT("ADC_MAX", 4095);
 
+#define ADC_TEMPERATURE_PIN 0xfe
+DECL_ENUMERATION("pin", "ADC_TEMPERATURE", ADC_TEMPERATURE_PIN);
+
 static const uint8_t adc_pins[] = {
     GPIO('A', 0), GPIO('A', 1), GPIO('A', 2), GPIO('A', 3),
     GPIO('A', 4), GPIO('A', 5), GPIO('A', 6), GPIO('A', 7),
     GPIO('B', 0), GPIO('B', 1), GPIO('C', 0), GPIO('C', 1),
     GPIO('C', 2), GPIO('C', 3), GPIO('C', 4), GPIO('C', 5),
+
+#if CONFIG_MACH_STM32F1
+    ADC_TEMPERATURE_PIN,
+#elif CONFIG_MACH_STM32F2 || CONFIG_MACH_STM32F407
+    ADC_TEMPERATURE_PIN, 0x00, 0x00,
+#elif CONFIG_MACH_STM32F446
+    0x00, 0x00, ADC_TEMPERATURE_PIN,
+#endif
+
 #if CONFIG_MACH_STM32F4
     0x00, 0x00, 0x00, 0x00,
     GPIO('F', 6), GPIO('F', 7), GPIO('F', 8), GPIO('F', 9),
@@ -29,7 +41,8 @@ static const uint8_t adc_pins[] = {
 };
 
 #if CONFIG_MACH_STM32F1
-#define CR2_FLAGS (ADC_CR2_ADON | (7 << ADC_CR2_EXTSEL_Pos) | ADC_CR2_EXTTRIG)
+#define CR2_FLAGS (ADC_CR2_ADON | (7 << ADC_CR2_EXTSEL_Pos) | ADC_CR2_EXTTRIG \
+                   | ADC_CR2_TSVREFE)
 #else
 #define CR2_FLAGS ADC_CR2_ADON
 #endif
@@ -71,11 +84,11 @@ gpio_adc_setup(uint32_t pin)
     ADC_TypeDef *adc = ADC1;
     uint32_t adc_base = ADC1_BASE;
 #if CONFIG_MACH_STM32F4
-    if (chan >= 16) {
+    if (chan >= 19) {
         // On the STM32F4, some ADC channels are only available from ADC3
         adc = ADC3;
         adc_base += 0x800;
-        chan -= 16;
+        chan -= 19;
     }
 #endif
 
@@ -94,7 +107,13 @@ gpio_adc_setup(uint32_t pin)
         adc->CR2 = CR2_FLAGS;
     }
 
-    gpio_peripheral(pin, GPIO_ANALOG, 0);
+    if (pin == ADC_TEMPERATURE_PIN) {
+#if !CONFIG_MACH_STM32F1
+        ADC123_COMMON->CCR = ADC_CCR_TSVREFE;
+#endif
+    } else {
+        gpio_peripheral(pin, GPIO_ANALOG, 0);
+    }
 
     return (struct gpio_adc){ .adc = adc, .chan = chan };
 }

--- a/src/stm32/stm32f0_adc.c
+++ b/src/stm32/stm32f0_adc.c
@@ -15,23 +15,11 @@
 
 DECL_CONSTANT("ADC_MAX", 4095);
 
-static const uint32_t adc_pins[][2] = {
-    {GPIO('A', 0), ADC_CHSELR_CHSEL0},
-    {GPIO('A', 1), ADC_CHSELR_CHSEL1},
-    {GPIO('A', 2), ADC_CHSELR_CHSEL2},
-    {GPIO('A', 3), ADC_CHSELR_CHSEL3},
-    {GPIO('A', 4), ADC_CHSELR_CHSEL4},
-    {GPIO('A', 5), ADC_CHSELR_CHSEL5},
-    {GPIO('A', 6), ADC_CHSELR_CHSEL6},
-    {GPIO('A', 7), ADC_CHSELR_CHSEL7},
-    {GPIO('B', 0), ADC_CHSELR_CHSEL8},
-    {GPIO('B', 1), ADC_CHSELR_CHSEL9},
-    {GPIO('C', 0), ADC_CHSELR_CHSEL10},
-    {GPIO('C', 1), ADC_CHSELR_CHSEL11},
-    {GPIO('C', 2), ADC_CHSELR_CHSEL12},
-    {GPIO('C', 3), ADC_CHSELR_CHSEL13},
-    {GPIO('C', 4), ADC_CHSELR_CHSEL14},
-    {GPIO('C', 5), ADC_CHSELR_CHSEL15}
+static const uint8_t adc_pins[] = {
+    GPIO('A', 0), GPIO('A', 1), GPIO('A', 2), GPIO('A', 3),
+    GPIO('A', 4), GPIO('A', 5), GPIO('A', 6), GPIO('A', 7),
+    GPIO('B', 0), GPIO('B', 1), GPIO('C', 0), GPIO('C', 1),
+    GPIO('C', 2), GPIO('C', 3), GPIO('C', 4), GPIO('C', 5),
 };
 
 struct gpio_adc
@@ -42,7 +30,7 @@ gpio_adc_setup(uint32_t pin)
     for (chan=0; ; chan++) {
         if (chan >= ARRAY_SIZE(adc_pins))
             shutdown("Not a valid ADC pin");
-        if (adc_pins[chan][0] == pin)
+        if (adc_pins[chan] == pin)
             break;
     }
 
@@ -82,7 +70,7 @@ gpio_adc_setup(uint32_t pin)
 
     gpio_peripheral(pin, GPIO_ANALOG, 0);
 
-    return (struct gpio_adc){ .adc = adc, .chan = adc_pins[chan][1] };
+    return (struct gpio_adc){ .adc = adc, .chan = 1 << chan };
 }
 
 // Try to sample a value. Returns zero if sample ready, otherwise

--- a/src/stm32/stm32f0_adc.c
+++ b/src/stm32/stm32f0_adc.c
@@ -1,6 +1,6 @@
 // ADC functions on STM32
 //
-// Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2019-2020  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -15,11 +15,15 @@
 
 DECL_CONSTANT("ADC_MAX", 4095);
 
+#define ADC_TEMPERATURE_PIN 0xfe
+DECL_ENUMERATION("pin", "ADC_TEMPERATURE", ADC_TEMPERATURE_PIN);
+
 static const uint8_t adc_pins[] = {
     GPIO('A', 0), GPIO('A', 1), GPIO('A', 2), GPIO('A', 3),
     GPIO('A', 4), GPIO('A', 5), GPIO('A', 6), GPIO('A', 7),
     GPIO('B', 0), GPIO('B', 1), GPIO('C', 0), GPIO('C', 1),
     GPIO('C', 2), GPIO('C', 3), GPIO('C', 4), GPIO('C', 5),
+    ADC_TEMPERATURE_PIN
 };
 
 struct gpio_adc
@@ -68,7 +72,11 @@ gpio_adc_setup(uint32_t pin)
         }
     }
 
-    gpio_peripheral(pin, GPIO_ANALOG, 0);
+    if (pin == ADC_TEMPERATURE_PIN) {
+        ADC1_COMMON->CCR = ADC_CCR_TSEN;
+    } else {
+        gpio_peripheral(pin, GPIO_ANALOG, 0);
+    }
 
     return (struct gpio_adc){ .adc = adc, .chan = 1 << chan };
 }


### PR DESCRIPTION
This PR adds support for reading the temperature from built in micro-controller sensors.  The ATSAM91 chips (Due and Duet boards), SAMD chips, and STM32 chips all have temperature sensors built in.  (The AVR chips and LPC176x chips do not appear to have this hardware.)

This is just the micro-controller code for the support.  At some point in the future, I'd like to add in streamlined host support.  For those that wish to test, though, it is possible to manually read these temperatures sensors with a config snippet similar to:
```
[adc_temperature sam3_mcu]
temperature1: 27
voltage1: 0.800
temperature2: 127
voltage2: 1.065 # voltage1 + 100 * .002650

[adc_temperature sam4_mcu]
temperature1: 27
voltage1: 1.44
temperature2: 127
voltage2: 1.910 # voltage1 + 100 * .004700

[adc_temperature samd_mcu]
temperature1: 25
voltage1: 0.667
temperature2: 125
voltage2: 0.907 # voltage1 + 100 * .002400

[adc_temperature stm32f1_mcu]  # Also valid for stm32f042 mcus
temperature1: 25
voltage1: 1.430
temperature2: 125
voltage2: 1.000 # voltage1 + 100 * -.004300

[adc_temperature stm32f4_mcu]  # Also valid for stm32f2 mcus
temperature1: 25
voltage1: 0.760
temperature2: 125
voltage2: 1.010 # voltage1 + 100 * .002500

[temperature_sensor my_mcu_sensor]
sensor_type: stm32f1_mcu  # Select appropriate mcu sensor type
sensor_pin: ADC_TEMPERATURE
adc_voltage: 3.3
gcode_id: C
min_temp: 0
max_temp: 120
```

To test with this branch:
`cd ~/klipper ; git fetch ; git checkout origin/work-mcutemp-20201006 ; sudo service klipper stop ; make ; make flash ; sudo service klipper start`

-Kevin

EDIT: Fixed stm32f103 temperature slope definition.