### PR TITLE
gcode_macro: add "register_remote_method" endpoint

### DIFF
--- a/docs/API_Server.md
+++ b/docs/API_Server.md
@@ -146,6 +146,36 @@ transition to a "shutdown" state. It behaves similarly to the G-Code
 `M112` command. For example:
 `{"id": 123, "method": "emergency_stop"}`
 
+### register_remote_method
+
+This endpoint allows clients to register methods that can be called
+from klipper.  It will return an empty object upon success.
+
+For example:
+`{"id": 123, "method": "register_remote_method",
+"params": {"response_template": {"action": "run_paneldue_beep"},
+"remote_method": "paneldue_beep"}}`
+will return:
+`{"id": 123, "result": {}}`
+
+The remote method `paneldue_beep` may now be called from Klipper. Note
+that if the method takes parameters they should be provided as keyword
+arguments. Below is an example of how it may called from a gcode_macro:
+```
+[gcode_macro PANELDUE_BEEP]
+default_parameter_FREQUENCY: 300
+default_parameter_DURATION: 1.
+gcode:
+  {action_call_remote_method("paneldue_beep",
+                             frequency=FREQUENCY|int,
+                             duration=DURATION|float)}
+```
+
+When the PANELDUE_BEEP gcode macro is executed, Klipper would send something
+like the following over the socket:
+`{"action": "run_paneldue_beep",
+"params": {"frequency": 300, "duration": 1.0}}
+
 ### objects/list
 
 This endpoint queries the list of available printer "objects" that one

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -305,6 +305,10 @@ Available "action" commands:
 - `action_emergency_stop(msg)`: Transition the printer to a shutdown
   state. The `msg` parameter is optional, it may be useful to describe
   the reason for the shutdown.
+- `action_call_remote_method(method_name)`: Calls a method registered
+  by a remote client.  If the method takes parameters they should
+  be provided via keyword arguments, ie:
+  `action_call_remote_method("print_stuff", my_arg="hello_world")`
 
 ### Variables
 

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -87,12 +87,20 @@ class PrinterGCodeMacro:
         return ""
     def _action_raise_error(self, msg):
         raise self.printer.command_error(msg)
+    def _action_call_remote_method(self, method, **kwargs):
+        webhooks = self.printer.lookup_object('webhooks')
+        try:
+            webhooks.call_remote_method(method, **kwargs)
+        except self.printer.command_error:
+            logging.exception("Remote Call Error")
+        return ""
     def create_template_context(self, eventtime=None):
         return {
             'printer': GetStatusWrapper(self.printer, eventtime),
             'action_emergency_stop': self._action_emergency_stop,
             'action_respond_info': self._action_respond_info,
             'action_raise_error': self._action_raise_error,
+            'action_call_remote_method': self._action_call_remote_method,
         }
 
 def load_config(config):

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -275,8 +275,11 @@ class WebHooks:
     def __init__(self, printer):
         self.printer = printer
         self._endpoints = {"list_endpoints": self._handle_list_endpoints}
+        self._remote_methods = {}
         self.register_endpoint("info", self._handle_info_request)
         self.register_endpoint("emergency_stop", self._handle_estop_request)
+        self.register_endpoint("register_remote_method",
+                               self._handle_rpc_registration)
         self.sconn = ServerSocket(self, printer)
 
     def register_endpoint(self, path, callback):
@@ -305,6 +308,14 @@ class WebHooks:
     def _handle_estop_request(self, web_request):
         self.printer.invoke_shutdown("Shutdown due to webhooks request")
 
+    def _handle_rpc_registration(self, web_request):
+        template = web_request.get_dict('response_template')
+        method = web_request.get_str('remote_method')
+        new_conn = web_request.get_client_connection()
+        logging.info("webhooks: registering remote method '%s' "
+                     "for connection id: %d" % (method, id(new_conn)))
+        self._remote_methods.setdefault(method, {})[new_conn] = template
+
     def get_connection(self):
         return self.sconn
 
@@ -319,6 +330,24 @@ class WebHooks:
     def get_status(self, eventtime):
         state_message, state = self.printer.get_state_message()
         return {'state': state, 'state_message': state_message}
+
+    def call_remote_method(self, method, **kwargs):
+        if method not in self._remote_methods:
+            raise self.printer.command_error(
+                "Remote method '%s' not registered" % (method))
+        conn_map = self._remote_methods[method]
+        valid_conns = {}
+        for conn, template in conn_map.items():
+            if not conn.is_closed():
+                valid_conns[conn] = template
+                out = {'params': kwargs}
+                out.update(template)
+                conn.send(out)
+        if not valid_conns:
+            del self._remote_methods[method]
+            raise self.printer.command_error(
+                "No active connections for method '%s'" % (method))
+        self._remote_methods[method] = valid_conns
 
 class GCodeHelper:
     def __init__(self, printer):


### PR DESCRIPTION
This adds the ability for webhooks clients to register methods that may be called from within a template.  The current implementation will allow for multiple clients to register the same method.  When invoked, the method is executed on all clients.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>