### PR TITLE
RFC: neopixel: Add support for pixel grouping

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1373,6 +1373,10 @@
 #   The number of Neopixel chips that are "daisy chained" to the
 #   provided pin. The default is 1 (which indicates only a single
 #   Neopixel is connected to the pin).
+#repeat_count: 1
+#   Number of times to repeat every pixel on the chain. For example,
+#   set this to 8 to handle rows of a 8x8 matrix as a single virtual
+#   pixel.
 #color_order_GRB: True
 #   Set the pixel order to green, red, blue. If using the WS2811 chip
 #   (in 800Khz mode) then set this to False. The default is True.

--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -22,6 +22,8 @@ class PrinterNeoPixel:
         self.mcu.register_config_callback(self.build_config)
         self.color_order_GRB = config.getboolean("color_order_GRB", True)
         self.chain_count = config.getint('chain_count', 1, minval=1, maxval=18)
+        self.pixel_repeat = config.getint('pixel_repeat', 1,
+                                          minval=1, maxval=255)
         self.neopixel_send_cmd = None
         # Initial color
         red = config.getfloat('initial_RED', 0., minval=0., maxval=1.)
@@ -38,7 +40,9 @@ class PrinterNeoPixel:
         rmt = self.mcu.seconds_to_clock(RESET_MIN_TIME)
         self.mcu.add_config_cmd("config_neopixel oid=%d pin=%s"
                                 " bit_max_ticks=%d reset_min_ticks=%d"
-                                % (self.oid, self.pin, bmt, rmt))
+                                " repeat_len=3 repeat_count=%d"
+                                % (self.oid, self.pin, bmt, rmt,
+                                   self.pixel_repeat))
         cmd_queue = self.mcu.alloc_command_queue()
         self.neopixel_send_cmd = self.mcu.lookup_command(
             "neopixel_send oid=%c data=%*s", cq=cmd_queue)


### PR DESCRIPTION
**N.B.:** This is an RFC, the firmware implementation has not been optimised (or tested) for 8-bit microcontrollers.

Due to protocol limitations, Klipper currently only supports short LED chains (18 pixels). There are cases where it would be desirable to use larger arrays of LEDs for illumination. Add a mechanism to groups
adjacent pixels into a larger virtual pixel to support longer LED chains.

This is implemented by adding an option to repeat a sequence of N bytes M times in the microcontroller firmware. The default
configuration repeats every block of 3 bytes exactly once. To support larger arrays, the repeat count can be increased.

For example, an 8x8 array can be addressed by row by setting the repeat count to 8. Setting the repeat count to 64 makes the entire array behave like a single pixel.
