### PR TITLE
Fix for TAZ6 (single extruder) Z homing and bed tilt points to match factory firmware

### DIFF
--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -150,10 +150,10 @@ sample_retract_dist: 1.0
 samples_tolerance: 0.075
 
 [bed_tilt]
-points: -5,-3
-        290,-3
-        290,292
-        -5,292
+points: -9,-9
+        288,-9
+        288,289
+        -9,289
 speed: 75
 horizontal_move_z: 5
 

--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -158,7 +158,7 @@ speed: 75
 horizontal_move_z: 5
 
 [safe_z_home]
-home_xy_position: -19,265
+home_xy_position: -19,258
 speed: 50.0
 z_hop: 10.0
 


### PR DESCRIPTION
Using the config file `config/printer-lulzbot-taz6-2017.cfg` with an unmodified TAZ6 printer causes the extruder nozzle to crash into the homing button trim when homing the Z axis.

I confirmed the behavior against the factory Marlin firmware on the same printer, which does not crash.

The factory Marlin firmware ([link to line in source code](https://gitlab.com/lulzbot3d/marlin/-/blob/TAZ_6.0_Single_Extruder_v2.1/Marlin/Configuration.h#L458)) uses X=-19, Y=258 as the homing position. Klipper's configuration for this printer uses X=-19, Y=265 which causes the problem as the button isn't big enough to accommodate 7mm of error from center -- though it's close!

This pull request changes the Y position for Z homing to match the factory Marlin firmware, and has been tested by me on an unmodified Lulzbot TAZ6 /w single extruder.

NOTE: The same problem might occur with Klipper's   `config/printer-lulzbot-taz6-dual-v3-2017.cfg` but I do not have a version 3 dual extruder to compare, so I to be safe this PR only fixes the single extruder TAZ6 config.