### PR TITLE
Change board_pins to use an explicit parameter to specify mcu name(s)

### DIFF
--- a/config/generic-replicape.cfg
+++ b/config/generic-replicape.cfg
@@ -155,7 +155,8 @@ aliases:
    SERVO_0=P9_14, SERVO_1=P9_16,
 
 [board_pins host]
-aliases:
+mcu: host
+aliases_foo:
    # Host aliases for Linux MCU
    HOST_X2_STOP=gpio30, HOST_Y2_STOP=gpio113, HOST_Z2_STOP=gpio4
    # Thermistors

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,12 @@ All dates in this document are approximate.
 
 # Changes
 
+20201120: The `[board_pins]` config section now specifies the mcu name
+in an explicit `mcu:` parameter.  If using board_pins for a secondary
+mcu, then the config must be updated to specify that name.  See the
+[config reference](Config_Reference.md#[board_pins]) for further
+details.
+
 20201112: The time reported by `print_stats.print_duration` has
 changed.  The duration prior to the first detected extrusion is
 now excluded.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1396,19 +1396,23 @@ software dependencies must be installed; refer to
 
 ## [board_pins]
 
-Board pin aliases. One may define aliases for the pins on a
-micro-controller. (If a micro-controller name is omitted in the
-board_pins config section name then it defaults to "mcu".)
+Board pin aliases (one may define any number of sections with a
+"board_pins" prefix). Use this to define aliases for the pins on a
+micro-controller.
 
 ```
-[board_pins mcu]
+[board_pins my_aliases]
+mcu: mcu
+#   A comma separated list of micro-controllers that may use the
+#   aliases. The default is to apply the aliases to the main "mcu".
 aliases:
+aliases_<name>:
 #   A comma separated list of "name=value" aliases to create for the
 #   given micro-controller. For example, "EXP1_1=PE6" would create an
 #   "EXP1_1" alias for the "PE6" pin. However, if "value" is enclosed
 #   in "<>" then "name" is created as a reserved pin (for example,
-#   "EXP1_9=<GND>" would reserve "EXP1_9"). This parameter must be
-#   provided.
+#   "EXP1_9=<GND>" would reserve "EXP1_9"). Any number of options
+#   starting with "aliases_" may be specified.
 ```
 
 ## [include]

--- a/klippy/extras/board_pins.py
+++ b/klippy/extras/board_pins.py
@@ -1,29 +1,36 @@
 # Support for custom board pin aliases
 #
-# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 class PrinterBoardAliases:
-    def __init__(self, config, chip_name):
+    def __init__(self, config):
         ppins = config.get_printer().lookup_object('pins')
-        pin_resolver = ppins.get_pin_resolver(chip_name)
-        aliases = config.get("aliases").strip()
-        if aliases.endswith(','):
-            aliases = aliases[:-1]
-        parts = [a.split('=', 1) for a in aliases.split(',')]
-        for pair in parts:
-            if len(pair) != 2:
-                raise ppins.error("Unable to parse aliases in %s"
-                                  % (config.get_name(),))
-            name, value = [s.strip() for s in pair]
-            if value.startswith('<') and value.endswith('>'):
-                pin_resolver.reserve_pin(name, value)
-            else:
-                pin_resolver.alias_pin(name, value)
+        mcu_names = [n.strip() for n in config.get('mcu', 'mcu').split(',')]
+        pin_resolvers = [ppins.get_pin_resolver(n) for n in mcu_names]
+        options = ["aliases"] + config.get_prefix_options("aliases_")
+        for opt in options:
+            aliases = config.get(opt, "").strip()
+            if not aliases:
+                continue
+            if aliases.endswith(','):
+                aliases = aliases[:-1]
+            parts = [a.split('=', 1) for a in aliases.split(',')]
+            for pair in parts:
+                if len(pair) != 2:
+                    raise ppins.error("Unable to parse aliases in %s"
+                                      % (config.get_name(),))
+                name, value = [s.strip() for s in pair]
+                if value.startswith('<') and value.endswith('>'):
+                    for pin_resolver in pin_resolvers:
+                        pin_resolver.reserve_pin(name, value)
+                else:
+                    for pin_resolver in pin_resolvers:
+                        pin_resolver.alias_pin(name, value)
 
 def load_config(config):
-    return PrinterBoardAliases(config, "mcu")
+    return PrinterBoardAliases(config)
 
 def load_config_prefix(config):
-    return PrinterBoardAliases(config, config.get_name().split()[1])
+    return PrinterBoardAliases(config)


### PR DESCRIPTION
This is a change to board_pins - the mcu that the aliases are applied to is changed to be configured via an explicit parameter instead of by the config section name.  This was discussed briefly in #3485 .

This may break some existing configs, but it should make configuring aliases easier in the future.

-Kevin
