### PR TITLE
kinematics: Make limits more strict for polar/delta configs

### DIFF
--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -146,9 +146,16 @@ class DeltaKinematics:
             limit_xy2 = -1.
         self.limit_xy2 = min(limit_xy2, self.slow_xy2)
     def get_status(self, eventtime):
-        max_xy = math.sqrt(self.max_xy2)
-        axes_min = [-max_xy, -max_xy, self.min_z, 0.]
-        axes_max = [max_xy, max_xy, self.max_z, 0.]
+        if self.need_home:
+            max_xy = math.sqrt(self.max_xy2)
+            axes_min = [-max_xy, -max_xy, self.min_z, 0.]
+            axes_max = [max_xy, max_xy, self.max_z, 0.]
+        else:
+            cur_pos = self.calc_tag_position()
+            max_x = math.sqrt(self.max_xy2 - cur_pos[1]**2)
+            max_y = math.sqrt(self.max_xy2 - cur_pos[0]**2)
+            axes_min = [-max_x, -max_y, self.min_z, 0.]
+            axes_max = [max_x, max_y, self.max_z, 0.]
         return {
             'homed_axes': '' if self.need_home else 'xyz',
             'axis_minimum': homing.Coord(*axes_min),

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -106,12 +106,20 @@ class PolarKinematics:
             move.limit_speed(self.max_z_velocity * z_ratio,
                              self.max_z_accel * z_ratio)
     def get_status(self, eventtime):
-        xy_home = "xy" if self.limit_xy2 >= 0. else ""
         z_home = "z" if self.limit_z[0] <= self.limit_z[1] else ""
-        lim_xy = self.rails[0].get_range()
-        lim_z = self.rails[1].get_range()
-        axes_min = [lim_xy[0], lim_xy[0], lim_z[0], 0.]
-        axes_max = [lim_xy[1], lim_xy[1], lim_z[1], 0.]
+        if self.limit_xy2 < 0.:
+            xy_home = ""
+            lim_xy = self.rails[0].get_range()
+            lim_z = self.rails[1].get_range()
+            axes_min = [lim_xy[0], lim_xy[0], lim_z[0], 0.]
+            axes_max = [lim_xy[1], lim_xy[1], lim_z[1], 0.]
+        else:
+            xy_home = "xy"
+            cur_pos = self.calc_tag_position()
+            max_x = math.sqrt(self.limit_xy2 - cur_pos[1]**2)
+            max_y = math.sqrt(self.limit_xy2 - cur_pos[0]**2)
+            axes_min = [-max_x, -max_y, self.min_z, 0.]
+            axes_max = [max_x, max_y, self.max_z, 0.]
         return {
             'homed_axes': xy_home + z_home,
             'axis_minimum': homing.Coord(*axes_min),

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -122,9 +122,16 @@ class RotaryDeltaKinematics:
             limit_xy2 = -1.
         self.limit_xy2 = limit_xy2
     def get_status(self, eventtime):
-        max_xy = math.sqrt(self.max_xy2)
-        axes_min = [-max_xy, -max_xy, self.min_z, 0.]
-        axes_max = [max_xy, max_xy, self.max_z, 0.]
+        if self.need_home:
+            max_xy = math.sqrt(self.max_xy2)
+            axes_min = [-max_xy, -max_xy, self.min_z, 0.]
+            axes_max = [max_xy, max_xy, self.max_z, 0.]
+        else:
+            cur_pos = self.calc_tag_position()
+            max_x = math.sqrt(self.max_xy2 - cur_pos[1]**2)
+            max_y = math.sqrt(self.max_xy2 - cur_pos[0]**2)
+            axes_min = [-max_x, -max_y, self.min_z, 0.]
+            axes_max = [max_x, max_y, self.max_z, 0.]
         return {
             'homed_axes': '' if self.need_home else 'XYZ',
             'axis_minimum': homing.Coord(*axes_min),


### PR DESCRIPTION
This is a WIP patch that builds on @mcmatrix's #3691, but further restricts the x and y limits to the build cylinder for polar and delta style printers (when the extruder is homed). This is done by computing the x and y limits as the two chords that pass through the current extruder position and are parallel to the corresponding axis. While this stricter behavior seems desirable to me, I might be unusual in that regard, so feel free to decline the patch.

Also, although the regression tests all appear to have passed locally, I don't currently have a Klipper polar or delta printer to test this on. So, assuming there's any interest in taking the patch, I would appreciate if someone could manually verify that it's working as intended. (That stated, I did just get a FLSUN Q5 as my only "round" printer, and will eventually get around to putting Klipper on it.)
