### PR TITLE
Fix TAZ6 single-extruder homing and bed tilt probing

### DIFF
--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -152,14 +152,14 @@ samples_tolerance: 0.075
 
 [bed_tilt]
 points: -9,-9
-        288,-9
-        288,289
+        289.4,-9
+        289.4,290
         -9,289
 speed: 75
 horizontal_move_z: 5
 
 [safe_z_home]
-home_xy_position: -19,258
+home_xy_position: -19.1,259.3
 speed: 50.0
 z_hop: 10.0
 

--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -48,7 +48,8 @@ step_pin: PC3
 dir_pin: !PL6
 enable_pin: !PA4
 microsteps: 16
-rotation_distance: 3.782
+gear_ratio: 48:9
+rotation_distance: 20.562
 nozzle_diameter: 0.400
 filament_diameter: 2.920
 heater_pin: PH6

--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -150,10 +150,10 @@ sample_retract_dist: 1.0
 samples_tolerance: 0.075
 
 [bed_tilt]
-points: -5,-3
-        290,-3
-        290,292
-        -5,292
+points: -9,-9
+        288,-9
+        288,289
+        -9,289
 speed: 75
 horizontal_move_z: 5
 

--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -158,7 +158,7 @@ speed: 75
 horizontal_move_z: 5
 
 [safe_z_home]
-home_xy_position: -19,265
+home_xy_position: -19,258
 speed: 50.0
 z_hop: 10.0
 


### PR DESCRIPTION
config: Fix TAZ6 homing and bed tilt probing

This configuration adjusts the Y position for Z homing, and the bed_tilt calibration points to match the factory Marlin firmware, and has been tested by me on an unmodified Lulzbot TAZ6 /w single extruder.

The factory Marlin firmware [(link to relevant lines](https://gitlab.com/lulzbot3d/marlin/-/blob/TAZ_6.0_Single_Extruder_v2.1/Marlin/Configuration.h#L458)) uses X=-19, Y=258 as the homing position. Klipper's configuration for this printer uses X=-19, Y=265 which causes the problem as the button isn't big enough to accommodate 7mm of error from center -- though it's close!

The bed tilt homing points in the existent Klipper config didn't and don't quite line up. This new configuration updates the left/right front/back values to match up with the factory firmware. See factory source here: https://gitlab.com/lulzbot3d/marlin/-/blob/TAZ_6.0_Single_Extruder_v2.1/Marlin/Configuration.h#L395

NOTE: The same problems might occur with Klipper's config/printer-lulzbot-taz6-dual-v3-2017.cfg but I do not have a version 3 dual extruder to compare, so to be safe this PR only fixes the single extruder TAZ6 config.

Signed-off-by: Steven T. Snyder github@steventsnyder.com