### PR TITLE
stm32f1: Fix for using 16MHz external crystal

### DIFF
--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -164,12 +164,12 @@ clock_setup(void)
         // Configure 72Mhz PLL from external crystal (HSE)
         RCC->CR |= RCC_CR_HSEON;
         uint32_t div = CONFIG_CLOCK_FREQ / (CONFIG_CLOCK_REF_FREQ / 2);
-        cfgr = 0;
+        cfgr = 1 << RCC_CFGR_PLLSRC_Pos;
         if (div < 16)
             cfgr = RCC_CFGR_PLLXTPRE_HSE_DIV2;
         else
             div /= 2;
-        cfgr |= (1 << RCC_CFGR_PLLSRC_Pos) | ((div - 2) << RCC_CFGR_PLLMULL_Pos);	
+        cfgr |= (div - 2) << RCC_CFGR_PLLMULL_Pos;
     } else {
         // Configure 72Mhz PLL from internal 8Mhz oscillator (HSI)
         uint32_t div2 = (CONFIG_CLOCK_FREQ / 8000000) * 2;

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -166,7 +166,7 @@ clock_setup(void)
         uint32_t div = CONFIG_CLOCK_FREQ / (CONFIG_CLOCK_REF_FREQ / 2);
         cfgr = 1 << RCC_CFGR_PLLSRC_Pos;
         if (div < 16)
-            cfgr = RCC_CFGR_PLLXTPRE_HSE_DIV2;
+            cfgr |= RCC_CFGR_PLLXTPRE_HSE_DIV2;
         else
             div /= 2;
         cfgr |= (div - 2) << RCC_CFGR_PLLMULL_Pos;

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -162,9 +162,14 @@ clock_setup(void)
     uint32_t cfgr;
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
         // Configure 72Mhz PLL from external crystal (HSE)
-        uint32_t div = CONFIG_CLOCK_FREQ / CONFIG_CLOCK_REF_FREQ;
         RCC->CR |= RCC_CR_HSEON;
-        cfgr = (1 << RCC_CFGR_PLLSRC_Pos) | ((div - 2) << RCC_CFGR_PLLMULL_Pos);
+        uint32_t div = CONFIG_CLOCK_FREQ / (CONFIG_CLOCK_REF_FREQ / 2);
+        cfgr = 0;
+        if (div < 16)
+            cfgr = RCC_CFGR_PLLXTPRE_HSE_DIV2;
+        else
+            div /= 2;
+        cfgr |= (1 << RCC_CFGR_PLLSRC_Pos) | ((div - 2) << RCC_CFGR_PLLMULL_Pos);	
     } else {
         // Configure 72Mhz PLL from internal 8Mhz oscillator (HSI)
         uint32_t div2 = (CONFIG_CLOCK_FREQ / 8000000) * 2;

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -165,7 +165,7 @@ clock_setup(void)
         RCC->CR |= RCC_CR_HSEON;
         uint32_t div = CONFIG_CLOCK_FREQ / (CONFIG_CLOCK_REF_FREQ / 2);
         cfgr = 1 << RCC_CFGR_PLLSRC_Pos;
-        if (div < 16)
+        if ((div & 1) && div <= 16)
             cfgr |= RCC_CFGR_PLLXTPRE_HSE_DIV2;
         else
             div /= 2;


### PR DESCRIPTION
Running the STM32F1 at 72MHz with a 16MHz external crystal requires a 4.5x frequency multiplier which the current code does not allow for.  With this change it instead calculates the multiplier required for half the crystal frequency and sets the RCC_CFGR_PLLXTPRE_HSE_DIV2 if the multiplier would not exceed the maximum of 16.

Signed-off-by: Matt Shepcar <matt@shepcar.co.uk>
