### PR TITLE
Add samples_result option to [probe] last

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -39,7 +39,7 @@ class PrinterProbe:
         self.sample_count = config.getint('samples', 1, minval=1)
         self.sample_retract_dist = config.getfloat('sample_retract_dist', 2.,
                                                    above=0.)
-        atypes = {'median': 'median', 'average': 'average', 'last': 'last'}
+        atypes = {'median': 'median', 'average': 'average'}
         self.samples_result = config.getchoice('samples_result', atypes,
                                                'average')
         self.samples_tolerance = config.getfloat('samples_tolerance', 0.100,

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -180,7 +180,7 @@ class PrinterProbe:
         # Calculate and return result
         if samples_result == 'median':
             return self._calc_median(positions)
-        else if samples_result == 'last':
+        elif samples_result == 'last':
             return positions[-1]
         return self._calc_mean(positions)
     cmd_PROBE_help = "Probe Z-height at current XY position"

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -39,7 +39,7 @@ class PrinterProbe:
         self.sample_count = config.getint('samples', 1, minval=1)
         self.sample_retract_dist = config.getfloat('sample_retract_dist', 2.,
                                                    above=0.)
-        atypes = {'median': 'median', 'average': 'average'}
+        atypes = {'median': 'median', 'average': 'average', 'last': 'last'}
         self.samples_result = config.getchoice('samples_result', atypes,
                                                'average')
         self.samples_tolerance = config.getfloat('samples_tolerance', 0.100,
@@ -180,6 +180,8 @@ class PrinterProbe:
         # Calculate and return result
         if samples_result == 'median':
             return self._calc_median(positions)
+        else if samples_result == 'last':
+            return positions[-1]
         return self._calc_mean(positions)
     cmd_PROBE_help = "Probe Z-height at current XY position"
     def cmd_PROBE(self, gcmd):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -46,6 +46,7 @@ class PrinterProbe:
                                                  minval=0.)
         self.samples_retries = config.getint('samples_tolerance_retries', 0,
                                              minval=0)
+        self.ignore_first = config.getboolean('ignore_first' , False)
         # Register z_virtual_endstop pin
         self.printer.lookup_object('pins').register_chip('probe', self)
         # Register homing event handlers
@@ -177,11 +178,12 @@ class PrinterProbe:
                 self._move(liftpos, lift_speed)
         if must_notify_multi_probe:
             self.multi_probe_end()
+        # Filter out first value
+        if self.ignore_first:
+            positions = positions[1:]
         # Calculate and return result
         if samples_result == 'median':
             return self._calc_median(positions)
-        elif samples_result == 'last':
-            return positions[-1]
         return self._calc_mean(positions)
     cmd_PROBE_help = "Probe Z-height at current XY position"
     def cmd_PROBE(self, gcmd):


### PR DESCRIPTION
Most of my probes are showing the phenomena that the first probe result is slightly off. See the following examples.

Fotek PL08N:
```
23.1.2021, 10:23:57: : PROBE_ACCURACY at X:125.000 Y:78.000 Z:20.662 (samples=10 retract=1.000 speed=5.0 lift_speed=50.0)
23.1.2021, 10:23:57: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:23:58: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:23:58: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:23:59: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:23:59: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:24:00: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:24:01: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:24:01: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:24:02: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:24:02: : probe at 125.000,78.000 is z=4.700000
23.1.2021, 10:24:02: : probe accuracy results: maximum 4.700000, minimum 4.700000, range 0.000000, average 4.700000, median 4.700000, standard deviation 0.000000

23.1.2021, 10:24:08: : PROBE_ACCURACY at X:125.000 Y:78.000 Z:25.026 (samples=10 retract=1.000 speed=5.0 lift_speed=50.0)
23.1.2021, 10:24:10: : probe at 125.000,78.000 is z=4.637500
23.1.2021, 10:24:10: : probe at 125.000,78.000 is z=4.650000
23.1.2021, 10:24:11: : probe at 125.000,78.000 is z=4.650000
23.1.2021, 10:24:11: : probe at 125.000,78.000 is z=4.650000
23.1.2021, 10:24:12: : probe at 125.000,78.000 is z=4.650000
23.1.2021, 10:24:12: : probe at 125.000,78.000 is z=4.650000
23.1.2021, 10:24:13: : probe at 125.000,78.000 is z=4.650000
23.1.2021, 10:24:14: : probe at 125.000,78.000 is z=4.650000
23.1.2021, 10:24:14: : probe at 125.000,78.000 is z=4.650000
23.1.2021, 10:24:15: : probe at 125.000,78.000 is z=4.650000
23.1.2021, 10:24:15: : probe accuracy results: maximum 4.650000, minimum 4.637500, range 0.012500, average 4.648750, median 4.650000, standard deviation 0.003750
```

original bltouch:
```
23.1.2021, 11:04:26: : PROBE_ACCURACY at X:125.000 Y:78.000 Z:25.024 (samples=10 retract=1.000 speed=5.0 lift_speed=50.0)
23.1.2021, 11:04:28: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:28: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:29: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:29: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:30: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:30: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:31: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:31: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:32: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:32: : probe at 125.000,78.000 is z=2.662500
23.1.2021, 11:04:33: : probe accuracy results: maximum 2.662500, minimum 2.662500, range 0.000000, average 2.662500, median 2.662500, standard deviation 0.000000

23.1.2021, 11:04:41: : PROBE_ACCURACY at X:125.000 Y:78.000 Z:20.675 (samples=10 retract=1.000 speed=5.0 lift_speed=50.0)
23.1.2021, 11:04:41: : probe at 125.000,78.000 is z=2.675000
23.1.2021, 11:04:42: : probe at 125.000,78.000 is z=2.687500
23.1.2021, 11:04:42: : probe at 125.000,78.000 is z=2.687500
23.1.2021, 11:04:43: : probe at 125.000,78.000 is z=2.687500
23.1.2021, 11:04:43: : probe at 125.000,78.000 is z=2.687500
23.1.2021, 11:04:44: : probe at 125.000,78.000 is z=2.687500
23.1.2021, 11:04:44: : probe at 125.000,78.000 is z=2.687500
23.1.2021, 11:04:45: : probe at 125.000,78.000 is z=2.687500
23.1.2021, 11:04:45: : probe at 125.000,78.000 is z=2.687500
23.1.2021, 11:04:46: : probe at 125.000,78.000 is z=2.687500
23.1.2021, 11:04:46: : probe accuracy results: maximum 2.687500, minimum 2.675000, range 0.012500, average 2.686250, median 2.687500, standard deviation 0.003750
```

Omron TL-Q5MC2-Z:
```
23.1.2021, 11:19:23: : PROBE_ACCURACY at X:125.000 Y:125.000 Z:25.007 (samples=10 retract=1.000 speed=5.0 lift_speed=50.0)
23.1.2021, 11:19:24: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:24: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:25: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:26: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:26: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:27: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:27: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:28: : probe at 125.000,125.000 is z=19.650000
23.1.2021, 11:19:28: : probe at 125.000,125.000 is z=19.650000
23.1.2021, 11:19:29: : probe at 125.000,125.000 is z=19.650000
23.1.2021, 11:19:29: : probe accuracy results: maximum 19.662500, minimum 19.650000, range 0.012500, average 19.658750, median 19.662500, standard deviation 0.005728

23.1.2021, 11:19:33: : PROBE_ACCURACY at X:125.000 Y:125.000 Z:20.650 (samples=10 retract=1.000 speed=5.0 lift_speed=50.0)
23.1.2021, 11:19:34: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:34: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:35: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:35: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:36: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:36: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:37: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:38: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:38: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:39: : probe at 125.000,125.000 is z=19.662500
23.1.2021, 11:19:39: : probe accuracy results: maximum 19.662500, minimum 19.662500, range 0.000000, average 19.662500, median 19.662500, standard deviation 0.000000
```

With this small change someone can probe 2 samples and second is taken. it makes my Switchwire firstlayer more consistant.
```
[probe]
#	probe
pin: ^PB1
x_offset: 0
y_offset: 25.0
z_offset: 0
speed: 5
samples: 2
samples_result: median
ignore_first: true
sample_retract_dist: 1
lift_speed: 50
```

Signed-off-by: Stephan3 <stephan.oelze@gmail.com>