### PR TITLE
menu: redesigned name scroller & menu rendering

### DIFF
--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -226,6 +226,7 @@ class PrinterLCD:
             else:
                 # write glyph
                 pos += self.lcd_chip.write_glyph(pos, row, text)
+        return pos
     def draw_progress_bar(self, row, col, width, value):
         pixels = -1 << int(width * 8 * (1. - value) + .5)
         pixels |= (1 << (width * 8 - 1)) | 1

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -133,14 +133,23 @@ class MenuElement(object):
         elif self.__scroll_next is True:
             self.__scroll_pos += 1
             self.__scroll_next = False
-        else:
+        elif self.__scroll_next is False:
+            pass  # hold scroll position
+        elif self.__scroll_next is None:
             self.__reset_scroller()
 
     def __reset_scroller(self):
         self.__scroll_pos = None
         self.__scroll_next = False
 
-    def scroller(self, value):
+    def need_scroller(self, value):
+        """
+        Allows to control the scroller
+        Parameters:
+            value (bool, None): True  - inc. scroll pos. on next update
+                                False - hold scroll pos.
+                                None  - reset the scroller
+        """
         self.__scroll_next = value
 
     def __slice_name(self, name, index):
@@ -637,10 +646,10 @@ class MenuList(MenuContainer):
                 if (selected and tpos > self.manager.cols
                         and current.is_scrollable()):
                     # scroll next
-                    current.scroller(True)
+                    current.need_scroller(True)
                 else:
-                    # reset scroll
-                    current.scroller(None)
+                    # reset scroller
+                    current.need_scroller(None)
                 # draw item suffix
                 if suffix:
                     display.draw_text(

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -24,12 +24,12 @@ class MenuElement(object):
             raise error(
                 'Abstract MenuElement cannot be instantiated directly')
         self._manager = manager
-        self.cursor = '>'
-        self._scroll = True
+        self._cursor = '>'
         # set class defaults and attributes from arguments
         self._index = kwargs.get('index', None)
         self._enable = kwargs.get('enable', True)
         self._name = kwargs.get('name', None)
+        self._scroll = kwargs.get('scroll', False)
         self._enable_tpl = self._name_tpl = None
         if config is not None:
             # overwrite class attributes from config
@@ -50,12 +50,9 @@ class MenuElement(object):
             self._ns = Template(
                 'menu ' + kwargs.get('ns', __id)).safe_substitute(__id=__id)
         self._last_heartbeat = None
-        self.__scroll_offs = 0
+        self.__scroll_offs = None
         self.__scroll_diff = 0
-        self.__scroll_dir = None
         self.__last_state = True
-        # display width is used and adjusted by cursor size
-        self._width = self.manager.cols - len(self._cursor)
         # menu scripts
         self._scripts = {}
         # init
@@ -90,7 +87,7 @@ class MenuElement(object):
 
     # override
     def is_scrollable(self):
-        return True
+        return bool(self._scroll)
 
     # override
     def is_enabled(self):
@@ -110,7 +107,6 @@ class MenuElement(object):
         # get default menu context
         context = self.manager.get_context(cxt)
         context['menu'].update({
-            'width': self._width,
             'ns': self.get_ns()
         })
         return context
@@ -122,7 +118,7 @@ class MenuElement(object):
 
     # Called when a item is selected
     def select(self):
-        self.__clear_scroll()
+        self.__init_scroller()
 
     def heartbeat(self, eventtime):
         self._last_heartbeat = eventtime
@@ -130,54 +126,32 @@ class MenuElement(object):
         if self.__last_state ^ state:
             self.__last_state = state
             if not self.is_editing():
-                self.__update_scroll(eventtime)
+                self.__update_scroller()
 
-    def __clear_scroll(self):
-        self.__scroll_dir = None
+    def __init_scroller(self):
+        self.__scroll_offs = None
         self.__scroll_diff = 0
-        self.__scroll_offs = 0
 
-    def __update_scroll(self, eventtime):
-        if self.__scroll_dir == 0 and self.__scroll_diff > 0:
-            self.__scroll_dir = 1
+    def __update_scroller(self):
+        if self.__scroll_offs is None and self.__scroll_diff > 0:
             self.__scroll_offs = 0
-        elif self.__scroll_dir and self.__scroll_diff > 0:
-            self.__scroll_offs += self.__scroll_dir
+        elif self.__scroll_diff > 0:
+            self.__scroll_offs += 1
             if self.__scroll_offs >= self.__scroll_diff:
-                self.__scroll_dir = -1
-            elif self.__scroll_offs <= 0:
-                self.__scroll_dir = 1
+                self.__scroll_offs = -self.__scroll_diff
         else:
-            self.__clear_scroll()
+            self.__init_scroller()
 
-    def __name_scroll(self, s):
-        if self.__scroll_dir is None:
-            self.__scroll_dir = 0
-            self.__scroll_offs = 0
-        return s[
-            self.__scroll_offs:self._width + self.__scroll_offs
-        ].ljust(self._width)
+    def start_scroller(self, difference):
+        if self.__scroll_diff == 0:
+            self.__scroll_diff = difference
 
     def render_name(self, selected=False):
         s = str(self._render_name())
-        # scroller
-        if self._width > 0:
-            self.__scroll_diff = len(s) - self._width
-            if (selected and self._scroll is True and self.is_scrollable()
-                    and self.__scroll_diff > 0):
-                s = self.__name_scroll(s)
-            else:
-                self.__clear_scroll()
-                s = s[:self._width].ljust(self._width)
+        if selected and self.__scroll_offs is not None:
+            s = s[abs(self.__scroll_offs):]
         else:
-            self.__clear_scroll()
-        # add cursors
-        if selected and not self.is_editing():
-            s = self.cursor + s
-        elif selected and self.is_editing():
-            s = '*' + s
-        else:
-            s = ' ' + s
+            self.__init_scroller()
         return s
 
     def get_ns(self, name='.'):
@@ -235,10 +209,6 @@ class MenuElement(object):
     def cursor(self):
         return str(self._cursor)[:1]
 
-    @cursor.setter
-    def cursor(self, value):
-        self._cursor = str(value)[:1]
-
     @property
     def manager(self):
         return self._manager
@@ -256,7 +226,7 @@ class MenuContainer(MenuElement):
                 'Abstract MenuContainer cannot be instantiated directly')
         super(MenuContainer, self).__init__(manager, config, **kwargs)
         self._populate_cb = kwargs.get('populate', None)
-        self.cursor = '>'
+        self._cursor = '>'
         self.__selected = None
         self._allitems = []
         self._names = []
@@ -413,8 +383,8 @@ class MenuContainer(MenuElement):
         return self.select_at(index)
 
     # override
-    def render_container(self, nrows, eventtime):
-        return []
+    def draw_container(self, nrows, eventtime):
+        pass
 
     def __iter__(self):
         return iter(self._items)
@@ -614,9 +584,8 @@ class MenuList(MenuContainer):
         #  add back as first item
         self.insert_item(self._itemBack, 0)
 
-    def render_container(self, nrows, eventtime):
-        manager = self.manager
-        lines = []
+    def draw_container(self, nrows, eventtime):
+        display = self.manager.display
         selected_row = self.selected
         # adjust viewport
         if selected_row is not None:
@@ -629,24 +598,47 @@ class MenuList(MenuContainer):
         # clamps viewport
         self._viewport_top = max(0, min(self._viewport_top, len(self) - nrows))
         try:
+            y = 0
             for row in range(self._viewport_top, self._viewport_top + nrows):
-                s = ""
+                text = ""
+                prefix = ""
+                suffix = ""
                 if row < len(self):
                     current = self[row]
                     selected = (row == selected_row)
                     if selected:
                         current.heartbeat(eventtime)
-                    name = manager.stripliterals(
-                        manager.aslatin(current.render_name(selected)))
-                    if isinstance(current, MenuList):
-                        s += name[:manager.cols-1].ljust(manager.cols-1)
-                        s += '>'
+                    text = current.render_name(selected)
+                    # add prefix (selection indicator)
+                    if selected and not current.is_editing():
+                        prefix = current.cursor
+                    elif selected and current.is_editing():
+                        prefix = '*'
                     else:
-                        s += name
-                lines.append(s[:manager.cols].ljust(manager.cols))
+                        prefix = ' '
+                    # add suffix (folder indicator)
+                    if isinstance(current, MenuList):
+                        suffix += '>'
+                # draw to display
+                plen = len(prefix)
+                slen = len(suffix)
+                width = self.manager.cols - plen - slen
+                # draw item prefix (cursor)
+                ppos = display.draw_text(y, 0, prefix, eventtime)
+                # draw item name
+                tpos = display.draw_text(y, ppos, text.ljust(width), eventtime)
+                # check scroller
+                diff = (tpos - ppos) - width
+                if (selected and diff > 0 and current.is_scrollable()):
+                    current.start_scroller(diff)
+                # draw item suffix
+                if suffix:
+                    display.draw_text(
+                        y, self.manager.cols - slen, suffix, eventtime)
+                # next display row
+                y += 1
         except Exception:
-            logging.exception('List rendering error')
-        return lines
+            logging.exception('List drawing error')
 
 
 class MenuVSDList(MenuList):
@@ -660,7 +652,8 @@ class MenuVSDList(MenuList):
             files = sdcard.get_file_list()
             for fname, fsize in files:
                 self.insert_item(self.manager.menuitem_from(
-                    'command', name=repr(fname), gcode='M23 /%s' % str(fname)))
+                    'command', name=repr(fname), scroll=True,
+                    gcode='M23 /%s' % str(fname)))
 
 
 menu_items = {
@@ -829,21 +822,16 @@ class MenuManager:
             container = self.menustack[self.stack_size() - lvl - 1]
         return container
 
-    def render(self, eventtime):
-        lines = []
-        self.update_context(eventtime)
-        container = self.stack_peek()
-        if self.running and isinstance(container, MenuContainer):
-            container.heartbeat(eventtime)
-            lines = container.render_container(self.rows, eventtime)
-        return lines
-
     def screen_update_event(self, eventtime):
         # screen update
         if not self.is_running():
             return False
-        for y, line in enumerate(self.render(eventtime)):
-            self.display.draw_text(y, 0, line, eventtime)
+        # draw menu
+        self.update_context(eventtime)
+        container = self.stack_peek()
+        if self.running and isinstance(container, MenuContainer):
+            container.heartbeat(eventtime)
+            container.draw_container(self.rows, eventtime)
         return True
 
     def up(self, fast_rate=False):
@@ -1058,9 +1046,5 @@ class MenuManager:
             return str(s)
 
     @classmethod
-    def asflatline(cls, s):
-        return ''.join(cls.aslatin(s).splitlines())
-
-    @classmethod
     def asflat(cls, s):
-        return cls.stripliterals(cls.asflatline(s))
+        return cls.stripliterals(''.join(cls.aslatin(s).splitlines()))


### PR DESCRIPTION
Redesigned the menu scroller and rendering functionality. 
Now it allows using the glyphs placeholders in menu names like `name: Temp: 25~degrees~ ` etc.

The placeholder rendering in menu item names is not working correctly when scrolling is used.
For example `name: "This ~degrees~ is a very long name for menu item"`. When the name starts to shift to 
the left then after reaching to placeholder marking it will break the placeholder rendering. 
 
Unfortunately, I didn't find a solution for this and therefore to make it work correctly the long name scrolling is disabled for standard menu items. The long name scrolling is enabled only for `virtual_sdcard` filenames.

Tested following LCDs: uc1701,  st7920,  hd44780
Looked okay but need to run a few more test rounds.

All ideas and tests are welcome.