### PR TITLE
Added PWM value (int, half scale) to M105 output

### DIFF
--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -37,7 +37,7 @@ class ControllerFan:
         for name in self.stepper_names:
             active |= self.stepper_enable.lookup_enable(name).is_motor_enabled()
         for heater in self.heaters:
-            _, target_temp = heater.get_temp(eventtime)
+            _, target_temp, pwm = heater.get_temp(eventtime)
             if target_temp:
                 active = True
         if active:

--- a/klippy/extras/heater_fan.py
+++ b/klippy/extras/heater_fan.py
@@ -28,7 +28,7 @@ class PrinterHeaterFan:
     def callback(self, eventtime):
         power = 0.
         for heater in self.heaters:
-            current_temp, target_temp = heater.get_temp(eventtime)
+            current_temp, target_temp, pwm = heater.get_temp(eventtime)
             if target_temp or current_temp > self.heater_temp:
                 power = self.fan_speed
         print_time = self.fan.get_mcu().estimated_print_time(eventtime)

--- a/klippy/extras/verify_heater.py
+++ b/klippy/extras/verify_heater.py
@@ -45,7 +45,7 @@ class HeaterCheck:
             reactor = self.printer.get_reactor()
             reactor.update_timer(self.check_timer, reactor.NEVER)
     def check_event(self, eventtime):
-        temp, target = self.heater.get_temp(eventtime)
+        temp, target, pwm = self.heater.get_temp(eventtime)
         if temp >= target - self.hysteresis or target <= 0.:
             # Temperature near target - reset checks
             if self.approaching_target and target:


### PR DESCRIPTION
This adds a third value to the M105 value for PWM (power output) which allows graphing and visualization of the temp vs 'realtime' pwm value on the heater. This greatly helps with troubleshooting PID and pid_integral_max values when the PID calibration alone isn't enough to prevent wide oscillations with a strong heater (i.e. E3D Volcano).

This value is simply copied from the already available last_pwm_value variable and so accurately reflects 0 when there is none without any additional logic.

The M105 output is changed from the current (example):
`Recv:21:59:51.063: ok B:24.7 /0.0 T0:21.7 /0.0`
to
`Recv:21:59:51.063: ok B:24.7 /0.0 @0 T0:21.7 /0.0 @0`
`Recv:21:59:51.063: ok B:24.7 /55.0 @127 T0:21.7 /195.0 @55`

This is a screenshot from Repetier Server with the new value.
https://i.imgur.com/yVnaUi0.png

Note that the PWM value is converted from the 0.00 to 1.0 floating value to 0-255 integer and then halved to match Marlin's output (0-127 max) for those applications which display it according to marlin. IMO this isn't ideal because as far as i can tell from looking into the matter, the halved output value seems to be arbitrary and severely limits granularity where a high level of such is provided by Klipper.

I was thinking to add a multiplier or divisor config option to allow for customizing the value on M105 output (i.e. default is no multiplier (1) so M105 output would be 0-255 or 0.5 to make it 0-127 ) alternatively a mode: i.e. [default]: off, "float": 0.000-1.000, "marlin": int 0-127, "integer": 0-255   I think the mode style would be easier to use, am open to suggestion.