### PR TITLE
(wip) Et4x

### DIFF
--- a/config/printer-anet-et4x-2020.cfg
+++ b/config/printer-anet-et4x-2020.cfg
@@ -177,7 +177,7 @@ button2_glyph:
  ..**.**..........
  ...**............
 
-button3_rect: 250,200,325,240
+button3_rect: 250,200,320,240
 button3_fgcolor: 255,255,255
 button3_bgcolor: 48,63,0
 button3_glyph:

--- a/config/printer-anet-et4x-2020.cfg
+++ b/config/printer-anet-et4x-2020.cfg
@@ -1,0 +1,225 @@
+# This file contains common pin mappings for the Anet ET4X printer.
+# To use this config, the firmware should be compiled for the
+# STM32F407. When running "make menuconfig", enable "extra low-level
+# configuration setup", select (no bootloader), disable "USB for
+# communication".
+
+# The "make flash" command does not work on the Anet ET4. Instead,
+# after running "make", copy the generated "out/klipper.bin" file to a
+# file named "project.bin" on an SD card and then restart the Alfawise
+# with that SD card.
+
+[stepper_x]
+step_pin: PB6
+dir_pin: !PB5
+enable_pin: !PB7
+step_distance: .0125
+endstop_pin: ^!PC13
+position_min: -3
+position_endstop: -3
+position_max: 220
+homing_speed: 50
+
+[stepper_y]
+step_pin: PB3
+dir_pin: PD6
+enable_pin: !PB4
+step_distance: .0125
+endstop_pin: ^!PE12
+position_min: -8
+position_endstop: -8
+position_max: 220
+homing_speed: 50
+
+[stepper_z]
+step_pin: PA12
+dir_pin: !PA11
+enable_pin: !PA15
+step_distance: .0025
+endstop_pin: ^!PE11
+position_endstop: 0
+position_max: 250
+homing_speed: 12
+second_homing_speed: 5
+
+[extruder]
+step_pin: PB9
+dir_pin: PB8
+enable_pin: !PE0
+step_distance: .010526
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PA0 # END_CONTROL
+sensor_pin:  PA1 # TEMP_EXB1
+sensor_type: EPCOS 100K B57560G104F
+control: pid
+pid_Kp: 20.375
+pid_Ki: 0.844
+pid_Kd: 123.016
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PE2 # BED_CONTROL
+sensor_pin: PA4 # TEMP_BED
+sensor_type: EPCOS 100K B57560G104F
+control: pid
+pid_Kp: 70.721
+pid_Ki: 1.981
+pid_Kd: 631.118
+min_temp: 0
+max_temp: 125
+
+[fan]
+pin: PE3 # LAY_FAN
+
+[heater_fan fan1]
+pin: PE1 # END_FAN
+
+[mcu]
+baud: 250000
+restart_method: command
+serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 3000
+max_z_velocity: 12
+max_z_accel: 50
+
+[pause_resume]
+#recover_velocity: 50.
+#   When capture/restore is enabled, the speed at which to return to
+#   the captured position (in mm/s).  Default is 50.0 mm/s.
+
+[filament_switch_sensor filament_sensor]
+switch_pin: PA2 # MAT_DET
+pause_on_runout: True
+
+# The printer ships without a probe, but the wiring loom is
+# already prepared for one
+
+# [probe]
+# pin: PC2 # LV_DET
+
+########################################
+# EXP1 / EXP2 (display) pins
+########################################
+
+[board_pins]
+aliases:
+#   P1 header
+    P1_1=PD7, P1_3=PB2, P1_5=PE4, P1_7=PB1, P1_9=<GND>,
+    P1_2=PD5, P1_4=PE5, P1_6=PB0, P1_8=PD4, P1_10=<3V3>,
+#   P2 header
+    P2_1= PE6, P2_3=PD15, P2_5=PD1, P2_7=PE8, P2_9=PE10,
+    P2_2=PD13, P2_4=PD14, P2_6=PD0, P2_8=PE7, P2_10=PE9
+
+[display]
+lcd_type: st7789v
+# fgcolor and bgcolor are adjusted for speed. See the
+# documentation for details.
+fgcolor: 224,255,56
+bgcolor: 8, 0, 64
+resx_pin: P2_1
+dcx_pin: P2_2
+csx_pin: P1_1
+wrx_pin: P1_2
+rdx_pin: P1_8
+d15_pin: P2_9
+d14_pin: P2_10
+d13_pin: P2_7
+d12_pin: P2_8
+d11_pin: P2_5
+d10_pin: P2_6
+d9_pin: P2_3
+d8_pin: P2_4
+rect: 0,0,320,192
+
+button0_rect: 0,200,75,240
+button0_fgcolor: 255,255,255
+button0_bgcolor: 48,63,0
+button0_glyph:
+  .......**.......
+  ......****......
+  .....**..**.....
+  ....**....**....
+  ...**......**...
+  ..**........**..
+  .**..........**.
+  ****************
+
+button1_rect: 83,200,158,240
+button1_fgcolor: 255,255,255
+button1_bgcolor: 0,0,63
+button1_glyph:
+  ........**....**
+  ......**....**..
+  ....**....**....
+  ..**....**......
+  **....**........
+  **....**........
+  ..**....**......
+  ....**....**....
+  ......**....**..
+  ........**....**
+
+button2_rect: 167,200,242,240
+button2_fgcolor: 255,255,255
+button2_bgcolor: 192,16,16
+button2_glyph:
+ ...............**
+ .............**..
+ ...........**....
+ **.......**......
+ .**....**........
+ ..**.**..........
+ ...**............
+
+button3_rect: 250,200,325,240
+button3_fgcolor: 255,255,255
+button3_bgcolor: 48,63,0
+button3_glyph:
+  ****************
+  .**..........**.
+  ..**........**..
+  ...**......**...
+  ....**....**....
+  .....**..**.....
+  ......****......
+  .......**.......
+
+[xpt2046]
+cs_pin: P1_3
+penirq_pin: !P1_7
+spi_software_miso_pin: P1_5
+spi_software_mosi_pin: P1_4
+spi_software_sclk_pin: P1_6
+button0_function: up
+button0_repeat_function: fast_up
+button0_points:
+      3695,3661
+      3136,3643
+      3155,2899
+      3633,2916
+button1_function: down
+button1_repeat_function: fast_down
+button1_points:
+      3697,955
+      3195,932
+      3209,229
+      3700,242
+button2_function: back
+button2_points:
+      3701,2778
+      3196,2774
+      3212,2014
+      3692,1995
+button3_function: click
+button3_longpress_function: long_click
+button3_points:
+      3617,1752
+      3201,1797
+      3177,1090
+      3600,1100

--- a/config/printer-anet-et4x-2020.cfg
+++ b/config/printer-anet-et4x-2020.cfg
@@ -4,16 +4,22 @@
 # configuration setup", select (no bootloader), disable "USB for
 # communication".
 
-# The "make flash" command does not work on the Anet ET4. Instead,
-# after running "make", copy the generated "out/klipper.bin" file to a
-# file named "project.bin" on an SD card and then restart the Alfawise
-# with that SD card.
+# The "make flash" command does not work on the Anet ET4. The regular
+# bootloaders cannot be used; the USB port is not connected to the MCU
+# directly, but is connected using a CH341 USB-to-serial adapter. The
+# BOOTx pins are not easily accessible.
+
+# Instead, the board can be programmed using the SWD interface available
+# on the J2 header of the board. The pins are unlabeled, but the first
+# three pins starting from the MCU towards the SD card slot are
+# GND, SWCLK and SWDIO.
 
 [stepper_x]
 step_pin: PB6
 dir_pin: !PB5
 enable_pin: !PB7
-step_distance: .0125
+rotation_distance: 40
+microsteps: 16
 endstop_pin: ^!PC13
 position_min: -3
 position_endstop: -3
@@ -24,7 +30,8 @@ homing_speed: 50
 step_pin: PB3
 dir_pin: PD6
 enable_pin: !PB4
-step_distance: .0125
+rotation_distance: 40
+microsteps: 16
 endstop_pin: ^!PE12
 position_min: -8
 position_endstop: -8
@@ -35,7 +42,8 @@ homing_speed: 50
 step_pin: PA12
 dir_pin: !PA11
 enable_pin: !PA15
-step_distance: .0025
+rotation_distance: 8
+microsteps: 16
 endstop_pin: ^!PE11
 position_endstop: 0
 position_max: 250
@@ -46,7 +54,8 @@ second_homing_speed: 5
 step_pin: PB9
 dir_pin: PB8
 enable_pin: !PE0
-step_distance: .010526
+rotation_distance: 33.68
+microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PA0 # END_CONTROL
@@ -89,9 +98,6 @@ max_z_velocity: 12
 max_z_accel: 50
 
 [pause_resume]
-#recover_velocity: 50.
-#   When capture/restore is enabled, the speed at which to return to
-#   the captured position (in mm/s).  Default is 50.0 mm/s.
 
 [filament_switch_sensor filament_sensor]
 switch_pin: PA2 # MAT_DET
@@ -118,10 +124,8 @@ aliases:
 
 [display]
 lcd_type: st7789v
-# fgcolor and bgcolor are adjusted for speed. See the
-# documentation for details.
-fgcolor: 224,255,56
-bgcolor: 8, 0, 64
+fgcolor: 255,255,0
+bgcolor: 0, 0, 64
 resx_pin: P2_1
 dcx_pin: P2_2
 csx_pin: P1_1
@@ -190,7 +194,7 @@ button3_glyph:
   ......****......
   .......**.......
 
-[xpt2046]
+[xpt2046 touch]
 cs_pin: P1_3
 penirq_pin: !P1_7
 spi_software_miso_pin: P1_5

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3083,7 +3083,7 @@ lcd_type:
 #   Controller" type displays), "emulated_st7920" (which emulate a ST7920
 #   display but won't work properly with the "st7920" display driver),
 #   "uc1701" (which is used in "MKS Mini 12864" type displays),
-#   "ssd1306", or "sh1106". This parameter must be provided.
+#   "ssd1306", "sh1106" or "st7789v". This parameter must be provided.
 #hd44780_protocol_init: True
 #    Perform 8-bit/4-bit protocol initialization on an hd44780 display.
 #    This is necessary on real hd44780 devices.  However, one may
@@ -3153,6 +3153,46 @@ lcd_type:
 #   A reset pin may be specified on ssd1306 displays. If it is not
 #   specified then the hardware must have a pull-up on the
 #   corresponding lcd line.
+#resx_pin:
+#csx_pin:
+#dcx_pin:
+#wrx_pin:
+#rdx_pin:
+#d15_pin:
+#d14_pin:
+#d13_pin:
+#d12_pin:
+#d11_pin:
+#d10_pin:
+#d9_pin:
+#d8_pin:
+#   The pins connected to an st7789v type lcd. The resx-, csx- and
+#   rdx pins are optional and need to be pulled up when not connected.
+#   The other pins must be provided, and must be connected to a single
+#   mcu.
+#fgcolor:
+#   Foreground color (RGB components range 0-255, separated by commas)
+#   when using an st7789v display. The display uses 16-bit colors in
+#   RGB565 format internally. The update rate of the display depends on
+#   the chosen colors; for maximum speed it is best to pick colors where
+#   both bytes of the RGB565 color are identical.
+#bgcolor:
+#   Background color, when using an st7789v display.
+#rect:
+#   size and location of the menu window, when using an st7789v display.
+#   4 integers, separated by commas: left, top, right, bottom
+#button<0-999>_rect:
+#button<0-999>_fgcolor:
+#button<0-999>_bgcolor:
+#   Definition for an on-screen button, when using an st7789v display.
+#   Format corresponds to the rect, fgcolor and bgcolor properties above.
+#   Multiple buttons are supported, but must have incremental numbers.
+#   Must all be provided for each defined on-screen button.
+#button<0-999>_glyph:
+#   Glyph to be drawn on the button, when using an st7789v display. Glyph
+#   data is stored as lines, where '.' is a background pixel and '*' is a
+#   foreground pixel. The glyph is centered on the button. Must be provided
+#   for each defined on-screen button.
 #display_group:
 #   The name of the display_data group to show on the display. This
 #   controls the content of the screen (see the "display_data" section

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3270,9 +3270,10 @@ to the coordinate space of the display the XPT 2046 is attached to).
 Buttons must be numbered sequentially, starting from 0. Buttons can be
 mapped to a menu key, or can trigger a gcode command template.
 
-To determine the boundaries of a button, enable debugging using
-`XPT_DEBUG enable=1`. Touch all corners of the button using a stylus in
-a consistent order (clockwise or counter-clockwise) and write down the
+To determine the boundaries of a button, enable touch reporting using
+`XPT_TOUCH_REPORT enable=1`. This will cause all touch events to be echoed
+to the terminal. Touch all corners of the button using a stylus in a
+consistent order (clockwise or counter-clockwise) and write down the
 reported coordinates.
 ```
 [xpt2046]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3260,6 +3260,62 @@ lcd_type:
 #   button.
 ```
 
+## [xpt2046]
+
+Support for an XPT 2046 resistive touch screen controller, controlled
+over SPI. Multiple 'soft buttons' are supported; a button is defined
+as a polygon in a two-dimensional coordinate space (which is unrelated
+to the coordinate space of the display the XPT 2046 is attached to).
+
+Buttons must be numbered sequentially, starting from 0. Buttons can be
+mapped to a menu key, or can trigger a gcode command template.
+
+To determine the boundaries of a button, enable debugging using
+`XPT_DEBUG enable=1`. Touch all corners of the button using a stylus in
+a consistent order (clockwise or counter-clockwise) and write down the
+reported coordinates.
+```
+[xpt2046]
+#spi_speed:
+#spi_bus:
+#spi_software_sclk_pin:
+#spi_software_mosi_pin:
+#spi_software_miso_pin:
+#   See the "common SPI settings" section for a description of the
+#   above parameters.
+#cs_pin:
+#penirq_pin:
+#   The pins connected to the XPT 2046 resistive display controller. These
+#   must be be provided.
+#button<0-999>_points:
+#   Polygon describing the button. Must be a simple (non-intersecting) polygon,
+#   defined as comma-separated coordinate values. One line per vertex.
+#button<0-999>_function:
+#   menu function tiggered when the button is pressed. Can be any of
+#   'up', 'fast_up', 'down', 'fast_down', 'click', 'long_click' or 'back'.
+#   The default is not to execute any menu function.
+#button<0-999>_gcode:
+#   A list of G-Code commands to execute when the button is pressed. See
+#   docs/Command_Templated.md for G-Code format.
+#   The default is not to execute any G-Code.
+#button<0-999>_repeat_function:
+#   menu function (see above) triggered repeatedly when the button is being
+#   pressed and held. Cannot be combined with longpress.
+#   The default is not to execute any menu function.
+#button<0-999>_repeat_gcode:
+#   A list of G-Code commands to execute repeatedly when the button is being
+#   pressed and held. Cannot be combined with longpress.
+#   The default is not to execute any G-Code.
+#button<0-999>_longpress_function:
+#   menu function (see above) triggered repeatedly when the button is being
+#   pressed and held. Cannot be combined with repeat.
+#   The default is not to execute any menu function.
+#button<0-999>_longpress_gcode:
+#   A list of G-Code commands to execute repeatedly when the button is being
+#   pressed and held. Cannot be combined with repeat.
+#   The default is not to execute any G-Code.
+```
+
 ## [display_data]
 
 Support for displaying custom data on an lcd screen. One may create

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -712,7 +712,7 @@ The following commands are available when an
   accelerometer does not have a name in its config section (simply
   `[adxl345]`) <chip> part of the name is not generated.
 - `ACCELEROMETER_QUERY [CHIP=<config_name>] [RATE=<value>]`: queries
-  accelerometer for the current value. If CHIP is not specified it
+  accelerometer fo  r the current value. If CHIP is not specified it
   defaults to "default". If RATE is not specified, the default value
   is used. This command is useful to test the connection to the
   ADXL345 accelerometer: one of the returned values should be a
@@ -760,3 +760,11 @@ is enabled (also see the
   defaults to the current time in "YYYYMMDD_HHMMSS" format. Note that
   the suggested input shaper parameters can be persisted in the config
   by issuing `SAVE_CONFIG` command.
+
+### XPT 2046 touch screen controller commands
+The following command is available when a
+[xpt_2046 config section](Config_Reference.md#xpt_2046)
+is enabled.
+- `XPT_DEBUG [ENABLE=[1|0]]`: Enables or disables debug reporting. When
+  enabled, all touch events and the associated coordinates are printed to the
+  terminal.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -765,6 +765,7 @@ is enabled (also see the
 The following command is available when a
 [xpt_2046 config section](Config_Reference.md#xpt_2046)
 is enabled.
-- `XPT_DEBUG [ENABLE=[1|0]]`: Enables or disables debug reporting. When
+- `XPT_TOUCH_REPORT [ENABLE=[1|0]]`: Enables or disables touch reporting. When
   enabled, all touch events and the associated coordinates are printed to the
-  terminal.
+  terminal. This can be used as an aid when defining button shapes in the
+  printer configuration.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -712,7 +712,7 @@ The following commands are available when an
   accelerometer does not have a name in its config section (simply
   `[adxl345]`) <chip> part of the name is not generated.
 - `ACCELEROMETER_QUERY [CHIP=<config_name>] [RATE=<value>]`: queries
-  accelerometer fo  r the current value. If CHIP is not specified it
+  accelerometer for the current value. If CHIP is not specified it
   defaults to "default". If RATE is not specified, the default value
   is used. This command is useful to test the connection to the
   ADXL345 accelerometer: one of the returned values should be a

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -6,7 +6,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, os, ast
-from . import hd44780, st7920, uc1701, menu
+from . import hd44780, st7920, uc1701, st7789v, menu
 
 # Normal time between each screen redraw
 REDRAW_TIME = 0.500
@@ -17,6 +17,7 @@ LCD_chips = {
     'st7920': st7920.ST7920, 'emulated_st7920': st7920.EmulatedST7920,
     'hd44780': hd44780.HD44780, 'uc1701': uc1701.UC1701,
     'ssd1306': uc1701.SSD1306, 'sh1106': uc1701.SH1106,
+    'st7789v': st7789v.ST7789V
 }
 
 # Storage of [display_template my_template] config sections

--- a/klippy/extras/display/st7789v.py
+++ b/klippy/extras/display/st7789v.py
@@ -203,10 +203,12 @@ class PixelRunIterator(object):
         full_byte = 0xff if thisbit else 0
 
         count = 1
-        self.remaining -= 1
 
-        while self.remaining > 0:
+        while True:
             self.remaining -= 1
+            if self.remaining == 0:
+                break
+
             self.current_bit >>= 1
             if self.current_bit == 0:
                 self.current_bit = 0x80
@@ -217,6 +219,11 @@ class PixelRunIterator(object):
                         break
                     count += 8
                     self.remaining -= 8
+                    if self.remaining == 0:
+                        break
+
+            if self.remaining == 0:
+                break
 
             if ((self.current_byte & self.current_bit) != 0) != thisbit:
                 break

--- a/klippy/extras/display/st7789v.py
+++ b/klippy/extras/display/st7789v.py
@@ -10,9 +10,6 @@ from .. import bus
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 
-# Spec says 66ns, keeping this at a higher value for debugging purposes
-ST7789_WRITE_DELAY = .000010
-
 # Spec says > 10 us
 ST7789_RESET_PULSE_LENGTH = .0050
 # Recovery time after reset
@@ -454,11 +451,11 @@ class ST7789V(object):
         self.mcu.add_config_cmd(
             "config_st7789v oid=%u dcx_pin=%s wrx_pin=%s d8_pin=%s"
             " d9_pin=%s d10_pin=%s d11_pin=%s d12_pin=%s d13_pin=%s"
-            " d14_pin=%s d15_pin=%s delay_ticks=%u" % (
+            " d14_pin=%s d15_pin=%s" % (
                 self.oid, self.pins['dcx'], self.pins['wrx'], self.pins['d8'],
                 self.pins['d9'], self.pins['d10'], self.pins['d11'],
                 self.pins['d12'], self.pins['d13'], self.pins['d14'],
-                self.pins['d15'], self.mcu.seconds_to_clock(ST7789_WRITE_DELAY)
+                self.pins['d15']
                 )
             )
 

--- a/klippy/extras/display/st7789v.py
+++ b/klippy/extras/display/st7789v.py
@@ -1,0 +1,534 @@
+# Support for ST7789V (240x320 graphics) LCD displays
+#
+# Copyright (C) 2020  Martijn van Buul <martijn.van.buul@gmail.com>
+# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import math
+from . import font8x14
+from .. import bus
+
+BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
+
+# Spec says 66ns, keeping this at a higher value for debugging purposes
+ST7789_WRITE_DELAY = .000010
+
+# Spec says > 10 us
+ST7789_RESET_PULSE_LENGTH = .0050
+# Recovery time after reset
+ST7789_RESET_DELAY = .150
+ST7789_MINIMAL_DELAY = 0.001
+
+TEXTGLYPHS = {
+    'right_arrow': '\x1a',
+    'degrees': '\xf8',
+    'left_arrow' : '\x1b'}
+
+class ST7789vParseException(Exception):
+    def __init__(self, value):
+        super(ST7789vParseException, self).__init__(value)
+        self.value = value
+
+def _parse_rect(rect_string):
+    components = rect_string.split(',')
+
+    try:
+        elements = tuple(int(math.floor(float(p.strip()))) for p in components)
+    except ValueError:
+        raise ST7789vParseException("Malformed rectangle '%s'"
+                                    % (rect_string,))
+
+    if len(elements) != 4:
+        raise ST7789vParseException("Malformed rectangle '%s'"
+                                    % (rect_string,))
+
+    return {
+        'left': elements[0],
+        'top' : elements[1],
+        'right' : elements[2],
+        'bottom' : elements[3]}
+
+def _parse_color(color_string):
+    components = color_string.split(',')
+
+    try:
+        elements = tuple(max(0, min(255, math.floor(float(p.strip()))))
+                         for p in components)
+    except ValueError:
+        raise ST7789vParseException("Malformed color '%s'" % (color_string,))
+
+    if len(elements) != 3:
+        raise ST7789vParseException("Malformed color '%s'" % (color_string,))
+
+    # convert to RGB565
+    _r = int(elements[0])
+    _g = int(elements[1])
+    _b = int(elements[2])
+
+    color = ((_r // 8) << 11) | ((_g // 4) << 5) | (_b // 8)
+    return color
+
+def _parse_glyph(data):
+    glyph_data = []
+    width = None
+    height = 0
+
+    for line in data.split('\n'):
+        line = line.strip().replace('.', '0').replace('*', '1')
+        if not line:
+            continue
+        height = height + 1
+        if width is None:
+            width = len(line)
+        elif len(line) != width or line.replace('0', '').replace('1', ''):
+            raise ST7789vParseException("Invalid glyph line %d" % (height,))
+
+        linedata = bytearray((width+7) // 8)
+        index = 0
+        while line:
+            this_chunk = line[0:8]
+            line = line[8:]
+
+            # pad chunk if less than 8 pixels wide
+            chunk_length = len(this_chunk)
+            if chunk_length != 8:
+                this_chunk += '0' * (8 - chunk_length)
+
+            linedata[index] = int(this_chunk, 2)
+            index += 1
+
+        glyph_data.append(linedata)
+
+    return glyph_data, width, height
+
+class ResetHelper(object):
+    def __init__(self, disp, resx_pin, csx_pin, rdx_pin, mcu, cmd_queue):
+        self.mcu_csx = None
+        self.mcu_rdx = None
+        self.display = disp
+
+        self.mcu = mcu
+        self.cmd_queue = cmd_queue
+
+        self.mcu_resx = bus.MCU_bus_digital_out(
+            self.mcu,
+            resx_pin,
+            self.cmd_queue)
+
+        if csx_pin is not None:
+            self.mcu_csx = bus.MCU_bus_digital_out(
+                self.mcu,
+                csx_pin,
+                self.cmd_queue)
+
+        if rdx_pin is not None:
+            self.mcu_rdx = bus.MCU_bus_digital_out(
+                self.mcu,
+                rdx_pin,
+                self.cmd_queue)
+
+    def init(self):
+        curtime = self.mcu.get_printer().get_reactor().monotonic()
+
+        print_time = self.mcu.estimated_print_time(curtime)
+        print_time += ST7789_RESET_PULSE_LENGTH
+
+        minclock = self.mcu.print_time_to_clock(print_time)
+        self.mcu_resx.update_digital_out(0, minclock=minclock)
+
+        if self.mcu_rdx is not None:
+            print_time = print_time + ST7789_MINIMAL_DELAY
+            minclock = self.mcu.print_time_to_clock(print_time)
+            self.mcu_rdx.update_digital_out(1, minclock=minclock)
+
+        if self.mcu_csx is not None:
+            print_time = print_time + ST7789_MINIMAL_DELAY
+            minclock = self.mcu.print_time_to_clock(print_time)
+            self.mcu_csx.update_digital_out(0, minclock=minclock)
+
+        print_time = print_time + ST7789_RESET_DELAY
+        minclock = self.mcu.print_time_to_clock(print_time)
+        self.mcu_resx.update_digital_out(1, minclock=minclock)
+
+        # Force a delay on the command queue before transmitting
+        # the software reset
+        print_time = print_time + ST7789_RESET_DELAY
+        minclock = self.mcu.print_time_to_clock(print_time)
+        self.mcu_resx.update_digital_out(1, minclock=minclock)
+
+        self.display.send([[0x01]]) # Software reset
+
+        # Force a delay on the command queue before transmitting
+        # the sleep out command
+        print_time = print_time + ST7789_RESET_DELAY
+        minclock = self.mcu.print_time_to_clock(print_time)
+        self.mcu_resx.update_digital_out(1, minclock=minclock)
+
+        self.display.send([[0x11]]) # Sleep out
+
+        # Force a delay on the command queue before transmitting
+        # any subsequent commands
+        print_time = print_time + ST7789_RESET_DELAY
+        minclock = self.mcu.print_time_to_clock(print_time)
+        self.mcu_resx.update_digital_out(1, minclock=minclock)
+
+class BitmapWriterHelper(object):
+    def __init__(self, display, fgcolor, bgcolor):
+        self.oid = display.oid
+        self.bitmap_cmd = display.bitmap_cmd
+        self.fgcolor = fgcolor
+        self.bgcolor = bgcolor
+        self.max_bytes_in_request = 60
+        self.buffer = None
+        self.use_continuation = False
+        self.reset()
+
+    def reset(self):
+        self.buffer = bytearray(0)
+        self.use_continuation = False
+
+    def flush(self):
+        if self.buffer:
+            self.bitmap_cmd.send([self.oid, self.use_continuation,
+                                  self.fgcolor, self.bgcolor, self.buffer])
+            self.reset()
+
+    def write(self, data):
+        self.buffer.extend(data)
+        if len(self.buffer) >= self.max_bytes_in_request:
+            self.bitmap_cmd.send([self.oid, self.use_continuation,
+                                  self.fgcolor, self.bgcolor,
+                                  self.buffer[0:self.max_bytes_in_request]])
+            self.buffer = self.buffer[self.max_bytes_in_request:]
+            self.use_continuation = True
+
+class Framebuffer(object):
+    def __init__(self, display, origin_x, origin_y,
+                 size_x, size_y, fgcolor, bgcolor):
+        self.size_x = size_x
+        self.display = display
+        self.size_y = size_y
+        self.origin_x = origin_x
+        self.end_x = origin_x + size_x
+        self.origin_y = origin_y
+        self.fgcolor = fgcolor
+        self.bgcolor = bgcolor
+        self.icons = {}
+
+        self.framebuffer = self.__makebuffer()
+        self.old_framebuffer = [None for _i in range(self.size_y)]
+
+        self.nr_columns = size_x // 8
+        self.nr_rows = size_y // 16
+
+    def __makebuffer(self):
+        return [bytearray((self.size_x+7)//8) for _i in range(self.size_y)]
+
+    def flush(self):
+        caset_sent = False
+        last_row = None
+        writer = BitmapWriterHelper(
+            self.display, self.fgcolor, self.bgcolor)
+
+        for row in range(self.size_y):
+            old_row = self.old_framebuffer[row]
+            new_row = self.framebuffer[row]
+            if old_row is None or old_row != new_row:
+                if not caset_sent:
+                    # CASET 0-319
+                    caset_cmd = [[0x2A,
+                                  self.origin_x >> 8, self.origin_x & 0xff,
+                                  self.end_x >> 8, self.end_x & 0xff]]
+                    self.display.send(caset_cmd)
+                    caset_sent = True
+
+                if last_row is None or last_row != row + 1:
+                    # Flush existing data, send RASET
+                    writer.flush()
+                    raset_cmd = [[0x2B,
+                                  0, row + self.origin_y, 0x0,
+                                  row + self.origin_y + 1]]
+                    self.display.send(raset_cmd)
+
+                last_row = row
+                writer.write(new_row)
+
+        writer.flush()
+        self.old_framebuffer[:] = self.framebuffer
+
+    def write_glyph(self, _x, _y, glyph_name):
+        icon = self.icons.get(glyph_name)
+        if icon is not None and _x < 19:
+            # Draw icon in graphics mode
+            for icondata in icon:
+                self.write_graphics(_x, _y, icondata)
+                _x += 1
+
+            return 2
+        char = TEXTGLYPHS.get(glyph_name)
+        if char is not None:
+            # Draw character
+            self.write_text(_x, _y, char)
+            return 1
+        return 0
+
+    def clear(self):
+        self.framebuffer = self.__makebuffer()
+
+    def set_glyphs(self, glyphs):
+        for glyph_name, glyph_data in glyphs.items():
+            icon = glyph_data.get('icon16x16')
+            if icon is not None:
+                self.icons[glyph_name] = icon
+
+    def write_text(self, _x, _y, data):
+        if _x + len(data) > self.nr_columns:
+            data = data[:self.nr_columns - min(_x, self.nr_columns)]
+
+        top_row = 16 * _y
+
+        for char in data:
+            font_char = font8x14.VGA_FONT[ord(char)]
+            for row in range(14):
+                self.framebuffer[top_row + row][_x] = font_char[row]
+            _x += 1
+
+    def write_graphics(self, _x, _y, data):
+        top_row = _y * 16
+
+        for row, content in enumerate(data):
+            self.framebuffer[top_row + row][_x] = content
+
+    def write_bitmap(self, _x, _y, bitmap):
+        if not bitmap:
+            return
+
+        shift_bits = _x & 7
+        carry_bits = 8 - shift_bits
+
+        start_column = _x // 8
+
+        for row, row_data in enumerate(bitmap):
+            output_row = self.framebuffer[_y+row]
+            carry = output_row[start_column] & (0xff << carry_bits)
+            nr_columns = min(len(row_data), self.size_x - start_column)
+
+            for col in range(nr_columns):
+                output_row[start_column + col] = (
+                    carry | (row_data[col] >> shift_bits))
+                carry = (row_data[col] << carry_bits) & 0xff
+
+            if shift_bits > 0:
+                # Write out carry, but avoid writing beyond the end of the row.
+                end_column = nr_columns + start_column
+                if end_column < self.size_x:
+                    output_row[end_column] = (
+                        (output_row[end_column] & (0xff >> shift_bits)) | carry)
+
+    def get_dimensions(self):
+        return (self.nr_columns, self.nr_rows)
+
+class ST7789VButton(object):
+    def __init__(self, display, config):
+        if config['rect'] is None:
+            raise ST7789vParseException("Missing rect")
+
+        if config['fgcolor'] is None:
+            raise ST7789vParseException("Missing fgcolor")
+
+        if config['bgcolor'] is None:
+            raise ST7789vParseException("Missing bgcolor")
+
+        if config['glyph'] is None:
+            raise ST7789vParseException("Missing glyph")
+
+        rect = _parse_rect(config['rect'])
+        fgcolor = _parse_color(config['fgcolor'])
+        bgcolor = _parse_color(config['bgcolor'])
+
+        glyph, glyph_width, glyph_height = _parse_glyph(config['glyph'])
+
+        top = rect['top']
+        left = rect['left']
+        width = rect['right'] - left
+        height = rect['bottom'] - top
+
+        self.__framebuffer = Framebuffer(display,
+                                         left, top,
+                                         width + 1, height + 1,
+                                         fgcolor, bgcolor)
+
+        glyph_x = (width - glyph_width) // 2
+        glyph_y = (height - glyph_height) // 2
+
+        self.__framebuffer.write_bitmap(glyph_x, glyph_y, glyph)
+
+    def flush(self):
+        self.__framebuffer.flush()
+
+class ST7789V(object):
+    def __init__(self, config):
+        printer = config.get_printer()
+
+        try:
+            self.fgcolor = _parse_color(config.get("fgcolor", "255,255,255"))
+        except ST7789vParseException as err:
+            raise config.error(("Error while parsing st7789v fgcolor: %s")
+                               %(err.value,))
+
+        try:
+            self.bgcolor = _parse_color(config.get("bgcolor", "0,0,0"))
+        except ST7789vParseException as err:
+            raise config.error(("Error while parsing st7789v bgcolor: %s")
+                               %(err.value,))
+
+
+        # pin config
+        ppins = printer.lookup_object('pins')
+
+        # mandatory pins
+        pins = {name:ppins.lookup_pin(config.get(name + '_pin'))
+                for name in ['dcx', 'wrx', 'd8', 'd9', 'd10',
+                             'd11', 'd12', 'd13', 'd14', 'd15']}
+
+        mcu = None
+        for pin_params in pins.values():
+            if mcu is not None and pin_params['chip'] != mcu:
+                raise ppins.error("st7789 all pins must be on same mcu")
+            mcu = pin_params['chip']
+        self.pins = {
+            name:pin_params['pin'] for name, pin_params in pins.iteritems()
+        }
+        self.mcu = mcu
+        self.oid = self.mcu.create_oid()
+        self.mcu.register_config_callback(self.build_config)
+        self.cmd_queue = self.mcu.alloc_command_queue()
+        self.send_cmd = None
+        self.floodfill_cmd = None
+        self.bitmap_cmd = None
+
+        self.reset = ResetHelper(
+            self,
+            config.get('resx_pin', None),
+            config.get('csx_pin', None),
+            config.get('rdx_pin', None),
+            mcu,
+            self.cmd_queue)
+
+        try:
+            menu_rect = _parse_rect(config.get('rect'))
+        except ST7789vParseException as err:
+            raise config.error(("Error while parsing st7789v rect: %s")
+                               %(err.value,))
+
+        self.menu_framebuffer = Framebuffer(self,
+                                            menu_rect['left'],
+                                            menu_rect['top'],
+                                            menu_rect['right'],
+                                            menu_rect['bottom'],
+                                            self.fgcolor, self.bgcolor)
+
+        # discover soft buttons
+        self.__soft_buttons = []
+
+        for i in range(999):
+            button_config = {
+                'rect' : config.get('button%d_rect' %(i,), None),
+                'fgcolor' : config.get('button%d_fgcolor'%(i,), None),
+                'bgcolor' : config.get('button%d_bgcolor'%(i,), None),
+                'glyph' : config.get('button%d_glyph'%(i,), None)
+            }
+
+            if None not in button_config.values():
+                try:
+                    self.__soft_buttons.append(
+                        ST7789VButton(self, button_config))
+                except ST7789vParseException as err:
+                    raise config.error(
+                        "Error while parsing st7789v button %d: %s"
+                        %(i, err.value))
+            else:
+                break
+
+    def build_config(self):
+        self.mcu.add_config_cmd(
+            "config_st7789v oid=%u dcx_pin=%s wrx_pin=%s d8_pin=%s"
+            " d9_pin=%s d10_pin=%s d11_pin=%s d12_pin=%s d13_pin=%s"
+            " d14_pin=%s d15_pin=%s delay_ticks=%u" % (
+                self.oid, self.pins['dcx'], self.pins['wrx'], self.pins['d8'],
+                self.pins['d9'], self.pins['d10'], self.pins['d11'],
+                self.pins['d12'], self.pins['d13'], self.pins['d14'],
+                self.pins['d15'], self.mcu.seconds_to_clock(ST7789_WRITE_DELAY)
+                )
+            )
+
+        self.send_cmd = self.mcu.lookup_command(
+            "st7789v_send_cmd oid=%c cmds=%*s", cq=self.cmd_queue)
+        self.floodfill_cmd = self.mcu.lookup_command(
+            "st7789v_floodfill oid=%c cont=%c len=%u data=%hu",
+            cq=self.cmd_queue)
+        self.bitmap_cmd = self.mcu.lookup_command(
+            "st7789v_bitmap oid=%c cont=%c fg=%hu bg=%hu data=%*s",
+            cq=self.cmd_queue)
+
+    def send(self, cmds):
+        for cmd in cmds:
+            self.send_cmd.send([self.oid, cmd],
+                               reqclock=BACKGROUND_PRIORITY_CLOCK)
+
+    def flush(self):
+        self.menu_framebuffer.flush()
+
+    def init(self):
+        self.reset.init()
+
+        # Initialisation sequence from marlin
+        # Lines idicated with an asterisk (*) indicate where registers are
+        # written with reset defaults according to the manual.
+        init_cmds = [[0xB2, 0x0c, 0x00, 0x33, 0x33], # Porch control  (*)
+                     [0xB7, 0x35], # Gate control                     (*)
+                     [0xBB, 0x1f], # Voltage compensation, 0.875V
+                     [0xC0, 0x2c], # LCM CTRL                         (*)
+                     #[0xC2, 0x01, 0xC3], # VDVVRHEN, marlin setting illegal?
+                     [0xC4, 0x20], # VDV set, 0V                      (*)
+                     [0xC6, 0x0f], # FRCTL2, 60 Hz                    (*)
+                     [0xD0, 0xA4, 0xA1], # PCTRL1, nonstandard?
+                     [0x36, 0xA0], # MADCTL, depends on orientation,
+                                   # RGB, MV MX
+                     [0x3A, 0x55], # COLMOD, 16 bpp
+                     [0x13]] # Normal display mode
+
+        self.send(init_cmds)
+        self.send([[0x2A, 0, 0, 0x1, 0x3F],  # CASET 0-319
+                   [0x2B, 0, 0, 0x0, 0xFE] # RASET 0-239
+                  ])
+
+        # Fill screen in black
+        self.floodfill_cmd.send([self.oid, 0, 10*320, 0])
+        for _i in range(23):
+            self.floodfill_cmd.send([self.oid, 1, 10*320, 0])
+
+        self.menu_framebuffer.flush()
+
+        for button in self.__soft_buttons:
+            button.flush()
+
+        self.send([[0x29]]) # display on
+
+    def set_glyphs(self, glyphs):
+        self.menu_framebuffer.set_glyphs(glyphs)
+
+    def write_text(self, _x, _y, data):
+        self.menu_framebuffer.write_text(_x, _y, data)
+
+    def write_graphics(self, _x, _y, data):
+        self.menu_framebuffer.write_graphics(_x, _y, data)
+
+    def write_glyph(self, _x, _y, glyph_name):
+        return self.menu_framebuffer.write_glyph(_x, _y, glyph_name)
+
+    def clear(self):
+        self.menu_framebuffer.clear()
+
+    def get_dimensions(self):
+        return self.menu_framebuffer.get_dimensions()

--- a/klippy/extras/xpt2046.py
+++ b/klippy/extras/xpt2046.py
@@ -1,0 +1,306 @@
+# XPT2046 resisitive touch screen controller
+#
+# Copyright (_c) 2020 Martijn van Buul <martijn.van.buul@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import math
+from . import bus
+
+REPEAT_BACKOFF = 0.5
+REPEAT_INTERVAL = 0.25
+LONGCLICK_INTERVAL = 1
+
+class XptConfigException(Exception):
+    def __init__(self, value):
+        super(XptConfigException, self).__init__(value)
+        self.value = value
+
+def _parse_coordinate(coordinate_string):
+    components = coordinate_string.strip().split(',')
+
+    try:
+        pair = tuple(math.floor(float(p.strip())) for p in components)
+    except ValueError:
+        raise XptConfigException(
+            "Malformed value '%s'" % (coordinate_string,))
+
+    if len(pair) != 2:
+        raise XptConfigException(
+            "Malformed value '%s'" % (coordinate_string,))
+
+    return pair
+
+class Xpt2046MenuAction(object):
+    def __init__(self, menu, function):
+        self._menu = menu
+        self._function = function
+
+    def invoke(self, eventtime):
+        self._menu.key_event(self._function, eventtime)
+
+class Xpt2046GcodeAction(object):
+    def __init__(self, printer, config, template_name):
+        gcode_macro = printer.load_object(config, 'gcode_macro')
+        self._gcode = printer.lookup_object("gcode")
+        self._template = gcode_macro.load_template(config, template_name)
+
+    def invoke(self, eventtime):
+        del eventtime
+        self._gcode.run_script(self._template.render())
+
+class Xpt2046DummyAction(object):
+    # pylint: disable=R0201
+    def invoke(self, eventtime):
+        del eventtime
+
+def _create_action(printer_object, config, action_prefix):
+    menu_function = config.get(action_prefix + '_function', None)
+    if menu_function:
+        menu_object = printer_object.lookup_object("menu")
+        return Xpt2046MenuAction(menu_object, menu_function)
+    if config.get(action_prefix + '_gcode', None):
+        return Xpt2046GcodeAction(printer_object, config,
+                                  action_prefix + '_gcode')
+    return None
+
+class Xpt2046Button(object):
+    def __init__(self, points):
+        self.points = []
+
+        max_x = None
+        points = points.split('\n')
+        for point in points:
+            if point:
+                new_point = _parse_coordinate(point)
+                if max_x is None or max_x < new_point[0]:
+                    max_x = new_point[0]
+
+                self.points.append(new_point)
+
+        if len(self.points) < 3:
+            raise XptConfigException(
+                "Polygon with at least 3 vertices expected")
+
+        self._max_ray_x = max_x + 100 # X coordinate used for ray casting
+
+    def check_xy(self, location):
+        def ccw(_a, _b, _c):
+            return ((_c[1]-_a[1]) * (_b[0]-_a[0]) >
+                    (_b[1]-_a[1]) * (_c[0]-_a[0]))
+
+        def intersect(_a, _b, _c, _d):
+            return (ccw(_a, _c, _d) != ccw(_b, _c, _d) and
+                    ccw(_a, _b, _c) != ccw(_a, _b, _d))
+
+        result = False
+        # use a 0.1 offset (while polygon points are truncated) to ensure
+        # that the casted ray can never be colinear with a polygon vertex
+        outside_location = (self._max_ray_x, location[1] + 0.1)
+        for i in range(len(self.points)-1):
+            if intersect(self.points[i], self.points[i+1],
+                         location, outside_location):
+                result = not result
+
+        if intersect(self.points[-1], self.points[0],
+                     location, outside_location):
+            result = not result
+
+        return result
+
+    # The following two methods are to be overridden by derived classes
+    # pylint: disable=R0201
+
+    # Called when a button is clicked. Can return a timestamp for an expected
+    # repeat event.
+    def clicked(self, eventtime):
+        del eventtime
+        return None
+
+    # Called repeatedly while a button is being held. Can return a timestamp
+    # for the next expected repeat event.
+    def repeat(self, eventtime):
+        del eventtime
+        return None
+
+class Xpt2046OneshotButton(Xpt2046Button):
+    def __init__(self, points, action):
+        super(Xpt2046OneshotButton, self).__init__(points)
+        self._action = action
+
+    #override
+    def clicked(self, eventtime):
+        self._action.invoke(eventtime)
+        return None
+
+class Xpt2046RepeatingButton(Xpt2046Button):
+    def __init__(self, points, action, repeat_action):
+        super(Xpt2046RepeatingButton, self).__init__(points)
+        self._action = action
+        self._repeat_action = repeat_action
+
+    #override
+    def clicked(self, eventtime):
+        self._action.invoke(eventtime)
+        return eventtime + REPEAT_BACKOFF
+
+    #override
+    def repeat(self, eventtime):
+        self._repeat_action.invoke(eventtime)
+        return eventtime + REPEAT_INTERVAL
+
+class Xpt2046LongclickButton(Xpt2046Button):
+    def __init__(self, points, action, longclick_action):
+        super(Xpt2046LongclickButton, self).__init__(points)
+
+        self._action = action
+        self._longclick_action = longclick_action
+
+    #override
+    def clicked(self, eventtime):
+        self._action.invoke(eventtime)
+        return eventtime + LONGCLICK_INTERVAL
+
+    #override
+    def repeat(self, eventtime):
+        self._longclick_action.invoke(eventtime)
+        return None # no more callbacks required
+
+class Xpt2046(object):
+    def __init__(self, config):
+        printer = config.get_printer()
+        self._reactor = printer.get_reactor()
+        self._gcode = printer.lookup_object("gcode")
+        self._repeat_timer = self._reactor.register_timer(self._repeat_event)
+        self._active_button = None
+        self._spi = bus.MCU_SPI_from_config(
+            config, 0, pin_option='cs_pin', default_speed=25000)
+
+        button_pin = config.get('penirq_pin')
+        buttons_object = printer.lookup_object("buttons")
+
+        buttons_object.register_buttons([button_pin], self._penirq_callback)
+
+        self.buttons = []
+
+        # Discover soft buttons
+        for i in range(999):
+            button_prefix = 'button%d' % (i,)
+
+            func = _create_action(printer, config, button_prefix)
+            if not func:
+                func = Xpt2046DummyAction()
+
+            repeat_func = _create_action(printer, config,
+                                         button_prefix + '_repeat')
+
+            long_func = _create_action(printer, config,
+                                       button_prefix + '_longpress')
+
+            button_points = config.get(button_prefix + '_points', None)
+
+            if not button_points or not (repeat_func or long_func or func):
+                break
+
+            try:
+                if repeat_func and long_func:
+                    raise XptConfigException(
+                        "repeat_(function/button) and long_(function/button) "
+                        "cannot be defined at the same time")
+                elif repeat_func:
+                    self.buttons.append(Xpt2046RepeatingButton(
+                        button_points, func, repeat_func))
+                elif long_func:
+                    self.buttons.append(Xpt2046LongclickButton(
+                        button_points, func, long_func))
+                else:
+                    self.buttons.append(Xpt2046OneshotButton(
+                        button_points, func))
+
+            except XptConfigException as err:
+                raise config.error(
+                    "Error while parsing xp2046 button %d: %s"
+                    %(i, err.value))
+
+        self._gcode.register_command(
+            "XPT_DEBUG", self._cmd_debug,
+            desc="Enable/disable touch panel reporting")
+        self.report_enabled = False
+
+        printer.register_event_handler("klippy:ready", self._handle_ready)
+
+    def _penirq_callback(self, eventtime, state):
+        if state:
+            result = self._get_touch_xy()
+            if self.report_enabled:
+                self._gcode.respond_info("XPT2046 touch: (%d,%d)" % result)
+
+            for button_candidate in self.buttons:
+                if button_candidate.check_xy(result):
+                    self._active_button = button_candidate
+                    desired_callback = button_candidate.clicked(eventtime)
+                    if desired_callback:
+                        self._reactor.update_timer(self._repeat_timer,
+                                                   desired_callback)
+                    break
+        else:
+            if self.report_enabled:
+                self._gcode.respond_info("XPT2046 release")
+
+            self._active_button = None
+
+    def _repeat_event(self, eventtime):
+        desired_callback = None
+        if self._active_button:
+            desired_callback = self._active_button.repeat(eventtime)
+
+        return desired_callback or self._reactor.NEVER
+
+    def _cmd_debug(self, gcmd):
+        enable = gcmd.get_int('ENABLE', None)
+        if enable is not None:
+            self.report_enabled = (enable != 0)
+        else:
+            self.report_enabled = not self.report_enabled
+
+        gcmd.respond_info("XPT2046 debugging has been %s"
+                          %("enabled" if self.report_enabled else "disabled"))
+
+    def _handle_ready(self):
+        # Ensure chip is in the correct powerdown mode.
+        self._spi.spi_send([0xD0, 0x00])
+
+    def _get_touch_xy(self):
+        # poll X and Y in three times, take median
+
+        # leave reference on, add empty byte for skewed output
+        payload = [0x91, 0x00,
+                   0xD1, 0x00,
+                   0x91, 0x00,
+                   0xD1, 0x00,
+                   0x91, 0x00,
+                   0xD0, 0x00, 0x00]
+
+        result = self._spi.spi_transfer(payload)['response']
+
+        # Output data is bytewise, but trailing by 3 clock pulses.
+        def _getsample(result, start):
+            return (ord(result[start+1]) >> 3) + (ord(result[start]) << 5)
+
+        def _median3(_a, _b, _c):
+            if _a > _b:
+                return _a if _a < _c else (_b if _b > _c else _c)
+            return _a if _a > _c else (_b if _b < _c else _c)
+
+        _x = _median3(
+            _getsample(result, 1),
+            _getsample(result, 5),
+            _getsample(result, 9))
+        _y = _median3(
+            _getsample(result, 3),
+            _getsample(result, 7),
+            _getsample(result, 11))
+
+        return (_x, _y)
+
+def load_config_prefix(config):
+    return Xpt2046(config)

--- a/klippy/extras/xpt2046.py
+++ b/klippy/extras/xpt2046.py
@@ -108,19 +108,16 @@ class Xpt2046Button(object):
         return result
 
     # The following two methods are to be overridden by derived classes
-    # pylint: disable=R0201
 
     # Called when a button is clicked. Can return a timestamp for an expected
     # repeat event.
     def clicked(self, eventtime):
-        del eventtime
-        return None
+        pass
 
     # Called repeatedly while a button is being held. Can return a timestamp
     # for the next expected repeat event.
     def repeat(self, eventtime):
-        del eventtime
-        return None
+        pass
 
 class Xpt2046OneshotButton(Xpt2046Button):
     def __init__(self, points, action):
@@ -222,7 +219,7 @@ class Xpt2046(object):
                     %(i, err.value))
 
         self._gcode.register_command(
-            "XPT_DEBUG", self._cmd_debug,
+            "XPT_TOUCH_REPORT", self._cmd_touch_report,
             desc="Enable/disable touch panel reporting")
         self.report_enabled = False
 
@@ -255,14 +252,14 @@ class Xpt2046(object):
 
         return desired_callback or self._reactor.NEVER
 
-    def _cmd_debug(self, gcmd):
+    def _cmd_touch_report(self, gcmd):
         enable = gcmd.get_int('ENABLE', None)
         if enable is not None:
             self.report_enabled = (enable != 0)
         else:
             self.report_enabled = not self.report_enabled
 
-        gcmd.respond_info("XPT2046 debugging has been %s"
+        gcmd.respond_info("XPT2046 touch reporting has been %s"
                           %("enabled" if self.report_enabled else "disabled"))
 
     def _handle_ready(self):

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,4 +7,5 @@ src-$(CONFIG_HAVE_GPIO_SPI) += spicmds.c thermocouple.c
 src-$(CONFIG_HAVE_GPIO_I2C) += i2ccmds.c
 src-$(CONFIG_HAVE_GPIO_HARD_PWM) += pwmcmds.c
 src-$(CONFIG_HAVE_GPIO_BITBANGING) += lcd_st7920.c lcd_hd44780.c buttons.c \
-    tmcuart.c spi_software.c neopixel.c sensor_adxl345.c pulse_counter.c
+    tmcuart.c spi_software.c neopixel.c sensor_adxl345.c pulse_counter.c \
+    lcd_st7789v.c

--- a/src/lcd_st7789v.c
+++ b/src/lcd_st7789v.c
@@ -62,22 +62,6 @@ st7789v_xmit(struct st7789v *h, uint8_t len, uint8_t *data)
     }
  }
 
-// Flood-fill bitmap data. This assumes 16bpp pixel format
-static void
-st7789v_floodfill(struct st7789v *h, uint8_t continuation,
-                  uint32_t len, uint16_t data)
-{
-    // RAMWR or WRMEMC/RAMWRC command
-    st7789v_xmit_byte(h, continuation ? 0x3c : 0x2c, 0);
-
-    const uint8_t loByte = data & 0xff;
-    const uint8_t hiByte = data >> 8;
-    for (uint32_t i = 0; i < len; ++i) {
-        st7789v_xmit_byte(h, hiByte, 1 );
-        st7789v_xmit_byte(h, loByte, 1 );
-    }
-}
-
 // Send 1bpp bitmap as 16bpp image data
 static void
 st7789v_bitmap(struct st7789v *h, uint8_t continuation, uint16_t fgcolor,
@@ -142,19 +126,6 @@ command_st7789v_send_cmd(uint32_t *args)
     st7789v_xmit(h, len, cmds);
 }
 DECL_COMMAND(command_st7789v_send_cmd, "st7789v_send_cmd oid=%c cmds=%*s");
-
-void
-command_st7789v_floodfill_cmd(uint32_t *args)
-{
-    struct st7789v *h = oid_lookup(args[0], command_config_st7789v);
-    uint8_t continuation = args[1];
-    uint32_t len = args[2];
-    uint16_t data = args[3];
-
-    st7789v_floodfill(h, continuation, len, data);
-}
-DECL_COMMAND(command_st7789v_floodfill_cmd,
-             "st7789v_floodfill oid=%c cont=%c len=%u data=%hu");
 
 void
 command_st7789v_bitmap_cmd(uint32_t *args)

--- a/src/lcd_st7789v.c
+++ b/src/lcd_st7789v.c
@@ -1,0 +1,227 @@
+// Commands for sending messages to an st7789V display connected
+// using the "8080-II series" interface
+//
+// Copyright (C) 2020  Martijn van Buul <martijn.van.buul@gmail.com>
+// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_CLOCK_FREQ
+#include "basecmd.h" // oid_alloc
+#include "board/gpio.h" // gpio_out_write
+#include "board/irq.h" // irq_disable
+#include "board/misc.h" // timer_from_us
+#include "command.h" // DECL_COMMAND
+#include "sched.h" // DECL_SHUTDOWN
+
+struct st7789v {
+    uint32_t last_write_time, write_wait_ticks;
+    uint8_t last_dcx;
+    uint8_t last_data;
+    struct gpio_out dcx, wrx, databits[8];
+};
+
+
+/****************************************************************
+ * Transmit functions
+ ****************************************************************/
+
+// Write 8 bits to the st7789v using the "8080-II series" interface
+static inline void
+st7789v_xmit_byte(struct st7789v *h, uint8_t data, uint8_t dcx )
+{
+    uint8_t mask = 0x01;
+    gpio_out_write(h->wrx, 0);
+    if (h->last_dcx != dcx)
+    {
+        gpio_out_write(h->dcx, dcx);
+        h->last_dcx = dcx;
+    }
+
+    for (int bit = 0; bit < 8; ++bit, mask <<=1)
+    {
+        const uint8_t new_data = data & mask;
+        if ( new_data != (h->last_data & mask) )
+        {
+            gpio_out_write( h->databits[bit], new_data);
+        }
+    }
+
+    gpio_out_write(h->wrx, 1);
+    h->last_data = data;
+}
+
+// Transmit a series of bytes to the chip. The first byte in every
+// request is assumed to be the 8-bit command; subsequent bytes
+// are parameters or display data.
+static void
+st7789v_xmit(struct st7789v *h, uint8_t len, uint8_t *data)
+{
+    uint32_t last_write_time=h->last_write_time,
+             write_wait_ticks=h->write_wait_ticks;
+
+    for (uint8_t i = 0; i < len; ++i) {
+        uint8_t b = *data++;
+        while (timer_read_time() - last_write_time < write_wait_ticks)
+            irq_poll();
+        st7789v_xmit_byte(h, b, (i != 0) );
+        last_write_time = timer_read_time();
+    }
+    h->last_write_time = last_write_time;
+}
+
+// Flood-fill bitmap data. This assumes 16bpp pixel format
+static void
+st7789v_floodfill(struct st7789v *h, uint8_t continuation,
+                  uint32_t len, uint16_t data)
+{
+    uint32_t last_write_time=h->last_write_time,
+             write_wait_ticks=h->write_wait_ticks;
+
+    while (timer_read_time() - last_write_time < write_wait_ticks)
+        irq_poll();
+
+    // RAMWR or WRMEMC/RAMWRC command
+    st7789v_xmit_byte(h, continuation ? 0x3c : 0x2c, 0);
+
+    const uint8_t loByte = data & 0xff;
+    const uint8_t hiByte = data >> 8;
+    for (uint32_t i = 0; i < len; ++i) {
+        st7789v_xmit_byte(h, hiByte, 1 );
+        st7789v_xmit_byte(h, loByte, 1 );
+    }
+
+    h->last_write_time = timer_read_time();
+}
+
+// Send 1bpp bitmap as 16bpp image data
+static void
+st7789v_bitmap(struct st7789v *h, uint8_t continuation, uint16_t fgcolor,
+               uint16_t bgcolor, uint8_t len, uint8_t *data)
+{
+    uint32_t last_write_time=h->last_write_time,
+             write_wait_ticks=h->write_wait_ticks;
+
+    while (timer_read_time() - last_write_time < write_wait_ticks)
+        irq_poll();
+
+    // RAMWR or WRMEMC/RAMWRC command
+    st7789v_xmit_byte(h, continuation ? 0x3c : 0x2c, 0);
+
+    const uint8_t loFG = fgcolor & 0xff;
+    const uint8_t hiFG = fgcolor >> 8;
+
+    const uint8_t loBG = bgcolor & 0xff;
+    const uint8_t hiBG = bgcolor >> 8;
+
+    for (uint16_t i = 0; i < len; ++i)
+    {
+        uint8_t d = data[i];
+        for (uint8_t j = 0; j < 8; ++j, d <<= 1)
+        {
+            if (d & 0x80)
+            {
+                st7789v_xmit_byte(h, hiFG, 1);
+                st7789v_xmit_byte(h, loFG, 1);
+            }
+            else
+            {
+                st7789v_xmit_byte(h, hiBG, 1);
+                st7789v_xmit_byte(h, loBG, 1);
+            }
+        }
+    }
+
+    h->last_write_time = timer_read_time();
+}
+/****************************************************************
+ * Interface
+ ****************************************************************/
+
+void
+command_config_st7789v(uint32_t *args)
+{
+    struct st7789v *h = oid_alloc(args[0], command_config_st7789v, sizeof(*h));
+    h->dcx = gpio_out_setup(args[1], 1);
+    h->wrx = gpio_out_setup(args[2], 1);
+
+    for (int bit = 0; bit < 8; ++bit)
+    {
+        h->databits[bit] = gpio_out_setup(args[3 + bit], 1);
+    }
+
+    h->last_dcx = 1;
+    h->last_data = 0xff;
+
+    if (!CONFIG_HAVE_STRICT_TIMING) {
+        h->write_wait_ticks = args[11];
+        return;
+    }
+
+    // Calibrate write_wait_ticks
+    irq_disable();
+    uint32_t start = timer_read_time();
+    st7789v_xmit_byte(h, 0, 0); // NOP command
+    uint32_t end = timer_read_time();
+    irq_enable();
+    uint32_t diff = end - start, delay_ticks = args[11];
+    if (delay_ticks > diff)
+        h->write_wait_ticks = delay_ticks - diff;
+}
+DECL_COMMAND(command_config_st7789v,
+             "config_st7789v oid=%c dcx_pin=%u wrx_pin=%u"
+             " d8_pin=%u d9_pin=%u d10_pin=%u d11_pin=%u"
+             " d12_pin=%u d13_pin=%u d14_pin=%u d15_pin=%u delay_ticks=%u");
+
+void
+command_st7789v_send_cmd(uint32_t *args)
+{
+    struct st7789v *h = oid_lookup(args[0], command_config_st7789v);
+    uint8_t len = args[1], *cmds = (void*)(size_t)args[2];
+    st7789v_xmit(h, len, cmds);
+}
+DECL_COMMAND(command_st7789v_send_cmd, "st7789v_send_cmd oid=%c cmds=%*s");
+
+void
+command_st7789v_floodfill_cmd(uint32_t *args)
+{
+    struct st7789v *h = oid_lookup(args[0], command_config_st7789v);
+    uint8_t continuation = args[1];
+    uint32_t len = args[2];
+    uint16_t data = args[3];
+
+    st7789v_floodfill(h, continuation, len, data);
+}
+DECL_COMMAND(command_st7789v_floodfill_cmd,
+             "st7789v_floodfill oid=%c cont=%c len=%u data=%hu");
+
+void
+command_st7789v_bitmap_cmd(uint32_t *args)
+{
+    struct st7789v *h = oid_lookup(args[0], command_config_st7789v);
+    uint8_t continuation = args[1];
+    uint16_t fgcolor = args[2];
+    uint16_t bgcolor = args[3];
+    uint8_t len = args[4], *data = (void*)(size_t)args[5];
+
+    st7789v_bitmap(h, continuation, fgcolor, bgcolor, len, data);
+}
+
+DECL_COMMAND(command_st7789v_bitmap_cmd,
+             "st7789v_bitmap oid=%c cont=%c fg=%hu bg=%hu data=%*s");
+
+void
+st7789v_shutdown(void)
+{
+    uint8_t i;
+    struct st7789v *h;
+    foreach_oid(i, h, command_config_st7789v) {
+        gpio_out_write(h->dcx, 0);
+        gpio_out_write(h->wrx, 0);
+        for (uint8_t j = 0; j < 8; ++j)
+        {
+            gpio_out_write(h->databits[j], 0);
+        }
+    }
+}
+DECL_SHUTDOWN(st7789v_shutdown);

--- a/src/lcd_st7789v.c
+++ b/src/lcd_st7789v.c
@@ -15,7 +15,6 @@
 #include "sched.h" // DECL_SHUTDOWN
 
 struct st7789v {
-    uint8_t last_data;
     struct gpio_out dcx, wrx, databits[8];
 };
 
@@ -27,20 +26,15 @@ struct st7789v {
 static inline void
 st7789v_xmit_byte(struct st7789v *h, uint8_t data)
 {
-    uint8_t mask = 0x01;
     gpio_out_write(h->wrx, 0);
-
+    uint8_t mask = 0x01;
     for (int bit = 0; bit < 8; ++bit, mask <<=1)
     {
         const uint8_t new_data = data & mask;
-        if ( new_data != (h->last_data & mask) )
-        {
-            gpio_out_write( h->databits[bit], new_data);
-        }
+        gpio_out_write( h->databits[bit], new_data);
     }
 
     gpio_out_write(h->wrx, 1);
-    h->last_data = data;
 }
 
 // Data is encrypted using an run-length encoded algorithm resembling
@@ -111,8 +105,6 @@ command_config_st7789v(uint32_t *args)
     {
         h->databits[bit] = gpio_out_setup(args[3 + bit], 1);
     }
-
-    h->last_data = 0xff;
 }
 DECL_COMMAND(command_config_st7789v,
              "config_st7789v oid=%c dcx_pin=%u wrx_pin=%u"


### PR DESCRIPTION
Implement drivers for the ST7789V display and the XPT 2046 touch screen controller, as found on the Anet ET4 and ET5 family. This printer has no 'normal' menu buttons or rotation encoder.

This implements a rudimentary touch screen interface; and allows soft buttons to be defined on the screen. These soft buttons can either be used as replacement menu buttons, or can be used to trigger G-code templates.

These screens are sluggish - at least on Klipper, due to the bitwise implementation of the 8-bit interface. This was gleaned from the hd44880 driver. Marlin uses a memory-mapped approach (only available on STM32F4 devices from what I can tell) which is
significantly faster. Accessing the bus on a port basis instead of a pin-basis would probably help a lot too, but doesn't really correspond to any other driver on Klipper. Chosing the foreground and background colors carefully helps; pixel data is transmitted in RGB565 format, and chosing colors where the MSB and LSB are equal helps. This only leaves a few useful colors
though.

I tried to reduce the amount of data sent over the message queue; pixel data is sent as 1bpp, and only modified parts of the screen are updated. I would welcome a throrough review on the timing though;  I haven't noticed any problems, but on my own printer, the display is connected to a seperate MCU. 

Obligatory screenshots:

![IMG_20210103_230214](https://user-images.githubusercontent.com/12941778/103489954-c5d22f80-4e18-11eb-965c-1bb89024ce78.jpg)

This is not ideal. The default screen layout for the home screen assumes a 4x20 layout, while this screen has a much higher resolution, but this can be improved by supplying a custom home screen. Other menus correctly use the available screen space:

![IMG_20210103_230322](https://user-images.githubusercontent.com/12941778/103489964-d71b3c00-4e18-11eb-9e9c-cbb394d1a272.jpg) 

I included a sample config file for the Anet ET4X printer, which uses this display.