### PR TITLE
Let hard-pwm use MCU move queue

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 # Main code build rules
 
 src-y += sched.c command.c basecmd.c debugcmds.c
-src-$(CONFIG_HAVE_GPIO) += initial_pins.c gpiocmds.c stepper.c endstop.c
+src-$(CONFIG_HAVE_GPIO) += initial_pins.c gpiocmds.c stepper.c endstop.c queue.c
 src-$(CONFIG_HAVE_GPIO_ADC) += adccmds.c
 src-$(CONFIG_HAVE_GPIO_SPI) += spicmds.c thermocouple.c
 src-$(CONFIG_HAVE_GPIO_I2C) += i2ccmds.c

--- a/src/basecmd.c
+++ b/src/basecmd.c
@@ -65,7 +65,6 @@ struct move_freed {
 static struct move_freed *move_free_list;
 static void *move_list;
 static uint16_t move_count;
-static uint16_t reserved_moves;
 static uint8_t move_item_size;
 
 // Is the config and move queue finalized?
@@ -106,14 +105,6 @@ move_request_size(int size)
         shutdown("Invalid move request size");
     if (size > move_item_size)
         move_item_size = size;
-}
-
-// Like move_request_size, but also reserves a move item
-void
-move_request_size_unsynchronized(int size)
-{
-    move_request_size(size);
-    reserved_moves++;
 }
 
 void
@@ -211,7 +202,7 @@ void
 command_get_config(uint32_t *args)
 {
     sendf("config is_config=%c crc=%u move_count=%hu is_shutdown=%c"
-          , is_finalized(), config_crc, move_count-reserved_moves,
+          , is_finalized(), config_crc, move_count,
           sched_is_shutdown());
 }
 DECL_COMMAND_FLAGS(command_get_config, HF_IN_SHUTDOWN, "get_config");
@@ -237,7 +228,6 @@ config_reset(uint32_t *args)
     move_free_list = NULL;
     move_list = NULL;
     move_count = move_item_size = 0;
-    reserved_moves = 0;
     alloc_init();
     sched_timer_reset();
     sched_clear_shutdown();

--- a/src/basecmd.h
+++ b/src/basecmd.h
@@ -8,6 +8,7 @@ void *alloc_chunk(size_t size);
 void move_free(void *m);
 void *move_alloc(void);
 void move_request_size(int size);
+void move_request_size_unsynchronized(int size);
 void *oid_lookup(uint8_t oid, void *type);
 void *oid_alloc(uint8_t oid, void *type, uint16_t size);
 void *oid_next(uint8_t *i, void *type);

--- a/src/basecmd.h
+++ b/src/basecmd.h
@@ -8,7 +8,6 @@ void *alloc_chunk(size_t size);
 void move_free(void *m);
 void *move_alloc(void);
 void move_request_size(int size);
-void move_request_size_unsynchronized(int size);
 void *oid_lookup(uint8_t oid, void *type);
 void *oid_alloc(uint8_t oid, void *type, uint16_t size);
 void *oid_next(uint8_t *i, void *type);

--- a/src/gpiocmds.c
+++ b/src/gpiocmds.c
@@ -65,9 +65,7 @@ digital_out_event(struct timer *timer)
         if (current->value == d->default_value || !d->max_duration) {
             // We either have set the default value
             // or there is no maximum duration
-            irqstatus_t irq = irq_save();
             mq_free_event(current);
-            irq_restore(irq);
             return SF_DONE;
         }
 
@@ -76,9 +74,7 @@ digital_out_event(struct timer *timer)
         d->timer.func = digital_end_event;
     }
 
-    irqstatus_t irq = irq_save();
     mq_free_event(current);
-    irq_restore(irq);
     return SF_RESCHEDULE;
 }
 
@@ -112,7 +108,7 @@ command_schedule_digital_out(uint32_t *args)
         if(d->max_duration && d->current_value != d->default_value) {
             // max_duration and currently not default value
             // There has to be a safety timer
-            if(new_event->waketime > d->timer.waketime) {
+            if(timer_is_before(d->timer.waketime, new_event->waketime)) {
                 shutdown("New digital_out event too late for max_duration");
             }
         }

--- a/src/gpiocmds.c
+++ b/src/gpiocmds.c
@@ -42,14 +42,14 @@ static uint_fast8_t
 digital_out_event(struct timer *timer)
 {
     struct digital_out_s *d = container_of(timer, struct digital_out_s, timer);
-    struct mq_event *c = mq_event_peek(&d->queue);
+    struct mq_event *c = mq_event_pop(&d->queue);
 
     struct do_event* current = container_of(c, struct do_event, event);
     gpio_out_write(d->pin, current->value);
     d->current_value = current->value;
 
     //may be NULL if no further elements are queued
-    struct mq_event* next = mq_event_pop(&d->queue);
+    struct mq_event* next = mq_event_peek(&d->queue);
 
     if(next) {
         //next event scheduled

--- a/src/gpiocmds.c
+++ b/src/gpiocmds.c
@@ -9,6 +9,7 @@
 #include "board/irq.h" // irq_disable
 #include "board/misc.h" // timer_is_before
 #include "command.h" // DECL_COMMAND
+#include "queue.h" // queueing
 #include "sched.h" // sched_add_timer
 
 
@@ -20,7 +21,14 @@ struct digital_out_s {
     struct timer timer;
     struct gpio_out pin;
     uint32_t max_duration;
-    uint8_t value, default_value;
+    uint8_t default_value;
+    struct queue queue;
+};
+
+struct do_event {
+    uint8_t value;
+    uint32_t waketime;
+    struct event event;
 };
 
 static uint_fast8_t
@@ -33,11 +41,37 @@ static uint_fast8_t
 digital_out_event(struct timer *timer)
 {
     struct digital_out_s *d = container_of(timer, struct digital_out_s, timer);
-    gpio_out_write(d->pin, d->value);
-    if (d->value == d->default_value || !d->max_duration)
+    struct event *c = get_current_event(&d->queue);
+
+    if(!c) {
+        // no pwm value, queue is empty
+        // this should not happen because we were scheduled for an event
         return SF_DONE;
-    d->timer.waketime += d->max_duration;
-    d->timer.func = digital_end_event;
+    }
+    struct do_event* current = event_get_data(c, struct do_event);
+    gpio_out_write(d->pin, current->value);
+
+    //may be NULL if no further elements are queued
+    struct event* next = get_next_event(&d->queue);
+
+    if(next) {
+        //next event scheduled
+        d->timer.waketime = event_get_data(next, struct do_event)->waketime;
+    } else {
+        // no next event scheduled
+        if (current->value == d->default_value || !d->max_duration) {
+            // We either have set the default value
+            // or there is no maximum duration
+            free_event(current);
+            return SF_DONE;
+        }
+
+        //nothing scheduled, so lets start the safety timeout
+        d->timer.waketime += d->max_duration;
+        d->timer.func = digital_end_event;
+    }
+
+    free_event(current);
     return SF_RESCHEDULE;
 }
 
@@ -50,6 +84,7 @@ command_config_digital_out(uint32_t *args)
     d->pin = pin;
     d->default_value = args[3];
     d->max_duration = args[4];
+    init_queue(&d->queue, sizeof(struct do_event));
 }
 DECL_COMMAND(command_config_digital_out,
              "config_digital_out oid=%c pin=%u value=%c default_value=%c"
@@ -59,11 +94,19 @@ void
 command_schedule_digital_out(uint32_t *args)
 {
     struct digital_out_s *d = oid_lookup(args[0], command_config_digital_out);
-    sched_del_timer(&d->timer);
-    d->timer.func = digital_out_event;
-    d->timer.waketime = args[1];
-    d->value = args[2];
-    sched_add_timer(&d->timer);
+    struct do_event* new_event = (struct do_event*) alloc_event();
+    new_event->waketime = args[1];
+    new_event->value = args[2];
+
+    if(!insert_event(&d->queue, &new_event->event)) {
+        //queue was empty and a timer needs to be added
+        if(d->timer.func == digital_end_event) {
+            sched_del_timer(&d->timer);
+        }
+        d->timer.waketime = args[1];
+        d->timer.func = digital_out_event;
+        sched_add_timer(&d->timer);
+    }
 }
 DECL_COMMAND(command_schedule_digital_out,
              "schedule_digital_out oid=%c clock=%u value=%c");
@@ -72,10 +115,13 @@ void
 command_update_digital_out(uint32_t *args)
 {
     struct digital_out_s *d = oid_lookup(args[0], command_config_digital_out);
-    sched_del_timer(&d->timer);
+    //FIXME: How to act here if queue is still populated?
     uint8_t value = args[1];
     gpio_out_write(d->pin, value);
-    if (value != d->default_value && d->max_duration) {
+    // if there is no event waiting, add time-out
+    if (get_current_event(&d->queue) == NULL &&
+            value != d->default_value && d->max_duration) {
+        sched_del_timer(&d->timer);
         d->timer.waketime = timer_read_time() + d->max_duration;
         d->timer.func = digital_end_event;
         sched_add_timer(&d->timer);

--- a/src/pwmcmds.c
+++ b/src/pwmcmds.c
@@ -94,10 +94,7 @@ command_schedule_pwm_out(uint32_t *args)
 
     if(!mq_event_insert(&p->queue, &new_event->event)){
         //queue was empty and a timer needs to be added
-        if(p->timer.func == pwm_end_event) {
-            //first, reset the end event timer
-            sched_del_timer(&p->timer);
-        }
+        sched_del_timer(&p->timer);
         p->timer.waketime = args[1];
         p->timer.func = pwm_event;
         sched_add_timer(&p->timer);

--- a/src/pwmcmds.c
+++ b/src/pwmcmds.c
@@ -36,14 +36,14 @@ static uint_fast8_t
 pwm_event(struct timer *timer)
 {
     struct pwm_out_s *p = container_of(timer, struct pwm_out_s, timer);
-    struct mq_event  *c = mq_event_peek(&p->queue);
+    struct mq_event  *c = mq_event_pop(&p->queue);
     struct pwm_event *current = container_of(c, struct pwm_event, event);
 
     gpio_pwm_write(p->pin, current->value);
     p->current_value = current->value;
 
     //may be NULL if no further elements are queued
-    struct mq_event* next = mq_event_pop(&p->queue);
+    struct mq_event* next = mq_event_peek(&p->queue);
 
     if(next) {
         //next event scheduled

--- a/src/queue.c
+++ b/src/queue.c
@@ -16,15 +16,15 @@ struct mq_event* mq_event_peek(struct mq_list* queue) {
 }
 
 /**
- * @return NULL if no next event
+ * @return NULL if no current event
  */
 struct mq_event* mq_event_pop(struct mq_list* queue) {
-    if(!queue->first) {
-        //no current! event
-        return NULL;
+    struct mq_event* current = queue->first;
+    if(current) {
+        queue->first = queue->first->next;
     }
-    queue->first = queue->first->next;
-    return queue->first;
+
+    return current;
 }
 void mq_init(struct mq_list* queue, size_t size_of_event) {
     queue->first = NULL;

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,0 +1,73 @@
+// Helper with queueing single-value events
+//
+// Copyright (C) 2016 Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "board/irq.h" // irq_disable
+#include "queue.h"
+
+/**
+ * @return NULL if no current event
+ */
+struct event* get_current_event(struct queue* queue) {
+    return queue->first;
+}
+
+/**
+ * @return NULL if no next event
+ */
+struct event* get_next_event(struct queue* queue) {
+    if(!queue->first) {
+        //no current! event
+        return NULL;
+    }
+    queue->first = queue->first->next;
+    return queue->first;
+}
+void init_queue(struct queue* queue, size_t size_of_event)
+{
+    queue->first = NULL;
+    queue->plast = NULL;
+
+    move_request_size(size_of_event);
+}
+
+void* alloc_event(void)
+{
+    return move_alloc();
+}
+
+void free_event(void* event)
+{
+    irq_disable();
+    move_free(event);
+    irq_enable();
+}
+
+/**
+ * @return NULL if queue was empty and a timer needs to be added
+ */
+uint8_t insert_event(struct queue* queue, struct event* event) {
+    uint8_t needs_adding_timer = 0;
+    event->next = NULL;
+
+    irq_disable();
+    if(queue->first) {
+        //there exists an element in queue
+        //if there is a queue->first, there has to be a queue->plast
+        //if there is no first, plast is invalid.
+        //enqueue new event into the last's "next" element
+        *queue->plast = event;
+    }
+    else {
+        // no first element set
+        queue->first = event;
+        needs_adding_timer = 1;
+    }
+
+    //plast to point to this new element's next pointer
+    queue->plast = &event->next;
+    irq_enable();
+    return !needs_adding_timer;
+}

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,4 +1,4 @@
-// Helper with queueing single-value events
+// Helper with queueing events using the move queue
 //
 // Copyright (C) 2016 Kevin O'Connor <kevin@koconnor.net>
 //

--- a/src/queue.c
+++ b/src/queue.c
@@ -26,6 +26,11 @@ struct mq_event* mq_event_pop(struct mq_list* queue) {
 
     return current;
 }
+
+void mq_discard(struct mq_list* queue) {
+    queue->first = NULL;
+}
+
 void mq_init(struct mq_list* queue, size_t size_of_event) {
     queue->first = NULL;
     queue->plast = NULL;

--- a/src/queue.c
+++ b/src/queue.c
@@ -30,7 +30,7 @@ void mq_init(struct mq_list* queue, size_t size_of_event) {
     queue->first = NULL;
     queue->plast = NULL;
 
-    move_request_size_unsynchronized(size_of_event);
+    move_request_size(size_of_event);
 }
 
 void* mq_alloc_event(void) {

--- a/src/queue.c
+++ b/src/queue.c
@@ -30,7 +30,7 @@ void init_queue(struct queue* queue, size_t size_of_event)
     queue->first = NULL;
     queue->plast = NULL;
 
-    move_request_size(size_of_event);
+    move_request_size_unsynchronized(size_of_event);
 }
 
 void* alloc_event(void)

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,39 +1,31 @@
-// Commands for controlling GPIO pins
-//
-// Copyright (C) 2016  Kevin O'Connor <kevin@koconnor.net>
-//
-// This file may be distributed under the terms of the GNU GPLv3 license.
-
 #ifndef SRC__GENERIC_QUEUE_H_
 #define SRC__GENERIC_QUEUE_H_
 
-#include "basecmd.h" // oid_alloc
-
-struct event {
-    struct event *next;
+struct mq_event {
+    struct mq_event *next;
 };
 
-struct queue {
-    struct event *first, **plast;
+struct mq_list {
+    struct mq_event *first, **plast;
 };
 
 /**
  * @return NULL if no current event
  */
-struct event* get_current_event(struct queue* queue);
+struct mq_event* mq_event_peek(struct mq_list* queue);
 /**
  * @return NULL if no next event
  */
-struct event* get_next_event(struct queue* queue);
-void init_queue(struct queue* queue, size_t size_of_event);
-void* alloc_event(void);
-void free_event(void* current);
-/**
- * @return NULL if queue was empty and a timer needs to be added
- */
-uint8_t insert_event(struct queue* queue, struct event* event);
+struct mq_event* mq_event_pop(struct mq_list* queue);
+void mq_init(struct mq_list* queue, size_t size_of_event);
+void* mq_alloc_event(void);
 
-#define event_get_data(event_ptr, type) \
-        container_of(event_ptr, type, event)
+// Free previously allocated storage from move_alloc(). Caller must
+// disable irqs.
+void mq_free_event(void* current);
+/**
+ * @return 0 if queue was empty and a timer needs to be added
+ */
+uint8_t mq_event_insert(struct mq_list* queue, struct mq_event* event);
 
 #endif /* SRC__GENERIC_QUEUE_H_ */

--- a/src/queue.h
+++ b/src/queue.h
@@ -14,7 +14,7 @@ struct mq_list {
  */
 struct mq_event* mq_event_peek(struct mq_list* queue);
 /**
- * @return NULL if no next event
+ * @return NULL if no current event
  */
 struct mq_event* mq_event_pop(struct mq_list* queue);
 void mq_init(struct mq_list* queue, size_t size_of_event);

--- a/src/queue.h
+++ b/src/queue.h
@@ -17,6 +17,10 @@ struct mq_event* mq_event_peek(struct mq_list* queue);
  * @return NULL if no current event
  */
 struct mq_event* mq_event_pop(struct mq_list* queue);
+
+// discards queue _without_ freeing its elements
+void mq_discard(struct mq_list* queue);
+
 void mq_init(struct mq_list* queue, size_t size_of_event);
 void* mq_alloc_event(void);
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,0 +1,39 @@
+// Commands for controlling GPIO pins
+//
+// Copyright (C) 2016  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#ifndef SRC__GENERIC_QUEUE_H_
+#define SRC__GENERIC_QUEUE_H_
+
+#include "basecmd.h" // oid_alloc
+
+struct event {
+    struct event *next;
+};
+
+struct queue {
+    struct event *first, **plast;
+};
+
+/**
+ * @return NULL if no current event
+ */
+struct event* get_current_event(struct queue* queue);
+/**
+ * @return NULL if no next event
+ */
+struct event* get_next_event(struct queue* queue);
+void init_queue(struct queue* queue, size_t size_of_event);
+void* alloc_event(void);
+void free_event(void* current);
+/**
+ * @return NULL if queue was empty and a timer needs to be added
+ */
+uint8_t insert_event(struct queue* queue, struct event* event);
+
+#define event_get_data(event_ptr, type) \
+        container_of(event_ptr, type, event)
+
+#endif /* SRC__GENERIC_QUEUE_H_ */

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -12,6 +12,7 @@
 #include "command.h" // DECL_COMMAND
 #include "sched.h" // struct timer
 #include "stepper.h" // command_config_stepper
+#include "queue.h" // move queue
 
 DECL_CONSTANT("STEP_DELAY", CONFIG_STEP_DELAY);
 
@@ -24,7 +25,7 @@ struct stepper_move {
     uint32_t interval;
     int16_t add;
     uint16_t count;
-    struct stepper_move *next;
+    struct mq_event event;
     uint8_t flags;
 };
 
@@ -43,7 +44,7 @@ struct stepper {
 #endif
     struct gpio_out step_pin, dir_pin;
     uint32_t position;
-    struct stepper_move *first, **plast;
+    struct mq_list queue;
     uint32_t min_stop_interval;
     // gcc (pre v6) does better optimization when uint8_t are bitfields
     uint8_t flags : 8;
@@ -60,8 +61,9 @@ enum {
 static uint_fast8_t
 stepper_load_next(struct stepper *s, uint32_t min_next_time)
 {
-    struct stepper_move *m = s->first;
-    if (!m) {
+    struct mq_event *c = mq_event_pop(&s->queue);
+
+    if (!c) {
         // There is no next move - the queue is empty
         if (s->interval - s->add < s->min_stop_interval
             && !(s->flags & SF_NO_NEXT_CHECK))
@@ -69,6 +71,8 @@ stepper_load_next(struct stepper *s, uint32_t min_next_time)
         s->count = 0;
         return SF_DONE;
     }
+
+    struct stepper_move *m = container_of(c, struct stepper_move, event);
 
     // Load next 'struct stepper_move' into 'struct stepper'
     s->next_step_time += m->interval;
@@ -101,8 +105,7 @@ stepper_load_next(struct stepper *s, uint32_t min_next_time)
         s->position += m->count;
     }
 
-    s->first = m->next;
-    move_free(m);
+    mq_free_event(m);
     return SF_RESCHEDULE;
 }
 
@@ -191,7 +194,7 @@ command_config_stepper(uint32_t *args)
     s->dir_pin = gpio_out_setup(args[2], 0);
     s->min_stop_interval = args[3];
     s->position = -POSITION_BIAS;
-    move_request_size(sizeof(struct stepper_move));
+    mq_init(&s->queue, sizeof(struct stepper_move));
 }
 DECL_COMMAND(command_config_stepper,
              "config_stepper oid=%c step_pin=%c dir_pin=%c"
@@ -209,39 +212,35 @@ void
 command_queue_step(uint32_t *args)
 {
     struct stepper *s = stepper_oid_lookup(args[0]);
-    struct stepper_move *m = move_alloc();
-    m->interval = args[1];
-    m->count = args[2];
-    if (!m->count)
+    struct stepper_move *new_event = mq_alloc_event();
+    new_event->interval = args[1];
+    new_event->count = args[2];
+    if (!new_event->count)
         shutdown("Invalid count parameter");
-    m->add = args[3];
-    m->next = NULL;
-    m->flags = 0;
+    new_event->add = args[3];
+    new_event->flags = 0;
 
     irq_disable();
     uint8_t flags = s->flags;
     if (!!(flags & SF_LAST_DIR) != !!(flags & SF_NEXT_DIR)) {
         flags ^= SF_LAST_DIR;
-        m->flags |= MF_DIR;
+        new_event->flags |= MF_DIR;
     }
     flags &= ~SF_NO_NEXT_CHECK;
-    if (m->count == 1 && (m->flags || flags & SF_LAST_RESET))
+    if (new_event->count == 1 && (new_event->flags || flags & SF_LAST_RESET))
         // count=1 moves after a reset or dir change can have small intervals
         flags |= SF_NO_NEXT_CHECK;
     flags &= ~SF_LAST_RESET;
-    if (s->count) {
-        s->flags = flags;
-        if (s->first)
-            *s->plast = m;
-        else
-            s->first = m;
-        s->plast = &m->next;
-    } else if (flags & SF_NEED_RESET) {
-        move_free(m);
-    } else {
-        s->flags = flags;
-        s->first = m;
-        stepper_load_next(s, s->next_step_time + m->interval);
+    if (flags & SF_NEED_RESET) {
+        mq_free_event(new_event);
+        irq_enable();
+        return;
+    }
+
+    s->flags = flags;
+    mq_event_insert(&s->queue, &new_event->event);
+    if (!s->count) {
+        stepper_load_next(s, s->next_step_time + new_event->interval);
         sched_add_timer(&s->time);
     }
     irq_enable();
@@ -317,10 +316,9 @@ stepper_stop(struct stepper *s)
     s->flags = (s->flags & SF_INVERT_STEP) | SF_NEED_RESET;
     gpio_out_write(s->dir_pin, 0);
     gpio_out_write(s->step_pin, s->flags & SF_INVERT_STEP);
-    while (s->first) {
-        struct stepper_move *next = s->first->next;
-        move_free(s->first);
-        s->first = next;
+    struct mq_event* e;
+    while ((e = mq_event_pop(&s->queue))) {
+        mq_free_event(container_of(e, struct stepper_move, event));
     }
 }
 
@@ -330,7 +328,6 @@ stepper_shutdown(void)
     uint8_t i;
     struct stepper *s;
     foreach_oid(i, s, command_config_stepper) {
-        s->first = NULL;
         stepper_stop(s);
     }
 }


### PR DESCRIPTION
As planned in #3338, this is a MCU-only implementation for a generic queue to be used in pwm and set_pin.
Due to the lack of knowledge of other commands using the move queue (on `klippy/chelper/stepcompress.c`), I have implemented a workaround in `basecmd`:
`void move_request_size_unsynchronized(int size)` "reserves" a place in the move queue for every configured command using the generic queue.
Current python code does not send updates of new pin values before the other command was processed, so no more than one place may be used.

This is not needed anymore if `steppersync` gains knowledge of that in a next PR.

I print on this branch nearly for a week now without incidents. The fallback/timeout functionality was tested by setting a pin (fan) to a non-default value with a max duration and killing the klippy-process on the host.
