### PR TITLE
Fix race condition of filament width sensor

### DIFF
--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -152,7 +152,11 @@ class HallFilamentWidthSensor:
         else:
             self.gcode.run_script("M221 S100")
             self.filament_array = []
-        return eventtime + 1
+
+        if self.is_active:
+            return eventtime + 1
+        else:
+            return self.reactor.NEVER
 
     def cmd_M407(self, gcmd):
         response = ""

--- a/klippy/extras/tsl1401cl_filament_width_sensor.py
+++ b/klippy/extras/tsl1401cl_filament_width_sensor.py
@@ -101,7 +101,11 @@ class FilamentWidthSensor:
         else:
             self.gcode.run_script("M221 S100")
             self.filament_array = []
-        return eventtime + 1
+
+        if self.is_active:
+            return eventtime + 1
+        else:
+            return self.reactor.NEVER
 
     def cmd_M407(self, gcmd):
         response = ""


### PR DESCRIPTION
I noticed that switching off the hall filament width sensor mid-print does not always switch off the active flow rate modifier.
With this fix, this problem did not occur to me again.