### PR TITLE
Re: Change SD card menu enable condition

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -18,6 +18,7 @@
 #       + Start printing
 #       + Resume printing
 #       + Pause printing
+#       + Cancel printing
 #       + ... (files)
 #   + Control
 #       + Home All
@@ -164,21 +165,50 @@ name: SD Card
 
 [menu __main __sdcard __start]
 type: command
-enable: {('virtual_sdcard' in printer) and not printer.idle_timeout.state == "Printing"}
+enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "standby" or printer.print_stats.state == "error" or printer.print_stats.state == "complete")}
 name: Start printing
 gcode: M24
 
 [menu __main __sdcard __resume]
 type: command
-enable: {('virtual_sdcard' in printer) and printer.idle_timeout.state == "Printing"}
+enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "pause"}
 name: Resume printing
-gcode: M24
+gcode:
+    {% if "pause_resume" in printer %}
+        RESUME
+    {% else %}
+        M24
+    {% endif %}
 
 [menu __main __sdcard __pause]
 type: command
-enable: {('virtual_sdcard' in printer) and printer.idle_timeout.state == "Printing"}
+enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "printing"}
 name: Pause printing
-gcode: M25
+gcode:
+    {% if "pause_resume" in printer %}
+        PAUSE
+    {% else %}
+        M25
+    {% endif %}
+
+[menu __main __sdcard __cancel]
+type: command
+enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "printing" or printer.print_stats.state == "pause")}
+name: Cancel printing
+gcode:
+    {% if 'pause_resume' in printer %}
+        CANCEL_PRINT
+    {% else %}
+        M25
+        M27
+        M26 S0
+        TURN_OFF_HEATERS
+        {% if printer.toolhead.position.z <= printer.toolhead.axis_maximum.z - 5 %}
+            G91
+            G0 Z5 F1000
+            G90
+        {% endif %}
+    {% endif %}
 
 ### menu control ###
 [menu __main __control]


### PR DESCRIPTION
Re-submit of  #3737 because I don't remember to put <code> signed-off-by </code> in to the commits.

### Summary 

- Change the SD card enable condition from using <code>printer.idle_timeout.state</code> to <code>printer.print_stats.state</code> because of the following reasons  
    *  When paused, the "Resume" option does not show up because at that time printer.idle_timeout.state == "Ready"  
    *  When paused, only "Start" option is available, it should be "Resume" (i known they use the same Gcode, but its confusing).  
    * The "Resume" option show up even when printing.  
- Added <code>Cancel printing</code> option.  
