### PR TITLE
Extended the functionality of Octoprint menu

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -2304,3 +2304,13 @@
 # Replicape support - see the generic-replicape.cfg file for further
 # details.
 #[replicape]
+
+# The octoprint section enables the Octoprint REST API
+# integration allowing to control the Octoprint instance
+# directly from the printer LCD.
+#[octoprint]
+#api_key: ABBAABBAABBA
+#  You can obtain the key from your Octoprint configuration
+#host: http://localhost:5000
+#  The 'host' key is optional. You only need to include it
+#  if you are not running the standard Raspberry Pi setup.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -701,4 +701,3 @@ section is enabled.
 - `OCTOPRINT PRINT_FILE=<resource>`: Starts printing the file with the given
   handle. The handle is returned by Octoprint in `refs/resource` key when
   querying the file list.
-

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -693,3 +693,12 @@ is enabled:
   to the current time in "YYYYMMDD_HHMMSS" format. Note that the suggested
   input shaper parameters can be persisted in the config by issuing
   `SAVE_CONFIG` command.
+
+## Octoprint REST API integration
+
+The following command is available when the "octoprint" config
+section is enabled.
+- `OCTOPRINT PRINT_FILE=<resource>`: Starts printing the file with the given
+  handle. The handle is returned by Octoprint in `refs/resource` key when
+  querying the file list.
+

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -11,6 +11,7 @@
 #       + Pause printing
 #       + Resume printing
 #       + Abort printing
+#       + Files
 #   + SD Card
 #       + Start printing
 #       + Resume printing
@@ -152,6 +153,11 @@ enable: {printer.idle_timeout.state == "Printing"}
 name: Abort printing
 gcode:
     {action_respond_info('action:cancel')}
+
+[menu __main __octoprint __files]
+type: octoprint
+name: Files
+enable: {not printer.idle_timeout.state == "Printing"}
 
 ### menu virtual sdcard ###
 [menu __main __sdcard]

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -621,12 +621,29 @@ class MenuVSDList(MenuList):
                     'gcode': "\n".join(gcode)
                 }))
 
+class MenuOctoprint(MenuList):
+    def __init__(self, manager, config):
+        super(MenuOctoprint, self).__init__(manager, config)
+
+    def _populate(self):
+        super(MenuOctoprint, self)._populate()
+        octoprint = self.manager.printer.lookup_object('octoprint', None)
+        if octoprint is None:
+            return
+        files = octoprint.list_files()
+        for name, resource in files:
+            self.insert_item(self.manager.menuitem_from({
+                    'type': 'command',
+                    'name': '%s' % name,
+                    'gcode': 'OCTOPRINT PRINT_FILE=%s' % resource
+                }))
 
 menu_items = {
     'command': MenuCommand,
     'input': MenuInput,
     'list': MenuList,
-    'vsdlist': MenuVSDList
+    'vsdlist': MenuVSDList,
+    'octoprint': MenuOctoprint
 }
 
 

--- a/klippy/extras/octoprint.py
+++ b/klippy/extras/octoprint.py
@@ -1,0 +1,48 @@
+# Octoprint REST API support
+#
+# Copyright (C) 2019  Stanislav Kljuhhin <stanislav.kljuhhin@me.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import requests, logging
+
+
+DEFAULT_HOST = 'http://localhost:5000'
+GET_FILES = '/api/files'
+
+class Octoprint:
+    def __init__(self, config):
+        self._host = config.get('host', DEFAULT_HOST)
+        self._headers = {'X-Api-Key': config.get('api_key')}
+        self._gcode = config.get_printer().lookup_object('gcode')
+        self._gcode.register_command('OCTOPRINT', self.cmd_OCTOPRINT)
+
+    def list_files(self):
+        try:
+            r = requests.get(self._host + GET_FILES, headers=self._headers)
+            r.raise_for_status()
+        except requests.exceptions.RequestException:
+            logging.exception('Octoprint: '
+                              'exception when requesting the file list')
+            return
+        for file in r.json().get('files', []):
+            yield file['name'], file['refs']['resource']
+
+    def _print_file(self, resource):
+        json = {'command': 'select', 'print': True}
+        try:
+            r = requests.post(resource, headers=self._headers, json=json)
+            r.raise_for_status()
+        except requests.exceptions.RequestException:
+            logging.exception('Octoprint: exception when starting the print')
+
+    def cmd_OCTOPRINT(self, params):
+        print_file = params.get('PRINT_FILE')
+        if print_file is None:
+            self._gcode.respond_info('Required parameter PRINT_FILE missing.')
+            return
+        self._print_file(print_file)
+        self._gcode.respond_info('Printing %s' % print_file)
+
+
+def load_config(config):
+    return Octoprint(config)

--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -6,3 +6,4 @@ cffi==1.12.2
 pyserial==3.4
 greenlet==0.4.15
 Jinja2==2.10.1
+requests==2.12.4


### PR DESCRIPTION
This PR extends the functionality of the Octoprint menu by displaying the list of Octoprint files in it and starting printing when a file is selected. (port of crzcrz:octoprint_api_integration_merge to Jinja2)

This allows to quickly start a print without reaching for a computer or a smartphone (if the printer is equipped with an LCD).

