### PR TITLE
Replace step_distance with rotation_distance

### DIFF
--- a/config/example-cartesian.cfg
+++ b/config/example-cartesian.cfg
@@ -11,7 +11,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .0225
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar3
 position_endstop: 0
 position_max: 200
@@ -20,7 +21,8 @@ position_max: 200
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-step_distance: .0225
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar14
 position_endstop: 0
 position_max: 200
@@ -29,7 +31,8 @@ position_max: 200
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .005
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar18
 position_endstop: 0.5
 position_max: 200
@@ -38,7 +41,8 @@ position_max: 200
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .004242
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.500
 filament_diameter: 3.500
 heater_pin: ar10

--- a/config/example-corexy.cfg
+++ b/config/example-corexy.cfg
@@ -11,7 +11,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar3
 position_endstop: 0
 position_max: 200
@@ -21,7 +22,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar14
 position_endstop: 0
 position_max: 200
@@ -31,7 +33,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar18
 position_endstop: 0.5
 position_max: 200
@@ -40,7 +43,8 @@ position_max: 200
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .0022
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/example-corexz.cfg
+++ b/config/example-corexz.cfg
@@ -10,7 +10,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar3
 position_endstop: 0
 position_max: 200
@@ -20,7 +21,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar14
 position_endstop: 0
 position_max: 200
@@ -30,7 +32,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar18
 position_endstop: 0.5
 position_max: 200
@@ -39,7 +42,8 @@ position_max: 200
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .0022
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/example-delta.cfg
+++ b/config/example-delta.cfg
@@ -10,7 +10,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar2
 homing_speed: 50
 position_endstop: 297.05
@@ -20,21 +21,24 @@ arm_length: 333.0
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar15
 
 [stepper_c]
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar19
 
 [extruder]
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .0022
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/example-polar.cfg
+++ b/config/example-polar.cfg
@@ -17,7 +17,8 @@ gear_ratio: 80:16
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar14
 position_endstop: 300
 position_max: 300
@@ -27,7 +28,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar18
 position_endstop: 0.5
 position_max: 200
@@ -36,7 +38,8 @@ position_max: 200
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .0022
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/example-polar.cfg
+++ b/config/example-polar.cfg
@@ -10,7 +10,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: 0.001963495
+microsteps: 16
+gear_ratio: 80:16
 
 [stepper_arm]
 step_pin: ar60

--- a/config/example-rotary-delta.cfg
+++ b/config/example-rotary-delta.cfg
@@ -10,7 +10,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: 0.001963495
+microsteps: 16
+gear_ratio: 107.000:16, 60:16
 endstop_pin: ^ar2
 homing_speed: 50
 position_endstop: 252
@@ -21,14 +22,16 @@ lower_arm_length: 320.000
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: 0.001963495
+microsteps: 16
+gear_ratio: 107.000:16, 60:16
 endstop_pin: ^ar15
 
 [stepper_c]
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: 0.001963495
+microsteps: 16
+gear_ratio: 107.000:16, 60:16
 endstop_pin: ^ar19
 
 [extruder]

--- a/config/example-rotary-delta.cfg
+++ b/config/example-rotary-delta.cfg
@@ -38,7 +38,8 @@ endstop_pin: ^ar19
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .0022
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/example-winch.cfg
+++ b/config/example-winch.cfg
@@ -14,7 +14,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 anchor_x: 0
 anchor_y: -2000
 anchor_z: -100
@@ -23,7 +24,8 @@ anchor_z: -100
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 anchor_x: 2000
 anchor_y: 1000
 anchor_z: -100
@@ -32,7 +34,8 @@ anchor_z: -100
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 anchor_x: -2000
 anchor_y: 1000
 anchor_z: -100
@@ -41,7 +44,8 @@ anchor_z: -100
 step_pin: ar36
 dir_pin: ar34
 enable_pin: !ar30
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 anchor_x: 0
 anchor_y: 0
 anchor_z: 3000
@@ -50,7 +54,8 @@ anchor_z: 3000
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .0022
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/generic-archim2.cfg
+++ b/config/generic-archim2.cfg
@@ -8,7 +8,8 @@
 step_pin: PC6
 dir_pin: PC5
 enable_pin: !PC9
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PD4
 position_endstop: 0
 position_max: 200
@@ -16,7 +17,6 @@ homing_speed: 50
 
 [tmc2130 stepper_x]
 cs_pin: PC7
-microsteps: 16
 run_current: .5
 sense_resistor: 0.120
 diag1_pin: !PA4
@@ -28,7 +28,8 @@ spi_software_miso_pin: PD1
 step_pin: PC12
 dir_pin: PC11
 enable_pin: !PC14
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PD6
 position_endstop: 0
 position_max: 400
@@ -36,7 +37,6 @@ homing_speed: 50
 
 [tmc2130 stepper_y]
 cs_pin: PC13
-microsteps: 16
 run_current: .5
 sense_resistor: 0.120
 diag1_pin: !PC15
@@ -48,7 +48,8 @@ spi_software_miso_pin: PD1
 step_pin: PC17
 dir_pin: PC16
 enable_pin: !PC19
-step_distance: .0125
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PA7
 position_endstop: 0
 position_max: 400
@@ -56,7 +57,6 @@ homing_speed: 50
 
 [tmc2130 stepper_z]
 cs_pin: PC18
-microsteps: 16
 run_current: .5
 sense_resistor: 0.120
 diag1_pin: PC4
@@ -68,7 +68,8 @@ spi_software_miso_pin: PD1
 step_pin: PB10
 dir_pin: PC10
 enable_pin: !PB22
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC24
@@ -83,7 +84,6 @@ max_temp: 250
 
 [tmc2130 extruder]
 cs_pin: PC20
-microsteps: 16
 run_current: .5
 sense_resistor: 0.120
 diag1_pin: !PB23
@@ -95,7 +95,8 @@ spi_software_miso_pin: PD1
 #step_pin: PB26
 #dir_pin: PB24
 #enable_pin: !PA11
-#step_distance: .002
+#microsteps: 16
+#rotation_distance: 33.500
 #nozzle_diameter: 0.400
 #filament_diameter: 1.750
 #heater_pin: PC23
@@ -110,7 +111,6 @@ spi_software_miso_pin: PD1
 
 #[tmc2130 extruder1]
 #cs_pin: PA10
-#microsteps: 16
 #run_current: .5
 #sense_resistor: 0.120
 #diag1_pin: PD0

--- a/config/generic-azteeg-x5-mini-v3.cfg
+++ b/config/generic-azteeg-x5-mini-v3.cfg
@@ -7,7 +7,8 @@
 step_pin: P2.1
 dir_pin: P0.11
 enable_pin: !P0.10
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P1.24
 position_endstop: 0
 position_max: 200
@@ -17,7 +18,8 @@ homing_speed: 50
 step_pin: P2.2
 dir_pin: P0.20
 enable_pin: !P0.19
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P1.26
 position_endstop: 0
 position_max: 200
@@ -27,7 +29,8 @@ homing_speed: 50
 step_pin: P2.3
 dir_pin: P0.22
 enable_pin: !P0.21
-step_distance: .0125
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^P1.28
 position_endstop: 0
 position_max: 200
@@ -37,7 +40,8 @@ homing_speed: 50
 step_pin: P2.0
 dir_pin: P0.5
 enable_pin: !P0.4
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: P2.5

--- a/config/generic-bigtreetech-gtr.cfg
+++ b/config/generic-bigtreetech-gtr.cfg
@@ -13,7 +13,8 @@
 step_pin: PC15
 dir_pin: PF0
 enable_pin: !PF1
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PF2
 position_endstop: 0
 position_max: 220
@@ -23,7 +24,8 @@ homing_speed: 50
 step_pin: PE3
 dir_pin: PE2
 enable_pin: !PE4
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC13
 position_endstop: 0
 position_max: 250
@@ -33,7 +35,8 @@ homing_speed: 50
 step_pin: PB8
 dir_pin: PB7
 enable_pin: !PB9
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PE0
 position_endstop: 0
 position_max: 200
@@ -44,7 +47,8 @@ second_homing_speed: 1
 step_pin: PG12
 dir_pin: PG11
 enable_pin: !PG13
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB1 # Heat0
@@ -114,42 +118,36 @@ max_z_accel: 5
 
 #[tmc2208 stepper_x]
 #uart_pin: PC14
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_y]
 #uart_pin: PE1
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_z]
 #uart_pin: PB5
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
 
 #[tmc2208 extruder]
 #uart_pin: PG10
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder1]
 #uart_pin: PD4
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder2]
 #uart_pin: PC12
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -161,7 +159,6 @@ max_z_accel: 5
 
 #[tmc2130 stepper_x]
 #cs_pin: PC14
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 0
@@ -171,7 +168,6 @@ max_z_accel: 5
 
 #[tmc2130 stepper_y]
 #cs_pin: PE1
-#microsteps: 16
 #sense_resistor: 0.075
 #run_current: 0.800
 #hold_current: 0.500
@@ -182,7 +178,6 @@ max_z_accel: 5
 
 #[tmc2130 stepper_z]
 #cs_pin: PB5
-#microsteps: 16
 #sense_resistor: 0.075
 #run_current: 0.650
 #hold_current: 0.450
@@ -193,7 +188,6 @@ max_z_accel: 5
 
 #[tmc2130 extruder]
 #cs_pin: PG10
-#microsteps: 16
 #sense_resistor: 0.075
 #run_current: 0.800
 #hold_current: 0.500
@@ -204,7 +198,6 @@ max_z_accel: 5
 
 #[tmc2130 extruder1]
 #cs_pin: PD4
-#microsteps: 16
 #sense_resistor: 0.075
 #run_current: 0.800
 #hold_current: 0.500
@@ -215,7 +208,6 @@ max_z_accel: 5
 
 #[tmc2130 extruder2]
 #cs_pin: PC12
-#microsteps: 16
 #sense_resistor: 0.075
 #run_current: 0.800
 #hold_current: 0.500
@@ -230,7 +222,6 @@ max_z_accel: 5
 
 #[tmc5160 stepper_x]
 #cs_pin: PC14
-#microsteps: 16
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 1
@@ -242,7 +233,6 @@ max_z_accel: 5
 
 #[tmc5160 stepper_y]
 #cs_pin: PE1
-#microsteps: 16
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 1
@@ -254,7 +244,6 @@ max_z_accel: 5
 
 #[tmc5160 stepper_z]
 #cs_pin: PB5
-#microsteps: 16
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 0.4
@@ -266,7 +255,6 @@ max_z_accel: 5
 
 #[tmc5160 extruder]
 #cs_pin: PG10
-#microsteps: 16
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 0.5
@@ -278,7 +266,6 @@ max_z_accel: 5
 
 #[tmc5160 extruder1]
 #cs_pin: PD4
-#microsteps: 16
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 0.800
@@ -290,7 +277,6 @@ max_z_accel: 5
 
 #[tmc5160 extruder2]
 #cs_pin: PC12
-#microsteps: 16
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 0.800

--- a/config/generic-bigtreetech-skr-e3-dip.cfg
+++ b/config/generic-bigtreetech-skr-e3-dip.cfg
@@ -15,7 +15,8 @@
 step_pin: PC6
 dir_pin: !PB15
 enable_pin: !PC7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC1
 position_endstop: 0
 position_max: 235
@@ -25,7 +26,8 @@ homing_speed: 50
 step_pin: PB13
 dir_pin: !PB12
 enable_pin: !PB14
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC0
 position_endstop: 0
 position_max: 235
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PB10
 dir_pin: PB2
 enable_pin: !PB11
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC15
 position_endstop: 0.0
 position_max: 250
@@ -44,7 +47,8 @@ position_max: 250
 step_pin: PB0
 dir_pin: !PC5
 enable_pin: !PB1
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
@@ -91,28 +95,24 @@ pins: !PC13
 
 #[tmc2208 stepper_x]
 #uart_pin: PC10
-#microsteps: 16
 #run_current: 0.580
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_y]
 #uart_pin: PC11
-#microsteps: 16
 #run_current: 0.580
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_z]
 #uart_pin: PC12
-#microsteps: 16
 #run_current: 0.580
 #hold_current: 0.500
 #stealthchop_threshold: 30
 
 #[tmc2208 extruder]
 #uart_pin: PD2
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -125,7 +125,6 @@ pins: !PC13
 #[tmc2130 stepper_x]
 #cs_pin: PC10
 #spi_bus: spi3
-#microsteps: 16
 #run_current: 0.580
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -133,7 +132,6 @@ pins: !PC13
 #[tmc2130 stepper_y]
 #cs_pin: PC11
 #spi_bus: spi3
-#microsteps: 16
 #run_current: 0.580
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -141,7 +139,6 @@ pins: !PC13
 #[tmc2130 stepper_z]
 #cs_pin: PC12
 #spi_bus: spi3
-#microsteps: 16
 #run_current: 0.580
 #hold_current: 0.450
 #stealthchop_threshold: 30
@@ -149,7 +146,6 @@ pins: !PC13
 #[tmc2130 extruder]
 #cs_pin: PD2
 #spi_bus: spi3
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.500
 #stealthchop_threshold: 5

--- a/config/generic-bigtreetech-skr-mini-e3-v1.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v1.0.cfg
@@ -15,7 +15,8 @@
 step_pin: PB13
 dir_pin: !PB12
 enable_pin: !PB14
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC0
 position_endstop: 0
 position_max: 235
@@ -25,7 +26,6 @@ homing_speed: 50
 uart_pin: PC11
 tx_pin: PC10
 uart_address: 0
-microsteps: 16
 run_current: 0.580
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -34,7 +34,8 @@ stealthchop_threshold: 250
 step_pin: PB10
 dir_pin: !PB2
 enable_pin: !PB11
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC1
 position_endstop: 0
 position_max: 235
@@ -44,7 +45,6 @@ homing_speed: 50
 uart_pin: PC11
 tx_pin: PC10
 uart_address: 2
-microsteps: 16
 run_current: 0.580
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -53,7 +53,8 @@ stealthchop_threshold: 250
 step_pin: PB0
 dir_pin: PC5
 enable_pin: !PB1
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC2
 position_endstop: 0.0
 position_max: 250
@@ -62,7 +63,6 @@ position_max: 250
 uart_pin: PC11
 tx_pin: PC10
 uart_address: 1
-microsteps: 16
 run_current: 0.580
 hold_current: 0.500
 stealthchop_threshold: 5
@@ -71,7 +71,8 @@ stealthchop_threshold: 5
 step_pin: PB3
 dir_pin: !PB4
 enable_pin: !PD2
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
@@ -88,7 +89,6 @@ max_temp: 250
 uart_pin: PC11
 tx_pin: PC10
 uart_address: 3
-microsteps: 16
 run_current: 0.650
 hold_current: 0.500
 stealthchop_threshold: 5

--- a/config/generic-bigtreetech-skr-mini-e3-v1.2.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v1.2.cfg
@@ -15,7 +15,8 @@
 step_pin: PB13
 dir_pin: !PB12
 enable_pin: !PB14
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC0
 position_endstop: 0
 position_max: 235
@@ -23,7 +24,6 @@ homing_speed: 50
 
 [tmc2209 stepper_x]
 uart_pin: PB15
-microsteps: 16
 run_current: 0.580
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -32,7 +32,8 @@ stealthchop_threshold: 250
 step_pin: PB10
 dir_pin: !PB2
 enable_pin: !PB11
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC1
 position_endstop: 0
 position_max: 235
@@ -40,7 +41,6 @@ homing_speed: 50
 
 [tmc2209 stepper_y]
 uart_pin: PC6
-microsteps: 16
 run_current: 0.580
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -49,14 +49,14 @@ stealthchop_threshold: 250
 step_pin: PB0
 dir_pin: PC5
 enable_pin: !PB1
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC2
 position_endstop: 0.0
 position_max: 250
 
 [tmc2209 stepper_z]
 uart_pin: PC10
-microsteps: 16
 run_current: 0.580
 hold_current: 0.500
 stealthchop_threshold: 5
@@ -65,7 +65,8 @@ stealthchop_threshold: 5
 step_pin: PB3
 dir_pin: !PB4
 enable_pin: !PD2
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
@@ -80,7 +81,6 @@ max_temp: 250
 
 [tmc2209 extruder]
 uart_pin: PC11
-microsteps: 16
 run_current: 0.650
 hold_current: 0.500
 stealthchop_threshold: 5

--- a/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
@@ -15,7 +15,8 @@
 step_pin: PB13
 dir_pin: !PB12
 enable_pin: !PB14
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC0
 position_endstop: 0
 position_max: 235
@@ -25,7 +26,6 @@ homing_speed: 50
 uart_pin: PC11
 tx_pin: PC10
 uart_address: 0
-microsteps: 16
 run_current: 0.580
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -34,7 +34,8 @@ stealthchop_threshold: 250
 step_pin: PB10
 dir_pin: !PB2
 enable_pin: !PB11
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC1
 position_endstop: 0
 position_max: 235
@@ -44,7 +45,6 @@ homing_speed: 50
 uart_pin: PC11
 tx_pin: PC10
 uart_address: 2
-microsteps: 16
 run_current: 0.580
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -53,7 +53,8 @@ stealthchop_threshold: 250
 step_pin: PB0
 dir_pin: PC5
 enable_pin: !PB1
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC2
 position_endstop: 0.0
 position_max: 250
@@ -62,7 +63,6 @@ position_max: 250
 uart_pin: PC11
 tx_pin: PC10
 uart_address: 1
-microsteps: 16
 run_current: 0.580
 hold_current: 0.500
 stealthchop_threshold: 5
@@ -71,7 +71,8 @@ stealthchop_threshold: 5
 step_pin: PB3
 dir_pin: !PB4
 enable_pin: !PD2
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
@@ -88,7 +89,6 @@ max_temp: 250
 uart_pin: PC11
 tx_pin: PC10
 uart_address: 3
-microsteps: 16
 run_current: 0.650
 hold_current: 0.500
 stealthchop_threshold: 5

--- a/config/generic-bigtreetech-skr-mini.cfg
+++ b/config/generic-bigtreetech-skr-mini.cfg
@@ -13,7 +13,8 @@
 step_pin: PC6
 dir_pin: PC7
 enable_pin: !PB15
-step_distance: .0025
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PC2 # X+ is PA2
 position_endstop: 0
 position_max: 200
@@ -23,7 +24,8 @@ homing_speed: 50
 step_pin: PB13
 dir_pin: PB14
 enable_pin: !PB12
-step_distance: .0025
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PC1 # Y+ is PA1
 position_endstop: 0
 position_max: 200
@@ -33,7 +35,8 @@ homing_speed: 50
 step_pin: PB10
 dir_pin: PB11
 enable_pin: !PB2
-step_distance: .0125
+microsteps: 16
+rotation_distance: 8
 endstop_pin: PC0 # Z+ is PC3
 position_endstop: 0.5
 position_max: 200
@@ -42,7 +45,8 @@ position_max: 200
 step_pin: PC5
 dir_pin: PB0
 enable_pin: !PC4
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PA8

--- a/config/generic-bigtreetech-skr-pro.cfg
+++ b/config/generic-bigtreetech-skr-pro.cfg
@@ -13,7 +13,8 @@
 step_pin: PE9
 dir_pin: PF1
 enable_pin: !PF2
-step_distance: .0025
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PB10
 position_endstop: 0
 position_max: 200
@@ -23,7 +24,8 @@ homing_speed: 50
 step_pin: PE11
 dir_pin: PE8
 enable_pin: !PD7
-step_distance: .0025
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PE12
 position_endstop: 0
 position_max: 200
@@ -33,7 +35,8 @@ homing_speed: 50
 step_pin: PE13
 dir_pin: PC2
 enable_pin: !PC0
-step_distance: .0125
+microsteps: 16
+rotation_distance: 8
 endstop_pin: PG8
 position_endstop: 0.5
 position_max: 200
@@ -42,7 +45,8 @@ position_max: 200
 step_pin: PE14
 dir_pin: PA0
 enable_pin: !PC3
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB1 # Heat0
@@ -105,42 +109,36 @@ max_z_accel: 100
 
 #[tmc2208 stepper_x]
 #uart_pin: PC13
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_y]
 #uart_pin: PE3
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_z]
 #uart_pin: PE1
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
 
 #[tmc2208 extruder]
 #uart_pin: PD4
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder1]
 #uart_pin: PD1
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder2]
 #uart_pin: PD6
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -154,7 +152,6 @@ max_z_accel: 100
 #cs_pin: PA15
 #spi_bus: spi3a
 ##diag1_pin: PB10
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -163,7 +160,6 @@ max_z_accel: 100
 #cs_pin: PB8
 #spi_bus: spi3a
 ##diag1_pin: PE12
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -172,7 +168,6 @@ max_z_accel: 100
 #cs_pin: PB9
 #spi_bus: spi3a
 ##diag1_pin: PG8
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
@@ -181,7 +176,6 @@ max_z_accel: 100
 #cs_pin: PB3
 #spi_bus: spi3a
 ##diag1_pin: PE15
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -190,7 +184,6 @@ max_z_accel: 100
 #cs_pin: PG15
 #spi_bus: spi3a
 ##diag1_pin: PE10
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -199,7 +192,6 @@ max_z_accel: 100
 #cs_pin: PG12
 #spi_bus: spi3a
 ##diag1_pin: PG5
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5

--- a/config/generic-bigtreetech-skr-v1.1.cfg
+++ b/config/generic-bigtreetech-skr-v1.1.cfg
@@ -8,7 +8,8 @@
 step_pin: P0.4
 dir_pin: !P0.5
 enable_pin: !P4.28
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: P1.29
 position_endstop: 0
 position_max: 200
@@ -18,7 +19,8 @@ homing_speed: 50
 step_pin: P2.1
 dir_pin: P2.2
 enable_pin: !P2.0
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: P1.27
 position_endstop: 0
 position_max: 200
@@ -28,7 +30,8 @@ homing_speed: 50
 step_pin: P0.20
 dir_pin: P0.21
 enable_pin: !P0.19
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: !P1.25
 position_endstop: 0.5
 position_max: 200
@@ -44,7 +47,8 @@ position_max: 200
 step_pin: P0.11
 dir_pin: P2.13
 enable_pin: !P2.12
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: P2.7

--- a/config/generic-bigtreetech-skr-v1.3.cfg
+++ b/config/generic-bigtreetech-skr-v1.3.cfg
@@ -8,7 +8,8 @@
 step_pin: P2.2
 dir_pin: !P2.6
 enable_pin: !P2.1
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: P1.29  # P1.28 for X-max
 position_endstop: 0
 position_max: 320
@@ -18,7 +19,8 @@ homing_speed: 50
 step_pin: P0.19
 dir_pin: !P0.20
 enable_pin: !P2.8
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: P1.27  # P1.26 for Y-max
 position_endstop: 0
 position_max: 300
@@ -28,7 +30,8 @@ homing_speed: 50
 step_pin: P0.22
 dir_pin: P2.11
 enable_pin: !P0.21
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: P1.25  # P1.24 for Z-max
 position_endstop: 0.5
 position_max: 400
@@ -37,7 +40,8 @@ position_max: 400
 step_pin: P2.13
 dir_pin: !P0.11
 enable_pin: !P2.12
-step_distance: .010526
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: P2.7
@@ -90,35 +94,30 @@ max_z_accel: 100
 
 #[tmc2208 stepper_x]
 #uart_pin: P1.17
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_y]
 #uart_pin: P1.15
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_z]
 #uart_pin: P1.10
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
 
 #[tmc2208 extruder]
 #uart_pin: P1.8
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder1]
 #uart_pin: P1.1
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -138,7 +137,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.29
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -149,7 +147,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.27
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -160,7 +157,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.25
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
@@ -171,7 +167,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.28
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -182,7 +177,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.26
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5

--- a/config/generic-bigtreetech-skr-v1.4.cfg
+++ b/config/generic-bigtreetech-skr-v1.4.cfg
@@ -8,7 +8,8 @@
 step_pin: P2.2
 dir_pin: P2.6
 enable_pin: !P2.1
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: !P1.29
 position_endstop: 0
 position_max: 235
@@ -18,7 +19,8 @@ homing_speed: 50
 step_pin: P0.19
 dir_pin: P0.20
 enable_pin: !P2.8
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: !P1.28
 position_endstop: 0
 position_max: 235
@@ -28,7 +30,8 @@ homing_speed: 50
 step_pin: P0.22
 dir_pin: !P2.11
 enable_pin: !P0.21
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: !P1.27
 position_endstop: 0.0
 position_max: 300
@@ -37,7 +40,8 @@ position_max: 300
 step_pin: P2.13
 dir_pin: !P0.11
 enable_pin: !P2.12
-step_distance: .010526
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: P2.7
@@ -89,35 +93,30 @@ max_z_accel: 100
 
 #[tmc2208 stepper_x]
 #uart_pin: P1.10
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 #
 #[tmc2208 stepper_y]
 #uart_pin: P1.9
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 #
 #[tmc2208 stepper_z]
 #uart_pin: P1.8
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
 #
 #[tmc2208 extruder]
 #uart_pin: P1.4
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 #
 #[tmc2208 extruder1]
 #uart_pin: P1.1
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -132,7 +131,6 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -143,7 +141,6 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -154,7 +151,6 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
@@ -165,7 +161,6 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -176,7 +171,6 @@ max_z_accel: 100
 #spi_software_miso_pin: P0.5
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5

--- a/config/generic-cramps.cfg
+++ b/config/generic-cramps.cfg
@@ -14,7 +14,8 @@
 step_pin: P8_13
 dir_pin: P8_12
 enable_pin: !P9_14
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P8_8
 position_endstop: 0
 position_max: 200
@@ -24,7 +25,8 @@ homing_speed: 50
 step_pin: P8_15
 dir_pin: P8_14
 enable_pin: !P9_14
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P8_10
 position_endstop: 0
 position_max: 200
@@ -34,7 +36,8 @@ homing_speed: 50
 step_pin: P8_19
 dir_pin: P8_18
 enable_pin: !P9_14
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^P9_13
 position_endstop: 0
 position_max: 200
@@ -43,7 +46,8 @@ position_max: 200
 step_pin: P9_16
 dir_pin: P9_12
 enable_pin: !P9_14
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: P9_15

--- a/config/generic-creality-v4.2.7.cfg
+++ b/config/generic-creality-v4.2.7.cfg
@@ -19,7 +19,8 @@
 step_pin: PB9
 dir_pin: PC2
 enable_pin: !PC3
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA5
 position_endstop: 0
 position_max: 235
@@ -29,7 +30,8 @@ homing_speed: 50
 step_pin: PB7
 dir_pin: PB8
 enable_pin: !PC3
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA6
 position_endstop: 0
 position_max: 235
@@ -39,7 +41,8 @@ homing_speed: 50
 step_pin: PB5
 dir_pin: !PB6
 enable_pin: !PC3
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PA7
 position_endstop: 0.0
 position_max: 250
@@ -49,7 +52,8 @@ max_extrude_only_distance: 100.0
 step_pin: PB3
 dir_pin: PB4
 enable_pin: !PC3
-step_distance: 0.010752
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PA1

--- a/config/generic-duet2-duex.cfg
+++ b/config/generic-duet2-duex.cfg
@@ -87,7 +87,8 @@
 step_pin: PD6
 dir_pin: PD11
 enable_pin: !PC6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC14
 position_endstop: 0
 position_max: 250
@@ -95,7 +96,6 @@ position_max: 250
 [tmc2660 stepper_x]
 cs_pin: PD14 # X_SPI_EN Required for communication
 spi_bus: usart1 # All TMC2660 drivers are connected to USART1
-microsteps: 16
 interpolate: True # 1/16 micro-steps interpolated to 1/256
 run_current: 1.000
 sense_resistor: 0.051
@@ -105,7 +105,8 @@ idle_current_percent: 20
 step_pin: PD7
 dir_pin: !PD12
 enable_pin: !PC6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA2
 position_endstop: 0
 position_max: 210
@@ -113,7 +114,6 @@ position_max: 210
 [tmc2660 stepper_y]
 cs_pin: PC9
 spi_bus: usart1
-microsteps: 16
 interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
@@ -123,7 +123,8 @@ idle_current_percent: 20
 step_pin: PD8
 dir_pin: PD13
 enable_pin: !PC6
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PD29
 position_endstop: 0.5
 position_max: 200
@@ -131,7 +132,6 @@ position_max: 200
 [tmc2660 stepper_z]
 cs_pin: PC10
 spi_bus: usart1
-microsteps: 16
 interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
@@ -141,12 +141,12 @@ sense_resistor: 0.051
 step_pin: PD0
 dir_pin: PD16
 enable_pin: !PC6
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 
 [tmc2660 stepper_z1]
 cs_pin: PD25
 spi_bus: usart1
-microsteps: 16
 interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
@@ -156,12 +156,12 @@ sense_resistor: 0.051
 step_pin: PD3
 dir_pin: !PD17
 enable_pin: !PC6
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 
 [tmc2660 stepper_z2]
 cs_pin: PD26
 spi_bus: usart1
-microsteps: 16
 interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
@@ -171,12 +171,12 @@ sense_resistor: 0.051
 step_pin: PD27
 dir_pin: !PC0
 enable_pin: !PC6
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 
 [tmc2660 stepper_z3]
 cs_pin: PB14
 spi_bus: usart1
-microsteps: 16
 interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
@@ -186,7 +186,8 @@ sense_resistor: 0.051
 step_pin: PD5
 dir_pin: PA1
 enable_pin: !PC6
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: !PA20
@@ -202,7 +203,6 @@ max_temp: 250
 [tmc2660 extruder]
 cs_pin: PC17
 spi_bus: usart1
-microsteps: 16
 interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
@@ -212,7 +212,8 @@ sense_resistor: 0.051
 step_pin: PD4
 dir_pin: PD9
 enable_pin: !PC6
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: !PA16
@@ -228,7 +229,6 @@ max_temp: 250
 [tmc2660 extruder1]
 cs_pin: PC25
 spi_bus: usart1
-microsteps: 16
 interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
@@ -238,7 +238,8 @@ sense_resistor: 0.051
 step_pin: PD2
 dir_pin: !PD28
 enable_pin: !PC6
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: !PC3
@@ -254,7 +255,6 @@ max_temp: 250
 [tmc2660 extruder2]
 cs_pin: PD23
 spi_bus: usart1
-microsteps: 16
 interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
@@ -264,7 +264,8 @@ sense_resistor: 0.051
 step_pin: PD1
 dir_pin: !PD22
 enable_pin: !PC6
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: !PC5
@@ -280,7 +281,6 @@ max_temp: 250
 [tmc2660 extruder3]
 cs_pin: PD24
 spi_bus: usart1
-microsteps: 16
 interpolate: True
 run_current: 1.000
 sense_resistor: 0.051

--- a/config/generic-duet2-maestro.cfg
+++ b/config/generic-duet2-maestro.cfg
@@ -7,7 +7,8 @@
 step_pin: PC20
 dir_pin: PC18
 enable_pin: !PA1
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA24
 position_endstop: 0
 position_max: 200
@@ -18,7 +19,6 @@ uart_pin: PA9
 tx_pin: PA10
 select_pins: !PC14, !PC16, !PC17
 sense_resistor: 0.075
-microsteps: 16
 run_current: 0.800
 stealthchop_threshold: 250
 
@@ -26,7 +26,8 @@ stealthchop_threshold: 250
 step_pin: PC2
 dir_pin: PA8
 enable_pin: !PA1
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB6
 position_endstop: 0
 position_max: 200
@@ -37,7 +38,6 @@ uart_pin: PA9
 tx_pin: PA10
 select_pins: PC14, !PC16, !PC17
 sense_resistor: 0.075
-microsteps: 16
 run_current: 0.800
 stealthchop_threshold: 250
 
@@ -45,7 +45,8 @@ stealthchop_threshold: 250
 step_pin: PC28
 dir_pin: PB4
 enable_pin: !PA1
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC10
 position_endstop: 0.5
 position_max: 200
@@ -55,7 +56,6 @@ uart_pin: PA9
 tx_pin: PA10
 select_pins: !PC14, PC16, !PC17
 sense_resistor: 0.075
-microsteps: 16
 run_current: 0.800
 stealthchop_threshold: 30
 
@@ -68,7 +68,8 @@ vssa_pin: PA19
 step_pin: PC4
 dir_pin: PB7
 enable_pin: !PA1
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: !PC1
@@ -87,7 +88,6 @@ uart_pin: PA9
 tx_pin: PA10
 select_pins: PC14, PC16, !PC17
 sense_resistor: 0.075
-microsteps: 16
 run_current: 0.800
 stealthchop_threshold: 5
 

--- a/config/generic-duet2.cfg
+++ b/config/generic-duet2.cfg
@@ -7,7 +7,8 @@
 step_pin: PD6
 dir_pin: PD11
 enable_pin: !PC6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC14
 position_endstop: 0
 position_max: 250
@@ -15,7 +16,6 @@ position_max: 250
 [tmc2660 stepper_x]
 cs_pin: PD14
 spi_bus: usart1
-microsteps: 16
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -23,7 +23,8 @@ sense_resistor: 0.051
 step_pin: PD7
 dir_pin: !PD12
 enable_pin: !PC6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA2
 position_endstop: 0
 position_max: 210
@@ -31,7 +32,6 @@ position_max: 210
 [tmc2660 stepper_y]
 cs_pin: PC9
 spi_bus: usart1
-microsteps: 16
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -39,7 +39,8 @@ sense_resistor: 0.051
 step_pin: PD8
 dir_pin: PD13
 enable_pin: !PC6
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PD29
 #endstop_pin: PD10  # E0 endstop
 #endstop_pin: PC16  # E1 endstop
@@ -49,7 +50,6 @@ position_max: 200
 [tmc2660 stepper_z]
 cs_pin: PC10
 spi_bus: usart1
-microsteps: 16
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -57,7 +57,8 @@ sense_resistor: 0.051
 step_pin: PD5
 dir_pin: PA1
 enable_pin: !PC6
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: !PA20
@@ -73,7 +74,6 @@ max_temp: 250
 [tmc2660 extruder]
 cs_pin: PC17
 spi_bus: usart1
-microsteps: 16
 run_current: 1.000
 sense_resistor: 0.051
 

--- a/config/generic-einsy-rambo.cfg
+++ b/config/generic-einsy-rambo.cfg
@@ -7,7 +7,8 @@
 step_pin: PC0
 dir_pin: PL0
 enable_pin: !PA7
-step_distance: .005
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB6
 #endstop_pin: tmc2130_stepper_x:virtual_endstop
 position_endstop: 0
@@ -15,7 +16,6 @@ position_max: 250
 
 [tmc2130 stepper_x]
 cs_pin: PG0
-microsteps: 16
 run_current: .5
 sense_resistor: 0.220
 diag1_pin: !PK2
@@ -24,7 +24,8 @@ diag1_pin: !PK2
 step_pin: PC1
 dir_pin: !PL1
 enable_pin: !PA6
-step_distance: .005
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB5
 #endstop_pin: tmc2130_stepper_y:virtual_endstop
 position_endstop: 0
@@ -32,7 +33,6 @@ position_max: 210
 
 [tmc2130 stepper_y]
 cs_pin: PG2
-microsteps: 16
 run_current: .5
 sense_resistor: 0.220
 diag1_pin: !PK7
@@ -41,7 +41,8 @@ diag1_pin: !PK7
 step_pin: PC2
 dir_pin: PL2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PB4
 #endstop_pin: tmc2130_stepper_z:virtual_endstop
 position_endstop: 0.5
@@ -49,7 +50,6 @@ position_max: 200
 
 [tmc2130 stepper_z]
 cs_pin: PK5
-microsteps: 16
 run_current: .5
 sense_resistor: 0.220
 diag1_pin: !PK6
@@ -58,7 +58,8 @@ diag1_pin: !PK6
 step_pin: PC3
 dir_pin: PL6
 enable_pin: !PA4
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PE5
@@ -73,7 +74,6 @@ max_temp: 250
 
 [tmc2130 extruder]
 cs_pin: PK4
-microsteps: 16
 run_current: .5
 sense_resistor: 0.220
 diag1_pin: !PK3

--- a/config/generic-flyboard.cfg
+++ b/config/generic-flyboard.cfg
@@ -14,7 +14,8 @@
 step_pin: PB9
 dir_pin: PE0
 enable_pin: !PE1
-step_distance: .0025
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PC3
 position_endstop: 0
 position_max: 200
@@ -24,7 +25,8 @@ homing_speed: 50
 step_pin: PB8
 dir_pin: PG11
 enable_pin: !PG12
-step_distance: .0025
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PF2
 position_endstop: 0
 position_max: 200
@@ -34,7 +36,8 @@ homing_speed: 50
 step_pin: PA8
 dir_pin: PD6
 enable_pin: !PD7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 8
 endstop_pin: PF0
 position_endstop: 0.5
 position_max: 200
@@ -43,7 +46,8 @@ position_max: 200
 step_pin: PC7
 dir_pin: PD3
 enable_pin: !PD4
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PF7 # Heat0
@@ -139,63 +143,54 @@ max_z_accel: 100
 
 #[tmc2208 stepper_x]
 #uart_pin: PG13
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_y]
 #uart_pin: PG10
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_z]
 #uart_pin: PD5
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
 
 #[tmc2208 extruder]
 #uart_pin: PD1
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder1]
 #uart_pin: PA14
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder2]
 #uart_pin: PG6
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder3]
 #uart_pin: PG3
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder4]
 #uart_pin: PD10
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder5]
 #uart_pin: PB12
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -208,7 +203,6 @@ max_z_accel: 100
 #[tmc2130 stepper_x]
 #cs_pin: PG13
 ##diag1_pin: PC3
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -216,7 +210,6 @@ max_z_accel: 100
 #[tmc2130 stepper_y]
 #cs_pin: PG10
 ##diag1_pin: PF2
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -224,7 +217,6 @@ max_z_accel: 100
 #[tmc2130 stepper_z]
 #cs_pin: PBD5
 ##diag1_pin: PF0
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
@@ -232,7 +224,6 @@ max_z_accel: 100
 #[tmc2130 extruder]
 #cs_pin: PD1
 ##diag1_pin: PE15
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -240,7 +231,6 @@ max_z_accel: 100
 #[tmc2130 extruder1]
 #cs_pin: PA14
 ##diag1_pin: PE10
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -248,7 +238,6 @@ max_z_accel: 100
 #[tmc2130 extruder2]
 #cs_pin: PG6
 ##diag1_pin: PC15
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -256,7 +245,6 @@ max_z_accel: 100
 #[tmc2130 extruder3]
 #cs_pin: PG3
 ##diag1_pin: PC15
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -264,7 +252,6 @@ max_z_accel: 100
 #[tmc2130 extruder4]
 #cs_pin: PD10
 ##diag1_pin: PC15
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -272,7 +259,6 @@ max_z_accel: 100
 #[tmc2130 extruder5]
 #cs_pin: PB12
 ##diag1_pin: PC15
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5

--- a/config/generic-fysetc-cheetah-v1.1.cfg
+++ b/config/generic-fysetc-cheetah-v1.1.cfg
@@ -13,7 +13,8 @@
 step_pin: PB8
 dir_pin: !PB9
 enable_pin: !PA8
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA1
 position_endstop: 0
 position_max: 200
@@ -23,7 +24,6 @@ homing_speed: 50
 uart_pin: PA3
 tx_pin: PA2
 uart_address: 0
-microsteps: 16
 run_current: 0.800
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -32,7 +32,8 @@ stealthchop_threshold: 250
 step_pin: PB2
 dir_pin: !PB3
 enable_pin: !PB1
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB4
 position_endstop: 0
 position_max: 200
@@ -42,7 +43,6 @@ homing_speed: 50
 uart_pin: PA3
 tx_pin: PA2
 uart_address: 2
-microsteps: 16
 run_current: 0.800
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -51,7 +51,8 @@ stealthchop_threshold: 250
 step_pin: PC0
 dir_pin: PC1
 enable_pin: !PC2
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PA15
 position_endstop: 0
 position_max: 200
@@ -60,7 +61,6 @@ position_max: 200
 uart_pin: PA3
 tx_pin: PA2
 uart_address: 1
-microsteps: 16
 run_current: 0.800
 hold_current: 0.500
 stealthchop_threshold: 5
@@ -69,7 +69,8 @@ stealthchop_threshold: 5
 step_pin: PC15
 dir_pin: !PC14
 enable_pin: !PC13
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC6
@@ -86,7 +87,6 @@ max_temp: 250
 uart_pin: PA3
 tx_pin: PA2
 uart_address: 3
-microsteps: 16
 run_current: 1.0
 hold_current: 0.500
 stealthchop_threshold: 5

--- a/config/generic-fysetc-cheetah-v1.2.cfg
+++ b/config/generic-fysetc-cheetah-v1.2.cfg
@@ -13,7 +13,8 @@
 step_pin: PB8
 dir_pin: !PB9
 enable_pin: !PA8
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA1
 position_endstop: 0
 position_max: 200
@@ -22,7 +23,6 @@ homing_speed: 50
 [tmc2208 stepper_x]
 uart_pin: PA12
 tx_pin: PA11
-microsteps: 16
 run_current: 0.800
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -31,7 +31,8 @@ stealthchop_threshold: 250
 step_pin: PB2
 dir_pin: !PB3
 enable_pin: !PB1
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB4
 position_endstop: 0
 position_max: 200
@@ -40,7 +41,6 @@ homing_speed: 50
 [tmc2208 stepper_y]
 uart_pin: PB7
 tx_pin: PB6
-microsteps: 16
 run_current: 0.800
 hold_current: 0.500
 stealthchop_threshold: 250
@@ -49,7 +49,8 @@ stealthchop_threshold: 250
 step_pin: PC0
 dir_pin: PC1
 enable_pin: !PC2
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PA15
 position_endstop: 0
 position_max: 200
@@ -57,7 +58,6 @@ position_max: 200
 [tmc2208 stepper_z]
 uart_pin: PB11
 tx_pin: PB10
-microsteps: 16
 run_current: 0.800
 hold_current: 0.500
 stealthchop_threshold: 5
@@ -66,7 +66,8 @@ stealthchop_threshold: 5
 step_pin: PC15
 dir_pin: !PC14
 enable_pin: !PC13
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC6
@@ -82,7 +83,6 @@ max_temp: 250
 [tmc2208 extruder]
 uart_pin: PA3
 tx_pin: PA2
-microsteps: 16
 run_current: 1.0
 hold_current: 0.500
 stealthchop_threshold: 5

--- a/config/generic-fysetc-f6.cfg
+++ b/config/generic-fysetc-f6.cfg
@@ -7,7 +7,8 @@
 step_pin: PF0
 dir_pin: PF1
 enable_pin: !PD7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PK1  # PK2 for X-max
 position_endstop: 0
 position_max: 200
@@ -16,7 +17,8 @@ position_max: 200
 step_pin: PF6
 dir_pin: PF7
 enable_pin: !PF2
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PJ1  # PJ0 for Y-max
 position_endstop: 0
 position_max: 200
@@ -25,7 +27,8 @@ position_max: 200
 step_pin: PL6
 dir_pin: PL1
 enable_pin: !PF4
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: PB6  # PE4 for Z-max
 position_endstop: 0
 position_max: 400
@@ -34,7 +37,8 @@ position_max: 400
 step_pin: PA4
 dir_pin: !PA6
 enable_pin: !PA2
-step_distance: .01
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PE3
@@ -107,7 +111,6 @@ pins: PB0
 #[tmc2208 stepper_x]
 #uart_pin: PG3
 #tx_pin: PJ2
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -115,7 +118,6 @@ pins: PB0
 #[tmc2208 stepper_y]
 #uart_pin: PJ3
 #tx_pin: PJ4
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -123,7 +125,6 @@ pins: PB0
 #[tmc2208 stepper_z]
 #uart_pin: PE2
 #tx_pin: PE6
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 100
@@ -131,7 +132,6 @@ pins: PB0
 #[tmc2208 extruder]
 #uart_pin: PJ5
 #tx_pin: PJ6
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -139,7 +139,6 @@ pins: PB0
 #[tmc2208 extruder1]
 #uart_pin: PE7
 #tx_pin: PD4
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -147,7 +146,6 @@ pins: PB0
 #[tmc2208 extruder2]
 #uart_pin: PA1
 #tx_pin: PD5
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -167,7 +165,6 @@ pins: PB0
 #[tmc2130 stepper_x]
 #cs_pin: PG4
 #diag1_pin: PK1
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -175,7 +172,6 @@ pins: PB0
 #[tmc2130 stepper_y]
 #cs_pin: PG2
 #diag1_pin: PJ1
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -183,7 +179,6 @@ pins: PB0
 #[tmc2130 stepper_z]
 #cs_pin: PJ7
 #diag1_pin: PB6
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -191,7 +186,6 @@ pins: PB0
 #[tmc2130 extruder]
 #cs_pin: PL2
 #diag1_pin: PE4
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -199,7 +193,6 @@ pins: PB0
 #[tmc2130 extruder1]
 #cs_pin: PC5
 #diag1_pin: PJ0
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -207,7 +200,6 @@ pins: PB0
 #[tmc2130 extruder2]
 #cs_pin: PL7
 #diag1_pin: PK2
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250

--- a/config/generic-fysetc-s6.cfg
+++ b/config/generic-fysetc-s6.cfg
@@ -10,7 +10,8 @@
 step_pin: PE11
 dir_pin: PE10
 enable_pin: !PE12
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PB14  # PA1 for X-max
 position_endstop: 0
 position_max: 200
@@ -19,7 +20,8 @@ position_max: 200
 step_pin: PD8
 dir_pin: PB12
 enable_pin: !PD9
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: PB13  # PA2 for Y-max
 position_endstop: 0
 position_max: 200
@@ -28,7 +30,8 @@ position_max: 200
 step_pin: PD14
 dir_pin: PD13
 enable_pin: !PD15
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: PA0  # PA3 for Z-max (and servo)
 position_endstop: 0
 position_max: 400
@@ -37,7 +40,8 @@ position_max: 400
 step_pin: PD5
 dir_pin: !PD6
 enable_pin: !PD4
-step_distance: .01
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB3
@@ -109,7 +113,6 @@ max_z_accel: 100
 #[tmc2208 stepper_x]
 #uart_pin: PE8
 #tx_pin: PE9
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -117,7 +120,6 @@ max_z_accel: 100
 #[tmc2208 stepper_y]
 #uart_pin: PE13
 #tx_pin: PE14
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -125,7 +127,6 @@ max_z_accel: 100
 #[tmc2208 stepper_z]
 #uart_pin: PD12
 #tx_pin: PD11
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 100
@@ -133,7 +134,6 @@ max_z_accel: 100
 #[tmc2208 extruder]
 #uart_pin: PA15
 #tx_pin: PD3
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -141,7 +141,6 @@ max_z_accel: 100
 #[tmc2208 extruder1]
 #uart_pin: PC5
 #tx_pin: PC4
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -149,7 +148,6 @@ max_z_accel: 100
 #[tmc2208 extruder2]
 #uart_pin: PE0
 #tx_pin: PE1
-#microsteps: 16
 #run_current: 0.8
 #hold_current: 0.5
 #stealthchop_threshold: 250
@@ -173,7 +171,6 @@ max_z_accel: 100
 #spi_bus: spi1
 #cs_pin: PE7
 #diag1_pin: PB14
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -182,7 +179,6 @@ max_z_accel: 100
 #spi_bus: spi1
 #cs_pin: PE15
 #diag1_pin: PB13
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -191,7 +187,6 @@ max_z_accel: 100
 #spi_bus: spi1
 #cs_pin: PD10
 #diag1_pin: PA0
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -200,7 +195,6 @@ max_z_accel: 100
 #spi_bus: spi1
 #cs_pin: PD7
 #diag1_pin: PA3
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -209,7 +203,6 @@ max_z_accel: 100
 #spi_bus: spi1
 #cs_pin: PC14
 #diag1_pin: PA2
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -218,7 +211,6 @@ max_z_accel: 100
 #spi_bus: spi1
 #cs_pin: PC15
 #diag1_pin: PA1
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250

--- a/config/generic-gt2560.cfg
+++ b/config/generic-gt2560.cfg
@@ -8,7 +8,8 @@
 step_pin: ar25
 dir_pin: ar23
 enable_pin: !ar27
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar22
 position_endstop: 0
 position_max: 200
@@ -18,7 +19,8 @@ homing_speed: 30
 step_pin: ar31
 dir_pin: ar33
 enable_pin: !ar29
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar26
 position_endstop: 0
 position_max: 200
@@ -28,7 +30,8 @@ homing_speed: 30
 step_pin: ar37
 dir_pin: !ar39
 enable_pin: !ar35
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar30
 position_endstop: 0
 position_max: 200
@@ -38,7 +41,8 @@ position_min: 0.0
 step_pin: ar43
 dir_pin: ar45
 enable_pin: !ar41
-step_distance: .0104789
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.4
 filament_diameter: 1.750
 heater_pin: ar2

--- a/config/generic-melzi.cfg
+++ b/config/generic-melzi.cfg
@@ -15,7 +15,8 @@
 step_pin: PD7
 dir_pin: PC5
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC2
 position_endstop: 0
 position_max: 200
@@ -25,7 +26,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: PC7
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC3
 position_endstop: 0
 position_max: 200
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PC4
 position_endstop: 0.5
 position_max: 200
@@ -44,7 +47,8 @@ position_max: 200
 step_pin: PB1
 dir_pin: PB0
 enable_pin: !PD6
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/generic-mightyboard.cfg
+++ b/config/generic-mightyboard.cfg
@@ -8,7 +8,8 @@
 step_pin: PF1
 dir_pin: !PF0
 enable_pin: !PF2
-step_distance: .010387
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PL1
 position_endstop: 152
 position_max: 153
@@ -19,7 +20,8 @@ homing_speed: 50
 step_pin: PF5
 dir_pin: !PF4
 enable_pin: !PF6
-step_distance: .010387
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PL3
 position_endstop: 77
 position_max: 78
@@ -30,7 +32,8 @@ homing_speed: 50
 step_pin: PK1
 dir_pin: !PK0
 enable_pin: !PK2
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: !PL6
 position_endstop: 0
 position_max: 230
@@ -40,7 +43,8 @@ position_min: 0
 step_pin: PA3
 dir_pin: !PA2
 enable_pin: !PA4
-step_distance: .010387
+microsteps: 16
+rotation_distance: 33.238
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PH3

--- a/config/generic-mini-rambo.cfg
+++ b/config/generic-mini-rambo.cfg
@@ -7,7 +7,8 @@
 step_pin: PC0
 dir_pin: PL1
 enable_pin: !PA7
-step_distance: .005
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB6
 #endstop_pin: ^PC7
 position_endstop: 0
@@ -17,7 +18,8 @@ position_max: 250
 step_pin: PC1
 dir_pin: !PL0
 enable_pin: !PA6
-step_distance: .005
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB5
 #endstop_pin: ^PA2
 position_endstop: 0
@@ -27,7 +29,8 @@ position_max: 210
 step_pin: PC2
 dir_pin: PL2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PB4
 #endstop_pin: ^PA1
 position_endstop: 0.5
@@ -37,7 +40,8 @@ position_max: 200
 step_pin: PC3
 dir_pin: PL6
 enable_pin: !PA4
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PE5

--- a/config/generic-minitronics1.cfg
+++ b/config/generic-minitronics1.cfg
@@ -13,7 +13,8 @@
 step_pin: PF2
 dir_pin: PF1
 enable_pin: !PF3
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PE3
 position_endstop: 0
 position_max: 200
@@ -23,7 +24,8 @@ homing_speed: 50
 step_pin: PA1
 dir_pin: PA2
 enable_pin: !PA0
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PE4
 position_endstop: 0
 position_max: 200
@@ -33,7 +35,8 @@ homing_speed: 50
 step_pin: PA4
 dir_pin: !PA5
 enable_pin: !PA3
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PB4
 position_endstop: 0.5
 position_max: 200
@@ -42,7 +45,8 @@ position_max: 200
 step_pin: PA7
 dir_pin: PA6
 enable_pin: !PG2
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB5

--- a/config/generic-mks-robin-e3.cfg
+++ b/config/generic-mks-robin-e3.cfg
@@ -19,7 +19,8 @@
 step_pin: PC0
 dir_pin: PB2
 enable_pin: !PC13
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA12
 position_endstop: 0
 position_max: 165
@@ -29,7 +30,8 @@ homing_speed: 50
 step_pin: PC2
 dir_pin: PB9
 enable_pin: !PB12
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA11
 position_endstop: 0
 position_max: 165
@@ -39,7 +41,8 @@ homing_speed: 50
 step_pin: PB7
 dir_pin: !PB6
 enable_pin: !PB8
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC6
 position_endstop: 0
 position_max: 200
@@ -48,7 +51,8 @@ position_max: 200
 step_pin: PB4
 dir_pin: PB3
 enable_pin: !PB5
-step_distance: 0.010753
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC9
@@ -63,28 +67,24 @@ max_temp: 250
 
 [tmc2209 stepper_x]
 uart_pin: PC7
-microsteps: 16
 run_current: 0.800
 hold_current: 0.500
 stealthchop_threshold: 250
 
 [tmc2209 stepper_y]
 uart_pin: PD2
-microsteps: 16
 run_current: 0.800
 hold_current: 0.500
 stealthchop_threshold: 250
 
 [tmc2209 stepper_z]
 uart_pin: PC12
-microsteps: 16
 run_current: 0.650
 hold_current: 0.450
 stealthchop_threshold: 30
 
 [tmc2209 extruder]
 uart_pin: PC11
-microsteps: 16
 run_current: 0.800
 hold_current: 0.500
 stealthchop_threshold: 5

--- a/config/generic-mks-robin-nano.cfg
+++ b/config/generic-mks-robin-nano.cfg
@@ -16,7 +16,8 @@
 step_pin: PE3
 dir_pin: !PE2
 enable_pin: !PE4
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: !PA15
 position_endstop: 0
 position_max: 200
@@ -26,7 +27,8 @@ homing_speed: 50
 step_pin: PE0
 dir_pin: !PB9
 enable_pin: !PE1
-step_distance: .01
+microsteps: 16
+rotation_distance: 40
 endstop_pin: !PA12
 position_endstop: 230
 position_max: 230
@@ -36,7 +38,8 @@ homing_speed: 50
 step_pin: PB5
 dir_pin: PB4
 enable_pin: !PB8
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: !PA11
 position_endstop: 0.5
 position_max: 200
@@ -45,7 +48,8 @@ position_max: 200
 step_pin: PD6
 dir_pin: !PD3
 enable_pin: !PB3
-step_distance: .0021
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC3

--- a/config/generic-mks-sgenl.cfg
+++ b/config/generic-mks-sgenl.cfg
@@ -7,7 +7,8 @@
 step_pin: P2.2
 dir_pin: !P2.3
 enable_pin: !P2.1
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P1.29  # ^P1.28 for X-max
 position_endstop: 0
 position_max: 320
@@ -17,7 +18,8 @@ homing_speed: 50
 step_pin: P0.19
 dir_pin: !P0.20
 enable_pin: !P2.8
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P1.27  # ^P1.26 for Y-max
 position_endstop: 0
 position_max: 300
@@ -27,7 +29,8 @@ homing_speed: 50
 step_pin: P0.22
 dir_pin: P2.11
 enable_pin: !P0.21
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^P1.25  # ^P1.24 for Z-max
 position_endstop: 0.5
 position_max: 400
@@ -36,7 +39,8 @@ position_max: 400
 step_pin: P2.13
 dir_pin: !P0.11
 enable_pin: !P2.12
-step_distance: .010526
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: P2.7
@@ -85,35 +89,30 @@ max_z_accel: 100
 
 #[tmc2208 stepper_x]
 #uart_pin: P1.1
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_y]
 #uart_pin: P1.8
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
 
 #[tmc2208 stepper_z]
 #uart_pin: P1.10
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
 
 #[tmc2208 extruder]
 #uart_pin: P1.15
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
 
 #[tmc2208 extruder1]
 #uart_pin: P1.17
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -129,7 +128,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.29
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -140,7 +138,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.27
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 250
@@ -151,7 +148,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.25
-#microsteps: 16
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 30
@@ -162,7 +158,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.28
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5
@@ -173,7 +168,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P4.28
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.26
-#microsteps: 16
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 5

--- a/config/generic-printrboard-g2.cfg
+++ b/config/generic-printrboard-g2.cfg
@@ -7,7 +7,8 @@
 step_pin: PB15
 dir_pin: !PA16
 enable_pin: !PB16
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA11
 position_endstop: 0
 position_max: 200
@@ -17,7 +18,8 @@ homing_speed: 50
 step_pin: PA29
 dir_pin: !PB1
 enable_pin: !PB0
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB26
 position_endstop: 150
 position_max: 150
@@ -27,7 +29,8 @@ homing_speed: 50
 step_pin: PA21
 dir_pin: PA26
 enable_pin: !PA25
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PA10
 position_endstop: 0
 position_min: -2
@@ -83,7 +86,8 @@ resistance3: 189
 step_pin: PB14
 dir_pin: PB23
 enable_pin: !PB22
-step_distance: .008
+microsteps: 16
+rotation_distance: 25.600
 nozzle_diameter: 0.300
 filament_diameter: 1.750
 heater_pin: PA5

--- a/config/generic-printrboard.cfg
+++ b/config/generic-printrboard.cfg
@@ -15,7 +15,8 @@
 step_pin: PA0
 dir_pin: !PA1
 enable_pin: !PE7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PE3
 position_endstop: 0
 position_max: 200
@@ -25,7 +26,8 @@ homing_speed: 50
 step_pin: PA2
 dir_pin: PA3
 enable_pin: !PE6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB0
 position_endstop: 0
 position_max: 200
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PA4
 dir_pin: !PA5
 enable_pin: !PC7
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PE4
 position_endstop: 0.5
 position_max: 200
@@ -44,7 +47,8 @@ position_max: 200
 step_pin: PA6
 dir_pin: PA7
 enable_pin: !PC3
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC5

--- a/config/generic-radds.cfg
+++ b/config/generic-radds.cfg
@@ -11,7 +11,8 @@
 step_pin: ar24
 dir_pin: ar23
 enable_pin: ar26
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar28
 #endstop_pin: ^ar34
 position_endstop: 0
@@ -22,7 +23,8 @@ homing_speed: 50
 step_pin: ar17
 dir_pin: !ar16
 enable_pin: ar22
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar30
 #endstop_pin: ^ar36
 position_endstop: 0
@@ -33,7 +35,8 @@ homing_speed: 50
 step_pin: ar2
 dir_pin: ar3
 enable_pin: ar15
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar32
 #endstop_pin: ^ar38
 position_endstop: 0.5
@@ -43,7 +46,8 @@ position_max: 200
 step_pin: analog7
 dir_pin: analog6
 enable_pin: analog8
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar13

--- a/config/generic-rambo.cfg
+++ b/config/generic-rambo.cfg
@@ -7,7 +7,8 @@
 step_pin: PC0
 dir_pin: PL1
 enable_pin: !PA7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB6
 #endstop_pin: ^PA2
 position_endstop: 0
@@ -18,7 +19,8 @@ homing_speed: 50
 step_pin: PC1
 dir_pin: !PL0
 enable_pin: !PA6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PB5
 #endstop_pin: ^PA1
 position_endstop: 0
@@ -29,7 +31,8 @@ homing_speed: 50
 step_pin: PC2
 dir_pin: PL2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PB4
 #endstop_pin: ^PC7
 position_endstop: 0.5
@@ -39,7 +42,8 @@ position_max: 200
 step_pin: PC3
 dir_pin: PL6
 enable_pin: !PA4
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PH6

--- a/config/generic-ramps.cfg
+++ b/config/generic-ramps.cfg
@@ -8,7 +8,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar3
 #endstop_pin: ^ar2
 position_endstop: 0
@@ -19,7 +20,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar14
 #endstop_pin: ^ar15
 position_endstop: 0
@@ -30,7 +32,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar18
 #endstop_pin: ^ar19
 position_endstop: 0.5
@@ -40,7 +43,8 @@ position_max: 200
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/generic-re-arm.cfg
+++ b/config/generic-re-arm.cfg
@@ -7,7 +7,8 @@
 step_pin: P2.1
 dir_pin: P0.11
 enable_pin: !P0.10
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P1.24
 #endstop_pin: ^P1.25
 position_endstop: 0.5
@@ -21,7 +22,8 @@ homing_speed: 50
 step_pin: P2.2
 dir_pin: P0.20
 enable_pin: !P0.19
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P1.26
 #endstop_pin: ^P1.27
 position_endstop: 0
@@ -32,7 +34,8 @@ homing_speed: 50
 step_pin: P2.3
 dir_pin: P0.22
 enable_pin: !P0.21
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^P1.29
 #endstop_pin: ^P1.28
 position_endstop: 0.5
@@ -43,7 +46,8 @@ position_max: 200
 step_pin: P2.0
 dir_pin: P0.5
 enable_pin: !P0.4
-step_distance: .0011365
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: P2.5

--- a/config/generic-replicape.cfg
+++ b/config/generic-replicape.cfg
@@ -36,7 +36,8 @@ stepper_e_current: 0.5
 step_pin: P8_17
 dir_pin: P8_26
 enable_pin: replicape:stepper_x_enable
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P9_25
 position_endstop: 0
 position_max: 200
@@ -46,7 +47,8 @@ homing_speed: 50
 step_pin: P8_12
 dir_pin: P8_19
 enable_pin: replicape:stepper_y_enable
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P9_23
 position_endstop: 0
 position_max: 200
@@ -56,7 +58,8 @@ homing_speed: 50
 step_pin: P8_13
 dir_pin: P8_14
 enable_pin: replicape:stepper_z_enable
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^P9_13
 position_endstop: 0
 position_max: 200
@@ -72,7 +75,8 @@ max_z_accel: 30
 step_pin: P9_12
 dir_pin: P8_15
 enable_pin: replicape:stepper_e_enable
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: replicape:power_e

--- a/config/generic-rumba.cfg
+++ b/config/generic-rumba.cfg
@@ -7,7 +7,8 @@
 step_pin: ar17
 dir_pin: ar16
 enable_pin: !ar48
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar37
 #endstop_pin: ^ar36
 position_endstop: 0
@@ -18,7 +19,8 @@ homing_speed: 50
 step_pin: ar54
 dir_pin: !ar47
 enable_pin: !ar55
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar35
 #endstop_pin: ^ar34
 position_endstop: 0
@@ -29,7 +31,8 @@ homing_speed: 50
 step_pin: ar57
 dir_pin: ar56
 enable_pin: !ar62
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar33
 #endstop_pin: ^ar32
 position_endstop: 0.5
@@ -39,7 +42,8 @@ position_max: 200
 step_pin: ar23
 dir_pin: ar22
 enable_pin: !ar24
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar2

--- a/config/generic-simulavr.cfg
+++ b/config/generic-simulavr.cfg
@@ -11,7 +11,8 @@
 step_pin: ar29
 dir_pin: ar28
 enable_pin: ar25
-step_distance: .0225
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar0
 position_min: -0.25
 position_endstop: 0
@@ -22,7 +23,8 @@ position_max: 200
 step_pin: ar27
 dir_pin: ar26
 enable_pin: ar25
-step_distance: .0225
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar1
 position_min: -0.25
 position_endstop: 0
@@ -33,7 +35,8 @@ position_max: 200
 step_pin: ar23
 dir_pin: ar22
 enable_pin: ar25
-step_distance: .005
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar2
 position_min: 0.1
 position_endstop: 0.5
@@ -44,7 +47,8 @@ position_max: 200
 step_pin: ar19
 dir_pin: ar18
 enable_pin: ar25
-step_distance: .004242
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.500
 filament_diameter: 3.500
 heater_pin: ar4

--- a/config/generic-smoothieboard.cfg
+++ b/config/generic-smoothieboard.cfg
@@ -7,7 +7,8 @@
 step_pin: P2.0
 dir_pin: P0.5
 enable_pin: !P0.4
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P1.24
 #endstop_pin: ^P1.25
 position_endstop: 0
@@ -18,7 +19,8 @@ homing_speed: 50
 step_pin: P2.1
 dir_pin: !P0.11
 enable_pin: !P0.10
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^P1.26
 #endstop_pin: ^P1.27
 position_endstop: 0
@@ -29,7 +31,8 @@ homing_speed: 50
 step_pin: P2.2
 dir_pin: P0.20
 enable_pin: !P0.19
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^P1.28
 #endstop_pin: ^P1.29
 position_endstop: 0.5
@@ -39,7 +42,8 @@ position_max: 200
 step_pin: P2.3
 dir_pin: P0.22
 enable_pin: !P0.21
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: P2.7

--- a/config/generic-ultimaker-ultimainboard-v2.cfg
+++ b/config/generic-ultimaker-ultimainboard-v2.cfg
@@ -8,7 +8,8 @@
 step_pin: ar25
 dir_pin: !ar23
 enable_pin: !ar27
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar22
 position_endstop: 0
 position_max: 230
@@ -18,7 +19,8 @@ homing_speed: 50.0
 step_pin: ar32
 dir_pin: ar33
 enable_pin: !ar31
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar26
 position_endstop: 225
 position_max: 225
@@ -28,7 +30,8 @@ homing_speed: 50.0
 step_pin: ar35
 dir_pin: !ar36
 enable_pin: !ar34
-step_distance: .005
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar29
 position_endstop: 215
 position_max: 215
@@ -38,7 +41,8 @@ homing_speed: 20.0
 step_pin: ar42
 dir_pin: ar43
 enable_pin: !ar37
-step_distance: .003546
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 2.850
 heater_pin: ar2
@@ -56,7 +60,8 @@ max_temp: 275
 #step_pin: ar49
 #dir_pin: ar47
 #enable_pin: !ar48
-#step_distance: .003546
+#microsteps: 16
+#rotation_distance: 33.500
 #nozzle_diameter: 0.400
 #filament_diameter: 2.850
 #heater_pin: ar3

--- a/config/kit-voron2-250mm.cfg
+++ b/config/kit-voron2-250mm.cfg
@@ -53,7 +53,8 @@ step_pin: ar54
 dir_pin: !ar55
 enable_pin: !ar38
 #   X on mcu_xye
-step_distance: 0.0125
+microsteps: 16
+rotation_distance: 40
 #   80 steps per mm - 1.8 deg - 1/16 microstepping
 endstop_pin: ^ar2
 #   X_MAX on mcu_xye
@@ -69,7 +70,8 @@ step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
 #   Y on mcu_xye
-step_distance: 0.0125
+microsteps: 16
+rotation_distance: 40
 #   80 steps per mm - 1.8 deg - 1/16 microstepping
 endstop_pin: ^ar15
 #   Y_MAX on mcu_xye
@@ -85,7 +87,8 @@ step_pin: z:ar54
 dir_pin: !z:ar55
 enable_pin: !z:ar38
 #   X on mcu_z
-step_distance: 0.00250
+microsteps: 16
+rotation_distance: 8
 #   400 steps per mm - 1.8 deg - 1/16 microstepping
 endstop_pin: ^!z:ar18
 #   Z_MIN on mcu_z
@@ -104,7 +107,8 @@ step_pin: z:ar60
 dir_pin: z:ar61
 enable_pin: !z:ar56
 #   Y on mcu_z
-step_distance: 0.00250
+microsteps: 16
+rotation_distance: 8
 #   400 steps per mm - 1.8 deg - 1/16 microstepping
 
 [stepper_z2]
@@ -113,7 +117,8 @@ step_pin: z:ar46
 dir_pin: !z:ar48
 enable_pin: !z:ar62
 #   Z on mcu_z
-step_distance: 0.00250
+microsteps: 16
+rotation_distance: 8
 #   400 steps per mm - 1.8 deg - 1/16 microstepping
 
 [stepper_z3]
@@ -122,7 +127,8 @@ step_pin: z:ar26
 dir_pin: z:ar28
 enable_pin: !z:ar24
 #   E0 on mcu_z
-step_distance: 0.00250
+microsteps: 16
+rotation_distance: 8
 #   400 steps per mm - 1.8 deg - 1/16 microstepping
 
 [extruder]
@@ -130,7 +136,8 @@ step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
 #   E0 on mcu_xye
-step_distance: 0.00180180
+microsteps: 16
+rotation_distance: 5.76576
 #   555 steps per mm - 1.8 deg - 1/16 microstepping (Mobius2)
 nozzle_diameter: 0.400
 filament_diameter: 1.750

--- a/config/kit-zav3d-2019.cfg
+++ b/config/kit-zav3d-2019.cfg
@@ -29,7 +29,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^ar3
 position_endstop: 0
 position_max: 200
@@ -41,7 +42,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^ar14
 position_endstop: 0
 position_max: 200
@@ -52,7 +54,8 @@ homing_speed: 50
 #step_pin: ar46
 #dir_pin: ar48
 #enable_pin: !ar62
-#step_distance: .0025
+#microsteps: 16
+#rotation_distance: 8
 ## I used Z_MAX_ENDSTOP
 #endstop_pin: ^ar19
 ## More about z-calibration is here https://vk.com/topic-107680682_34101598
@@ -66,7 +69,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 position_min: -3
 position_max: 230
 endstop_pin: probe:z_virtual_endstop
@@ -77,7 +81,8 @@ endstop_pin: probe:z_virtual_endstop
 step_pin: ar26
 dir_pin: !ar28
 enable_pin: !ar24
-step_distance: .004242
+microsteps: 16
+rotation_distance: 13.5744
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/printer-adimlab-2018.cfg
+++ b/config/printer-adimlab-2018.cfg
@@ -7,7 +7,8 @@
 step_pin: ar25
 dir_pin: !ar23
 enable_pin: !ar27
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar22
 position_min: -5
 position_endstop: -5
@@ -18,7 +19,8 @@ homing_speed: 30.0
 step_pin: ar32
 dir_pin: !ar33
 enable_pin: !ar31
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar26
 position_endstop: 0
 position_max: 310
@@ -28,7 +30,8 @@ homing_speed: 30.0
 step_pin: ar35
 dir_pin: ar36
 enable_pin: !ar34
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!ar29
 position_endstop: 0.0
 position_max: 400
@@ -38,7 +41,8 @@ homing_speed: 5.0
 step_pin: ar42
 dir_pin: ar43
 enable_pin: !ar37
-step_distance: .010799
+microsteps: 16
+rotation_distance: 34.557
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar2

--- a/config/printer-alfawise-u30-2018.cfg
+++ b/config/printer-alfawise-u30-2018.cfg
@@ -16,7 +16,8 @@
 step_pin: PB4
 dir_pin: !PB3
 enable_pin: !PB5
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: !PC1
 position_endstop: 0
 position_max: 230
@@ -26,7 +27,8 @@ homing_speed: 50
 step_pin: PB7
 dir_pin: PB6
 enable_pin: !PB8
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: !PC15
 position_endstop: 0
 position_max: 222
@@ -36,7 +38,8 @@ homing_speed: 50
 step_pin: PE0
 dir_pin: !PB9
 enable_pin: !PE1
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: !PE6
 position_endstop: 0.0
 position_max: 250
@@ -45,7 +48,8 @@ position_max: 250
 step_pin: PE3
 dir_pin: PE2
 enable_pin: !PE4
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD3

--- a/config/printer-anet-a4-2018.cfg
+++ b/config/printer-anet-a4-2018.cfg
@@ -12,7 +12,8 @@
 step_pin: PD7
 dir_pin: !PC5
 enable_pin: !PD6
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC2
 position_endstop: 215
 arm_length: 215
@@ -22,14 +23,16 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: !PC7
 enable_pin: !PD6
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC3
 
 [stepper_c]
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC4
 homing_speed: 20
 
@@ -37,7 +40,8 @@ homing_speed: 20
 step_pin: PB1
 dir_pin: PB0
 enable_pin: !PD6
-step_distance: .01045
+microsteps: 16
+rotation_distance: 33.440
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-anet-a8-2017.cfg
+++ b/config/printer-anet-a8-2017.cfg
@@ -12,7 +12,8 @@
 step_pin: PD7
 dir_pin: PC5
 enable_pin: !PD6
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC2
 position_endstop: -30
 position_max: 220
@@ -23,7 +24,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: PC7
 enable_pin: !PD6
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC3
 position_endstop: -8
 position_min: -8
@@ -34,7 +36,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PC4
 position_endstop: 0.5
 position_max: 240
@@ -44,7 +47,8 @@ homing_speed: 20
 step_pin: PB1
 dir_pin: PB0
 enable_pin: !PD6
-step_distance: .0105
+microsteps: 16
+rotation_distance: 33.600
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-anet-e10-2018.cfg
+++ b/config/printer-anet-e10-2018.cfg
@@ -12,7 +12,8 @@
 step_pin: PD7
 dir_pin: PC5
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC2
 position_endstop: -3
 position_max: 220
@@ -23,7 +24,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: !PC7
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC3
 position_endstop: -22
 position_min: -22
@@ -34,7 +36,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PC4
 position_endstop: 0.5
 position_max: 300
@@ -44,7 +47,8 @@ homing_speed: 20
 step_pin: PB1
 dir_pin: !PB0
 enable_pin: !PD6
-step_distance: 0.01
+microsteps: 16
+rotation_distance: 32.000
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-anet-e16-2019.cfg
+++ b/config/printer-anet-e16-2019.cfg
@@ -12,7 +12,8 @@
 step_pin: PD7
 dir_pin: PC5
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC2
 position_endstop: -3
 position_max: 300
@@ -23,7 +24,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: !PC7
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC3
 position_endstop: -22
 position_min: -22
@@ -34,7 +36,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PC4
 position_endstop: 0.5
 position_max: 400
@@ -44,7 +47,8 @@ homing_speed: 20
 step_pin: PB1
 dir_pin: !PB0
 enable_pin: !PD6
-step_distance: 0.01
+microsteps: 16
+rotation_distance: 32.000
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-anycubic-4max-2018.cfg
+++ b/config/printer-anycubic-4max-2018.cfg
@@ -7,7 +7,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar3
 position_min: -2
 position_endstop: -2
@@ -18,7 +19,8 @@ homing_speed: 60.0
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar14
 position_endstop: 0
 position_max: 215
@@ -28,7 +30,8 @@ homing_speed: 60.0
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!ar18
 position_endstop: 0.5
 position_max: 305
@@ -38,7 +41,8 @@ homing_speed: 8.0
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: 0.010354
+microsteps: 16
+rotation_distance: 33.133
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 max_extrude_only_distance: 2000

--- a/config/printer-anycubic-i3-mega-2017.cfg
+++ b/config/printer-anycubic-i3-mega-2017.cfg
@@ -10,7 +10,8 @@
 step_pin: ar54
 dir_pin: !ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar3
 position_min: -5
 position_endstop: -5
@@ -21,7 +22,8 @@ homing_speed: 30.0
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar42
 position_endstop: 0
 position_max: 210
@@ -31,7 +33,8 @@ homing_speed: 30.0
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!ar18
 position_endstop: 0.0
 position_max: 205
@@ -41,14 +44,16 @@ homing_speed: 5.0
 step_pin: ar36
 dir_pin: ar34
 enable_pin: !ar30
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!ar43
 
 [extruder]
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .010799
+microsteps: 16
+rotation_distance: 34.557
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/printer-anycubic-kossel-2016.cfg
+++ b/config/printer-anycubic-kossel-2016.cfg
@@ -11,7 +11,8 @@
 step_pin: ar54
 dir_pin: !ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar2
 homing_speed: 60
 # The next parameter needs to be adjusted for
@@ -25,21 +26,24 @@ arm_length: 229.4
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar15
 
 [stepper_c]
 step_pin: ar46
 dir_pin: !ar48
 enable_pin: !ar62
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar19
 
 [extruder]
 step_pin: ar26
 dir_pin: !ar28
 enable_pin: !ar24
-step_distance: 0.010989
+microsteps: 16
+rotation_distance: 35.165
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/printer-anycubic-kossel-plus-2017.cfg
+++ b/config/printer-anycubic-kossel-plus-2017.cfg
@@ -11,7 +11,8 @@
 step_pin: ar54
 dir_pin: !ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar2
 homing_speed: 60
 # The next parameter needs to be adjusted for
@@ -25,21 +26,24 @@ arm_length: 269.0
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar15
 
 [stepper_c]
 step_pin: ar46
 dir_pin: !ar48
 enable_pin: !ar62
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar19
 
 [extruder]
 step_pin: ar26
 dir_pin: !ar28
 enable_pin: !ar24
-step_distance: 0.0104166
+microsteps: 16
+rotation_distance: 33.333
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/printer-creality-cr10-2017.cfg
+++ b/config/printer-creality-cr10-2017.cfg
@@ -15,7 +15,8 @@
 step_pin: PD7
 dir_pin: !PC5
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC2
 position_endstop: 0
 position_max: 300
@@ -25,7 +26,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: !PC7
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC3
 position_endstop: 0
 position_max: 300
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC4
 position_endstop: 0.0
 position_max: 400
@@ -44,7 +47,8 @@ position_max: 400
 step_pin: PB1
 dir_pin: !PB0
 enable_pin: !PD6
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-creality-cr10mini-2017.cfg
+++ b/config/printer-creality-cr10mini-2017.cfg
@@ -15,7 +15,8 @@
 step_pin: PD7
 dir_pin: !PC5
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC2
 position_endstop: 0
 position_max: 300
@@ -25,7 +26,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: !PC7
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC3
 position_endstop: 0
 position_max: 220
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC4
 position_endstop: 0.0
 position_max: 300
@@ -44,7 +47,8 @@ position_max: 300
 step_pin: PB1
 dir_pin: !PB0
 enable_pin: !PD6
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-creality-cr10s-2017.cfg
+++ b/config/printer-creality-cr10s-2017.cfg
@@ -7,7 +7,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar3
 position_endstop: 0
 position_max: 300
@@ -17,7 +18,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar14
 position_endstop: 0
 position_max: 300
@@ -27,7 +29,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: !ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar18
 position_endstop: 0
 position_max: 400
@@ -36,7 +39,8 @@ position_max: 400
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .010526
+microsteps: 16
+rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/printer-creality-cr20-2018.cfg
+++ b/config/printer-creality-cr20-2018.cfg
@@ -7,7 +7,8 @@
 step_pin: PF0
 dir_pin: PF1
 enable_pin: !PD7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PE5
 position_endstop: 0
 position_max: 235
@@ -17,7 +18,8 @@ homing_speed: 50
 step_pin: PF6
 dir_pin: PF7
 enable_pin: !PF2
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 235
@@ -27,7 +29,8 @@ homing_speed: 50
 step_pin: PL3
 dir_pin: !PL1
 enable_pin: !PK0
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PD3
 position_endstop: 0
 position_max: 250
@@ -36,7 +39,8 @@ position_max: 250
 step_pin: PA4
 dir_pin: PA6
 enable_pin: !PA2
-step_distance: .010526
+microsteps: 16
+rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB4

--- a/config/printer-creality-cr20-pro-2019.cfg
+++ b/config/printer-creality-cr20-pro-2019.cfg
@@ -7,7 +7,8 @@
 step_pin: PF0
 dir_pin: PF1
 enable_pin: !PD7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PE5
 position_endstop: 0
 position_max: 235
@@ -17,7 +18,8 @@ homing_speed: 100
 step_pin: PF6
 dir_pin: PF7
 enable_pin: !PF2
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 235
@@ -27,7 +29,8 @@ homing_speed: 100
 step_pin: PL3
 dir_pin: !PL1
 enable_pin: !PK0
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: probe:z_virtual_endstop
 position_max: 250
 homing_speed: 10.0
@@ -37,7 +40,8 @@ position_min: -1.0
 step_pin: PA4
 dir_pin: PA6
 enable_pin: !PA2
-step_distance: .010526
+microsteps: 16
+rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB4

--- a/config/printer-creality-ender2-2017.cfg
+++ b/config/printer-creality-ender2-2017.cfg
@@ -15,7 +15,8 @@
 step_pin: PD7
 dir_pin: !PC5
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC2
 position_endstop: 0
 position_max: 165
@@ -25,7 +26,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: !PC7
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC3
 position_endstop: 0
 position_max: 165
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC4
 position_endstop: 0.0
 position_max: 205
@@ -44,7 +47,8 @@ position_max: 205
 step_pin: PB1
 dir_pin: !PB0
 enable_pin: !PD6
-step_distance: 0.010753
+microsteps: 16
+rotation_distance: 34.410
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 max_extrude_only_distance: 500.0

--- a/config/printer-creality-ender3-2018.cfg
+++ b/config/printer-creality-ender3-2018.cfg
@@ -15,7 +15,8 @@
 step_pin: PD7
 dir_pin: !PC5
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC2
 position_endstop: 0
 position_max: 235
@@ -25,7 +26,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: !PC7
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC3
 position_endstop: 0
 position_max: 235
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PC4
 position_endstop: 0.0
 position_max: 250
@@ -45,7 +48,8 @@ max_extrude_only_distance: 100.0
 step_pin: PB1
 dir_pin: !PB0
 enable_pin: !PD6
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-creality-ender3-v2-2020.cfg
+++ b/config/printer-creality-ender3-v2-2020.cfg
@@ -20,7 +20,8 @@
 step_pin: PC2
 dir_pin: PB9
 enable_pin: !PC3
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA5
 position_endstop: 0
 position_max: 235
@@ -30,7 +31,8 @@ homing_speed: 50
 step_pin: PB8
 dir_pin: PB7
 enable_pin: !PC3
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA6
 position_endstop: 0
 position_max: 235
@@ -40,7 +42,8 @@ homing_speed: 50
 step_pin: PB6
 dir_pin: !PB5
 enable_pin: !PC3
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PA7
 position_endstop: 0.0
 position_max: 250
@@ -50,7 +53,8 @@ max_extrude_only_distance: 100.0
 step_pin: PB4
 dir_pin: PB3
 enable_pin: !PC3
-step_distance: 0.010752
+microsteps: 16
+rotation_distance: 34.406
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PA1

--- a/config/printer-creality-ender3pro-2020.cfg
+++ b/config/printer-creality-ender3pro-2020.cfg
@@ -20,7 +20,8 @@
 step_pin: PC2
 dir_pin: PB9
 enable_pin: !PC3
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA5
 position_endstop: 0
 position_max: 235
@@ -30,7 +31,8 @@ homing_speed: 50
 step_pin: PB8
 dir_pin: PB7
 enable_pin: !PC3
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA6
 position_endstop: 0
 position_max: 235
@@ -40,7 +42,8 @@ homing_speed: 50
 step_pin: PB6
 dir_pin: !PB5
 enable_pin: !PC3
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^PA7
 position_endstop: 0.0
 position_max: 250
@@ -50,7 +53,8 @@ max_extrude_only_distance: 100.0
 step_pin: PB4
 dir_pin: PB3
 enable_pin: !PC3
-step_distance: 0.010752
+microsteps: 16
+rotation_distance: 34.406
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PA1

--- a/config/printer-creality-ender5-2019.cfg
+++ b/config/printer-creality-ender5-2019.cfg
@@ -15,7 +15,8 @@
 step_pin: PD7
 dir_pin: !PC5
 enable_pin: !PD6
-step_distance: .012500
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC2
 position_endstop: 235
 position_max: 235
@@ -25,7 +26,8 @@ homing_speed: 30
 step_pin: PC6
 dir_pin: !PC7
 enable_pin: !PD6
-step_distance: .012500
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC3
 position_endstop: 235
 position_max: 235
@@ -35,7 +37,8 @@ homing_speed: 30
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: .002500 # Use .001250 for Ender5 versions after late 2019
+microsteps: 16
+rotation_distance: 8 # Use 4 for Ender5 versions after late 2019
 endstop_pin: ^PC4
 position_endstop: 0.0
 position_max: 300
@@ -45,7 +48,8 @@ max_extrude_only_distance: 100.0
 step_pin: PB1
 dir_pin: !PB0
 enable_pin: !PD6
-step_distance: 0.010526
+microsteps: 16
+rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-creality-ender5plus-2019.cfg
+++ b/config/printer-creality-ender5plus-2019.cfg
@@ -9,7 +9,8 @@
 step_pin: PF0
 dir_pin: PF1
 enable_pin: !PD7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PE5
 position_endstop: 350
 position_max: 350
@@ -19,7 +20,8 @@ homing_speed: 100
 step_pin: PF6
 dir_pin: PF7
 enable_pin: !PF2
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PJ1
 position_endstop: 350
 position_max: 350
@@ -29,7 +31,8 @@ homing_speed: 100
 step_pin: PL3
 dir_pin: PL1
 enable_pin: !PK0
-step_distance: .001266
+microsteps: 16
+rotation_distance: 4
 endstop_pin: probe:z_virtual_endstop
 position_max: 400
 position_min: 0
@@ -39,7 +42,8 @@ homing_speed: 10.0
 step_pin: PA4
 dir_pin: PA6
 enable_pin: !PA2
-step_distance: .010526
+microsteps: 16
+rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB4

--- a/config/printer-lulzbot-mini1-2016.cfg
+++ b/config/printer-lulzbot-mini1-2016.cfg
@@ -16,7 +16,8 @@ dir_pin: PL1
 #define X_ENABLE_PIN       29
 enable_pin: !PA7
 # 1/100
-step_distance: .010000
+microsteps: 16
+rotation_distance: 32
 #define X_MIN_PIN          12
 endstop_pin: ^!PB6
 position_endstop: -3
@@ -34,7 +35,8 @@ dir_pin: !PL0
 #define Y_ENABLE_PIN       28
 enable_pin: !PA6
 # 1/100
-step_distance: .010000
+microsteps: 16
+rotation_distance: 32
 #define Y_MIN_PIN          11
 endstop_pin: ^!PB5
 position_endstop: -7
@@ -52,7 +54,8 @@ dir_pin: PL2
 #define Z_ENABLE_PIN       27
 enable_pin: !PA5
 # 1/1600
-step_distance: 0.000625
+microsteps: 16
+rotation_distance: 2
 #define Z_MAX_PIN          23
 endstop_pin: ^!PA1
 # I have replaced the original nozzle with
@@ -73,7 +76,8 @@ dir_pin: !PL6
 #define E0_ENABLE_PIN      26
 enable_pin: !PA4
 # 1/833
-step_distance: 0.001200480192076831
+microsteps: 16
+rotation_distance: 3.842
 nozzle_diameter: 0.400
 filament_diameter: 2.850
 #define HEATER_0_PIN        3

--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -10,7 +10,8 @@
 step_pin: PC0
 dir_pin: PL1
 enable_pin: !PA7
-step_distance: .010000
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^PB6
 position_endstop: -20
 position_min: -20
@@ -21,7 +22,8 @@ homing_speed: 50
 step_pin: PC1
 dir_pin: !PL0
 enable_pin: !PA6
-step_distance: .010000
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^PA1
 position_endstop: 306
 position_min: -20
@@ -32,7 +34,8 @@ homing_speed: 50
 step_pin: PC2
 dir_pin: PL2
 enable_pin: !PA5
-step_distance: 0.000625
+microsteps: 16
+rotation_distance: 2
 endstop_pin: ^!PB4
 position_endstop: -0.7
 position_min: -1.5
@@ -44,7 +47,8 @@ homing_speed: 1
 step_pin: PC3
 dir_pin: !PL6
 enable_pin: !PA4
-step_distance: 0.001182
+microsteps: 16
+rotation_distance: 3.782
 nozzle_diameter: 0.400
 filament_diameter: 2.920
 heater_pin: PH6
@@ -63,7 +67,8 @@ min_extrude_temp: 140
 #step_pin: PC3
 #dir_pin: !PL6
 #enable_pin: !PA4
-#step_distance: 0.002381
+#microsteps: 16
+#rotation_distance: 7.619
 #nozzle_diameter: 0.400
 #filament_diameter: 2.920
 #heater_pin: PH6

--- a/config/printer-lulzbot-taz6-dual-v3-2017.cfg
+++ b/config/printer-lulzbot-taz6-dual-v3-2017.cfg
@@ -33,7 +33,8 @@
 step_pin: PC0
 dir_pin: PL1
 enable_pin: !PA7
-step_distance: .010000
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^PB6
 position_endstop: -20
 position_min: -20
@@ -45,7 +46,8 @@ second_homing_speed: 5
 step_pin: PC1
 dir_pin: !PL0
 enable_pin: !PA6
-step_distance: .010000
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^PA1
 position_endstop: 306
 position_min: -17
@@ -57,7 +59,8 @@ second_homing_speed: 5
 step_pin: PC2
 dir_pin: PL2
 enable_pin: !PA5
-step_distance: 0.000625
+microsteps: 16
+rotation_distance: 2
 endstop_pin: ^!PB4
 position_endstop: 5.0
 position_min: -5.8
@@ -72,7 +75,8 @@ second_homing_speed: 1
 step_pin: PC4
 dir_pin: !PL7
 enable_pin: !PA3
-step_distance: 0.001315789473
+microsteps: 16
+rotation_distance: 4.211
 nozzle_diameter: 0.500
 filament_diameter: 2.850
 heater_pin: PH4
@@ -93,7 +97,8 @@ min_extrude_temp: 120
 step_pin: PC3
 dir_pin: PL6
 enable_pin: !PA4
-step_distance: 0.001315789473
+microsteps: 16
+rotation_distance: 4.211
 nozzle_diameter: 0.500
 filament_diameter: 2.850
 heater_pin: PH6

--- a/config/printer-makergear-m2-2012.cfg
+++ b/config/printer-makergear-m2-2012.cfg
@@ -7,35 +7,36 @@
 step_pin: PC0
 dir_pin: !PL1
 enable_pin: !PA7
-step_distance: .0225
+microsteps: 8
+rotation_distance: 36
 endstop_pin: ^!PB6
 position_endstop: 0.0
 position_max: 200
 homing_speed: 50
 
 [endstop_phase stepper_x]
-phases: 32
 endstop_accuracy: .200
 
 [stepper_y]
 step_pin: PC1
 dir_pin: PL0
 enable_pin: !PA6
-step_distance: .0225
+microsteps: 8
+rotation_distance: 36
 endstop_pin: ^!PB5
 position_endstop: 0.0
 position_max: 250
 homing_speed: 50
 
 [endstop_phase stepper_y]
-phases: 32
 endstop_accuracy: .200
 
 [stepper_z]
 step_pin: PC2
 dir_pin: !PL2
 enable_pin: !PA5
-step_distance: .005
+microsteps: 8
+rotation_distance: 8
 endstop_pin: ^!PB4
 position_min: 0.1
 position_endstop: 0.7
@@ -43,14 +44,15 @@ position_max: 200
 homing_retract_dist: 2.0
 
 [endstop_phase stepper_z]
-phases: 32
 endstop_accuracy: .070
 
 [extruder]
 step_pin: PC3
 dir_pin: PL6
 enable_pin: !PA4
-step_distance: .004242
+microsteps: 8
+gear_ratio: 57:11
+rotation_distance: 35.170
 nozzle_diameter: 0.350
 filament_diameter: 1.750
 heater_pin: PH6

--- a/config/printer-makergear-m2-2016.cfg
+++ b/config/printer-makergear-m2-2016.cfg
@@ -8,7 +8,8 @@
 step_pin: PC0
 dir_pin: !PL1
 enable_pin: !PA7
-step_distance: .01125
+microsteps: 16
+rotation_distance: 36
 endstop_pin: ^!PB6
 position_endstop: 0
 position_max: 205
@@ -18,7 +19,8 @@ homing_speed: 50
 step_pin: PC1
 dir_pin: PL0
 enable_pin: !PA6
-step_distance: .01125
+microsteps: 16
+rotation_distance: 36
 endstop_pin: ^!PB5
 position_endstop: 0
 position_max: 250
@@ -28,7 +30,8 @@ homing_speed: 50
 step_pin: PC2
 dir_pin: !PL2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PB4
 position_min: 0.1
 position_endstop: 0.7
@@ -40,7 +43,9 @@ homing_retract_dist: 2.0
 step_pin: PC3
 dir_pin: PL6
 enable_pin: !PA4
-step_distance: .00188
+microsteps: 16
+gear_ratio: 57:11
+rotation_distance: 31.174
 nozzle_diameter: 0.350
 filament_diameter: 1.750
 heater_pin: PH6

--- a/config/printer-micromake-d1-2016.cfg
+++ b/config/printer-micromake-d1-2016.cfg
@@ -8,7 +8,8 @@
 step_pin: ar54
 dir_pin: !ar55
 enable_pin: !ar38
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^ar2
 homing_speed: 100
 position_endstop: 319.5
@@ -18,21 +19,24 @@ arm_length: 217.0
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^ar15
 
 [stepper_c]
 step_pin: ar46
 dir_pin: !ar48
 enable_pin: !ar62
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^ar19
 
 [extruder]
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: 0.006271
+microsteps: 16
+rotation_distance: 20.067
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/printer-monoprice-mini-delta-2017.cfg
+++ b/config/printer-monoprice-mini-delta-2017.cfg
@@ -26,7 +26,8 @@ homing_speed: 50
 step_pin: PB12
 dir_pin: PB11
 enable_pin: !PB10
-step_distance: .0175 # This is 57.14 steps per mm
+microsteps: 16
+rotation_distance: 56
 endstop_pin: ^PC14
 position_endstop: 125.00
 arm_length: 120.8
@@ -37,21 +38,24 @@ arm_length: 120.8
 step_pin: PB2
 dir_pin: PB1
 enable_pin: !PB10
-step_distance: .0175 # This is 57.14 steps per mm
+microsteps: 16
+rotation_distance: 56
 endstop_pin: ^PC15
 
 [stepper_c]
 step_pin: PB14
 dir_pin: PB13
 enable_pin: !PB10
-step_distance: .0175 # This is 57.14 steps per mm
+microsteps: 16
+rotation_distance: 56
 endstop_pin: ^PC13
 
 [extruder]
 step_pin: PA7
 dir_pin: !PA6
 enable_pin: !PB0
-step_distance: .02062 # This is 48.50 steps per mm
+microsteps: 16
+rotation_distance: 65.984
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PA1

--- a/config/printer-monoprice-select-mini-v2-2018.cfg
+++ b/config/printer-monoprice-select-mini-v2-2018.cfg
@@ -51,12 +51,13 @@ homing_speed: 15
 step_pin: PB14
 dir_pin: !PB15 #modify stepper direction if necessary
 enable_pin: !PA8
-# step_distance varies in the printer model. Check the correct step-rate of
-# your Select Mini in the original firmware (with M503) and calculate the
-# appropriate value for step_distance = 1/steps per unit. This has to be done
-# for all axis.
-# This config contains values for later MSPMv2 printers with 93 steps per mm.
-step_distance: .01075 # 93 steps/mm
+# rotation_distance varies in the printer model. Check the correct
+# step-rate of your Select Mini in the original firmware (with M503)
+# and calculate the appropriate value for rotation_distance. This has
+# to be done for all axes.
+# This config contains values for later MSPMv2 printers.
+microsteps: 16
+rotation_distance: 34.510 # 17 teeth on pulley; MXL belt (2.03 pitch)
 endstop_pin: ^!PB4
 position_endstop: 0
 position_max: 120
@@ -67,7 +68,8 @@ homing_speed: 15
 step_pin: PB12
 dir_pin: PB13 #modify stepper direction if necessary
 enable_pin: !PA8
-step_distance: .010753 # 93 steps/mm. check comment in [stepper_x] section
+microsteps: 16
+rotation_distance: 34.510 # check comment in [stepper_x] section
 endstop_pin: ^!PA15
 position_endstop: 0
 position_max: 120
@@ -78,7 +80,9 @@ homing_speed: 10
 step_pin: PB10
 dir_pin: PB2 #modify stepper direction if necessary
 enable_pin: !PB11
-step_distance: 0.000911 # 1097.5 steps/mm. check comment in [stepper_x] section
+microsteps: 16
+full_steps_per_rotation: 48
+rotation_distance: 0.7 # M4 rod.  check comment in [stepper_x] section
 endstop_pin: ^!PB5
 position_endstop: 0.5
 position_max: 120
@@ -88,7 +92,8 @@ position_max: 120
 step_pin: PB0
 dir_pin: !PC13 #modify stepper direction if necessary
 enable_pin: !PB1
-step_distance: 0.010301 # 97 steps/mm. check comment in [stepper_x] section
+microsteps: 16
+rotation_distance: 32.990 # 97 steps/mm. check comment in [stepper_x] section
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 # heater

--- a/config/printer-mtw-create-2015.cfg
+++ b/config/printer-mtw-create-2015.cfg
@@ -8,7 +8,8 @@
 step_pin: PC0
 dir_pin: !PL1
 enable_pin: !PA7
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^PB6
 #endstop_pin: ^PA2
 position_endstop: 0
@@ -19,7 +20,8 @@ homing_speed: 50
 step_pin: PC1
 dir_pin: PL0
 enable_pin: !PA6
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^PB5
 #endstop_pin: ^PA1
 position_endstop: 0
@@ -30,7 +32,8 @@ homing_speed: 50
 step_pin: PC2
 dir_pin: PL2
 enable_pin: !PA5
-step_distance: .00125
+microsteps: 16
+rotation_distance: 4
 endstop_pin: probe:z_virtual_endstop
 #endstop_pin: ^PC7
 #position_endstop: 0.5
@@ -40,7 +43,8 @@ position_max: 225
 step_pin: PC3
 dir_pin: PL6
 enable_pin: !PA4
-step_distance: .0102
+microsteps: 16
+rotation_distance: 32.640
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PH6
@@ -60,7 +64,8 @@ max_temp: 275
 #enable_pin: !PA3
 #heater_pin: PH4
 #sensor_pin: PF1
-#step_distance: .0102
+#microsteps: 16
+#rotation_distance: 32.640
 #nozzle_diameter: 0.400
 #filament_diameter: 1.750
 #sensor_type: ATC Semitec 104GT-2

--- a/config/printer-seemecnc-rostock-max-v2-2015.cfg
+++ b/config/printer-seemecnc-rostock-max-v2-2015.cfg
@@ -8,7 +8,8 @@
 step_pin: PC0
 dir_pin: !PL1
 enable_pin: !PA7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA2
 homing_speed: 50
 position_endstop: 380
@@ -18,21 +19,24 @@ arm_length: 290.800
 step_pin: PC1
 dir_pin: PL0
 enable_pin: !PA6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PA1
 
 [stepper_c]
 step_pin: PC2
 dir_pin: !PL2
 enable_pin: !PA5
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^PC7
 
 [extruder]
 step_pin: PC3
 dir_pin: !PL6
 enable_pin: !PA4
-step_distance: .010793
+microsteps: 16
+rotation_distance: 34.538
 nozzle_diameter: 0.500
 filament_diameter: 1.750
 heater_pin: PH6

--- a/config/printer-sovol-sv01-2020.cfg
+++ b/config/printer-sovol-sv01-2020.cfg
@@ -8,7 +8,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar3
 position_endstop: 0
 position_max: 300
@@ -18,7 +19,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar14
 position_endstop: 0
 position_max: 255
@@ -28,7 +30,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: !ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar18
 position_endstop: 0
 position_max: 300
@@ -37,7 +40,8 @@ position_max: 300
 step_pin: ar26
 dir_pin: !ar28
 enable_pin: !ar24
-step_distance: .0024
+microsteps: 16
+rotation_distance: 7.680
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/printer-sunlu-s8-2020.cfg
+++ b/config/printer-sunlu-s8-2020.cfg
@@ -9,7 +9,8 @@
 step_pin: ar54
 dir_pin: !ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar3
 position_endstop: 0
 position_max: 310
@@ -19,7 +20,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar14
 position_endstop: 0
 position_max: 310
@@ -29,7 +31,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!ar18
 position_endstop: 0.5
 position_max: 400
@@ -38,7 +41,8 @@ position_max: 400
 step_pin: ar26
 dir_pin: !ar28
 enable_pin: !ar24
-step_distance: .0104
+microsteps: 16
+rotation_distance: 33.280
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/printer-tevo-flash-2018.cfg
+++ b/config/printer-tevo-flash-2018.cfg
@@ -3,7 +3,7 @@
 
 # Note, this config has only been tested on a modified Tevo Flash
 # (using a Bondtech BMG extruder). If using a stock printer it may be
-# necessary to update the extruder step_distance parameter.
+# necessary to update the extruder rotation_distance parameter.
 
 # See docs/Config_Reference.md for a description of parameters.
 
@@ -11,7 +11,8 @@
 step_pin: ar54
 dir_pin: !ar55
 enable_pin: !ar38
-step_distance: .012491
+microsteps: 16
+rotation_distance: 40
 endstop_pin: !ar3
 position_endstop: -13
 position_min: -13
@@ -22,7 +23,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: .012441
+microsteps: 16
+rotation_distance: 40
 endstop_pin: !ar14
 position_endstop: -3
 position_min: -3
@@ -33,7 +35,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: .002520
+microsteps: 16
+rotation_distance: 8
 position_max: 250
 endstop_pin: probe:z_virtual_endstop
 position_min: -2
@@ -42,13 +45,16 @@ position_min: -2
 step_pin: ar36
 dir_pin: ar34
 enable_pin: !ar30
-step_distance: .002520
+microsteps: 16
+rotation_distance: 8
 
 [extruder]
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .002401
+microsteps: 16
+gear_ratio: 3:1
+rotation_distance: 23.050
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10

--- a/config/printer-tevo-tarantula-pro-2020.cfg
+++ b/config/printer-tevo-tarantula-pro-2020.cfg
@@ -11,7 +11,8 @@
 step_pin: ar54
 dir_pin: !ar55
 enable_pin: !ar38
-step_distance: 0.012583
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar3
 position_endstop: -2
 position_max: 220
@@ -22,7 +23,8 @@ homing_speed: 25.0
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: 0.01256
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar14
 position_endstop: 0
 position_max: 220
@@ -32,7 +34,8 @@ homing_speed: 25.0
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: 0.002492
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!ar18
 position_endstop: 0
 position_max: 200
@@ -42,13 +45,15 @@ position_max: 200
 #step_pin: ar36
 #dir_pin: ar34
 #enable_pin: !ar30
-#step_distance: 0.002492
+#microsteps: 16
+#rotation_distance: 8
 
 [extruder]
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: 0.002470
+microsteps: 16
+rotation_distance: 7.904
 nozzle_diameter: 0.400
 filament_diameter: 1.75
 

--- a/config/printer-tronxy-p802e-2020.cfg
+++ b/config/printer-tronxy-p802e-2020.cfg
@@ -13,7 +13,8 @@
 step_pin: PD7
 dir_pin: PC5
 enable_pin: !PD6
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC2
 position_endstop: -8
 position_max: 220
@@ -24,7 +25,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: PC7
 enable_pin: !PD6
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC3
 position_endstop: 0
 position_min: 0
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PC4
 position_endstop: 0
 position_max: 210
@@ -45,7 +48,8 @@ homing_speed: 20
 step_pin: PB1
 dir_pin: PB0
 enable_pin: !PD6
-step_distance: .0105
+microsteps: 16
+rotation_distance: 33.600
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-tronxy-p802m-2020.cfg
+++ b/config/printer-tronxy-p802m-2020.cfg
@@ -13,7 +13,8 @@
 step_pin: PD7
 dir_pin: PC5
 enable_pin: !PD6
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC2
 position_endstop: -8
 position_max: 220
@@ -24,7 +25,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: PC7
 enable_pin: !PD6
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC3
 position_endstop: 0
 position_min: -5
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PC4
 position_endstop: 0
 position_max: 230
@@ -45,7 +48,8 @@ homing_speed: 20
 step_pin: PB1
 dir_pin: PB0
 enable_pin: !PD6
-step_distance: .0105
+microsteps: 16
+rotation_distance: 33.600
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-tronxy-x5s-2018.cfg
+++ b/config/printer-tronxy-x5s-2018.cfg
@@ -15,7 +15,8 @@
 step_pin: PD7
 dir_pin: !PC5
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC2
 position_endstop: 0
 position_max: 330
@@ -25,7 +26,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: !PC7
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC3
 position_endstop: 0
 position_max: 310
@@ -35,7 +37,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: PB2
 enable_pin: !PD6
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PC4
 position_endstop: 0.5
 position_max: 400
@@ -44,7 +47,8 @@ position_max: 400
 step_pin: PB1
 dir_pin: PB0
 enable_pin: !PD6
-step_distance: .0111
+microsteps: 16
+rotation_distance: 35.520
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-tronxy-x5sa-v6-2019.cfg
+++ b/config/printer-tronxy-x5sa-v6-2019.cfg
@@ -26,7 +26,8 @@ max_z_accel: 30
 step_pin: PE5
 dir_pin: !PE6
 enable_pin: !PC13
-step_distance: .006275
+microsteps: 16
+rotation_distance: 20
 endstop_pin: !PG10
 position_endstop: -1
 position_min: -1
@@ -39,7 +40,8 @@ second_homing_speed: 10.0
 step_pin: PE2
 dir_pin: !PE3
 enable_pin: !PE4
-step_distance: .006275
+microsteps: 16
+rotation_distance: 20
 endstop_pin: !PA12
 position_endstop: 0
 position_max: 330
@@ -51,7 +53,8 @@ second_homing_speed: 10.0
 step_pin: PB9
 dir_pin: PE0
 enable_pin: !PE1
-step_distance: .00125
+microsteps: 16
+rotation_distance: 4
 endstop_pin: probe:z_virtual_endstop
 position_max: 400
 position_min: -2
@@ -60,7 +63,8 @@ position_min: -2
 step_pin: PB4
 dir_pin: PB5
 enable_pin: !PB8
-step_distance: 0.0111
+microsteps: 16
+rotation_distance: 35.520
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PG12

--- a/config/printer-tronxy-x8-2018.cfg
+++ b/config/printer-tronxy-x8-2018.cfg
@@ -19,7 +19,8 @@ serial: /dev/ttyUSB0
 step_pin: PD7
 dir_pin: PC5
 enable_pin: !PD6
-step_distance: 0.010
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC2
 position_endstop: -47
 position_max: 220
@@ -30,7 +31,8 @@ homing_speed: 50
 step_pin: PC6
 dir_pin: PC7
 enable_pin: !PD6
-step_distance: 0.010
+microsteps: 16
+rotation_distance: 32
 endstop_pin: ^!PC3
 position_endstop: 0
 position_max: 220
@@ -41,7 +43,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PD6
-step_distance: 0.0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PC4
 position_endstop: 0
 position_max: 210
@@ -51,7 +54,8 @@ homing_speed: 10
 step_pin: PB1
 dir_pin: PB0
 enable_pin: !PD6
-step_distance: 0.009931
+microsteps: 16
+rotation_distance: 31.779
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/printer-twotrees-sapphire-plus-2020.cfg
+++ b/config/printer-twotrees-sapphire-plus-2020.cfg
@@ -21,7 +21,8 @@
 step_pin: PE3
 dir_pin: !PE2
 enable_pin: !PE4
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: !PA15
 position_endstop: 0
 position_max: 300
@@ -31,7 +32,8 @@ homing_speed: 50
 step_pin: PE0
 dir_pin: !PB9
 enable_pin: !PE1
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: !PA12
 position_endstop: 300
 position_max: 300
@@ -41,7 +43,8 @@ homing_speed: 50
 step_pin: PB5
 dir_pin: PB4
 enable_pin: !PB8
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: !PA11
 position_endstop: 0
 position_max: 340
@@ -50,14 +53,16 @@ position_max: 340
 step_pin: PA6
 dir_pin: PA1
 enable_pin: !PA3
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: !PC4
 
 [extruder]
 step_pin: PD6
 dir_pin: !PD3
 enable_pin: !PB3
-step_distance: .0021
+microsteps: 16
+rotation_distance: 6.720
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC3

--- a/config/printer-twotrees-sapphire-pro-2020.cfg
+++ b/config/printer-twotrees-sapphire-pro-2020.cfg
@@ -18,7 +18,8 @@
 step_pin: PE3
 dir_pin: !PE2
 enable_pin: !PE4
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: !PA15
 position_endstop: 0
 position_max: 230
@@ -28,7 +29,8 @@ homing_speed: 50
 step_pin: PE0
 dir_pin: !PB9
 enable_pin: !PE1
-step_distance: .01
+microsteps: 16
+rotation_distance: 32
 endstop_pin: !PA12
 position_endstop: 230
 position_max: 230
@@ -38,7 +40,8 @@ homing_speed: 50
 step_pin: PB5
 dir_pin: PB4
 enable_pin: !PB8
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: !PA11
 position_endstop: 0.5
 position_max: 230
@@ -47,7 +50,8 @@ position_max: 230
 step_pin: PD6
 dir_pin: !PD3
 enable_pin: !PB3
-step_distance: .0021
+microsteps: 16
+rotation_distance: 6.720
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC3

--- a/config/printer-velleman-k8200-2013.cfg
+++ b/config/printer-velleman-k8200-2013.cfg
@@ -10,7 +10,8 @@
 step_pin: ar54
 dir_pin: !ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar3
 position_endstop: 0
 position_max: 200
@@ -20,7 +21,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar14
 position_endstop: 0
 position_max: 200
@@ -30,7 +32,8 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: !ar48
 enable_pin: !ar63
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^ar18
 position_endstop: 0.5
 # Set position_max to 200 if you have the original Z-axis setup.
@@ -41,9 +44,10 @@ step_pin: ar26
 # Remove the "!" from dir_pin if you have an original extruder
 dir_pin: !ar28
 enable_pin: !ar24
-# You will have to calculate your own step_distance.
+# You will have to calculate your own rotation_distance.
 # This is for the belted extruder https://www.thingiverse.com/thing:339928
-step_distance: .001333
+microsteps: 16
+rotation_distance: 4.266
 nozzle_diameter: 0.400
 filament_diameter: 2.85
 heater_pin: ar10

--- a/config/printer-wanhao-duplicator-6-2016.cfg
+++ b/config/printer-wanhao-duplicator-6-2016.cfg
@@ -8,7 +8,8 @@
 step_pin: PA3
 dir_pin: !PA1
 enable_pin: !PA5
-step_distance: 0.0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PA0
 position_endstop: 0
 position_max: 200
@@ -18,7 +19,8 @@ homing_speed: 50
 step_pin: PC5
 dir_pin: PC4
 enable_pin: !PC6
-step_distance: 0.0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PA4
 position_endstop: 0
 position_max: 200
@@ -28,7 +30,8 @@ homing_speed: 50
 step_pin: PC2
 dir_pin: !PC1
 enable_pin: !PC3
-step_distance: 0.0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PA7
 position_endstop: 0.5
 position_max: 175
@@ -38,7 +41,8 @@ homing_speed: 25
 step_pin: PL7
 dir_pin: !PL6
 enable_pin: !PC0
-step_distance: 0.010091
+microsteps: 16
+rotation_distance: 33.291
 nozzle_diameter: 0.400
 filament_diameter: 1.7500
 heater_pin: PE4

--- a/config/printer-wanhao-duplicator-9-2018.cfg
+++ b/config/printer-wanhao-duplicator-9-2018.cfg
@@ -8,7 +8,8 @@
 step_pin: ar61
 dir_pin: !ar62
 enable_pin: !ar60
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar54
 position_endstop: 0
 position_max: 295
@@ -18,7 +19,8 @@ homing_speed: 30.0
 step_pin: ar64
 dir_pin: ar65
 enable_pin: !ar2
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar24
 position_endstop: 0
 position_max: 290
@@ -28,7 +30,8 @@ homing_speed: 30.0
 step_pin: ar67
 dir_pin: ar69
 enable_pin: !ar66
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: probe:z_virtual_endstop
 position_max: 370
 position_min: -0.99
@@ -37,7 +40,8 @@ position_min: -0.99
 step_pin: ar58
 dir_pin: ar59
 enable_pin: !ar57
-step_distance: .009980
+microsteps: 16
+rotation_distance: 31.936
 nozzle_diameter: 0.4
 filament_diameter: 1.75
 heater_pin: ar4

--- a/config/printer-wanhao-duplicator-i3-mini-2017.cfg
+++ b/config/printer-wanhao-duplicator-i3-mini-2017.cfg
@@ -10,7 +10,8 @@
 step_pin: ar22
 dir_pin: !ar23
 enable_pin: !ar57
-step_distance: 0.0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar19
 position_endstop: 120
 position_max: 120
@@ -20,7 +21,8 @@ homing_speed: 30.0
 step_pin: ar25
 dir_pin: ar26
 enable_pin: !ar24
-step_distance: 0.0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!ar18
 position_endstop: 0
 position_max: 135
@@ -30,7 +32,8 @@ homing_speed: 30.0
 step_pin: ar29
 dir_pin: ar39
 enable_pin: !ar28
-step_distance: 0.0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!ar38
 position_endstop: 0.5
 position_max: 100
@@ -39,7 +42,8 @@ position_max: 100
 step_pin: ar55
 dir_pin: !ar56
 enable_pin: !ar54
-step_distance: 0.010638298
+microsteps: 16
+rotation_distance: 34.043
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar4

--- a/config/printer-wanhao-duplicator-i3-plus-2017.cfg
+++ b/config/printer-wanhao-duplicator-i3-plus-2017.cfg
@@ -11,7 +11,8 @@
 step_pin: PF7
 dir_pin: !PK0
 enable_pin: !PF6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PF0
 position_endstop: 0
 position_max: 200
@@ -21,7 +22,8 @@ homing_speed: 30.0
 step_pin: PK2
 dir_pin: !PK3
 enable_pin: !PK1
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PA2
 position_endstop: 0
 position_max: 200
@@ -31,7 +33,8 @@ homing_speed: 30.0
 step_pin: PK5
 dir_pin: PK7
 enable_pin: !PK4
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PA1
 position_endstop: 0.5
 position_max: 180
@@ -40,7 +43,8 @@ position_max: 180
 step_pin: PF4
 dir_pin: PF5
 enable_pin: !PF3
-step_distance: 0.010417
+microsteps: 16
+rotation_distance: 33.334
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PG5

--- a/config/printer-wanhao-duplicator-i3-plus-mark2-2019.cfg
+++ b/config/printer-wanhao-duplicator-i3-plus-mark2-2019.cfg
@@ -8,7 +8,8 @@
 step_pin: PF7
 dir_pin: !PK0
 enable_pin: !PF6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PF0
 position_endstop: 0
 position_max: 200
@@ -18,7 +19,8 @@ homing_speed: 30.0
 step_pin: PK2
 dir_pin: !PK3
 enable_pin: !PE4
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PA2
 position_endstop: 0
 position_max: 200
@@ -28,7 +30,8 @@ homing_speed: 30.0
 step_pin: PK5
 dir_pin: PK7
 enable_pin: !PK4
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: probe:z_virtual_endstop
 position_max: 180
 position_min: -0.5
@@ -37,7 +40,8 @@ position_min: -0.5
 step_pin: PF4
 dir_pin: PF5
 enable_pin: !PF3
-step_distance: 0.010417
+microsteps: 16
+rotation_distance: 33.334
 nozzle_diameter: 0.300
 filament_diameter: 1.750
 heater_pin: PG5

--- a/config/printer-wanhao-duplicator-i3-v2.1-2017.cfg
+++ b/config/printer-wanhao-duplicator-i3-v2.1-2017.cfg
@@ -32,14 +32,11 @@
 #
 # - Copy this sample file you are currently reading to ~/printer.cfg,
 #   and customize the following parameters:
-#   * [extruder] > step_distance
+#   * [extruder] > rotation_distance
 #
 #     This is the inverse of "E steps" (extruder steps per mm) from the stock
 #     Wanhao Repetier-based firmware.
 #     (See https://3dprinterwiki.info/extruder-steps/ )
-#
-#     For example, if your E-steps are set to 107.0 steps per mm,
-#     then step_distance should be (1 / 107.0) ~= .009346
 #
 #   * [extruder] > PID parameters (pid_Kp, pid_Ki, pid_Kd)
 #   * [heater_bed] > PID parameters (pid_Kp, pid_Ki, pid_Kd)
@@ -92,7 +89,8 @@
 step_pin: PD7
 dir_pin: PC5
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC2
 position_endstop: 0
 position_max: 200
@@ -102,7 +100,8 @@ homing_speed: 40
 step_pin: PC6
 dir_pin: PC7
 enable_pin: !PD6
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^!PC3
 position_endstop: 0
 position_max: 200
@@ -112,7 +111,8 @@ homing_speed: 40
 step_pin: PB3
 dir_pin: !PB2
 enable_pin: !PA5
-step_distance: 0.0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^!PC4
 position_endstop: 0.5
 position_max: 180
@@ -122,7 +122,8 @@ homing_speed: 2
 step_pin: PB1
 dir_pin: !PB0
 enable_pin: !PD6
-step_distance: .009346
+microsteps: 16
+rotation_distance: 29.888
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5

--- a/config/sample-bigtreetech-exp-mot.cfg
+++ b/config/sample-bigtreetech-exp-mot.cfg
@@ -5,7 +5,8 @@
 step_pin: EXP2_6
 dir_pin: EXP2_5
 enable_pin: !EXP2_7
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 position_max: 320
 homing_speed: 50
 
@@ -13,7 +14,8 @@ homing_speed: 50
 step_pin: EXP2_3
 dir_pin: EXP2_4
 enable_pin: !EXP1_8
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 position_max: 300
 homing_speed: 50
 
@@ -21,7 +23,8 @@ homing_speed: 50
 step_pin: EXP2_1
 dir_pin: EXP2_2
 enable_pin: !EXP1_7
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 position_endstop: 0.5
 position_max: 400
 

--- a/config/sample-idex.cfg
+++ b/config/sample-idex.cfg
@@ -8,7 +8,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar3
 position_endstop: 0
 position_max: 200
@@ -19,7 +20,8 @@ homing_speed: 50
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar10
@@ -54,7 +56,8 @@ axis: x
 step_pin: ar16
 dir_pin: ar17
 enable_pin: !ar23
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar2
 position_endstop: 200
 position_max: 200
@@ -64,7 +67,8 @@ homing_speed: 50
 step_pin: ar36
 dir_pin: ar34
 enable_pin: !ar30
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: ar11

--- a/config/sample-mmu2s-diy.cfg
+++ b/config/sample-mmu2s-diy.cfg
@@ -24,17 +24,17 @@ default_type: command
 step_pin: mmboard:PC5
 dir_pin: !mmboard:PB0
 enable_pin: !mmboard:PC4
+microsteps: 16
 # 140 : mk8 gear
-#step_distance: .007142
+#rotation_distance: 22.857
 # 165 : fystec gear for mmu2s
-step_distance: .00606
+rotation_distance: 19.394
 velocity: 20
 accel: 10
 endstop_pin: ^mmboard:PC2 # PINDA X+
 
 [tmc2208 manual_stepper gear_stepper]
 uart_pin: mmboard:PC14
-microsteps: 16
 run_current: 1.000
 hold_current: 0.600
 interpolate: True
@@ -45,13 +45,13 @@ sense_resistor: 0.110
 step_pin: mmboard:PB13
 dir_pin: mmboard:PB14
 enable_pin: !mmboard:PB12
-step_distance: .040000
+microsteps: 16
+rotation_distance: 128
 velocity: 100
 accel: 80
 
 [tmc2209 manual_stepper idler_stepper]
 uart_pin: mmboard:PB7
-microsteps: 16
 run_current: 0.800
 hold_current: 0.800
 interpolate: True
@@ -64,14 +64,14 @@ step_pin: mmboard:PC6
 dir_pin: mmboard:PC7
 enable_pin: !mmboard:PB15
 # 80 step/mm
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 velocity: 35
 accel: 100
 endstop_pin: !mmboard:PC0 # switch endstop on the left Z-
 
 [tmc2209 manual_stepper selector_stepper]
 uart_pin: mmboard:PC12
-microsteps: 16
 run_current: 1.000
 hold_current: 0.400
 interpolate: True

--- a/config/sample-multi-extruder.cfg
+++ b/config/sample-multi-extruder.cfg
@@ -8,7 +8,8 @@
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-step_distance: .004242
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.500
 filament_diameter: 3.500
 heater_pin: ar10
@@ -34,7 +35,8 @@ gcode:
 step_pin: ar36
 dir_pin: ar34
 enable_pin: !ar30
-step_distance: .004242
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.500
 filament_diameter: 3.500
 heater_pin: ar9

--- a/config/sample-multi-mcu.cfg
+++ b/config/sample-multi-mcu.cfg
@@ -25,7 +25,8 @@ pin_map: arduino
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar3
 position_endstop: 0
 position_max: 200
@@ -35,7 +36,8 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-step_distance: .0125
+microsteps: 16
+rotation_distance: 40
 endstop_pin: ^ar14
 position_endstop: 0
 position_max: 200
@@ -45,7 +47,8 @@ homing_speed: 50
 step_pin: zboard:ar46
 dir_pin: zboard:ar48
 enable_pin: !zboard:ar62
-step_distance: .0025
+microsteps: 16
+rotation_distance: 8
 endstop_pin: ^zboard:ar18
 position_endstop: 0.5
 position_max: 200
@@ -54,7 +57,8 @@ position_max: 200
 step_pin: auxboard:ar26
 dir_pin: auxboard:ar28
 enable_pin: !auxboard:ar24
-step_distance: .002
+microsteps: 16
+rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: auxboard:ar10

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,12 @@ All dates in this document are approximate.
 
 # Changes
 
+20201218: Rotary delta and polar printers must now specify a
+`gear_ratio` for their rotary steppers, and they may no longer specify
+a `step_distance` parameter.  See the
+[config reference](Config_Reference.md#stepper) for the format of the
+new gear_ratio paramter.
+
 20201213: It is not valid to specify a Z "position_endstop" when using
 "probe:z_virtual_endstop".  An error will now be raised if a Z
 "position_endstop" is specified with "probe:z_virtual_endstop".

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,11 @@ All dates in this document are approximate.
 
 # Changes
 
+20201218: The `endstop_phase` setting in the endstop_phase module has
+been replaced with `trigger_phase`. If using the endstop phases module
+then it will be necessary to recalibrate any endstop phases by running
+the ENDSTOP_PHASE_CALIBRATE command.
+
 20201218: Rotary delta and polar printers must now specify a
 `gear_ratio` for their rotary steppers, and they may no longer specify
 a `step_distance` parameter.  See the

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1112,21 +1112,17 @@ for additional information.
 
 ```
 [endstop_phase stepper_z]
-#phases:
-#   This specifies the number of phases of the given stepper motor
-#   driver (which is the number of micro-steps multiplied by four).
-#   This setting is automatically determined if one uses a TMC driver
-#   with run-time configuration. Otherwise, this parameter must be
-#   provided.
 #endstop_accuracy:
 #   Sets the expected accuracy (in mm) of the endstop. This represents
 #   the maximum error distance the endstop may trigger (eg, if an
 #   endstop may occasionally trigger 100um early or up to 100um late
 #   then set this to 0.200 for 200um). The default is
-#   phases*step_distance.
-#endstop_phase:
+#   4*rotation_distance/full_steps_per_rotation.
+#trigger_phase:
 #   This specifies the phase of the stepper motor driver to expect
-#   when hitting the endstop. Only set this value if one is sure the
+#   when hitting the endstop. It is composed of two numbers separated
+#   by a forward slash character - the phase and the total number of
+#   phases (eg, "7/64"). Only set this value if one is sure the
 #   stepper motor driver is reset every time the mcu is reset. If this
 #   is not set, then the stepper phase will be detected on the first
 #   home and that phase will be used on all subsequent homes.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -116,6 +116,9 @@ the "kinematics" option in the [printer] config section) require
 different names for the stepper (eg, `stepper_x` vs `stepper_a`).
 Below are common stepper definitions.
 
+See the [rotation distance document](Rotation_Distance.md) for
+information on calculating the `rotation_distance` parameter.
+
 ```
 [stepper_x]
 step_pin:

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -127,9 +127,24 @@ enable_pin:
 #   Enable pin (default is enable high; use ! to indicate enable
 #   low). If this parameter is not provided then the stepper motor
 #   driver must always be enabled.
-step_distance:
-#   Distance in mm that each step causes the axis to travel. This
+rotation_distance:
+#   Distance (in mm) that the axis travels with one full rotation of
+#   the stepper motor. This parameter must be provided.
+microsteps:
+#   The number of microsteps the stepper motor driver uses. This
 #   parameter must be provided.
+#full_steps_per_rotation: 200
+#   The number of full steps for one rotation of the stepper motor.
+#   Set this to 200 for a 1.8 degree stepper motor or set to 400 for a
+#   0.9 degree motor. The default is 200.
+#gear_ratio:
+#   The gear ratio if the stepper motor is connected to the axis via a
+#   gearbox. For example, one may specify "5:1" if a 5 to 1 gearbox is
+#   in use. If the axis has multiple gearboxes one may specify a comma
+#   separated list of gear ratios (for example, "57:11, 2:1"). If a
+#   gear_ratio is specified then rotation_distance specifies the
+#   distance the axis travels for one full rotation of the final gear.
+#   The default is to not use a gear ratio.
 endstop_pin:
 #   Endstop switch detection pin. This parameter must be provided for
 #   the X, Y, and Z steppers on cartesian style printers.
@@ -367,11 +382,11 @@ kinematics: polar
 # The stepper_bed section is used to describe the stepper controlling
 # the bed.
 [stepper_bed]
-step_distance:
-#   On a polar printer the step_distance is the amount each step pulse
-#   moves the bed in radians (for example, a 1.8 degree stepper with
-#   16 micro-steps would be 2 * pi * (1.8 / 360) / 16 == 0.001963495).
-#   This parameter must be provided.
+gear_ratio:
+#   A gear_ratio must be specified and rotation_distance may not be
+#   specified. For example, if the bed has an 80 toothed pulley driven
+#   by a stepper with a 16 toothed pulley then one would specify a
+#   gear ratio of "80:16". This parameter must be provided.
 max_z_velocity:
 #   This sets the maximum velocity (in mm/s) of movement along the z
 #   axis. This setting can be used to restrict the maximum speed of
@@ -429,11 +444,13 @@ shoulder_height:
 # right arm (at 30 degrees). This section also controls the homing
 # parameters (homing_speed, homing_retract_dist) for all arms.
 [stepper_a]
-step_distance:
-#   On a rotary delta printer the step_distance is the amount each
-#   step pulse moves the upper arm in radians (for example, a directly
-#   connected 1.8 degree stepper with 16 micro-steps would be 2 * pi *
-#   (1.8 / 360) / 16 == 0.001963495). This parameter must be provided.
+gear_ratio:
+#   A gear_ratio must be specified and rotation_distance may not be
+#   specified. For example, if the arm has an 80 toothed pulley driven
+#   by a pulley with 16 teeth, which is in turn connected to a 60
+#   toothed pulley driven by a stepper with a 16 toothed pulley, then
+#   one would specify a gear ratio of "80:16, 60:16". This parameter
+#   must be provided.
 position_endstop:
 #   Distance (in mm) between the nozzle and the bed when the nozzle is
 #   in the center of the build area and the endstop triggers. This
@@ -501,10 +518,10 @@ kinematics: winch
 # cable winch. A minimum of 3 and a maximum of 26 cable winches may be
 # defined (stepper_a to stepper_z) though it is common to define 4.
 [stepper_a]
-step_distance:
-#   The step_distance is the nominal distance (in mm) the toolhead
-#   moves towards the cable winch on each step pulse. This parameter
-#   must be provided.
+rotation_distance:
+#   The rotation_distance is the nominal distance (in mm) the toolhead
+#   moves towards the cable winch for each full rotation of the
+#   stepper motor. This parameter must be provided.
 anchor_x:
 anchor_y:
 anchor_z:
@@ -541,7 +558,8 @@ tuning pressure advance.
 step_pin:
 dir_pin:
 enable_pin:
-step_distance:
+microsteps:
+rotation_distance:
 #   See the "stepper" section for a description of the above parameters.
 nozzle_diameter:
 #   Diameter of the nozzle orifice (in mm). This parameter must be
@@ -1613,7 +1631,8 @@ at 1 (for example, "stepper_z1", "stepper_z2", etc.).
 #step_pin:
 #dir_pin:
 #enable_pin:
-#step_distance:
+#microsteps:
+#rotation_distance:
 #   See the "stepper" section for the definition of the above parameters.
 #endstop_pin:
 #   If an endstop_pin is defined for the additional stepper then the
@@ -1670,7 +1689,8 @@ axis:
 #step_pin:
 #dir_pin:
 #enable_pin:
-#step_distance:
+#microsteps:
+#rotation_distance:
 #endstop_pin:
 #position_endstop:
 #position_min:
@@ -1695,7 +1715,8 @@ more information.
 #step_pin:
 #dir_pin:
 #enable_pin:
-#step_distance:
+#microsteps:
+#rotation_distance:
 #   See the "stepper" section for the definition of the above
 #   parameters.
 ```
@@ -1715,7 +1736,8 @@ normal printer kinematics.
 #step_pin:
 #dir_pin:
 #enable_pin:
-#step_distance:
+#microsteps:
+#rotation_distance:
 #   See the "stepper" section for a description of these parameters.
 #velocity:
 #   Set the default velocity (in mm/s) for the stepper. This value
@@ -2531,10 +2553,6 @@ cs_pin:
 #spi_software_miso_pin:
 #   See the "common SPI settings" section for a description of the
 #   above parameters.
-microsteps:
-#   The number of microsteps to configure the driver to use. Valid
-#   values are 1, 2, 4, 8, 16, 32, 64, 128, 256. This parameter must
-#   be provided.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). The default is True.
@@ -2601,10 +2619,6 @@ uart_pin:
 #   A comma separated list of pins to set prior to accessing the
 #   tmc2208 UART. This may be useful for configuring an analog mux for
 #   UART communication. The default is to not configure any pins.
-microsteps:
-#   The number of microsteps to configure the driver to use. Valid
-#   values are 1, 2, 4, 8, 16, 32, 64, 128, 256. This parameter must
-#   be provided.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). The default is True.
@@ -2654,7 +2668,6 @@ by the name of the corresponding stepper config section (for example,
 uart_pin:
 #tx_pin:
 #select_pins:
-#microsteps:
 #interpolate: True
 run_current:
 #hold_current:
@@ -2715,10 +2728,6 @@ cs_pin:
 #spi_software_miso_pin:
 #   See the "common SPI settings" section for a description of the
 #   above parameters.
-microsteps:
-#   The number of microsteps to configure the driver to use. Valid
-#   values are 1, 2, 4, 8, 16, 32, 64, 128, 256. This parameter must
-#   be provided.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). This only works if microsteps
@@ -2786,10 +2795,6 @@ cs_pin:
 #spi_software_miso_pin:
 #   See the "common SPI settings" section for a description of the
 #   above parameters.
-microsteps:
-#   The number of microsteps to configure the driver to use. Valid
-#   values are 1, 2, 4, 8, 16, 32, 64, 128, 256. This parameter must
-#   be provided.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). The default is True.

--- a/docs/Config_checks.md
+++ b/docs/Config_checks.md
@@ -100,7 +100,7 @@ then it generally indicates that the "dir_pin" for the axis needs to
 be inverted. This is done by adding a '!' to the "dir_pin" in the
 printer config file (or removing it if one is already there). If the
 motor moves significantly more or significantly less than one
-millimeter then verify the "step_distance" setting.
+millimeter then verify the "rotation_distance" setting.
 
 Run the above test for each stepper motor defined in the config
 file. (Set the STEPPER parameter of the STEPPER_BUZZ command to the

--- a/docs/Endstop_Phase.md
+++ b/docs/Endstop_Phase.md
@@ -121,6 +121,6 @@ Additional notes
   will arrange for the micro-controller to always be reset via a USB
   power reset, which would arrange for both the micro-controller and
   stepper motor drivers to be reset together. If using this mechanism,
-  one would then need to manually configure the "endstop_phase" config
+  one would then need to manually configure the "trigger_phase" config
   sections (see [config reference](Config_Reference.md#endstop_phase)
   for the details).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -262,9 +262,9 @@ around 10000 steps per second. If it is requested to move at a speed
 that would require a higher step rate then Marlin will generally just
 step as fast as it can. Klipper is able to achieve much higher step
 rates, but the stepper motor may not have sufficient torque to move at
-a higher speed. So, for a Z axis with a very precise step_distance the
-actual obtainable max_z_velocity may be smaller than what is
-configured in Marlin.
+a higher speed. So, for a Z axis with a high gearing ratio or high
+microsteps setting the actual obtainable max_z_velocity may be smaller
+than what is configured in Marlin.
 
 ### My TMC motor driver turns off in the middle of a print
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,7 +2,7 @@ Frequently asked questions
 ==========================
 
 1. [How can I donate to the project?](#how-can-i-donate-to-the-project)
-2. [How do I calculate the step_distance parameter in the printer config file?](#how-do-i-calculate-the-step_distance-parameter-in-the-printer-config-file)
+2. [How do I calculate the rotation_distance config parameter?](#how-do-i-calculate-the-rotation_distance-config-parameter)
 3. [Where's my serial port?](#wheres-my-serial-port)
 4. [When the micro-controller restarts the device changes to /dev/ttyUSB1](#when-the-micro-controller-restarts-the-device-changes-to-devttyusb1)
 5. [The "make flash" command doesn't work](#the-make-flash-command-doesnt-work)
@@ -31,25 +31,9 @@ Frequently asked questions
 Thanks. Kevin has a Patreon page at:
 [https://www.patreon.com/koconnor](https://www.patreon.com/koconnor)
 
-### How do I calculate the step_distance parameter in the printer config file?
+### How do I calculate the rotation_distance config parameter?
 
-If you know the steps per millimeter for the axis then use a
-calculator to divide 1.0 by steps_per_mm. Then round this number to
-six decimal places and place it in the config (six decimal places is
-nano-meter precision).
-
-The step_distance defines the distance that the axis will travel on
-each motor driver pulse. It can also be calculated from the axis
-pitch, motor step angle, and driver microstepping. If unsure, do a web
-search for "calculate steps per mm" to find an online calculator.
-
-Klipper uses step_distance instead of steps_per_mm in order to use
-consistent units of measurement in the config file. (The config uses
-millimeters for all distance measurements.) It is believed that
-steps_per_mm originated as an optimization on old 8-bit
-micro-controllers (the desire to use a multiply instead of a divide in
-some low-level code). Continuing to configure this one distance in
-units of "inverse millimeters" is felt to be quirky and unnecessary.
+See the [rotation distance document](Rotation_Distance.md).
 
 ### Where's my serial port?
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -172,8 +172,10 @@ The following standard commands are supported:
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active
   extruder.
-- `SET_EXTRUDER_STEP_DISTANCE [EXTRUDER=<config_name>] [DISTANCE=<distance>]`:
-  Set a new value for the provided extruder's step_distance. Value is
+- `SET_EXTRUDER_STEP_DISTANCE [EXTRUDER=<config_name>]
+  [DISTANCE=<distance>]`: Set a new value for the provided extruder's
+  "step distance". The "step distance" is
+  `rotation_distance/(full_steps_per_rotation*microsteps)`. Value is
   not retained on Klipper reset. Use with caution, small changes can
   result in excessive pressure between extruder and hot end. Do proper
   calibration steps with filament before use. If 'DISTANCE' value is

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -17,6 +17,8 @@ communication with the Klipper developers.
 - [Installation](Installation.md): Guide to installing Klipper.
 - [Config Reference](Config_Reference.md): Description of config
   parameters.
+  - [Rotation Distance](Rotation_Distance.md): Calculating the
+    rotation_distance stepper parameter.
 - [Config checks](Config_checks.md): Verify basic pin settings in the
   config file.
 - [Bed level](Bed_Level.md): Information on "bed leveling" in Klipper.

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -114,11 +114,12 @@ Recv: // probe accuracy results: maximum 2.519448, minimum 2.506948, range 0.012
 Ideally the tool will report an identical maximum and minimum value.
 (That is, ideally the probe obtains an identical result on all ten
 probes.) However, it's normal for the minimum and maximum values to
-differ by one Z step_distance or up to 5 microns (.005mm). The
-distance between the minimum and the maximum value is called the
-range. So, in the above example, since the printer uses a Z
-step_distance of .0125, a range of 0.012500 would be considered
-normal.
+differ by one Z "step distance" or up to 5 microns (.005mm). A "step
+distance" is
+`rotation_distance/(full_steps_per_rotation*microsteps)`. The distance
+between the minimum and the maximum value is called the range. So, in
+the above example, since the printer uses a Z step distance of .0125,
+a range of 0.012500 would be considered normal.
 
 If the results of the test show a range value that is greater than 25
 microns (.025mm) then the probe does not have sufficient accuracy for

--- a/docs/Rotation_Distance.md
+++ b/docs/Rotation_Distance.md
@@ -1,0 +1,172 @@
+Stepper motor drivers on Klipper require a `rotation_distance`
+parameter in each
+[stepper config section](Config_Reference.md#stepper). The
+`rotation_distance` is the amount of distance that the axis moves with
+one full revolution of the stepper motor. This document describes how
+one can configure this value.
+
+# Obtaining rotation_distance from steps_per_mm (or step_distance)
+
+The designers of your 3d printer originally calculated `steps_per_mm`
+from a rotation distance. If you know the steps_per_mm then it is
+possible to use this general formula to obtain that original rotation
+distance:
+```
+rotation_distance = <full_steps_per_rotation> * <microsteps> / <steps_per_mm>
+```
+
+Or, if you have an older Klipper configuration and know the
+`step_distance` parameter you can use this formula:
+```
+rotation_distance = <full_steps_per_rotation> * <microsteps> * <step_distance>
+```
+
+The `<full_steps_per_rotation>` setting is determined from the type of
+stepper motor. Most stepper motors are "1.8 degree steppers" and
+therefore have 200 full steps per rotation (360 divided by 1.8 is
+200). Some stepper motors are "0.9 degree steppers" and thus have 400
+full steps per rotation. Other stepper motors are rare. If unsure, do
+not set full_steps_per_rotation in the config file and use 200 in the
+formula above.
+
+The `<microsteps>` setting is determined by the stepper motor driver.
+Most drivers use 16 microsteps. If unsure, set `microsteps: 16` in the
+config and use 16 in the formula above.
+
+Almost all printers should have a whole number for `rotation_distance`
+on x, y, and z type axes. If the above formula results in a
+rotation_distance that is within .01 of a whole number then round the
+final value to that whole_number.
+
+# Calibrating rotation_distance on extruders
+
+On an extruder, the `rotation_distance` is the amount of distance the
+filament travels for one full rotation of the stepper motor. The best
+way to get an accurate value for this setting is to use a "measure and
+trim" procedure.
+
+First start with an initial guess for the rotation distance. This may
+be obtained from
+[steps_per_mm](#obtaining-rotation_distance-from-steps_per_mm-or-step_distance)
+or by [inspecting the hardware](#extruder).
+
+Then use the following procedure to "measure and trim":
+1. Make sure the extruder has filament in it, the hotend is heated to
+   an appropriate temperature, and the printer is ready to extrude.
+2. Use a marker to place a mark on the filament around 70mm from the
+   intake of the extruder body. Then use a digital calipers to measure
+   the actual distance of that mark as precisely as one can. Note this
+   as `<initial_mark_distance>`.
+3. Extrude 50mm of filament with the following command sequence: `G91`
+   followed by `G1 E50 F60`. Note 50mm as
+   `<requested_extrude_distance>`. Wait for the extruder to finish the
+   move (it will take about 50 seconds).
+4. Use the digital calipers to measure the new distance between the
+   extruder body and the mark on the filament. Note this as
+   `<subsequent_mark_distance>`. Then calculate
+   `actual_extrude_distance = <initial_mark_distance> -
+   <subsequent_mark_distance>`.
+5. Calculate rotation_distance as `rotation_distance =
+   <previous_rotation_distance> * <actual_extrude_distance> /
+   <requested_extrude_distance>`. Round the new rotation_distance to
+   three decimal places.
+
+If the actual_extrude_distance differs from requested_extrude_distance
+by more than about 2mm then it is a good idea to perform the steps
+above a second time.
+
+Note: Do *not* use a "measure and trim" type of method to calibrate x,
+y, or z type axes. The "measure and trim" method is not accurate
+enough for those axes and will likely lead to a worse configuration.
+Instead, if needed, those axes can be determined by
+[measuring the belts, pulleys, and lead screw hardware](#obtaining-rotation_distance-by-inspecting-the-hardware).
+
+# Obtaining rotation_distance by inspecting the hardware
+
+It's possible to calculate rotation_distance with knowledge of the
+stepper motors and printer kinematics. This may be useful if the
+steps_per_mm is not known or if designing a new printer.
+
+## Belt driven axes
+
+It is easy to calculate rotation_distance for a linear axis that uses
+a belt and pulley.
+
+First determine the type of belt. Most printers use a 2mm belt pitch
+(that is, each tooth on the belt is 2mm apart). Then count the number
+of teeth on the stepper motor pulley. The rotation_distance is then
+calculated as:
+```
+rotation_distance = <belt_pitch> * <number_of_teeth_on_pulley>
+```
+
+For example, if a printer has a 2mm belt and uses a pulley with 20
+teeth, then the rotation distance is 40.
+
+## Axes with a lead screw
+
+It is easy to calculate the rotation_distance for common lead screws
+using the following formula:
+```
+rotation_distance = <screw_pitch> * <number_of_separate_threads>
+```
+
+For example, the common "T8 leadscrew" has a rotation distance of 8
+(it has a pitch of 2mm and has 4 separate threads).
+
+Older printers with "threaded rods" have only one "thread" on the lead
+screw and thus the rotation distance is the pitch of the screw. (The
+screw pitch is the distance between each groove on the screw.) So, for
+example, an M6 metric rod has a rotation distance of 1 and an M8 rod
+has a rotation distance of 1.25.
+
+## Extruder
+
+It's possible to obtain an initial rotation distance for extruders by
+measuring the diameter of the "hobbed bolt" that pushes the filament
+and using the following formula: `rotation_distance =
+<diameter> * 3.14`
+
+If the extruder uses gears then it will also be necessary to
+[determine and set the gear_ratio](#using-a-gear_ratio) for the
+extruder.
+
+The actual rotation distance on an extruder will vary from printer to
+printer, because the grip of the "hobbed bolt" that engages the
+filament can vary. It can even vary between filament spools. After
+obtaining an initial rotation_distance, use the
+[measure and trim procedure](#calibrating-rotation_distance-on-extruders)
+to obtain a more accurate setting.
+
+# Using a gear_ratio
+
+Setting a `gear_ratio` can make it easier to configure the
+`rotation_distance` on steppers that have a gear box (or similar)
+attached to it. Most steppers do not have a gear box - if unsure then
+do not set `gear_ratio` in the config.
+
+When `gear_ratio` is set, the `rotation_distance` represents the
+distance the axis moves with one full rotation of the final gear on
+the gear box. If, for example, one is using a gearbox with a "5:1"
+ratio, then one could calculate the rotation_distance with
+[knowledge of the hardware](#obtaining-rotation_distance-by-inspecting-the-hardware)
+and then add `gear_ratio: 5:1` to the config.
+
+For gearing implemented with belts and pulleys, it is possible to
+determine the gear_ratio by counting the teeth on the pulleys. For
+example, if a stepper with a 16 toothed pulley drives the next pulley
+with 80 teeth then one would use `gear_ratio: 80:16`. Indeed, one
+could open a common off the shelf "gear box" and count the teeth in it
+to confirm its gear ratio. Note that the common "5.18:1 planetary
+gearbox" is more accurately configured with `gear_ratio: 57:11`.
+
+If several gears are used on an axis then it is possible to provide a
+comma separated list to gear_ratio. For example, a "5:1" gear box
+driving a 16 toothed to 80 toothed pulley could use `gear_ratio: 5:1,
+80:16`.
+
+In most cases, gear_ratio should be defined with whole numbers as
+common gears and pulleys have a whole number of teeth on them.
+However, in cases where a belt drives a pulley using friction instead
+of teeth, it may make sense to use a floating point number in the gear
+ratio (eg, `gear_ratio: 107.237:16`).

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -4,8 +4,12 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
+import stepper
 
 TRINAMIC_DRIVERS = ["tmc2130", "tmc2208", "tmc2209", "tmc2660", "tmc5160"]
+
+def convert_phase(driver_phase, driver_phases, phases):
+    return (int(float(driver_phase) / driver_phases * phases + .5) % phases)
 
 class EndstopPhase:
     def __init__(self, config):
@@ -17,37 +21,26 @@ class EndstopPhase:
         self.printer.register_event_handler("homing:home_rails_end",
                                             self.handle_home_rails_end)
         self.printer.load_object(config, "endstop_phase")
-        self.printer.load_object(config, "force_move")
+        # Obtain step_distance and microsteps from stepper config section
+        sconfig = config.getsection(self.name)
+        self.step_dist = stepper.parse_step_distance(sconfig)
+        self.phases = sconfig.getint("microsteps", note_valid=False) * 4
         # Read config
-        self.phases = config.getint('phases', None, minval=1)
-        self.endstop_phase = config.getint('endstop_phase', None, minval=0)
+        self.endstop_phase = None
+        trigger_phase = config.get('trigger_phase', None)
+        if trigger_phase is not None:
+            try:
+                p, ps = [int(v.strip()) for v in trigger_phase.split('/')]
+            except:
+                raise config.error("Unable to parse trigger_phase '%s'"
+                                   % (trigger_phase,))
+            if p >= ps:
+                raise config.error("Invalid trigger_phase '%s'"
+                                   % (trigger_phase,))
+            self.endstop_phase = convert_phase(p, ps, self.phases)
         self.endstop_align_zero = config.getboolean('endstop_align_zero', False)
         self.endstop_accuracy = config.getfloat('endstop_accuracy', None,
                                                 above=0.)
-        self.step_dist = self.endstop_phase_accuracy = None
-    def handle_connect(self):
-        # Determine number of stepper phases
-        for driver in TRINAMIC_DRIVERS:
-            driver_name = "%s %s" % (driver, self.name)
-            module = self.printer.lookup_object(driver_name, None)
-            if module is not None:
-                self.get_phase = module.get_phase
-                if self.phases is not None:
-                    raise self.printer.config_error(
-                        "endstop_phase phases set with tmc driver")
-                self.phases = module.get_microsteps() * 4
-                break
-        else:
-            self.get_phase = None
-            if self.phases is None:
-                raise self.printer.config_error(
-                    "endstop_phase phases must be specified")
-        if self.endstop_phase is not None and self.endstop_phase >= self.phases:
-            raise self.printer.config_error(
-                "endstop_phase endstop_phase parameter not valid")
-        # Lookup stepper step_dist
-        force_move = self.printer.lookup_object("force_move")
-        self.step_dist = force_move.lookup_stepper(self.name).get_step_dist()
         # Determine endstop accuracy
         if self.endstop_accuracy is None:
             self.endstop_phase_accuracy = self.phases//2 - 1
@@ -63,6 +56,15 @@ class EndstopPhase:
         if self.printer.get_start_args().get('debugoutput') is not None:
             self.endstop_phase_accuracy = self.phases
         self.phase_history = [0] * self.phases
+        self.get_phase = None
+    def handle_connect(self):
+        # Check for trinamic driver with get_phase() method
+        for driver in TRINAMIC_DRIVERS:
+            driver_name = "%s %s" % (driver, self.name)
+            module = self.printer.lookup_object(driver_name, None)
+            if module is not None:
+                self.get_phase = module.get_phase
+                break
     def align_endstop(self, pos):
         if not self.endstop_align_zero or self.endstop_phase is None:
             return pos
@@ -76,13 +78,14 @@ class EndstopPhase:
     def get_homed_offset(self, stepper):
         if self.get_phase is not None:
             try:
-                phase = self.get_phase()
+                driver_phase, driver_phases = self.get_phase()
             except Exception as e:
                 msg = "Unable to get stepper %s phase: %s" % (self.name, str(e))
                 logging.exception(msg)
                 raise self.printer.command_error(msg)
             if stepper.is_dir_inverted():
-                phase = (self.phases - 1) - phase
+                driver_phase = (driver_phases - 1) - driver_phase
+            phase = convert_phase(driver_phase, driver_phases, self.phases)
         else:
             phase = stepper.get_mcu_position() % self.phases
         self.phase_history[phase] += 1
@@ -140,10 +143,11 @@ class EndstopPhases:
         if get_phase is None:
             return
         try:
-            phase = get_phase()
+            driver_phase, driver_phases = get_phase()
         except:
             logging.exception("Error in EndstopPhases get_phase")
             return
+        phase = convert_phase(driver_phase, driver_phases, len(phase_history))
         phase_history[phase] += 1
     def handle_home_rails_end(self, rails):
         for rail in rails:
@@ -163,11 +167,12 @@ class EndstopPhases:
         if info is None:
             raise gcmd.error("Stats not available for stepper %s"
                              % (stepper_name,))
-        endstop_phase = self.generate_stats(stepper_name, info)
+        endstop_phase, phases = self.generate_stats(stepper_name, info)
         configfile = self.printer.lookup_object('configfile')
-        section = 'endstop_phase %s' % stepper_name
+        section = 'endstop_phase %s' % (stepper_name,)
         configfile.remove_section(section)
-        configfile.set(section, "endstop_phase", endstop_phase)
+        configfile.set(section, "trigger_phase",
+                       "%s/%s" % (endstop_phase, phases))
         gcmd.respond_info(
             "The SAVE_CONFIG command will update the printer config\n"
             "file with these parameters and restart the printer.")
@@ -188,9 +193,9 @@ class EndstopPhases:
                  if wph[j]]
         best_phase = best % phases
         lo, hi = found[0] % phases, found[-1] % phases
-        self.gcode.respond_info("%s: endstop_phase=%d (range %d to %d)"
-                                % (stepper_name, best_phase, lo, hi))
-        return best_phase
+        self.gcode.respond_info("%s: trigger_phase=%d/%d (range %d to %d)"
+                                % (stepper_name, best_phase, phases, lo, hi))
+        return best_phase, phases
     def report_stats(self):
         if not self.tracking:
             self.gcode.respond_info(

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -283,7 +283,7 @@ class TMCMicrostepHelper:
             field_name = "MSTEP"
         reg = self.mcu_tmc.get_register(self.fields.lookup_register(field_name))
         mscnt = self.fields.get_field(field_name, reg)
-        return (1023 - mscnt) >> self.fields.get_field("MRES")
+        return 1023 - mscnt, 1024
 
 # Helper to configure "stealthchop" mode
 def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -1,9 +1,10 @@
 # Common helper code for TMC stepper drivers
 #
-# Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, collections
+import stepper
 
 
 ######################################################################
@@ -263,9 +264,14 @@ class TMCMicrostepHelper:
     def __init__(self, config, mcu_tmc):
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
+        stepper_name = " ".join(config.get_name().split()[1:])
+        stepper_config = ms_config = config.getsection(stepper_name)
+        if stepper_config.get('microsteps', None, note_valid=False) is None:
+            # Older config format with microsteps in tmc config section
+            ms_config = config
         steps = {'256': 0, '128': 1, '64': 2, '32': 3, '16': 4,
                  '8': 5, '4': 6, '2': 7, '1': 8}
-        mres = config.getchoice('microsteps', steps)
+        mres = ms_config.getchoice('microsteps', steps)
         self.fields.set_field("MRES", mres)
         self.fields.set_field("intpol", config.getboolean("interpolate", True))
     def get_microsteps(self):
@@ -287,7 +293,7 @@ def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):
     if velocity:
         stepper_name = " ".join(config.get_name().split()[1:])
         stepper_config = config.getsection(stepper_name)
-        step_dist = stepper_config.getfloat('step_distance', note_valid=False)
+        step_dist = stepper.parse_step_distance(stepper_config)
         step_dist_256 = step_dist / (1 << fields.get_field("MRES"))
         threshold = int(tmc_freq * step_dist_256 / velocity + .5)
         fields.set_field("TPWMTHRS", max(0, min(0xfffff, threshold)))

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -183,7 +183,7 @@ def PrinterStepper(config, units_in_radians=False):
     step_pin_params = ppins.lookup_pin(step_pin, can_invert=True)
     dir_pin = config.get('dir_pin')
     dir_pin_params = ppins.lookup_pin(dir_pin, can_invert=True)
-    step_dist = config.getfloat('step_distance', above=0.)
+    step_dist = parse_step_distance(config, units_in_radians, True)
     mcu_stepper = MCU_stepper(name, step_pin_params, dir_pin_params, step_dist,
                               units_in_radians)
     # Support for stepper enable pin handling
@@ -193,6 +193,47 @@ def PrinterStepper(config, units_in_radians=False):
     force_move = printer.load_object(config, 'force_move')
     force_move.register_stepper(mcu_stepper)
     return mcu_stepper
+
+# Parse stepper gear_ratio config parameter
+def parse_gear_ratio(config, note_valid):
+    gear_ratio = config.get('gear_ratio', None, note_valid=note_valid)
+    if gear_ratio is None:
+        return 1.
+    result = 1.
+    try:
+        gears = gear_ratio.split(',')
+        for gear in gears:
+            g1, g2 = [float(v.strip()) for v in gear.split(':')]
+            result *= g1 / g2
+    except:
+        raise config.error("Unable to parse gear_ratio: %s" % (gear_ratio,))
+    return result
+
+# Obtain "step distance" information from a config section
+def parse_step_distance(config, units_in_radians=None, note_valid=False):
+    if units_in_radians is None:
+        # Caller doesn't know if units are in radians - infer it
+        rd = config.get('rotation_distance', None, note_valid=False)
+        gr = config.get('gear_ratio', None, note_valid=False)
+        units_in_radians = rd is None and gr is not None
+    if units_in_radians:
+        rotation_dist = 2. * math.pi
+        config.get('gear_ratio', note_valid=note_valid)
+    else:
+        rotation_dist = config.getfloat('rotation_distance', None,
+                                        above=0., note_valid=note_valid)
+    if rotation_dist is None:
+        # Older config format with step_distance
+        return config.getfloat('step_distance', above=0., note_valid=note_valid)
+    # Newer config format with rotation_distance
+    microsteps = config.getint('microsteps', minval=1, note_valid=note_valid)
+    full_steps = config.getint('full_steps_per_rotation', 200, minval=1,
+                               note_valid=note_valid)
+    if full_steps % 4:
+        raise config.error("full_steps_per_rotation invalid in section '%s'"
+                           % (config.get_name(),))
+    gearing = parse_gear_ratio(config, note_valid)
+    return rotation_dist / (full_steps * microsteps * gearing)
 
 
 ######################################################################

--- a/test/klippy/rotary_delta_calibrate.cfg
+++ b/test/klippy/rotary_delta_calibrate.cfg
@@ -3,7 +3,8 @@
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-step_distance: 0.000010
+microsteps: 16
+gear_ratio: 107.000:16, 60:16
 endstop_pin: ^ar2
 homing_speed: 50
 #position_endstop: 252
@@ -14,14 +15,16 @@ lower_arm_length: 320.000
 step_pin: ar60
 dir_pin: ar61
 enable_pin: !ar56
-step_distance: 0.000010
+microsteps: 16
+gear_ratio: 107.000:16, 60:16
 endstop_pin: ^ar15
 
 [stepper_c]
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-step_distance: 0.000010
+microsteps: 16
+gear_ratio: 107.000:16, 60:16
 endstop_pin: ^ar19
 
 [mcu]


### PR DESCRIPTION
I'd like to move forward with a change to stepper configuration last discussed in PR #2354 .  It removes the stepper `step_distance` parameter and introduces a new `rotation_distance` parameter.

I'm proposing two major phases for this change.  The first phase would be a merge of this branch (ideally later this week - 20201218).  With that merge the following would occur:
- Users that utilize endstop_phases would need to update their configs to use the new rotation_distance config.
- Users with "rotary delta" and "polar" printers would need to stop using `step_distance` and start using `gear_ratio`.
- All other users would be able to convert to rotation_distance, but would not be required to make any config change at that time.

The second phase would be targeted for a little over six months later (~20210615).  At that point:
- All users, that haven't already converted, would be required to convert to rotation_distance.

I've put together a document describing how one can convert from step_distance (or steps_per_mm) to rotation_distance.  It is at: https://github.com/KevinOConnor/klipper/blob/work-rotation-distance-20200105/docs/Rotation_Distance.md .  The updated config reference is at: https://github.com/KevinOConnor/klipper/blob/work-rotation-distance-20200105/docs/Config_Reference.md#stepper

There's a few reasons I'd like to go forward with this change:
1. Trinamic stepper motor drivers are rapidly becoming the most common drivers on 3d printers.  These drivers make it easy to change the microstep setting.  However, changing that setting in Klipper is error prone, because changing it also requires changes to step_distance and endstop_phases.  With a conversion to rotation_distance it becomes possible to test different microstep settings by only altering the microstep config parameter.
2. On rotary delta, polar printers, and future printer kinematics, having to specify step_distance in radians is a confusing and error prone process.  Defining a `gear_ratio` instead is dramatically simpler.
3. The step_distance parameter isn't easy to understand.  I think it's easier to work with than steps_per_mm, but it still isn't immediately obvious how the value is obtained.  In contrast, rotation_distance is almost always a whole number and it is fairly straight-forward to find its origin for those that are curious.
4. Support for future "closed loop" stepper drivers will need more information than step_distance provides.  I believe using more descriptive parameters (rotation_distance, microsteps, full_steps_per_rotation, and gear_ratio) will be more "future proof".

In particular, I ran into an error with step_distance when I updated one of my printers a few weeks ago.  I went from an old 8-bit control board using 8 microsteps to a newer board with tmc2208 drivers.  In that process I had a typo in the converted step_distance which took me a couple of test prints and over an hour to track down.  I would not have had that error with a simpler rotation_distance configuration.

Comments?
-Kevin