### PR TITLE
Document menu_root

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -2010,6 +2010,10 @@
 #   Timeout for menu. Being inactive this amount of seconds will
 #   trigger menu exit or return to root menu when having autorun
 #   enabled. The default is 0 seconds (disabled)
+#menu_root:
+#   Name of the main menu section to show when clicking the encoder
+#   on the home screen. The defaults is __main, and this shows the
+#   the default menus in defined in klippy/extras/display/menu.cfg
 #menu_reverse_navigation:
 #   When enabled it will reverse up and down directions for list
 #   navigation. The default is False. This parameter is optional.

--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -2013,7 +2013,7 @@
 #menu_root:
 #   Name of the main menu section to show when clicking the encoder
 #   on the home screen. The defaults is __main, and this shows the
-#   the default menus in defined in klippy/extras/display/menu.cfg
+#   the default menus as defined in klippy/extras/display/menu.cfg
 #menu_reverse_navigation:
 #   When enabled it will reverse up and down directions for list
 #   navigation. The default is False. This parameter is optional.


### PR DESCRIPTION
Document the previously undocumented menu_root parameter in the [display] section