### PR TITLE
bltouch: Recommend using a pullup on the sensor_pin

### DIFF
--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -10,11 +10,13 @@ Hook up the BL-Touch "servo" connector to a `control_pin` according to
 the BL-Touch documentation or your MCU documentation. Using the
 original wiring, the yellow wire from the triple is the `control_pin`
 and the white wire from the pair is the `sensor_pin`. You need to
-configure these pins according to your wiring. For example:
+configure these pins according to your wiring. Most BL-Touch devices
+require a pullup on the sensor pin (prefix the pin name with "^"). For
+example:
 
 ```
 [bltouch]
-sensor_pin: P1.24
+sensor_pin: ^P1.24
 control_pin: P1.26
 ```
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1552,8 +1552,9 @@ section for the details).
 ```
 [bltouch]
 sensor_pin:
-#   Pin connected to the BLTouch sensor pin. This parameter must be
-#   provided.
+#   Pin connected to the BLTouch sensor pin. Most BLTouch devices
+#   require a pullup on the sensor pin (prefix the pin name with "^").
+#   This parameter must be provided.
 control_pin:
 #   Pin connected to the BLTouch control pin. This parameter must be
 #   provided.


### PR DESCRIPTION
@FanDjango - I've seen a few Klipper issues where users get confusing results because they fail to set a pullup on the bltouch sensor_pin.  My general understanding is that it is safe to always define the sensor_pin with a pullup.  (And in some cases it is required.)  However, given the large number of bltouch revisions and clones, I'm not a 100% sure of this, so I've been reluctant to change the documentation to state it.  Would you know if it's safe to recommend always setting the pullup?

Thanks,
-Kevin