### PR TITLE
Update generic-bigtreetech-skr-v1.4.cfg

### DIFF
--- a/config/generic-bigtreetech-skr-v1.4.cfg
+++ b/config/generic-bigtreetech-skr-v1.4.cfg
@@ -136,7 +136,7 @@ max_z_accel: 100
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
-#diag1_pin: 1.29
+#diag1_pin: P1.29
 
 #[tmc2130 stepper_y]
 #cs_pin: P1.9
@@ -147,7 +147,7 @@ max_z_accel: 100
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
-#diag1_pin: 1.28
+#diag1_pin: P1.28
 
 #[tmc2130 stepper_z]
 #cs_pin: P1.8
@@ -158,7 +158,7 @@ max_z_accel: 100
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
-#diag1_pin: 1.27
+#diag1_pin: P1.27
 
 #[tmc2130 extruder]
 #cs_pin: P1.4
@@ -169,7 +169,7 @@ max_z_accel: 100
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
-#diag1_pin: 1.26
+#diag1_pin: P1.26
 
 #[tmc2130 extruder1]
 #cs_pin: P1.1
@@ -180,7 +180,7 @@ max_z_accel: 100
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
-#diag1_pin: 1.25
+#diag1_pin: P1.25
 
 
 ########################################


### PR DESCRIPTION
Corrected the diag1_pin numbers; useful for anyone copying and pasting the lines from the example config. It's something really easy to look over and can lead to some hair pulling from the time wasted trying to troubleshoot the tmc diag pin error from Klipper.

I'd like to apologize in advance if I have not formatted this correctly. This is my first PR to anything. If there's anything I can do better please let me know. 

Signed-off-by: Juan Moreno <uncholowapo@gmail.com>