### PR TITLE
Change move min/max limits menu.cfg to the new priner variables

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -264,8 +264,8 @@ name: Move 10mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: {printer.toolhead.axis_minimum.x}
+input_max: {printer.toolhead.axis_maximum.x}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -277,8 +277,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: {printer.toolhead.axis_minimum.y}
+input_max: {printer.toolhead.axis_maximum.y}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -292,7 +292,7 @@ enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
 input_min: 0
-input_max: 200
+input_max: {printer.toolhead.axis_maximum.z}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -305,8 +305,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: -50
-input_max: 50
+input_min: -{printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
+input_max: {printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
 input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -324,8 +324,8 @@ name: Move 1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: {printer.toolhead.axis_minimum.x}
+input_max: {printer.toolhead.axis_maximum.x}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -337,8 +337,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: {printer.toolhead.axis_minimum.y}
+input_max: {printer.toolhead.axis_maximum.y}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -352,7 +352,7 @@ enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
 input_min: 0
-input_max: 200
+input_max: {printer.toolhead.axis_maximum.z}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -365,8 +365,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: -50
-input_max: 50
+input_min: -{printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
+input_max: {printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
 input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -384,8 +384,8 @@ name: Move 0.1mm
 type: input
 name: Move X:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.x}
-input_min: 0
-input_max: 200
+input_min: {printer.toolhead.axis_minimum.x}
+input_max: {printer.toolhead.axis_maximum.x}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -397,8 +397,8 @@ gcode:
 type: input
 name: Move Y:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.y}
-input_min: 0
-input_max: 200
+input_min: {printer.toolhead.axis_minimum.y}
+input_max: {printer.toolhead.axis_maximum.y}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -412,7 +412,7 @@ enable: {not printer.idle_timeout.state == "Printing"}
 name: Move Z:{'%05.1f' % menu.input}
 input: {printer.gcode_move.gcode_position.z}
 input_min: 0
-input_max: 200
+input_max: {printer.toolhead.axis_maximum.z}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
@@ -425,8 +425,8 @@ type: input
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Move E:{'%+06.1f' % menu.input}
 input: 0
-input_min: -50
-input_max: 50
+input_min: -{printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
+input_max: {printer.configfile.config.extruder.max_extrude_only_distance|default(50)}
 input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis


### PR DESCRIPTION
Changed the movement limits to the new available printer variables (thank you for adding mcmatrix ) 
printer.toolhead.axis_minimum.(x/y/z)
printer.toolhead.axis_maximim.(x/y/z) 
That will work now for all printers and reduce to user involvement for customising there menus .

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com