### PR TITLE
config: Add printer-sunlu-s8-2020.cfg printer config

### DIFF
--- a/config/printer-sunlu-s8-2020.cfg
+++ b/config/printer-sunlu-s8-2020.cfg
@@ -1,0 +1,104 @@
+# This file contains pin mappings for the SUNLU S8 v1.01 (circa 2020), which
+# is a modified RAMPS v1.3 board. To use this config, the firmware should be
+# compiled for the AVR atmega2560. The following pins are available for
+# expansion (e.g. ABL): ^ar19 (Z+ endstop), ar4, ar5, ar6, ar11
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: ar54
+dir_pin: !ar55
+enable_pin: !ar38
+step_distance: .0125
+endstop_pin: ^!ar3
+position_endstop: 0
+position_max: 310
+homing_speed: 50
+
+[stepper_y]
+step_pin: ar60
+dir_pin: !ar61
+enable_pin: !ar56
+step_distance: .0125
+endstop_pin: ^!ar14
+position_endstop: 0
+position_max: 310
+homing_speed: 50
+
+[stepper_z]
+step_pin: ar46
+dir_pin: ar48
+enable_pin: !ar62
+step_distance: .0025
+endstop_pin: ^!ar18
+position_endstop: 0.5
+position_max: 400
+
+[extruder]
+step_pin: ar26
+dir_pin: !ar28
+enable_pin: !ar24
+step_distance: .0104
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+control: pid
+pid_kp: 25.588
+pid_ki: 1.496
+pid_kd: 109.388
+min_temp: 0
+max_temp: 250
+
+[filament_switch_sensor runout]
+pause_on_runout: True
+switch_pin: ^ar2
+
+[heater_bed]
+heater_pin: ar8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+control: pid
+pid_kp: 74.786
+pid_ki: 0.766
+pid_kd: 1825.718
+min_temp: 0
+max_temp: 110
+
+[verify_heater heater_bed]
+# The stock printer heats slowly due to a large bed and no external MOSFET.
+# This should be reduced if an external MOSFET is added to increase max_temp
+# and heating rate.
+check_gain_time: 240
+
+[fan]
+pin: ar9
+
+[heater_fan fan1]
+pin: ar7
+heater: extruder
+heater_temp: 50.0
+fan_speed: 1.0
+
+[mcu]
+serial: /dev/ttyUSB0
+pin_map: arduino
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 10
+max_z_accel: 100
+
+[display]
+lcd_type: st7920
+cs_pin: ar16
+sclk_pin: ar23
+sid_pin: ar17
+encoder_pins: ^ar33, ^ar31
+click_pin: ^!ar35
+
+[output_pin beeper]
+pin: ar37


### PR DESCRIPTION
Adds SUNLU S8 printer config  (successfully tested).

Signed-off-by: Justin Schuh <code@justinschuh.com>