### PR TITLE
Apply pressure_advance to synced extruder_stepper

### DIFF
--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -102,8 +102,6 @@ class PrinterExtruder:
         epos = self.stepper.get_commanded_position()
         stepper.set_position([epos, 0., 0.])
         stepper.set_trapq(self.trapq)
-        sk = stepper.get_stepper_kinematics()
-        self.extruder_set_smooth_time(sk, self.pressure_advance_smooth_time)
     def stats(self, eventtime):
         return self.heater.stats(eventtime)
     def check_move(self, move):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -102,6 +102,8 @@ class PrinterExtruder:
         epos = self.stepper.get_commanded_position()
         stepper.set_position([epos, 0., 0.])
         stepper.set_trapq(self.trapq)
+        sk = stepper.get_stepper_kinematics()
+        self.extruder_set_smooth_time(sk, self.pressure_advance_smooth_time)
     def stats(self, eventtime):
         return self.heater.stats(eventtime)
     def check_move(self, move):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -90,6 +90,9 @@ class PrinterExtruder:
         self.extruder_set_smooth_time(self.sk_extruder, new_smooth_time)
         self.pressure_advance = pressure_advance
         self.pressure_advance_smooth_time = smooth_time
+        try: synced_stepper
+        except: print("synced_stepper not defined")
+        else: self.sync_stepper(synced_stepper)
     def get_status(self, eventtime):
         return dict(self.heater.get_status(eventtime),
                     pressure_advance=self.pressure_advance,
@@ -103,8 +106,12 @@ class PrinterExtruder:
         sk = stepper.get_stepper_kinematics()
         if self.pressure_advance > 0:
             self.extruder_set_smooth_time(sk, self.pressure_advance_smooth_time)
+        if self.pressure_advance == 0:
+            self.extruder_set_smooth_time(sk, 0.)
         stepper.set_position([epos, 0., 0.])
         stepper.set_trapq(self.trapq)
+        global synced_stepper
+        synced_stepper = stepper
     def stats(self, eventtime):
         return self.heater.stats(eventtime)
     def check_move(self, move):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -100,6 +100,9 @@ class PrinterExtruder:
         return self.heater
     def sync_stepper(self, stepper):
         epos = self.stepper.get_commanded_position()
+        sk = stepper.get_stepper_kinematics()
+        if self.pressure_advance > 0:
+            self.extruder_set_smooth_time(sk, self.pressure_advance_smooth_time)
         stepper.set_position([epos, 0., 0.])
         stepper.set_trapq(self.trapq)
     def stats(self, eventtime):

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -128,8 +128,6 @@ class MCU_stepper:
                                                      self._step_dist)
             self.set_trapq(self._trapq)
         return old_sk
-    def get_stepper_kinematics(self):
-        return self._stepper_kinematics
     def note_homing_end(self, did_trigger=False):
         ret = self._ffi_lib.stepcompress_reset(self._stepqueue, 0)
         if ret:

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -128,6 +128,8 @@ class MCU_stepper:
                                                      self._step_dist)
             self.set_trapq(self._trapq)
         return old_sk
+    def get_stepper_kinematics(self):
+        return self._stepper_kinematics
     def note_homing_end(self, did_trigger=False):
         ret = self._ffi_lib.stepcompress_reset(self._stepqueue, 0)
         if ret:


### PR DESCRIPTION
This PR is intended to address the issue discussed here: https://github.com/KevinOConnor/klipper/issues/3038
In setups with a singe defined extruder_stepper, it will apply the active extruder's pressure advance parameters to the synced extruder_stepper. In setups with multiple defined extruder_steppers, it will only apply the active extruder's pressure advance parameters to the most recently synced extruder_stepper.