### PR TITLE
Endstops on a different MCU to stepper motors

### DIFF
--- a/docs/MCU_Commands.md
+++ b/docs/MCU_Commands.md
@@ -256,9 +256,9 @@ Stepper commands
   generated with dir=0.
 
 * `endstop_home oid=%c clock=%u sample_ticks=%u sample_count=%c
-  rest_ticks=%u pin_value=%c` : This command is used during stepper
-  "homing" operations. To use this command a 'config_endstop' command
-  with the same 'oid' parameter must have been issued during
+  rest_ticks=%u report_ticks=%u pin_value=%c` : This command is used
+  during stepper "homing" operations. To use this command a 'config_endstop'
+  command with the same 'oid' parameter must have been issued during
   micro-controller configuration. When this command is invoked, the
   micro-controller will sample the endstop pin every 'rest_ticks'
   clock ticks and check if it has a value equal to 'pin_value'. If the

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -62,6 +62,8 @@ defs_itersolve = """
         , double x, double y, double z);
     void itersolve_set_position(struct stepper_kinematics *sk
         , double x, double y, double z);
+    void itersolve_set_commanded_pos(struct stepper_kinematics *sk
+        , double position);
     double itersolve_get_commanded_pos(struct stepper_kinematics *sk);
 """
 

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -38,6 +38,9 @@ defs_stepcompress = """
     int stepcompress_queue_msg(struct stepcompress *sc
         , uint32_t *data, int len);
 
+    void stepcompress_enable_step_tracking(struct stepcompress *sc, int enable);
+    int stepcompress_count_steps_after(struct stepcompress *sc, uint64_t clock);
+
     struct steppersync *steppersync_alloc(struct serialqueue *sq
         , struct stepcompress **sc_list, int sc_num, int move_num);
     void steppersync_free(struct steppersync *ss);

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -273,6 +273,13 @@ itersolve_set_position(struct stepper_kinematics *sk
     sk->commanded_pos = itersolve_calc_position_from_coord(sk, x, y, z);
 }
 
+void __visible
+itersolve_set_commanded_pos(struct stepper_kinematics *sk
+                       , double pos)
+{
+    sk->commanded_pos = pos;
+}
+
 double __visible
 itersolve_get_commanded_pos(struct stepper_kinematics *sk)
 {

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -36,6 +36,8 @@ double itersolve_calc_position_from_coord(struct stepper_kinematics *sk
                                           , double x, double y, double z);
 void itersolve_set_position(struct stepper_kinematics *sk
                             , double x, double y, double z);
+void itersolve_set_commanded_pos(struct stepper_kinematics *sk
+                            , double pos);
 double itersolve_get_commanded_pos(struct stepper_kinematics *sk);
 
 #endif // itersolve.h

--- a/klippy/chelper/stepcompress.c
+++ b/klippy/chelper/stepcompress.c
@@ -363,7 +363,8 @@ queue_flush(struct stepcompress *sc, uint64_t move_clock)
             return ret;
 
         if (sc->track_steps) {
-            // record sent moves so we can figure out where we were at a given point in time
+            // record sent moves so we can figure out
+            // where we were at a given point in time
             struct sent_move *sm = malloc(sizeof(*sm));
             sm->move = move;
             sm->clock = sc->last_step_clock;

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -18,6 +18,9 @@ int stepcompress_commit(struct stepcompress *sc);
 int stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock);
 int stepcompress_queue_msg(struct stepcompress *sc, uint32_t *data, int len);
 
+void stepcompress_enable_step_tracking(struct stepcompress *sc, int enable);
+int stepcompress_count_steps_after(struct stepcompress *sc, uint64_t clock);
+
 struct serialqueue;
 struct steppersync *steppersync_alloc(
     struct serialqueue *sq, struct stepcompress **sc_list, int sc_num

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -195,10 +195,11 @@ class BLTouchEndstopWrapper:
         for s, mcu_pos in self.start_mcu_pos:
             if s.get_mcu_position() == mcu_pos:
                 raise self.printer.command_error("BLTouch failed to deploy")
-    def home_start(self, print_time, sample_time, sample_count, rest_time):
+    def home_start(self, print_time, sample_time, sample_count,
+                   rest_time, report_time):
         rest_time = min(rest_time, ENDSTOP_REST_TIME)
         return self.mcu_endstop.home_start(print_time, sample_time,
-                                           sample_count, rest_time)
+                                    sample_count, rest_time, report_time)
     def get_position_endstop(self):
         return self.position_endstop
     def set_output_mode(self, mode):

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -79,7 +79,9 @@ class Homing:
                 error = "Failed to home %s: Timeout during homing" % (name,)
         # Determine stepper halt positions
         self.toolhead.flush_step_generation()
-        end_mcu_pos = [(s, name, spos, s.get_mcu_position(), s.get_homed_mcu_position())
+        end_mcu_pos = [(s, name, spos,
+                        s.get_mcu_position(),
+                        s.get_homed_mcu_position())
                        for s, name, spos in start_mcu_pos]
         if probe_pos:
             for s, name, spos, epos, hpos in end_mcu_pos:

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -143,7 +143,7 @@ class Homing:
             raise self.printer.command_error(error)
         # Check if some movement occurred
         if verify_movement and not allSteppersMoved:
-            # matts TODO: this probably isn't a valid way to check 
+            # matts TODO: this probably isn't a valid way to check
             # with remote end-stops
             if probe_pos:
                 raise self.printer.command_error(

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -143,9 +143,13 @@ class Homing:
             raise self.printer.command_error(error)
         # Check if some movement occurred
         if verify_movement and not allSteppersMoved:
+            # matts TODO: this probably isn't a valid way to check 
+            # with remote end-stops
             if probe_pos:
                 raise self.printer.command_error(
                     "Probe triggered prior to movement")
+            # matts TODO: wrong name
+            name = steppers[0].get_name()
             raise self.printer.command_error(
                 "Endstop %s still triggered after retract" % (name,))
     def home_rails(self, rails, forcepos, movepos):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -116,8 +116,8 @@ class PrinterProbe:
         pos = toolhead.get_position()
         pos[2] = self.z_position
         endstops = [(self.mcu_probe, "probe")]
-        # TODO - make sure probe is not triggered before deciding on 5 being safe?
-        # or just consider probing to always be safe unless it's being used as an endstop?
+        # TODO - make sure probe is not triggered before blind move and
+        #        retract a safe distance first?
         max_blind_travel = min(5.0, self.z_offset)
         if self.mcu_probe.has_remote_steppers() and self.z_offset < 0.1:
             raise self.printer.command_error("Not safe to probe with "
@@ -297,6 +297,8 @@ class ProbeEndstopWrapper:
         self.has_remote_steppers = self.mcu_endstop.has_remote_steppers
         self.has_triggered = self.mcu_endstop.has_triggered
         self.get_last_report_time = self.mcu_endstop.get_last_report_time
+        self.get_next_expected_report_time = \
+            self.mcu_endstop.get_next_expected_report_time
         self.printer.register_event_handler("toolhead:ready",
                                     self._add_steppers)
 

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -62,10 +62,11 @@ class CoreXYKinematics:
             homepos = [None, None, None, None]
             homepos[axis] = hi.position_endstop
             forcepos = list(homepos)
+            # matts - test, only home by 25mm for now
             if hi.positive_dir:
-                forcepos[axis] -= 1.5 * (hi.position_endstop - position_min)
+                forcepos[axis] -= 25 #1.5 * (hi.position_endstop - position_min)
             else:
-                forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
+                forcepos[axis] += 25 #1.5 * (position_max - hi.position_endstop)
             # Perform homing
             homing_state.home_rails([rail], forcepos, homepos)
     def _motor_off(self, print_time):

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -65,11 +65,10 @@ class CoreXYKinematics:
             homepos = [None, None, None, None]
             homepos[axis] = hi.position_endstop
             forcepos = list(homepos)
-            # matts - test, only home by 25mm for now
             if hi.positive_dir:
-                forcepos[axis] -= 25 #1.5 * (hi.position_endstop - position_min)
+                forcepos[axis] -= 1.5 * (hi.position_endstop - position_min)
             else:
-                forcepos[axis] += 25 #1.5 * (position_max - hi.position_endstop)
+                forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
             # Perform homing
             homing_state.home_rails([rail], forcepos, homepos)
     def _motor_off(self, print_time):

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -42,7 +42,6 @@ class MCU_endstop:
         self._mcu = mcu
         self._steppers = []
         self._local_steppers = []
-        self._remote_steppers = []
         self._remote_endstops = {}
         self._pin = pin_params['pin']
         self._pullup = pin_params['pullup']
@@ -63,7 +62,6 @@ class MCU_endstop:
         if mcu is self._mcu:
             self._local_steppers.append(stepper)
         else:
-            self._remote_steppers.append(stepper)
             if mcu not in self._remote_endstops:
                 self._remote_endstops[mcu] = MCU_remote_endstop(mcu)
             self._remote_endstops[mcu].add_stepper(stepper)
@@ -93,8 +91,6 @@ class MCU_endstop:
             oid=self._oid, cq=cmd_queue)
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    triggered=True):
-        for s in self._remote_steppers:
-            s.start_homing_step_tracking()
         clock = self._mcu.print_time_to_clock(print_time)
         rest_ticks = self._mcu.print_time_to_clock(print_time+rest_time) - clock
         self._next_query_print_time = print_time + self.RETRY_QUERY

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -26,11 +26,14 @@ class MCU_remote_endstop:
         for i, s in enumerate(self._steppers):
             self._mcu.add_config_cmd(
                 "remote_endstop_set_stepper oid=%d pos=%d stepper_oid=%d" % (
-                    self._oid, i, s.get_oid()), is_init=True)   
-        self._stop_cmd = self._mcu.lookup_command("remote_endstop_stop_steppers oid=%c") 
-    
+                    self._oid, i, s.get_oid()), is_init=True)
+        self._stop_cmd = self._mcu.lookup_command(
+            "remote_endstop_stop_steppers oid=%c")
+
     def stop(self):
-         logging.info("Stopping steppers %s on MCU %s", ','.join([s.get_name() for s in self._steppers]), self._mcu.get_name())
+         logging.info("Stopping steppers %s on MCU %s",
+            ','.join([s.get_name() for s in self._steppers]),
+            self._mcu.get_name())
          self._stop_cmd.send([self._oid])
 
 class MCU_endstop:
@@ -86,8 +89,8 @@ class MCU_endstop:
             "endstop_query_state oid=%c", cq=cmd_queue)
         self._query_cmd = self._mcu.lookup_query_command(
             "endstop_query_state oid=%c",
-            "endstop_state oid=%c homing=%c pin_value=%c triggered_time=%u", oid=self._oid,
-            cq=cmd_queue)
+            "endstop_state oid=%c homing=%c pin_value=%c triggered_time=%u",
+            oid=self._oid, cq=cmd_queue)
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    triggered=True):
         for s in self._remote_steppers:
@@ -115,7 +118,8 @@ class MCU_endstop:
             if params['homing']:
                 self._last_sent_time = params['#sent_time']
             else:
-                self._triggered_time = self._mcu.clock_to_print_time(self._mcu.clock32_to_clock64(params['triggered_time']))
+                self._triggered_time = self._mcu.clock_to_print_time(
+                    self._mcu.clock32_to_clock64(params['triggered_time']))
                 self._min_query_time = self._reactor.NEVER
                 self._reactor.async_complete(self._trigger_completion, True)
     def _home_retry(self, eventtime):
@@ -144,7 +148,8 @@ class MCU_endstop:
         self._mcu.register_response(None, "endstop_state", self._oid)
         self._home_cmd.send([self._oid, 0, 0, 0, 0, 0])
         for s in self._steppers:
-            s.note_homing_end(did_trigger=did_trigger, triggered_time=self._triggered_time)
+            s.note_homing_end(did_trigger=did_trigger,
+                triggered_time=self._triggered_time)
         if not self._trigger_completion.test():
             self._trigger_completion.complete(False)
         return did_trigger

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -9,7 +9,7 @@ import serialhdl, pins, chelper, clocksync
 class error(Exception):
     pass
 
-class MCU_remote_endstop:
+class MCU_stepper_group:
     def __init__(self, mcu):
         self._mcu = mcu
         self._steppers = []
@@ -21,14 +21,14 @@ class MCU_remote_endstop:
     def _build_config(self):
         self._oid = self._mcu.create_oid()
         self._mcu.add_config_cmd(
-            "config_remote_endstop oid=%d stepper_count=%d" % (
+            "config_stepper_group oid=%d stepper_count=%d" % (
                 self._oid, len(self._steppers)))
         for i, s in enumerate(self._steppers):
             self._mcu.add_config_cmd(
-                "remote_endstop_set_stepper oid=%d pos=%d stepper_oid=%d" % (
+                "stepper_group_set_stepper oid=%d pos=%d stepper_oid=%d" % (
                     self._oid, i, s.get_oid()), is_init=True)
         self._stop_cmd = self._mcu.lookup_command(
-            "remote_endstop_stop_steppers oid=%c")
+            "stepper_group_stop oid=%c")
 
     def stop(self):
          logging.info("Stopping steppers %s on MCU %s",
@@ -37,12 +37,12 @@ class MCU_remote_endstop:
          self._stop_cmd.send([self._oid])
 
 class MCU_endstop:
-    RETRY_QUERY = 0.1 #1.000
+    RETRY_QUERY = 1.000
     def __init__(self, mcu, pin_params):
         self._mcu = mcu
         self._steppers = []
         self._local_steppers = []
-        self._remote_endstops = {}
+        self._remote_steppers = {}
         self._pin = pin_params['pin']
         self._pullup = pin_params['pullup']
         self._invert = pin_params['invert']
@@ -62,9 +62,11 @@ class MCU_endstop:
         if mcu is self._mcu:
             self._local_steppers.append(stepper)
         else:
-            if mcu not in self._remote_endstops:
-                self._remote_endstops[mcu] = MCU_remote_endstop(mcu)
-            self._remote_endstops[mcu].add_stepper(stepper)
+            if mcu not in self._remote_steppers:
+                self._remote_steppers[mcu] = MCU_stepper_group(mcu)
+            self._remote_steppers[mcu].add_stepper(stepper)
+    def has_remote_steppers(self):
+        return len(self._remote_steppers) > 0
     def get_steppers(self):
         return list(self._steppers)
     def _build_config(self):
@@ -74,7 +76,8 @@ class MCU_endstop:
                 self._oid, self._pin, self._pullup, len(self._local_steppers)))
         self._mcu.add_config_cmd(
             "endstop_home oid=%d clock=0 sample_ticks=0 sample_count=0"
-            " rest_ticks=0 pin_value=0" % (self._oid,), on_restart=True)
+            " rest_ticks=0 report_ticks=0 pin_value=0" % (self._oid,),
+            on_restart=True)
         for i, s in enumerate(self._local_steppers):
             self._mcu.add_config_cmd(
                 "endstop_set_stepper oid=%d pos=%d stepper_oid=%d" % (
@@ -82,7 +85,7 @@ class MCU_endstop:
         cmd_queue = self._mcu.alloc_command_queue()
         self._home_cmd = self._mcu.lookup_command(
             "endstop_home oid=%c clock=%u sample_ticks=%u sample_count=%c"
-            " rest_ticks=%u pin_value=%c", cq=cmd_queue)
+            " rest_ticks=%u report_ticks=%u pin_value=%c", cq=cmd_queue)
         self._requery_cmd = self._mcu.lookup_command(
             "endstop_query_state oid=%c", cq=cmd_queue)
         self._query_cmd = self._mcu.lookup_query_command(
@@ -90,20 +93,30 @@ class MCU_endstop:
             "endstop_state oid=%c homing=%c pin_value=%c triggered_time=%u",
             oid=self._oid, cq=cmd_queue)
     def home_start(self, print_time, sample_time, sample_count, rest_time,
-                   triggered=True):
+                   report_interval=0.0, triggered=True):
         clock = self._mcu.print_time_to_clock(print_time)
         rest_ticks = self._mcu.print_time_to_clock(print_time+rest_time) - clock
+        report_ticks = 0
+        if report_interval:
+
+            report_interval = 0.02 # TODO: TESTING 50 reports per second
+
+            report_ticks = self._mcu.print_time_to_clock(
+                print_time + report_interval) - clock
+            logging.info("Report interval = %f ticks = %d", report_interval, report_ticks)
         self._next_query_print_time = print_time + self.RETRY_QUERY
         self._min_query_time = self._reactor.monotonic()
         self._last_sent_time = 0.
         self._triggered_time = 0.
+        self._last_report_time = 0.
         self._home_end_time = self._reactor.NEVER
         self._trigger_completion = self._reactor.completion()
+        #self._report_completion = self._reactor.completion()
         self._mcu.register_response(self._handle_endstop_state,
                                     "endstop_state", self._oid)
         self._home_cmd.send(
             [self._oid, clock, self._mcu.seconds_to_clock(sample_time),
-             sample_count, rest_ticks, triggered ^ self._invert],
+             sample_count, rest_ticks, report_ticks, triggered ^ self._invert],
             reqclock=clock)
         self._home_completion = self._reactor.register_callback(
             self._home_retry)
@@ -111,11 +124,14 @@ class MCU_endstop:
     def _handle_endstop_state(self, params):
         logging.debug("endstop_state %s", params)
         if params['#sent_time'] >= self._min_query_time:
+            t = self._mcu.clock_to_print_time(
+                    self._mcu.clock32_to_clock64(params['triggered_time']))
             if params['homing']:
                 self._last_sent_time = params['#sent_time']
+                self._last_report_time = t
+                #self._reactor.async_complete(self._report_completion, True)
             else:
-                self._triggered_time = self._mcu.clock_to_print_time(
-                    self._mcu.clock32_to_clock64(params['triggered_time']))
+                self._triggered_time = t
                 self._min_query_time = self._reactor.NEVER
                 self._reactor.async_complete(self._trigger_completion, True)
     def _home_retry(self, eventtime):
@@ -124,7 +140,7 @@ class MCU_endstop:
         while 1:
             did_trigger = self._trigger_completion.wait(eventtime + 0.100)
             if did_trigger is not None:
-                for remote in self._remote_endstops.values():
+                for remote in self._remote_steppers.values():
                     remote.stop()
                 # Homing completed successfully
                 return True
@@ -142,7 +158,7 @@ class MCU_endstop:
         self._home_end_time = home_end_time
         did_trigger = self._home_completion.wait()
         self._mcu.register_response(None, "endstop_state", self._oid)
-        self._home_cmd.send([self._oid, 0, 0, 0, 0, 0])
+        self._home_cmd.send([self._oid, 0, 0, 0, 0, 0, 0])
         for s in self._steppers:
             s.note_homing_end(did_trigger=did_trigger,
                 triggered_time=self._triggered_time)
@@ -155,6 +171,12 @@ class MCU_endstop:
             return 0
         params = self._query_cmd.send([self._oid], minclock=clock)
         return params['pin_value'] ^ self._invert
+    def get_last_report_time(self):
+        return self._last_report_time
+    def has_triggered(self):
+        return self._triggered_time > 0.
+    #def wait_for_report(self, time):
+    #    self._report_completion.wait(time)
 
 class MCU_digital_out:
     def __init__(self, mcu, pin_params):

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -87,6 +87,8 @@ class MCU_stepper:
         self._get_position_cmd = self._mcu.lookup_query_command(
             "stepper_get_position oid=%c",
             "stepper_position oid=%c pos=%i", oid=self._oid)
+        self._stop_cmd = self._mcu.lookup_query_command(
+            "stepper_stop oid=%c")
         self._ffi_lib.stepcompress_fill(
             self._stepqueue, self._mcu.seconds_to_clock(max_error),
             self._invert_dir, step_cmd_id, dir_cmd_id)
@@ -172,6 +174,8 @@ class MCU_stepper:
     def is_active_axis(self, axis):
         return self._ffi_lib.itersolve_is_active_axis(
             self._stepper_kinematics, axis)
+    def stop(self):
+        self._stop_cmd.send([self._oid])
 
 # Helper code to build a stepper object from a config section
 def PrinterStepper(config, units_in_radians=False):

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -277,6 +277,8 @@ class ToolHead:
                    "manual_probe", "tuning_tower"]
         for module_name in modules:
             self.printer.load_object(config, module_name)
+        self.printer.send_event("toolhead:ready", self)
+
     # Print time tracking
     def _update_move_time(self, next_print_time):
         batch_time = MOVE_BATCH_TIME

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -189,8 +189,13 @@ MIN_KIN_TIME = 0.100
 MOVE_BATCH_TIME = 0.500
 SDS_CHECK_TIME = 0.001 # step+dir+step filter in stepcompress.c
 
+# drip feed 50ms segments during homing
 DRIP_SEGMENT_TIME = 0.050
+# allow at least 5ms to transmit a segment - TODO make this configurable
+MIN_DRIP_SEGMENT_TIME = 0.005
+# buffer a maximum of 100ms of steps on the MCU
 DRIP_TIME = 0.100
+
 class DripModeEndSignal(Exception):
     pass
 
@@ -448,44 +453,95 @@ class ToolHead:
         return self.extruder
     # Homing "drip move" handling
     def _update_drip_move_time(self, next_print_time):
-        flush_delay = DRIP_TIME + self.move_flush_time + self.kin_flush_delay
+        # MCU is not flushed fully to the print_time but lags behind a bit
+        mcu_flush_delay = self.move_flush_time + self.kin_flush_delay
+        start_time = self.mcu.estimated_print_time(self.reactor.monotonic())
         while self.print_time < next_print_time:
             if self.drip_completion.test():
                 raise DripModeEndSignal()
             curtime = self.reactor.monotonic()
             est_print_time = self.mcu.estimated_print_time(curtime)
-            wait_time = self.print_time - est_print_time - flush_delay
+            wait_time = (self.print_time - est_print_time
+                         - mcu_flush_delay - DRIP_TIME)
+            next_segment_time = min(self.print_time + DRIP_SEGMENT_TIME,
+                                    next_print_time)
+            # Must always buffer at least MIN_DRIP_SEGMENT_TIME on MCUs
+            # or they may starve and report "No next step" or "Timer too close"
+            min_print_time = (est_print_time + mcu_flush_delay
+                              + MIN_DRIP_SEGMENT_TIME)
+            for es in self.drip_endstops_with_remote_steppers:
+                if es.has_triggered():
+                    # TODO: we actually need to know if the endstop triggered
+                    # AND the remote steppers have acknowledged that they've
+                    # stopped (only relevant when homing multiple axes at once
+                    # like on a delta?)
+                    continue
+                # Limit blind move distance to avoid crashing
+                max_allowed_print_time = (es.get_last_report_time()
+                                          + self.drip_max_blind_travel_t
+                                          + mcu_flush_delay)
+                if max_allowed_print_time <= min_print_time:
+                    # TODO: proper error reporting
+                    logging.info("ERROR: Endstop %s failed to respond quickly "
+                        "enough. Last report was %fms, need %fms or later "
+                        "(%fms later than expected, %fms last trip time). "
+                        "Current time is approx %f",
+                        es.get_steppers()[0].get_name(),
+                        (es.get_last_report_time() - start_time) * 1000.0,
+                        (min_print_time - self.drip_max_blind_travel_t -
+                         mcu_flush_delay - start_time) * 1000.0,
+                        (est_print_time -
+                         es.get_next_expected_report_time()) * 1000.0,
+                        es.get_last_report_trip_time() * 1000.0,
+                        (est_print_time - start_time) * 1000.0)
+                    raise DripModeEndSignal()
+                elif max_allowed_print_time <= self.print_time:
+                    # Can't buffer any more: must wait for endstop report
+                    report_wait_time = min(0.050, max(0.001,
+                        es.get_next_expected_report_time() - est_print_time))
+                    if wait_time < report_wait_time:
+                        wait_time = report_wait_time
+                        logging.info("Waiting %fms for endstop %s "
+                            "(last report was at %fms)",
+                            report_wait_time * 1000.0,
+                            es.get_steppers()[0].get_name(),
+                            (es.get_last_report_time() - start_time) * 1000.0,
+                            (self.print_time - self.drip_max_blind_travel_t
+                                - start_time) * 1000.0)
+                elif next_segment_time > max_allowed_print_time:
+                    next_segment_time = max_allowed_print_time
+                    #if wait_time <= 0.:
+                    #    logging.info("Reducing drip feed rate to stay within "
+                    #        "safe distance of endstop %s ",
+                    #        es.get_steppers()[0].get_name())
+                else:
+                    logging.info("Safe to drip feed %fms, "
+                        "max_allowed_print_time is %fms in future",
+                        (next_segment_time - self.print_time) * 1000.0,
+                        (max_allowed_print_time - est_print_time) * 1000.0)
+            last_print_time = self.print_time
+            if wait_time > 0.:
+                next_segment_time = self.print_time
+            else:
+                wait_time = 0.
             if wait_time > 0. and self.can_pause:
                 # Pause before sending more steps
                 self.drip_completion.wait(curtime + wait_time)
-                continue
-            npt = min(self.print_time + DRIP_SEGMENT_TIME, next_print_time)
-            # Limit blind move distance to avoid crashing
-            for es in self.drip_endstops_with_remote_steppers:
-                if es.has_triggered():
-                    continue
-                t = es.get_last_report_time() + self.drip_max_blind_travel_t
-                if t <= self.print_time:
-                    logging.info("Endstop %s to respond quickly enough.. last report was %f, need %f or later",
-                        es.get_steppers()[0].get_name(),
-                        es.get_last_report_time(), self.print_time - self.drip_max_blind_travel_t)
-                    
-                    # hack.. can't wait because step times have already been decided, 
-                    # this just needs to time out and fail??
-                    t = npt
+            else:
+                self._update_move_time(next_segment_time)
+            if 0:
+                logging.info("EPT %f PT %f : Currently buffered = %fms "
+                        "Wait time = %fms  Segment size = %fms  "
+                        "How far into future = %fms Safety margin = %fms",
+                        (est_print_time - start_time) * 1000.0,
+                        (self.print_time - start_time) * 1000.0,
+                        (self.print_time - est_print_time
+                            - mcu_flush_delay) * 1000.0,
+                        wait_time * 1000.0,
+                        (next_segment_time - last_print_time) * 1000.0,
+                        (next_segment_time - est_print_time) * 1000.0,
+                        (next_segment_time - min_print_time) * 1000.0)
 
-                    #es.wait_for_report(curtime + 1.0)
-                    #t = es.get_last_report_time() + self.drip_max_blind_travel_t
-                    #if t <= self.print_time:
-                    #    logging.info("Timed out waiting for endstop. last report was %f",
-                    #        es.get_last_report_time())
-                    #    raise DripModeEndSignal()
-                else:
-                    logging.info("Endstop %s last report was %f",
-                        es.get_steppers()[0].get_name(), es.get_last_report_time())
-
-                npt = min(npt, t)
-            self._update_move_time(npt)
     def drip_move(self, newpos, speed, drip_completion,
                   endstops_with_remote_steppers, max_blind_travel_d):
         # Transition from "Flushed"/"Priming"/main state to "Drip" state
@@ -499,7 +555,7 @@ class ToolHead:
         self.drip_endstops_with_remote_steppers = endstops_with_remote_steppers
         self.drip_max_blind_travel_t = max_blind_travel_d / speed
         if endstops_with_remote_steppers:
-            logging.info("Homing blind at %fmm/s with maximum drip interval "
+            logging.info("Homing at %fmm/s with maximum blind travel "
                 "of %fmm %fs", speed, max_blind_travel_d,
                 max_blind_travel_d / speed)
         # Submit move

--- a/src/endstop.c
+++ b/src/endstop.c
@@ -136,8 +136,8 @@ endstop_report(uint8_t oid, struct endstop *e)
     e->flags &= ~ESF_REPORT;
     irq_enable();
 
-    sendf("endstop_state oid=%c homing=%c pin_value=%c triggered_time=%u"
-          , oid, !!(eflags & ESF_HOMING), gpio_in_read(e->pin), e->triggered_time);
+    sendf("endstop_state oid=%c homing=%c pin_value=%c triggered_time=%u",
+        oid, !!(eflags & ESF_HOMING), gpio_in_read(e->pin), e->triggered_time);
 }
 
 void
@@ -200,7 +200,8 @@ command_remote_endstop_stop_steppers(uint32_t *args)
     uint8_t count = e->stepper_count;
     while (count--)
         if (e->steppers[count])
-            stepper_stop(e->steppers[count]);    
+            stepper_stop(e->steppers[count]);
     irq_enable();
 }
-DECL_COMMAND(command_remote_endstop_stop_steppers, "remote_endstop_stop_steppers oid=%c");
+DECL_COMMAND(command_remote_endstop_stop_steppers,
+             "remote_endstop_stop_steppers oid=%c");

--- a/src/endstop.c
+++ b/src/endstop.c
@@ -88,10 +88,10 @@ endstop_report_event(struct timer *t)
     if (!(e->flags & ESF_REPORT))
     {
         e->triggered_time = t->waketime;
-        t->waketime += e->report_interval;
         e->flags |= ESF_REPORT;
         sched_wake_task(&endstop_wake);
     }
+    t->waketime += e->report_interval;
     return SF_RESCHEDULE;
 }
 

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -298,7 +298,8 @@ command_stepper_get_position(uint32_t *args)
     uint32_t position = stepper_get_position(s);
     uint32_t stopped_next_step_time = s->stopped_next_step_time;
     irq_enable();
-    sendf("stepper_position oid=%c pos=%i stopped_time=%i", oid, position - POSITION_BIAS, stopped_next_step_time);
+    sendf("stepper_position oid=%c pos=%i stopped_time=%i",
+        oid, position - POSITION_BIAS, stopped_next_step_time);
 }
 DECL_COMMAND(command_stepper_get_position, "stepper_get_position oid=%c");
 

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -320,6 +320,17 @@ stepper_stop(struct stepper *s)
 }
 
 void
+command_stepper_stop(uint32_t *args)
+{
+    uint8_t oid = args[0];
+    struct stepper *s = stepper_oid_lookup(oid);
+    irq_disable();
+    stepper_stop(s);
+    irq_enable();
+}
+DECL_COMMAND(command_stepper_stop, "stepper_stop oid=%c");
+
+void
 stepper_shutdown(void)
 {
     uint8_t i;


### PR DESCRIPTION
Draft pull request just to ask for some feedback/discussion on these changes.

The idea of this branch is to facilitate non-contact end-stops/probes attached to an MCU on a toolhead to reduce the amount of moving wiring points (no need for endstops wired at the end of moving rails/gantries).  My prototype board design is [here for reference](https://easyeda.com/matt_1626/voron-print-head-power_copy).

There are two main parts to these changes:

- Only drip feed a safe amount of steps to the motors during 'blind homing'. The idea here is to have the end stop report back to klippy on a regular basis so that it knows whether it is safe to continue moving the robot.  To minimise any over shoot the motors are signalled to stop as soon as klippy knows the end stop triggered.
- Compensate for any over shoot caused by the delay in signalling the motors to stop.  To do this I simply record the moves that were sent to the MCU and then count how many steps occurred after the reported end stop trigger time (and before the motor stopped).  

This is just a proof of concept and it needs a lot of clean up and testing.  