### PR TITLE
config: Add example printer-twotrees-sapphire-plus-2020.cfg config

### DIFF
--- a/config/printer-twotrees-sapphire-plus-2020.cfg
+++ b/config/printer-twotrees-sapphire-plus-2020.cfg
@@ -1,0 +1,99 @@
+# This file contains common pin mappings for the Two Trees Sapphire
+# Plus printer from 2020 (revision 2 with dual Z axis).
+
+# To use this config, the firmware should be compiled for the STM32F103.
+# When running "make menuconfig" you have to:
+# - enable "extra low-level configuration setup",
+# - select the 28KiB bootloader,
+# - disable "USB for communication"
+# - select USART3 for the "Serial Port"
+# - set "GPIO pins to set at micro-controller startup" to "!PC6,!PD13"
+
+# Note that the "make flash" command does not work with the Sapphire
+# Pro. After running "make", run the following command:
+#   ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano35.bin
+# Copy the file out/Robin_nano35.bin to an SD card and then restart the
+# printer with that SD card.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PE3
+dir_pin: !PE2
+enable_pin: !PE4
+step_distance: .01
+endstop_pin: !PA15
+position_endstop: 0
+position_max: 300
+homing_speed: 50
+
+[stepper_y]
+step_pin: PE0
+dir_pin: !PB9
+enable_pin: !PE1
+step_distance: .01
+endstop_pin: !PA12
+position_endstop: 300
+position_max: 300
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB5
+dir_pin: PB4
+enable_pin: !PB8
+step_distance: .0025
+endstop_pin: !PA11
+position_endstop: 0
+position_max: 340
+
+[stepper_z1]
+step_pin: PA6
+dir_pin: PA1
+enable_pin: !PA3
+step_distance: .0025
+endstop_pin: !PC4
+
+[extruder]
+step_pin: PD6
+dir_pin: !PD3
+enable_pin: !PB3
+step_distance: .0021
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC3
+sensor_type: EPCOS 100K B57560G104F # Stock
+sensor_pin: PC1
+min_temp: 0
+max_temp: 250
+control: pid
+pid_Kp: 17.48
+pid_Ki: 1.32
+pid_Kd: 57.81
+
+[heater_bed]
+heater_pin: PA0
+sensor_type: EPCOS 100K B57560G104F # Stock
+sensor_pin: PC0
+min_temp: 0
+max_temp: 130
+control: pid
+pid_Kp: 325.10
+pid_Ki: 63.35
+pid_Kd: 417.10
+
+[fan]
+pin: PB1
+
+[mcu]
+serial: /dev/ttyUSB0
+restart_method: command
+
+[printer]
+kinematics: corexy
+max_velocity: 250
+max_accel: 4500
+max_z_velocity: 25
+max_z_accel: 100
+
+[static_digital_output reset_display]
+pins: !PC6, !PD13

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -133,6 +133,7 @@ CONFIG ../../config/printer-creality-ender3-v2-2020.cfg
 CONFIG ../../config/printer-creality-ender3pro-2020.cfg
 CONFIG ../../config/printer-tronxy-x5sa-v6-2019.cfg
 CONFIG ../../config/printer-twotrees-sapphire-pro-2020.cfg
+CONFIG ../../config/printer-twotrees-sapphire-plus-2020.cfg
 
 # Printers using the stm32f407
 DICTIONARY stm32f407.dict


### PR DESCRIPTION
Based on config for Sapphire Pro but adapted for Sapphire Plus.