### PR TITLE
Fix typo in bed leveling doc

### DIFF
--- a/docs/Bed_Level.md
+++ b/docs/Bed_Level.md
@@ -6,7 +6,7 @@ performing bed leveling in Klipper.
 
 It's important to understand the goal of bed leveling. If the printer
 is commanded to a position `X0 Y0 Z10` during a print, then the goal
-is for the printer's nozzle to be exactly 10mm from the printer's
+is for the printer's nozzle to be exactly 0.1mm from the printer's
 bed. Further, should the printer then be commanded to a position of
 `X50 Z10` the goal is for the nozzle to maintain an exact distance of
 10mm from the bed during that entire horizontal move.


### PR DESCRIPTION
I think I found a small error in the documentation of the nozzle height for Z=0 and I created that PR to correct this.