### PR TITLE
Extend kinematics for reporting xyz-axis min/max

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -187,6 +187,11 @@ The following are common printer attributes:
 - `printer.toolhead.homed_axes`: The current cartesian axes considered
   to be in a "homed" state. This is a string containing one or more of
   "x", "y", "z".
+- `printer.toolhead.axis_minimum`,
+  `printer.toolhead.axis_maximum`: The axis travel limits (mm) after homing.
+  It is possible to access the x, y, z components of this
+  limit value (eg, `printer.toolhead.axis_minimum.x`,
+  `printer.toolhead.axis_maximum.z`).
 - `printer.toolhead.max_velocity`, `printer.toolhead.max_accel`,
   `printer.toolhead.max_accel_to_decel`,
   `printer.toolhead.square_corner_velocity`: The current printing

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import stepper
+import stepper, homing
 
 class CartKinematics:
     def __init__(self, toolhead, config):
@@ -118,7 +118,15 @@ class CartKinematics:
             self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
     def get_status(self, eventtime):
         axes = [a for a, (l, h) in zip("xyz", self.limits) if l <= h]
-        return { 'homed_axes': "".join(axes) }
+        axes_min = [0.0, 0.0, 0.0, 0.0]
+        axes_max = [0.0, 0.0, 0.0, 0.0]
+        for pos, rail in enumerate(self.rails):
+            axes_min[pos], axes_max[pos] = rail.get_range()
+        return {
+            'homed_axes': "".join(axes),
+            'axis_minimum': homing.Coord(*axes_min),
+            'axis_maximum': homing.Coord(*axes_max)
+        }
     # Dual carriage support
     def _activate_carriage(self, carriage):
         toolhead = self.printer.lookup_object('toolhead')

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math
-import stepper
+import stepper, homing
 
 class CoreXYKinematics:
     def __init__(self, toolhead, config):
@@ -95,7 +95,15 @@ class CoreXYKinematics:
             self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
     def get_status(self, eventtime):
         axes = [a for a, (l, h) in zip("xyz", self.limits) if l <= h]
-        return {'homed_axes': "".join(axes)}
+        axes_min = [0.0, 0.0, 0.0, 0.0]
+        axes_max = [0.0, 0.0, 0.0, 0.0]
+        for pos, rail in enumerate(self.rails):
+            axes_min[pos], axes_max[pos] = rail.get_range()
+        return {
+            'homed_axes': "".join(axes),
+            'axis_minimum': homing.Coord(*axes_min),
+            'axis_maximum': homing.Coord(*axes_max)
+        }
 
 def load_kinematics(toolhead, config):
     return CoreXYKinematics(toolhead, config)

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math
-import stepper
+import stepper, homing
 
 class CoreXZKinematics:
     def __init__(self, toolhead, config):
@@ -94,7 +94,15 @@ class CoreXZKinematics:
             self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
     def get_status(self, eventtime):
         axes = [a for a, (l, h) in zip("xyz", self.limits) if l <= h]
-        return {'homed_axes': "".join(axes)}
+        axes_min = [0.0, 0.0, 0.0, 0.0]
+        axes_max = [0.0, 0.0, 0.0, 0.0]
+        for pos, rail in enumerate(self.rails):
+            axes_min[pos], axes_max[pos] = rail.get_range()
+        return {
+            'homed_axes': "".join(axes),
+            'axis_minimum': homing.Coord(*axes_min),
+            'axis_maximum': homing.Coord(*axes_max)
+        }
 
 def load_kinematics(toolhead, config):
     return CoreXZKinematics(toolhead, config)

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-import stepper, mathutil
+import stepper, mathutil, homing
 
 # Slow moves once the ratio of tower to XY movement exceeds SLOW_RATIO
 SLOW_RATIO = 3.
@@ -146,7 +146,14 @@ class DeltaKinematics:
             limit_xy2 = -1.
         self.limit_xy2 = min(limit_xy2, self.slow_xy2)
     def get_status(self, eventtime):
-        return {'homed_axes': '' if self.need_home else 'xyz'}
+        max_xy = math.sqrt(self.max_xy2)
+        axes_min = [-max_xy, -max_xy, self.min_z, 0.]
+        axes_max = [max_xy, max_xy, self.max_z, 0.]
+        return {
+            'homed_axes': '' if self.need_home else 'xyz',
+            'axis_minimum': homing.Coord(*axes_min),
+            'axis_maximum': homing.Coord(*axes_max)
+        }
     def get_calibration(self):
         endstops = [rail.get_homing_info().position_endstop
                     for rail in self.rails]

--- a/klippy/kinematics/none.py
+++ b/klippy/kinematics/none.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import homing
 
 class NoneKinematics:
     def __init__(self, toolhead, config):
@@ -18,7 +19,12 @@ class NoneKinematics:
     def check_move(self, move):
         pass
     def get_status(self, eventtime):
-        return {'homed_axes': ''}
+        axes_lim = [0.0, 0.0, 0.0, 0.0]
+        return {
+            'homed_axes': '',
+            'axis_minimum': homing.Coord(*axes_lim),
+            'axis_maximum': homing.Coord(*axes_lim)
+        }
 
 def load_kinematics(toolhead, config):
     return NoneKinematics(toolhead, config)

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math
-import stepper
+import stepper, homing
 
 class PolarKinematics:
     def __init__(self, toolhead, config):
@@ -108,7 +108,15 @@ class PolarKinematics:
     def get_status(self, eventtime):
         xy_home = "xy" if self.limit_xy2 >= 0. else ""
         z_home = "z" if self.limit_z[0] <= self.limit_z[1] else ""
-        return {'homed_axes': xy_home + z_home}
+        lim_xy = self.rails[0].get_range()
+        lim_z = self.rails[1].get_range()
+        axes_min = [lim_xy[0], lim_xy[0], lim_z[0], 0.]
+        axes_max = [lim_xy[1], lim_xy[1], lim_z[1], 0.]
+        return {
+            'homed_axes': xy_home + z_home,
+            'axis_minimum': homing.Coord(*axes_min),
+            'axis_maximum': homing.Coord(*axes_max)
+        }
 
 def load_kinematics(toolhead, config):
     return PolarKinematics(toolhead, config)

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-import stepper, mathutil, chelper
+import stepper, mathutil, chelper, homing
 
 class RotaryDeltaKinematics:
     def __init__(self, toolhead, config):
@@ -122,7 +122,14 @@ class RotaryDeltaKinematics:
             limit_xy2 = -1.
         self.limit_xy2 = limit_xy2
     def get_status(self, eventtime):
-        return {'homed_axes': '' if self.need_home else 'XYZ'}
+        max_xy = math.sqrt(self.max_xy2)
+        axes_min = [-max_xy, -max_xy, self.min_z, 0.]
+        axes_max = [max_xy, max_xy, self.max_z, 0.]
+        return {
+            'homed_axes': '' if self.need_home else 'XYZ',
+            'axis_minimum': homing.Coord(*axes_min),
+            'axis_maximum': homing.Coord(*axes_max)
+        }
     def get_calibration(self):
         return self.calibration
 

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import stepper, mathutil
+import stepper, mathutil, homing
 
 class WinchKinematics:
     def __init__(self, toolhead, config):
@@ -47,7 +47,16 @@ class WinchKinematics:
         pass
     def get_status(self, eventtime):
         # XXX - homed_checks and rail limits not implemented
-        return {'homed_axes': 'xyz'}
+        axes_min = [0.0, 0.0, 0.0, 0.0]
+        axes_max = [0.0, 0.0, 0.0, 0.0]
+        for pos, axis in enumerate('xyz'):
+            axes_min[pos] = min([a[pos] for a in self.anchors])
+            axes_max[pos] = max([a[pos] for a in self.anchors])
+        return {
+            'homed_axes': 'xyz',
+            'axis_minimum': homing.Coord(*axes_min),
+            'axis_maximum': homing.Coord(*axes_max)
+        }
 
 def load_kinematics(toolhead, config):
     return WinchKinematics(toolhead, config)


### PR DESCRIPTION
Extend kinematic classes for reporting XYZ-axis min/max values.
These values can be used in the movement menu.

Example output:
```
printer['toolhead'].max_accel = 2000.0
printer['toolhead'].homed_axes =
printer['toolhead'].axis_max = {'y': 128.52, 'x': 128.52, 'z': 231.47}
printer['toolhead'].estimated_print_time = 3157.17333085
printer['toolhead'].max_velocity = 500.0
printer['toolhead'].print_time = 0.001
printer['toolhead'].axis_min = {'y': -128.52, 'x': -128.52, 'z': -5.0}
printer['toolhead'].max_accel_to_decel = 1000.0
printer['toolhead'].position = Coord(x=0.0, y=0.0, z=0.0, e=0.0)
```