### PR TITLE
hd44780: Add hd44780 LDO OLED protocol init

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3025,6 +3025,11 @@ lcd_type:
 #   Controller" type displays), "uc1701" (which is used in "MKS Mini
 #   12864" type displays), "ssd1306", or "sh1106". This parameter must
 #   be provided.
+#hd44780_protocol_init: True
+#    Perform 8-bit/4-bit protocol initialization on an hd44780 display.
+#    This is necessary on real hd44780 devices.  However, one may
+#    need to disable this on some "clone" devices.  The default
+#    is True.
 #rs_pin:
 #e_pin:
 #d4_pin:

--- a/klippy/extras/display/hd44780.py
+++ b/klippy/extras/display/hd44780.py
@@ -21,6 +21,8 @@ class HD44780:
         ppins = self.printer.lookup_object('pins')
         pins = [ppins.lookup_pin(config.get(name + '_pin'))
                 for name in ['rs', 'e', 'd4', 'd5', 'd6', 'd7']]
+        self.hd44780_protocol_init = config.getboolean('hd44780_protocol_init',
+            True)
         self.line_length = config.getchoice('line_length', LINE_LENGTH_OPTIONS,
             LINE_LENGTH_DEFAULT)
         mcu = None
@@ -89,7 +91,10 @@ class HD44780:
         curtime = self.printer.get_reactor().monotonic()
         print_time = self.mcu.estimated_print_time(curtime)
         # Program 4bit / 2-line mode and then issue 0x02 "Home" command
-        init = [[0x33], [0x33], [0x32], [0x28, 0x28, 0x02]]
+        if self.hd44780_protocol_init:
+            init = [[0x33], [0x33], [0x32], [0x28, 0x28, 0x02]]
+        else:
+            init = [[0x02]]
         # Reset (set positive direction ; enable display and hide cursor)
         init.append([0x06, 0x0c])
         for i, cmds in enumerate(init):


### PR DESCRIPTION
The LDO OLED needs a different init.
Fixes: #3722

Signed-off-by: Thomas Kroll <t.kroll@outlook.com>