### PR TITLE
Export a "parsed" version of the config file to command templates and api server

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -214,12 +214,14 @@ The following are common printer attributes:
   as "triggered" during the last QUERY_PROBE command. Note, due to the
   order of template expansion (see above), the QUERY_PROBE command
   must be run prior to the macro containing this reference.
-- `printer.configfile.config["<section>"]["<option>"]`: Returns the
-  given config file setting as read by Klipper during the last
-  software start or restart. (Any settings changed at run-time will
-  not be reflected here.) All values are returned as strings (if math
-  is to be performed on the value then it must be converted to a
-  Python number).
+- `printer.configfile.settings.<section>.<option>`: Returns the given
+  config file setting (or default value) during the last software
+  start or restart. (Any settings changed at run-time will not be
+  reflected here.)
+- `printer.configfile.config.<section>.<option>`: Returns the given
+  raw config file setting as read by Klipper during the last software
+  start or restart. (Any settings changed at run-time will not be
+  reflected here.) All values are returned as strings.
 - `printer["gcode_macro <macro_name>"].<variable>`: The current value
   of a [gcode_macro variable](#variables).
 - `printer.webhooks.state`: Returns a string indicating the current

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -1,9 +1,9 @@
 # Add ability to define custom g-code macros
 #
-# Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import traceback, logging, ast
+import traceback, logging, ast, copy
 import jinja2
 
 
@@ -26,7 +26,7 @@ class GetStatusWrapper:
             raise KeyError(val)
         if self.eventtime is None:
             self.eventtime = self.printer.get_reactor().monotonic()
-        self.cache[sval] = res = dict(po.get_status(self.eventtime))
+        self.cache[sval] = res = copy.deepcopy(po.get_status(self.eventtime))
         return res
     def __contains__(self, val):
         try:
@@ -157,9 +157,8 @@ class GCodeMacro:
         pdesc = "Renamed builtin of '%s'" % (self.alias,)
         self.gcode.register_command(self.rename_existing, prev_cmd, desc=pdesc)
         self.gcode.register_command(self.alias, self.cmd, desc=self.cmd_desc)
-        return dict(self.variables)
     def get_status(self, eventtime):
-        return dict(self.variables)
+        return self.variables
     cmd_SET_GCODE_VARIABLE_help = "Set the value of a G-Code macro variable"
     def cmd_SET_GCODE_VARIABLE(self, gcmd):
         variable = gcmd.get('VARIABLE')

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -284,8 +284,8 @@ class PrinterHeaters:
                 "G-Code sensor id %s already registered" % (gcode_id,))
         self.gcode_id_to_sensor[gcode_id] = psensor
     def get_status(self, eventtime):
-        return {'available_heaters': list(self.available_heaters),
-                'available_sensors': list(self.available_sensors)}
+        return {'available_heaters': self.available_heaters,
+                'available_sensors': self.available_sensors}
     def turn_off_all_heaters(self, print_time=0.):
         for heater in self.heaters.values():
             heater.set_temp(0.)

--- a/klippy/extras/query_endstops.py
+++ b/klippy/extras/query_endstops.py
@@ -8,7 +8,7 @@ class QueryEndstops:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.endstops = []
-        self.last_state = {}
+        self.last_state = []
         # Register webhook if server is available
         webhooks = self.printer.lookup_object('webhooks')
         webhooks.register_endpoint(

--- a/klippy/extras/save_variables.py
+++ b/klippy/extras/save_variables.py
@@ -57,7 +57,7 @@ class SaveVariables:
         gcmd.respond_info("Variable Saved")
         self.loadVariables()
     def get_status(self, eventtime):
-        return {'variables': dict(self.allVariables)}
+        return {'variables': self.allVariables}
 
 def load_config(config):
     return SaveVariables(config)


### PR DESCRIPTION
It's currently possible to obtain the raw values from the Klipper config file by accessing values like `{printer.configfile.config.printer.max_z_velocity}`.  However, doing so can be tedious because the value is always returned as a string and it may not be present if the user is relying on a default value.

This PR adds new exports such as `{printer.configfile.settings.printer.max_z_velocity}` which report the "parsed" value that Klipper uses - or the default value if the user did not specify a value.

This method isn't always assured to report accurate default values (it's possible the code will have a default, but not internally obtain the default using the common `config.get()` method), but it's going to be accurate for most settings.

@Arksine @mcmatrix @meteyou @cadriel - do you have any comments on this?

-Kevin