### PR TITLE
WIP: Calibration guide specific to Klipper

### DIFF
--- a/docs/Calibration.md
+++ b/docs/Calibration.md
@@ -15,6 +15,7 @@ the limit is the plastic extrusion rate, and not the motion speed.
 
 In this guide we will try to give the basics and a summary of the Klipper
 specific features that can be used to calibrate your printer.
+
 Please try to follow the guide in order.
 
 We will refer to external documentation to supplement this, but some of the
@@ -30,21 +31,22 @@ config file is successfully loaded.
 
 
 
-# Mechanical tuning
+# Mechanical checks, maintenance and basic/common tuning
+
+Here we go over some of the basic and common checks and calibrations that
+one often needs to do with a 3D Printer.
 
 
 ## Check the mechanical aspects of your printer
 
 First you need to ensure that your printer is physically well set up.
 
-### Frame maintenance
-
-Verify that the following is all good:
-
-* Tighten screws
-* Frame stiffness: if in question add corner stiffening measures
-* Check linear movement components: play, friction, smoothness, greasing, etc…
-* Check to see that the idlers are not on a bent rod.
+* Ensure that all the screws are tight.
+* Verify that the linear motion parts of your printer is not bent, and the
+  linear bearings move smoothly. If they are not adequately smooth, try and
+  lubricate it with the appropriate lubricant (TODO: Reccomend some lubricants, Grease: PTFE/Lithium, Oils: Silicon/Mineral).
+  If you have V-Slot wheels, ensure that the eccentric nut is rotated so that
+  the wheels are firmly against the frame but not so tight it constricts movement. (TODO: Add qualification as to how tight is recommended)
 * Ensure that the pulleys are centered on the stepper motors correctly.
 * Ensure that the belt, pulleys and idlers are straight. if they are misaligned
   you will get similar issues as an overtight belt, where the belt repeatedly
@@ -54,100 +56,104 @@ Verify that the following is all good:
   For most printers, if you pluck them they should like a bass guitar.
 
 
-### Electronics & safety
+## Check your Electronics
 
-Also, on the electronics:
+Common checks on your electronics
 
-* Ensure that all the electronics are cool. If any of the stepper motors, or
-  the control circuitry is too hot to keep your finger on it will cause issues.
-* Verify that your wiring is in good order, and has strain relief applied on
-  moving parts. It's better that the wiring doesn't bend near a plug, and best
-  if the movement is over a large portion of the cabling so that you don't
-  develop a weak spot.
-* An undersized powersupply can cause all kinds of intermittent print quality
-  issues, such as irregular underextrusion or temperature fluctuations.
-  Diagnosing and fixing such issues is outside of the scope of this guide.
-
-
-Even though Klipper does its best to ensure safety by detecting common failure
-issues that could be dangerous and caused by machine failure, you are dealing
-with a high-power device. Ensure you have a strategy to manage a dangerous
-situation if any develops.
-
-Have a smoke detector installed correctly near your 3D printer so you can catch
-any fires early enough if they occur before any real damage gets done.
-
-It's best if you have some insulation on your hotend and heated bed.
-This will allow much more consistent temperatures, and help prevent burning
-your fingers accidentally.
+* Ensure that all the electronics are cool enough. If any of the stepper
+  motors, or the control circuitry is too hot to keep your finger on it,
+  it will cause issues.
+  In that case, please consider tuning your stepper current. (TODO: Link to guides re stepper current set-up)
+* It's best if you have some insulation on your heated parts,
+  such as a silicone sock over the hotend and insulation under the heated bed.
+  This will allow much more consistent temperatures.
+  If you change the insulation on your heated parts, please remember to
+  do PID autotuning (TODO: Link to pid_autotune section)
 
 
 ## PID autotuning
 
-TODO
+TODO: Link to PID autotuning in Config Checks
 
 
 ## Bed levelling
 
-TODO
+[Bed levelling](Bed_Level.md)
 
- or Resonance Compensation
 
 # A good time to do a baseline print
 
-TODO
+Now that your printer should be basically working, it's a good idea to have a baseline print.
+TODO: Link to various small/good test prints (e.g. test cube)
 
 
 
 # Extrusion tuning
 
+TODO: Describe the purpose of this section
 
 ## Extruder step calibration (coarse)
 
-TODO
+TODO: Link to section in Config Checks
+TODO: Link to https://reprap.org/wiki/Triffid_Hunter%27s_Calibration_Guide#E_steps
 
 
 ## Slicer flow calbiration (fine)
 
-TODO
+TODO: Mention that this is a slicer configuration that is unique to your printer
+TODO: Mention SuperSlicer's calibration print
+TODO: Mention https://reprap.org/wiki/Triffid_Hunter%27s_Calibration_Guide#E_Steps_Fine_Tuning
+TODO: Links to https://3dprintbeginner.com/flow-rate-calibration/ and https://teachingtechyt.github.io/calibration.html#flow
+TODO: Mention that one can (and probably should) update the extruder steps so that one can just print at 100% flow.
 
 
 
 # Determining the safe maximum print speed
 
+TODO: Describe the purpose of this section
 
 ## Determine maximum feedrate of your hot-end
 
-TODO
+TODO: Links to https://teachingtechyt.github.io/calibration.html#accel - Calculating maximum feedrate - optional
+Consider updating this
 
 
 ## Maximum safe acceleration
 
-TODO
+TODO: Ringing? Should we just get to an acceptable level here, and mention that one can may get better results using Resonance Compensation (which is definitely an advanced tuning process)
+TODO: Vibration cube?
 
 
 ### On `square_corner_velocity`
 
-TODO
+TODO: Describe what it does
+TODO: Compare it to Jerk
+
 
 
 # Fine tuning
 
-
-## Resonance Compensation
-
-TODO
+TODO: Describe the purpose of this section
 
 
 ## Pressure Advance
 
-TODO
+[Pressure Advance](Pressure_Advance.md)
 
 
 ## Retraction tuning
 
-TODO
+TODO: Could we do a calibration util to generate a good retraction tower?
+TODO: Mention other retraction towers (e.g. teaching tech, SuperSlicer, etc?)
 
+
+
+# Advanced tuning
+
+
+## Resonance Compensation
+
+[Resonance Compensation](Resonance_Compensation.md)
 
 
 # All done!

--- a/docs/Calibration.md
+++ b/docs/Calibration.md
@@ -1,0 +1,155 @@
+This document provides a list of steps one could do to ensure their
+3D printer is calibrated to the best of it's ability.
+
+This guide assumes the printer is in a working state, if not please follow
+the [Config Checks](Config_checks.md) first.
+
+Klipper is a great way to get good performance out of any FDM printer.
+Just about any printer you should be able to get good results at between
+60-80mm/s with a standard 0.4mm nozzle. Often on the lower-spec machines
+the limit is the plastic extrusion rate, and not the motion speed.
+
+
+
+# How to use this guide
+
+In this guide we will try to give the basics and a summary of the Klipper
+specific features that can be used to calibrate your printer.
+Please try to follow the guide in order.
+
+We will refer to external documentation to supplement this, but some of the
+external documentation may not be directly applicable to a Klipper setup.
+We will indicate which portions of the documentation is directly usable.
+
+During this guide, it may be necessary to make changes to the Klipper
+config file. Be sure to issue a RESTART command after every change to
+the config file to ensure that the change takes effect (type "restart"
+in the Octoprint terminal tab and then click "Send"). It's also a good
+idea to issue a STATUS command after every RESTART to verify that the
+config file is successfully loaded.
+
+
+
+# Mechanical tuning
+
+
+## Check the mechanical aspects of your printer
+
+First you need to ensure that your printer is physically well set up.
+
+### Frame maintenance
+
+Verify that the following is all good:
+
+* Tighten screws
+* Frame stiffness: if in question add corner stiffening measures
+* Check linear movement components: play, friction, smoothness, greasing, etc…
+* Check to see that the idlers are not on a bent rod.
+* Ensure that the pulleys are centered on the stepper motors correctly.
+* Ensure that the belt, pulleys and idlers are straight. if they are misaligned
+  you will get similar issues as an overtight belt, where the belt repeatedly
+  catches on the lip of the pulley.
+* The tension in the belts need to be "not too tight, not too loose".
+  They should not be able to slip or wiggle around.
+  For most printers, if you pluck them they should like a bass guitar.
+
+
+### Electronics & safety
+
+Also, on the electronics:
+
+* Ensure that all the electronics are cool. If any of the stepper motors, or
+  the control circuitry is too hot to keep your finger on it will cause issues.
+* Verify that your wiring is in good order, and has strain relief applied on
+  moving parts. It's better that the wiring doesn't bend near a plug, and best
+  if the movement is over a large portion of the cabling so that you don't
+  develop a weak spot.
+* An undersized powersupply can cause all kinds of intermittent print quality
+  issues, such as irregular underextrusion or temperature fluctuations.
+  Diagnosing and fixing such issues is outside of the scope of this guide.
+
+
+Even though Klipper does its best to ensure safety by detecting common failure
+issues that could be dangerous and caused by machine failure, you are dealing
+with a high-power device. Ensure you have a strategy to manage a dangerous
+situation if any develops.
+
+Have a smoke detector installed correctly near your 3D printer so you can catch
+any fires early enough if they occur before any real damage gets done.
+
+It's best if you have some insulation on your hotend and heated bed.
+This will allow much more consistent temperatures, and help prevent burning
+your fingers accidentally.
+
+
+## PID autotuning
+
+TODO
+
+
+## Bed levelling
+
+TODO
+
+ or Resonance Compensation
+
+# A good time to do a baseline print
+
+TODO
+
+
+
+# Extrusion tuning
+
+
+## Extruder step calibration (coarse)
+
+TODO
+
+
+## Slicer flow calbiration (fine)
+
+TODO
+
+
+
+# Determining the safe maximum print speed
+
+
+## Determine maximum feedrate of your hot-end
+
+TODO
+
+
+## Maximum safe acceleration
+
+TODO
+
+
+### On `square_corner_velocity`
+
+TODO
+
+
+# Fine tuning
+
+
+## Resonance Compensation
+
+TODO
+
+
+## Pressure Advance
+
+TODO
+
+
+## Retraction tuning
+
+TODO
+
+
+
+# All done!
+
+TODO


### PR DESCRIPTION
This is my WIP attempt at compiling a calibration guide, specifically for Klipper.

The guide is still very raw, and is still missing much content or proper integration with the existing docs.

I don't want to duplicate any of the existing docs that we already have, so will probably break this up into an index document,and then sub-documents.
To make it "flow" with the existing docs I will very likely have to restructure existing parts of `Overview.md`.

I also haven't properly considered the implications of referring to external guides. For example Triffid Hunter's guide on reprap, or Teaching Tech or 3D Print Beginner guides which are all excellent resources (some of which are Marlin-specific in part)

Do I add a qualification to indicate the Marlin specific parts that should be ignored? Should I just point to the exact information and trust that the reader doesn't go ahead and try to run some Marlin Specific gcode that fails and then logs an issue that our docs are wrong?
Is it even allowed? I'm not seeing external references in the current docs?

This will take some time to hash out properly, and I'd love lots of info and ideas to make this a good starting point for anyone. :slightly_smiling_face: 

This was primarily motivated by my struggles to get some of the basics like a good first layer dialed in with manual bed levelling and Klipper (which was so different from the Marlin experience that it was actually a revelation when I finally figured out the right way).
Also my struggles with getting good Resonance Compensation with acceptably little smoothing (https://github.com/KevinOConnor/klipper/issues/3027) to requests about tuning (https://github.com/KevinOConnor/klipper/issues/3592) and some interesting discussions (https://github.com/KevinOConnor/klipper/issues/3596)

DONE:
* [x] Tuning outline
* [ ] Restructure index
* [x] Mechanical checks
* [ ] PID
* [ ] Bed levelling
  * [ ] Current bed levelling doc assumes no significant Z-backlash, which is a naïve assumption (and wrong for my printer)
* [ ] Extruder step calibration
* [ ] Slicer flow calibration
  * [ ] How is TT doing it badly? What is the correct way?
* [ ] Safe max print speed
  * [ ] Softer filaments such as Nylon/TPU flows much worse when there is backpressure (such as when printing)
* [ ] square_corner_velocity (equivalent of jerk)
* [ ] Pressure advance
* [ ] Retraction tuning
* [ ] Resonance compensation
  * [ ] Mention that this may reduce fine details, and is mostly recommended for when you're battling with resonances.

Signed-off-by: Nickolas Grigoriadis <nagrigoriadis@gmail.com>