### PR TITLE
Update menu.cfg

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -277,7 +277,7 @@ type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
 input_min: {printer.configfile.config.stepper_x.position_min|default(0)}
-input_max: {printer.configfile.config.stepper_x.position_max}
+input_max: {printer.configfile.config.stepper_x.position_max|default(200)}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -290,7 +290,7 @@ type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
 input_min: {printer.configfile.config.stepper_y.position_min|default(0)}
-input_max: {printer.configfile.config.stepper_y.position_max}
+input_max: {printer.configfile.config.stepper_y.position_max|default(200)}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -304,7 +304,7 @@ enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
 input_min: {printer.configfile.config.stepper_z.position_min|default(0)}
-input_max: {printer.configfile.config.stepper_z.position_max}
+input_max: {printer.configfile.config.stepper_z.position_max|default(200)}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -337,7 +337,7 @@ type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
 input_min: {printer.configfile.config.stepper_x.position_min|default(0)}
-input_max: {printer.configfile.config.stepper_x.position_max}
+input_max: {printer.configfile.config.stepper_x.position_max|default(200)}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -350,7 +350,7 @@ type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
 input_min: {printer.configfile.config.stepper_y.position_min|default(0)}
-input_max: {printer.configfile.config.stepper_y.position_max}
+input_max: {printer.configfile.config.stepper_y.position_max|default(200)}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -364,7 +364,7 @@ enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
 input_min: {printer.configfile.config.stepper_z.position_min|default(0)}
-input_max: {printer.configfile.config.stepper_z.position_max}
+input_max: {printer.configfile.config.stepper_z.position_max|default(200)}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -397,7 +397,7 @@ type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
 input_min: {printer.configfile.config.stepper_x.position_min|default(0)}
-input_max: {printer.configfile.config.stepper_x.position_max}
+input_max: {printer.configfile.config.stepper_x.position_max|default(200)}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -410,7 +410,7 @@ type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
 input_min: {printer.configfile.config.stepper_y.position_min|default(0)}
-input_max: {printer.configfile.config.stepper_y.position_max}
+input_max: {printer.configfile.config.stepper_y.position_max|default(200)}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -424,7 +424,7 @@ enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
 input_min: {printer.configfile.config.stepper_z.position_min|default(0)}
-input_max: {printer.configfile.config.stepper_z.position_max}
+input_max: {printer.configfile.config.stepper_z.position_max|default(200)}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -844,4 +844,3 @@ gcode:
          { action_respond_info("printer['%s'] = %s" % (name1, printer[name1])) }
       {% endfor %}
    {% endfor %}
-   

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -276,7 +276,7 @@ name: Move 10mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: ({% if 'position_min' in printer.configfile.config.stepper_x %} {printer.configfile.config.stepper_x.position_min} {% else %} 0 {% endif %})
+input_min: {printer.configfile.config.stepper_x.position_min|default(0)}
 input_max: {printer.configfile.config.stepper_x.position_max}
 input_step: 10.0
 gcode:
@@ -289,7 +289,7 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: ({% if 'position_min' in printer.configfile.config.stepper_y %} {printer.configfile.config.stepper_y.position_min} {% else %} 0 {% endif %})
+input_min: {printer.configfile.config.stepper_y.position_min|default(0)}
 input_max: {printer.configfile.config.stepper_y.position_max}
 input_step: 10.0
 gcode:
@@ -303,7 +303,7 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: ({% if 'position_min' in printer.configfile.config.stepper_z %} {printer.configfile.config.stepper_z.position_min} {% else %} 0 {% endif %})
+input_min: {printer.configfile.config.stepper_z.position_min|default(0)}
 input_max: {printer.configfile.config.stepper_z.position_max}
 input_step: 10.0
 gcode:
@@ -317,8 +317,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance|int *-1} {% else %} -50 {% endif %})
-input_max: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance} {% else %} 50 {% endif %})
+input_min: -{printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
+input_max: {printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -336,7 +336,7 @@ name: Move 1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: ({% if 'position_min' in printer.configfile.config.stepper_x %} {printer.configfile.config.stepper_x.position_min} {% else %} 0 {% endif %})
+input_min: {printer.configfile.config.stepper_x.position_min|default(0)}
 input_max: {printer.configfile.config.stepper_x.position_max}
 input_step: 1.0
 gcode:
@@ -349,7 +349,7 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: ({% if 'position_min' in printer.configfile.config.stepper_y %} {printer.configfile.config.stepper_y.position_min} {% else %} 0 {% endif %})
+input_min: {printer.configfile.config.stepper_y.position_min|default(0)}
 input_max: {printer.configfile.config.stepper_y.position_max}
 input_step: 1.0
 gcode:
@@ -363,7 +363,7 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: ({% if 'position_min' in printer.configfile.config.stepper_z %} {printer.configfile.config.stepper_z.position_min} {% else %} 0 {% endif %})
+input_min: {printer.configfile.config.stepper_z.position_min|default(0)}
 input_max: {printer.configfile.config.stepper_z.position_max}
 input_step: 1.0
 gcode:
@@ -377,8 +377,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance|int *-1} {% else %} -50 {% endif %})
-input_max: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance} {% else %} 50 {% endif %})
+input_min: -{printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
+input_max: {printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -396,7 +396,7 @@ name: Move 0.1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: ({% if 'position_min' in printer.configfile.config.stepper_x %} {printer.configfile.config.stepper_x.position_min} {% else %} 0 {% endif %})
+input_min: {printer.configfile.config.stepper_x.position_min|default(0)}
 input_max: {printer.configfile.config.stepper_x.position_max}
 input_step: 0.1
 gcode:
@@ -409,7 +409,7 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: ({% if 'position_min' in printer.configfile.config.stepper_y %} {printer.configfile.config.stepper_y.position_min} {% else %} 0 {% endif %})
+input_min: {printer.configfile.config.stepper_y.position_min|default(0)}
 input_max: {printer.configfile.config.stepper_y.position_max}
 input_step: 0.1
 gcode:
@@ -423,7 +423,7 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: ({% if 'position_min' in printer.configfile.config.stepper_z %} {printer.configfile.config.stepper_z.position_min} {% else %} 0 {% endif %})
+input_min: {printer.configfile.config.stepper_z.position_min|default(0)}
 input_max: {printer.configfile.config.stepper_z.position_max}
 input_step: 0.1
 gcode:
@@ -437,8 +437,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance|int *-1} {% else %} -50 {% endif %})
-input_max: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance} {% else %} 50 {% endif %})
+input_min: -{printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
+input_max: {printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -744,7 +744,7 @@ gcode: ABORT
 type: command
 name: Start probing
 gcode:
-    PROBE_CALIBRATE 
+    PROBE_CALIBRATE
 
 [menu __main __setup __calib __probe_Z_offset __move_z]
 type: input
@@ -790,7 +790,7 @@ gcode: ABORT
 type: command
 name: Start probing
 gcode:
-    Z_ENDSTOP_CALIBRATE 
+    Z_ENDSTOP_CALIBRATE
 
 [menu __main __setup __calib __z_endstop __move_z]
 type: input
@@ -844,3 +844,4 @@ gcode:
          { action_respond_info("printer['%s'] = %s" % (name1, printer[name1])) }
       {% endfor %}
    {% endfor %}
+   

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -82,6 +82,18 @@
 #               + Test Z: ++
 #               + Accept
 #               + Abort
+#           + Probe Z offset
+#               + Start probing
+#               + Move Z: 000.00
+#               + Test Z: ++
+#               + Accept
+#               + Abort
+#           + Z endstop
+#               + Start probing
+#               + Move Z: 000.00
+#               + Test Z: ++
+#               + Accept
+#               + Abort
 #           + Bed probe
 #       + Dump parameters
 
@@ -264,8 +276,8 @@ name: Move 10mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: ({% if 'position_min' in printer.configfile.config.stepper_x %} {printer.configfile.config.stepper_x.position_min} {% else %} 0 {% endif %})
+input_max: {printer.configfile.config.stepper_x.position_max}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -277,8 +289,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: ({% if 'position_min' in printer.configfile.config.stepper_y %} {printer.configfile.config.stepper_y.position_min} {% else %} 0 {% endif %})
+input_max: {printer.configfile.config.stepper_y.position_max}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -291,8 +303,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: 0
-input_max: 200
+input_min: ({% if 'position_min' in printer.configfile.config.stepper_z %} {printer.configfile.config.stepper_z.position_min} {% else %} 0 {% endif %})
+input_max: {printer.configfile.config.stepper_z.position_max}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -305,8 +317,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: -50
-input_max: 50
+input_min: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance|int *-1} {% else %} -50 {% endif %})
+input_max: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance} {% else %} 50 {% endif %})
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -324,8 +336,8 @@ name: Move 1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: ({% if 'position_min' in printer.configfile.config.stepper_x %} {printer.configfile.config.stepper_x.position_min} {% else %} 0 {% endif %})
+input_max: {printer.configfile.config.stepper_x.position_max}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -337,8 +349,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: ({% if 'position_min' in printer.configfile.config.stepper_y %} {printer.configfile.config.stepper_y.position_min} {% else %} 0 {% endif %})
+input_max: {printer.configfile.config.stepper_y.position_max}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -351,8 +363,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: 0
-input_max: 200
+input_min: ({% if 'position_min' in printer.configfile.config.stepper_z %} {printer.configfile.config.stepper_z.position_min} {% else %} 0 {% endif %})
+input_max: {printer.configfile.config.stepper_z.position_max}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -365,8 +377,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: -50
-input_max: 50
+input_min: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance|int *-1} {% else %} -50 {% endif %})
+input_max: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance} {% else %} 50 {% endif %})
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -384,8 +396,8 @@ name: Move 0.1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: ({% if 'position_min' in printer.configfile.config.stepper_x %} {printer.configfile.config.stepper_x.position_min} {% else %} 0 {% endif %})
+input_max: {printer.configfile.config.stepper_x.position_max}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -397,8 +409,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: ({% if 'position_min' in printer.configfile.config.stepper_y %} {printer.configfile.config.stepper_y.position_min} {% else %} 0 {% endif %})
+input_max: {printer.configfile.config.stepper_y.position_max}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -411,8 +423,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: 0
-input_max: 200
+input_min: ({% if 'position_min' in printer.configfile.config.stepper_z %} {printer.configfile.config.stepper_z.position_min} {% else %} 0 {% endif %})
+input_max: {printer.configfile.config.stepper_z.position_max}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -425,8 +437,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: -50
-input_max: 50
+input_min: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance|int *-1} {% else %} -50 {% endif %})
+input_max: ({% if 'max_extrude_only_distance' in printer.configfile.config.extruder %} {printer.configfile.config.extruder.max_extrude_only_distance} {% else %} 50 {% endif %})
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -649,11 +661,12 @@ gcode: PID_CALIBRATE HEATER=heater_bed TARGET=60 WRITE_FILE=1
 
 [menu __main __setup __calib]
 type: list
+enable: {(not printer.idle_timeout.state == "Printing")}
 name: Calibration
 
 [menu __main __setup __calib __delta_calib_auto]
 type: command
-enable: {not printer.idle_timeout.state == "Printing"}
+enable: {(not printer.idle_timeout.state == "Printing") and ((printer.configfile.config.printer.kinematics == "delta") or (printer.configfile.config.printer.kinematics == "rotary_delta"))}
 name: Delta cal. auto
 gcode:
     G28
@@ -661,12 +674,22 @@ gcode:
 
 [menu __main __setup __calib __delta_calib_man]
 type: list
-enable: {not printer.idle_timeout.state == "Printing"}
+enable: {(not printer.idle_timeout.state == "Printing") and ((printer.configfile.config.printer.kinematics == "delta") or (printer.configfile.config.printer.kinematics == "rotary_delta"))}
 name: Delta cal. man
+
+[menu __main __setup __calib __probe_Z_offset]
+type: list
+enable: {(not printer.idle_timeout.state == "Printing") and ('probe' in printer.configfile.config)}
+name: Probe Z offset
+
+[menu __main __setup __calib __z_endstop]
+type: list
+enable: {(not printer.idle_timeout.state == "Printing") and 'position_endstop' in printer.configfile.config.stepper_z}
+name: Z endstop
 
 [menu __main __setup __calib __bedprobe]
 type: command
-enable: {not printer.idle_timeout.state == "Printing"}
+enable: {(not printer.idle_timeout.state == "Printing") and (('probe' in printer.configfile.config) or ('bltouch' in printer.configfile.config))}
 name: Bed probe
 gcode: PROBE
 
@@ -713,6 +736,98 @@ name: Accept
 gcode: ACCEPT
 
 [menu __main __setup __calib __delta_calib_man __abort]
+type: command
+name: Abort
+gcode: ABORT
+
+[menu __main __setup __calib __probe_Z_offset __start]
+type: command
+name: Start probing
+gcode:
+    PROBE_CALIBRATE 
+
+[menu __main __setup __calib __probe_Z_offset __move_z]
+type: input
+name: Move Z: {'%03.2f' % menu.input}
+input: {printer.gcode_move.gcode_position.z}
+input_step: 1
+realtime: True
+gcode:
+    {%- if menu.event == 'change' -%}
+        G1 Z{'%.2f' % menu.input}
+    {%- elif menu.event == 'long_click' -%}
+        G1 Z{'%.2f' % menu.input}
+        SAVE_GCODE_STATE NAME=__move__axis
+        G91
+        G1 Z2
+        G1 Z-2
+        RESTORE_GCODE_STATE NAME=__move__axis
+    {%- endif -%}
+
+[menu __main __setup __calib __probe_Z_offset __test_z]
+type: input
+name: Test Z: {['++','+','+.01','+.05','+.1','+.5','-.5','-.1','-.05','-.01','-','--'][menu.input|int]}
+input: 5
+input_min: 0
+input_max: 11
+input_step: 1
+gcode:
+    {%- if menu.event == 'long_click' -%}
+        TESTZ Z={['++','+','+.01','+.05','+.1','+.5','-.5','-.1','-.05','-.01','-','--'][menu.input|int]}
+    {%- endif -%}
+
+[menu __main __setup __calib __probe_Z_offset __accept]
+type: command
+name: Accept
+gcode: ACCEPT
+
+[menu __main __setup __calib __probe_Z_offset __abort]
+type: command
+name: Abort
+gcode: ABORT
+
+[menu __main __setup __calib __z_endstop __start]
+type: command
+name: Start probing
+gcode:
+    Z_ENDSTOP_CALIBRATE 
+
+[menu __main __setup __calib __z_endstop __move_z]
+type: input
+name: Move Z: {'%03.2f' % menu.input}
+input: {printer.gcode_move.gcode_position.z}
+input_step: 1
+realtime: True
+gcode:
+    {%- if menu.event == 'change' -%}
+        G1 Z{'%.2f' % menu.input}
+    {%- elif menu.event == 'long_click' -%}
+        G1 Z{'%.2f' % menu.input}
+        SAVE_GCODE_STATE NAME=__move__axis
+        G91
+        G1 Z2
+        G1 Z-2
+        RESTORE_GCODE_STATE NAME=__move__axis
+    {%- endif -%}
+
+[menu __main __setup __calib __z_endstop __test_z]
+type: input
+name: Test Z: {['++','+','+.01','+.05','+.1','+.5','-.5','-.1','-.05','-.01','-','--'][menu.input|int]}
+input: 5
+input_min: 0
+input_max: 11
+input_step: 1
+gcode:
+    {%- if menu.event == 'long_click' -%}
+        TESTZ Z={['++','+','+.01','+.05','+.1','+.5','-.5','-.1','-.05','-.01','-','--'][menu.input|int]}
+    {%- endif -%}
+
+[menu __main __setup __calib __z_endstop __accept]
+type: command
+name: Accept
+gcode: ACCEPT
+
+[menu __main __setup __calib __z_endstop __abort]
 type: command
 name: Abort
 gcode: ABORT


### PR DESCRIPTION
To make the LCD menu more common, limits are taken from the printer.cfg instead of hard coded.
Also calibration items are added and combined with the kinematics. 

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com