### PR TITLE
print_stats:  exclude initialization time from "print_duration"

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,10 @@ All dates in this document are approximate.
 
 # Changes
 
+20201112: The time reported by `print_stats.print_duration` has
+changed.  The duration prior to the first detected extrusion is
+now excluded.
+
 20201029: The neopixel `color_order_GRB` config option has been
 removed. If necessary, update the config to set the new `color_order`
 option to RGB, GRB, RGBW, or GRBW.


### PR DESCRIPTION
As previously discussed, this excludes time spent prior to the first extrusion from `print_stats.print_duration`.  The result is a more accurate representation of the print duration in comparison to the time estimates generated by slicers.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com> 