### PR TITLE
Change SD card menu enable condition

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -193,7 +193,7 @@ gcode:
 
 [menu __main __sdcard __cancel]
 type: command
-enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "printing" or printer.print_stats.state == "pause")}
+enable: {('virtual_sdcard' in printer) and ('pause_resume' in printer) and (printer.print_stats.state == "printing" or printer.print_stats.state == "pause")}
 name: Cancel printing
 gcode: CANCEL_PRINT
 

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -195,7 +195,7 @@ gcode:
 type: command
 enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "printing" or printer.print_stats.state == "pause")}
 name: Cancel printing
-gcode: 
+gcode:
     {% if 'pause_resume' in printer %}
         CANCEL_PRINT
     {% else %}

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -193,9 +193,22 @@ gcode:
 
 [menu __main __sdcard __cancel]
 type: command
-enable: {('virtual_sdcard' in printer) and ('pause_resume' in printer) and (printer.print_stats.state == "printing" or printer.print_stats.state == "pause")}
+enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "printing" or printer.print_stats.state == "pause")}
 name: Cancel printing
-gcode: CANCEL_PRINT
+gcode: 
+    {% if 'pause_resume' in printer %}
+        CANCEL_PRINT
+    {% else %}
+        M25
+        M27
+        M26 S0
+        TURN_OFF_HEATERS
+        {% if printer.toolhead.position.z <= printer.toolhead.axis_maximum.z - 5 %}
+            G91
+            G0 Z5 F1000
+            G90
+        {% endif %}
+    {% endif %}
 
 ### menu control ###
 [menu __main __control]

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -164,19 +164,19 @@ name: SD Card
 
 [menu __main __sdcard __start]
 type: command
-enable: {('virtual_sdcard' in printer) and not printer.idle_timeout.state == "Printing"}
+enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "standby"}
 name: Start printing
 gcode: M24
 
 [menu __main __sdcard __resume]
 type: command
-enable: {('virtual_sdcard' in printer) and printer.idle_timeout.state == "Printing"}
+enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "paused"}
 name: Resume printing
 gcode: M24
 
 [menu __main __sdcard __pause]
 type: command
-enable: {('virtual_sdcard' in printer) and printer.idle_timeout.state == "Printing"}
+enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "printing"}
 name: Pause printing
 gcode: M25
 

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -18,6 +18,7 @@
 #       + Start printing
 #       + Resume printing
 #       + Pause printing
+#       + Cancel printing
 #       + ... (files)
 #   + Control
 #       + Home All
@@ -172,13 +173,29 @@ gcode: M24
 type: command
 enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "paused"}
 name: Resume printing
-gcode: M24
+gcode:
+    {% if "pause_resume" in printer %}
+        RESUME
+    {% else %}
+        M24
+    {% endif %}
 
 [menu __main __sdcard __pause]
 type: command
 enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "printing"}
 name: Pause printing
-gcode: M25
+gcode:
+    {% if "pause_resume" in printer %}
+        PAUSE
+    {% else %}
+        M25
+    {% endif %}
+
+[menu __main __sdcard __cancel]
+type: command
+enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "printing" or printer.print_stats.state == "pause")}
+name: Cancel printing
+gcode: CANCEL_PRINT
 
 ### menu control ###
 [menu __main __control]

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -164,7 +164,7 @@ name: SD Card
 
 [menu __main __sdcard __start]
 type: command
-enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "standby"}
+enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "standby" or printer.print_stats.state == "error" or printer.print_stats.state == "complete")}
 name: Start printing
 gcode: M24
 


### PR DESCRIPTION
## Edited :  Re-submit moved to #3826 because I don't remember to put <code>signed-off-by</code> in to the commits.

I change the SD card menu "Start/Pause/Resume" enable condition.
I think the SD card menu should use <code>printer.print_stats.state</code> instead of <code>printer.idle_timeout.state</code> because of the bellow reasons.

- When paused, the "Resume" option does not show up because at that time <code>printer.idle_timeout.state == "Ready"</code>  
- When paused, only "Start" option is available, it should be "Resume" (i known they use the same Gcode, but its confusing)  
- The "Resume" option show up even when printing.