### PR TITLE
Add last_z_min to last_z_result to get the latest z result in an Macro

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -214,7 +214,7 @@ The following are common printer attributes:
   as "triggered" during the last QUERY_PROBE command. Note, due to the
   order of template expansion (see above), the QUERY_PROBE command
   must be run prior to the macro containing this reference.
-- `printer.probe.last_z_min`: Returns the Z result value of the last 
+- `printer.probe.last_z_min`: Returns the Z result value of the last
   PROBE command.
 - `printer.configfile.settings.<section>.<option>`: Returns the given
   config file setting (or default value) during the last software

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -214,6 +214,8 @@ The following are common printer attributes:
   as "triggered" during the last QUERY_PROBE command. Note, due to the
   order of template expansion (see above), the QUERY_PROBE command
   must be run prior to the macro containing this reference.
+- `printer.probe.last_z_min`: Returns the Z result value of the last 
+  PROBE command.
 - `printer.configfile.settings.<section>.<option>`: Returns the given
   config file setting (or default value) during the last software
   start or restart. (Any settings changed at run-time will not be

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -214,7 +214,7 @@ The following are common printer attributes:
   as "triggered" during the last QUERY_PROBE command. Note, due to the
   order of template expansion (see above), the QUERY_PROBE command
   must be run prior to the macro containing this reference.
-- `printer.probe.last_z_min`: Returns the Z result value of the last
+- `printer.probe.last_z_result`: Returns the Z result value of the last
   PROBE command.
 - `printer.configfile.settings.<section>.<option>`: Returns the given
   config file setting (or default value) during the last software

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -26,7 +26,7 @@ class PrinterProbe:
         self.probe_calibrate_z = 0.
         self.multi_probe_pending = False
         self.last_state = False
-        self.last_z_min = 0
+        self.last_z_min = 0.
         # Infer Z position to move to during a probe
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')
@@ -186,7 +186,7 @@ class PrinterProbe:
     def cmd_PROBE(self, gcmd):
         pos = self.run_probe(gcmd)
         gcmd.respond_info("Result is z=%.6f" % (pos[2],))
-        self.last_z_min = pos [2]
+        self.last_z_min = pos[2]
     cmd_QUERY_PROBE_help = "Return the status of the z-probe"
     def cmd_QUERY_PROBE(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -26,7 +26,7 @@ class PrinterProbe:
         self.probe_calibrate_z = 0.
         self.multi_probe_pending = False
         self.last_state = False
-        self.last_z_min = 0.
+        self.last_z_result = 0.
         # Infer Z position to move to during a probe
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')
@@ -186,7 +186,7 @@ class PrinterProbe:
     def cmd_PROBE(self, gcmd):
         pos = self.run_probe(gcmd)
         gcmd.respond_info("Result is z=%.6f" % (pos[2],))
-        self.last_z_min = pos[2]
+        self.last_z_result = pos[2]
     cmd_QUERY_PROBE_help = "Return the status of the z-probe"
     def cmd_QUERY_PROBE(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')
@@ -195,7 +195,7 @@ class PrinterProbe:
         self.last_state = res
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     def get_status(self, eventtime):
-        return {'last_query': self.last_state,'last_z_min': self.last_z_min}
+        return {'last_query': self.last_state,'last_z_result': self.last_z_result}
     cmd_PROBE_ACCURACY_help = "Probe Z-height accuracy at current XY position"
     def cmd_PROBE_ACCURACY(self, gcmd):
         speed = gcmd.get_float("PROBE_SPEED", self.speed, above=0.)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -195,7 +195,8 @@ class PrinterProbe:
         self.last_state = res
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     def get_status(self, eventtime):
-        return {'last_query': self.last_state,'last_z_result': self.last_z_result}
+        return {'last_query': self.last_state,
+                'last_z_result': self.last_z_result}
     cmd_PROBE_ACCURACY_help = "Probe Z-height accuracy at current XY position"
     def cmd_PROBE_ACCURACY(self, gcmd):
         speed = gcmd.get_float("PROBE_SPEED", self.speed, above=0.)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -26,7 +26,7 @@ class PrinterProbe:
         self.probe_calibrate_z = 0.
         self.multi_probe_pending = False
         self.last_state = False
-	self.last_z_min = 0
+        self.last_z_min = 0
         # Infer Z position to move to during a probe
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')
@@ -186,7 +186,7 @@ class PrinterProbe:
     def cmd_PROBE(self, gcmd):
         pos = self.run_probe(gcmd)
         gcmd.respond_info("Result is z=%.6f" % (pos[2],))
-	self.last_z_min = pos [2]
+        self.last_z_min = pos [2]
     cmd_QUERY_PROBE_help = "Return the status of the z-probe"
     def cmd_QUERY_PROBE(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -26,6 +26,7 @@ class PrinterProbe:
         self.probe_calibrate_z = 0.
         self.multi_probe_pending = False
         self.last_state = False
+	self.last_z_min = 0
         # Infer Z position to move to during a probe
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')
@@ -185,6 +186,7 @@ class PrinterProbe:
     def cmd_PROBE(self, gcmd):
         pos = self.run_probe(gcmd)
         gcmd.respond_info("Result is z=%.6f" % (pos[2],))
+	self.last_z_min = pos [2]
     cmd_QUERY_PROBE_help = "Return the status of the z-probe"
     def cmd_QUERY_PROBE(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')
@@ -193,7 +195,7 @@ class PrinterProbe:
         self.last_state = res
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     def get_status(self, eventtime):
-        return {'last_query': self.last_state}
+        return {'last_query': self.last_state,'last_z_min': self.last_z_min}
     cmd_PROBE_ACCURACY_help = "Probe Z-height accuracy at current XY position"
     def cmd_PROBE_ACCURACY(self, gcmd):
         speed = gcmd.get_float("PROBE_SPEED", self.speed, above=0.)


### PR DESCRIPTION
Code provided by @jornada812
The essence of the changes - a variable has been added, in which the Z of the sensor triggering is written and this value can now be returned and used in a macro.

Signed-off-by Christian Schnellrieder
