### PR TITLE
Note PROBE_CALIBRATE results invalidated on motion system update

### DIFF
--- a/docs/Delta_Calibrate.md
+++ b/docs/Delta_Calibrate.md
@@ -30,6 +30,13 @@ automatic probe has a bias of more than 25 microns (.025mm) then use
 manual probing instead. Manual probing only takes a few minutes and it
 eliminates error introduced by the probe.
 
+If using a probe that is mounted on the side of the hotend (that is,
+it has an X or Y offset) then note that performing delta calibration
+will invalidate the results of probe calibration. These types of
+probes are rarely suitable for use on a delta (because minor effector
+tilt will result in a probe location bias). If using the probe anyway,
+then be sure to rerun probe calibration after any delta calibration.
+
 Basic delta calibration
 =======================
 
@@ -228,3 +235,15 @@ Additional notes
   errors elsewhere in the hardware. For example, small differences in
   arm length may result in a tilt to the effector and some of that
   tilt may be accounted for by adjusting the arm length parameters.
+
+Using Bed Mesh on a Delta
+=========================
+
+It is possible to use [bed mesh](Bed_Mesh.md) on a delta. However, it
+is important to obtain good delta calibration prior to enabling a bed
+mesh. Running bed mesh with poor delta calibration will result in
+confusing and poor results.
+
+Note that performing delta calibration will invalidate any previously
+obtained bed mesh. After performing a new delta calibration be sure to
+rerun BED_MESH_CALIBRATE.

--- a/docs/Manual_Level.md
+++ b/docs/Manual_Level.md
@@ -185,3 +185,9 @@ This means that:
 
 Repeat the process several times until you get a good level bed -
 normally when all adjustments are below 6 minutes.
+
+If using a probe that is mounted on the side of the hotend (that is,
+it has an X or Y offset) then note that adjusting the bed tilt will
+invalidate any previous probe calibration that was performed with a
+tilted bed. Be sure to run [probe calibration](Probe_Calibrate.md)
+after the bed screws have been adjusted.

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -70,6 +70,21 @@ results to the config file with:
 SAVE_CONFIG
 ```
 
+Note that if a change is made to the printer's motion system, hotend
+position, or probe location then it will invalidate the results of
+PROBE_CALIBRATE.
+
+If the probe has an X or Y offset and the bed tilt is changed (eg, by
+adjusting bed screws, running DELTA_CALIBRATE, running Z_TILT_ADJUST,
+running QUAD_GANTRY_LEVEL, or similar) then it will invalidate the
+results of PROBE_CALIBRATE. After making any of the above adjustments
+it will be necessary to run PROBE_CALIBRATE again.
+
+If the results of PROBE_CALIBRATE are invalidated, then any previous
+[bed mesh](Bed_Mesh.md) results that were obtained using the probe are
+also invalidated - it will be necessary to rerun BED_MESH_CALIBRATE
+after recalibrating the probe.
+
 # Repeatability check
 
 After calibrating the probe X, Y, and Z offsets it is a good idea to


### PR DESCRIPTION
Any hardware change to the hotend or probe, change to the kinematics,
or change to the bed tilt is likely to invalidate the results of
PROBE_CALIBRATE.  Try to warn the user of that.

@Arksine - this mentions bed mesh a few times, so it would be great if you could review this as well.

Thanks,
-Kevin