### PR TITLE
config: Update menu.cfg to use printer limits

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -264,8 +264,8 @@ name: Move 10mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_x.position_min|default(0)}
+input_max: {printer.configfile.config.stepper_x.position_max}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -277,8 +277,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_y.position_min|default(0)}
+input_max: {printer.configfile.config.stepper_y.position_max}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -291,8 +291,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_z.position_min|default(0)}
+input_max: {printer.configfile.config.stepper_z.position_max}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -305,8 +305,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: -50
-input_max: 50
+input_min: -{printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
+input_max: {printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -324,8 +324,8 @@ name: Move 1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_x.position_min|default(0)}
+input_max: {printer.configfile.config.stepper_x.position_max}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -337,8 +337,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_y.position_min|default(0)}
+input_max: {printer.configfile.config.stepper_y.position_max}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -351,8 +351,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_z.position_min|default(0)}
+input_max: {printer.configfile.config.stepper_z.position_max}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -365,8 +365,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: -50
-input_max: 50
+input_min: -{printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
+input_max: {printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -384,8 +384,8 @@ name: Move 0.1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_x.position_min|default(0)}
+input_max: {printer.configfile.config.stepper_x.position_max}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -397,8 +397,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_y.position_min|default(0)}
+input_max: {printer.configfile.config.stepper_y.position_max}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -411,8 +411,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
-input_min: 0
-input_max: 200
+input_min: {printer.configfile.config.stepper_z.position_min|default(0)}
+input_max: {printer.configfile.config.stepper_z.position_max}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -425,8 +425,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: -50
-input_max: 50
+input_min: -{printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
+input_max: {printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis


### PR DESCRIPTION
Replaces hardcoded motion limits with values from printer.cfg.

Signed-off-by: Justin Schuh code@justinschuh.com