### PR TITLE
SPI DAC DAC084S085 implementation

### DIFF
--- a/config/generic-alligator-r2.cfg
+++ b/config/generic-alligator-r2.cfg
@@ -1,0 +1,138 @@
+# Remember:
+# ^ = use pull-up;
+# ! = invert signal;
+# Flash procedure:
+# sudo /etc/init.d/alligator-manager --erase
+# sudo bossac -e -w -v -b -R -i -p ttyAMA0 klipper.bin
+#
+# see alligator github for alligator manager
+
+[virtual_sdcard]
+path: ~/sdcard
+
+[pause_resume]
+[display_status]
+[include mainsail_macros.cfg]
+
+[static_digital_output DRV8825_microstepping] 
+pins:PC10
+pins:PC29
+pins:PC19
+pins:PC18
+
+[dac084S085 my_digipot]
+enable_pin: PB14
+spi_bus : spi0
+motor1 : 90
+motor2 : 90
+motor3 : 90
+motor4 : 40
+
+
+[stepper_a]
+step_pin: PB24
+dir_pin: !PB25
+enable_pin: !PA15
+step_distance: .003125
+endstop_pin: ^!PC6
+homing_speed: 50
+second_homing_speed:20
+position_endstop: 504
+arm_length: 430
+
+[stepper_b]
+step_pin: PB22
+dir_pin: !PB23
+enable_pin: !PA15
+step_distance: .003125
+endstop_pin: ^!PC3
+position_endstop: 800
+homing_speed: 50
+second_homing_speed:20
+
+
+[stepper_c]
+step_pin: PC27
+dir_pin: !PC28
+enable_pin: !PA15
+step_distance: .003125
+endstop_pin: ^!PC1
+position_endstop: 800
+homing_speed: 50
+second_homing_speed:20
+
+
+[extruder]
+step_pin: PC25
+dir_pin: !PC26
+enable_pin: !PA15
+step_distance: 0.002
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PA1
+
+sensor_type: NTC 100K beta 3950
+sensor_pin: PA24
+#spi_bus : spi0
+#spi_speed: 4000000
+#rtd_nominal_r: 100
+#rtd_reference_r: 430
+#rtd_num_of_wires: 2
+#rtd_use_50Hz_filter: True
+
+#control: pid
+#pid_Kp: 25.000
+#pid_Ki: 1.200
+#pid_Kd: 100.100
+min_extrude_temp: 150
+min_temp: 0
+max_temp: 275
+
+[heater_fan my_hotend_fan]
+pin: PA5
+kick_start_time: 1
+heater: extruder
+heater_temp: 50.0
+fan_speed: 1.0
+
+[fan]
+pin: PA7
+kick_start_time: 0.5
+
+[heater_bed]
+heater_pin: PA0
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PA16
+# pin puo' essere PA16(vicino a mcu) o PA24(vicino a ethernet)
+control: pid
+pid_kp: 73.517
+pid_ki: 1.132
+pid_kd: 1193.728
+min_temp: 0
+max_temp: 130
+
+
+[printer]
+kinematics: delta
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 300
+delta_radius: 250
+
+minimum_z_position: -15
+
+
+[probe]
+pin: ^PC2
+z_offset: 0
+speed: 50
+samples: 3
+
+[delta_calibrate]
+radius: 410
+horizontal_move_z: 20
+
+[mcu]
+serial: /dev/ttyAMA0
+baud: 250000
+restart_method = command

--- a/klippy/extras/dac084S085.py
+++ b/klippy/extras/dac084S085.py
@@ -1,0 +1,25 @@
+# SPI DAC DAC084S085 implementation
+#
+# Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+from . import bus
+import time
+
+class dac084S085:
+    def __init__(self, config):
+        self.spi = bus.MCU_SPI_from_config(config, 1, pin_option="enable_pin", default_speed=10000000)
+
+	channel = [0,3,2,1,0 ]
+        for i in range(1,5):
+            vref = config.getint('motor%d' % (i,), None, minval=0., maxval=255)
+
+            if vref is not None:
+            buff = 0x01 << 12
+	    	buff |= (channel[i]) << 14
+	    	buff |= vref << 4
+	    	self.spi.spi_send([buff])
+		time.sleep(0.05)
+
+def load_config_prefix(config):
+    return dac084S085(config)


### PR DESCRIPTION
This is the integration of the SPI DAC that controls the motor drivers's VRef on my Alligator rev.2 board made by Jacopo Franco and Marco Antonini. 
Thanks in advance and congratulation for the work you've done.