### PR TITLE
Fix deprecated usage of Exception.message attribute

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -530,7 +530,7 @@ class BedMeshCalibrate:
         try:
             z_mesh.build_mesh(probed_matrix)
         except BedMeshError as e:
-            raise self.gcode.error(e.message)
+            raise self.gcode.error(str(e))
         self.bedmesh.set_mesh(z_mesh)
         self.gcode.respond_info("Mesh Bed Leveling Complete")
         self.bedmesh.save_profile("default")
@@ -988,7 +988,7 @@ class ProfileManager:
         try:
             z_mesh.build_mesh(probed_matrix)
         except BedMeshError as e:
-            raise self.gcode.error(e.message)
+            raise self.gcode.error(str(e))
         self.current_profile = prof_name
         self.bedmesh.set_mesh(z_mesh)
     def remove_profile(self, prof_name):

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -29,7 +29,7 @@ class WebRequestError(gcode.CommandError):
     def to_dict(self):
         return {
             'error': 'WebRequestError',
-            'message': self.message}
+            'message': str(self)}
 
 class Sentinel:
     pass
@@ -224,12 +224,12 @@ class ClientConnection:
             func = self.webhooks.get_callback(web_request.get_method())
             func(web_request)
         except self.printer.command_error as e:
-            web_request.set_error(WebRequestError(e.message))
+            web_request.set_error(WebRequestError(str(e)))
         except Exception as e:
             msg = ("Internal Error on WebRequest: %s"
                    % (web_request.get_method()))
             logging.exception(msg)
-            web_request.set_error(WebRequestError(e.message))
+            web_request.set_error(WebRequestError(str(e)))
             self.printer.invoke_shutdown(msg)
         result = web_request.finish()
         if result is None:


### PR DESCRIPTION
I've been using the rebased Python 3 branch for few months now. No problems encountered so far, except that setting invalid values with gcode commands through webhooks triggers a shutdown. After I learned that this shouldn't happen, I found the problem:

In some exception handling situations, `Exception.message` is used to get the message. This attribute is [deprecated](https://www.python.org/dev/peps/pep-0352/) since Python 2.6 and removed in Python 3. This raises an `AttributeError` exception in the exception handling code and prevent recovery.
This PR replaces the occurrences of `e.message` with `str(e)`. (`e.args[0]` is another possibility)

I did set this PR for the master branch since it fixes a deprecation on python 2.6/2.7 (it should emit a notice with `warnings.warn()`), but feel free to apply it on the python 3 branch if you want.