### PR TITLE
Wanhao Duplicator 6: Add output_pin for case lights

### DIFF
--- a/config/printer-wanhao-duplicator-6-2016.cfg
+++ b/config/printer-wanhao-duplicator-6-2016.cfg
@@ -105,3 +105,16 @@ lcd_type: ssd1306
 reset_pin: PE3
 encoder_pins: ^PG1, ^PG0
 click_pin: ^!PD2
+
+[output_pin caselight]
+pin: PH5
+value: 0
+pwm: True
+
+[gcode_macro LIGHTS_OFF]
+gcode:
+    SET_PIN PIN=caselight VALUE=0
+
+[gcode_macro LIGHTS_ON]
+gcode:
+    SET_PIN PIN=caselight VALUE=1


### PR DESCRIPTION
The Monoprice Maker Ultimate / Wanhao Duplicator 6 has case lights wired to PH5, this PR creates an `output_pin` named `CASE_LED_LIGHTS` to replace the Marlin `M355` functionality