### PR TITLE
power_limit: Add module to limit power to a set of heaters.

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -616,7 +616,8 @@ heater_pin:
 #   fully enabled for extended periods, while a value of 0.5 would
 #   allow the pin to be enabled for no more than half the time. This
 #   setting may be used to limit the total power output (over extended
-#   periods) to the heater. The default is 1.0.
+#   periods) to the heater. The default is 1.0.  If you need to limit
+#   the power to the whole printer, see [power_limiter]
 sensor_type:
 #   Type of sensor - common thermistors are "EPCOS 100K B57560G104F",
 #   "ATC Semitec 104GT-2", "NTC 100K beta 3950", "Honeywell 100K
@@ -688,6 +689,27 @@ control:
 min_temp:
 max_temp:
 #   See the "extruder" section for a description of the above parameters.
+```
+
+## [power_limiter]
+
+Prevents a group of heaters from using more than a fixed amount of power.
+You may have multiple overlapping [power_limiter] clauses, for example if
+you need to limit power to the whole machine, but you *also* need to limit
+current through a fuse to the hotend.
+
+```
+[power_limiter]
+devices:
+#   Comma seperated list of the names of devices to limit power to
+#   For example:   devices: extruder,heater_bed
+device_powers:
+#   Comma seperated list of the power of each heater (when on 100%)
+limit_watts:
+#   Total wattage that can be enabled at the same time.   If more power
+#   than this is requested, a heater will have to wait (first come,
+#   first served). If there is insufficient power for too long,
+#   [heater_verify] may shut the machine down.
 ```
 
 # Bed level support

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -33,7 +33,8 @@ class Heater:
         is_fileoutput = (self.printer.get_start_args().get('debugoutput')
                          is not None)
         self.can_extrude = self.min_extrude_temp <= 0. or is_fileoutput
-        self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
+        max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
+        self.power_limiter = SimplePowerLimiter(max_power)
         self.smooth_time = config.getfloat('smooth_time', 2., above=0.)
         self.inv_smooth_time = 1. / self.smooth_time
         self.lock = threading.Lock()
@@ -90,7 +91,7 @@ class Heater:
     def get_pwm_delay(self):
         return self.pwm_delay
     def get_max_power(self):
-        return self.max_power
+        return self.power_limiter.get_power_limit()
     def get_smooth_time(self):
         return self.smooth_time
     def set_temp(self, degrees):
@@ -148,7 +149,6 @@ class Heater:
 class ControlBangBang:
     def __init__(self, heater, config):
         self.heater = heater
-        self.heater_max_power = heater.get_max_power()
         self.max_delta = config.getfloat('max_delta', 2.0, above=0.)
         self.heating = False
     def temperature_update(self, read_time, temp, target_temp):
@@ -157,7 +157,7 @@ class ControlBangBang:
         elif not self.heating and temp <= target_temp-self.max_delta:
             self.heating = True
         if self.heating:
-            self.heater.set_pwm(read_time, self.heater_max_power)
+            self.heater.set_pwm(read_time, self.heater.get_max_power())
         else:
             self.heater.set_pwm(read_time, 0.)
     def check_busy(self, eventtime, smoothed_temp, target_temp):
@@ -174,12 +174,11 @@ PID_SETTLE_SLOPE = .1
 class ControlPID:
     def __init__(self, heater, config):
         self.heater = heater
-        self.heater_max_power = heater.get_max_power()
         self.Kp = config.getfloat('pid_Kp') / PID_PARAM_BASE
         self.Ki = config.getfloat('pid_Ki') / PID_PARAM_BASE
         self.Kd = config.getfloat('pid_Kd') / PID_PARAM_BASE
         self.min_deriv_time = heater.get_smooth_time()
-        imax = config.getfloat('pid_integral_max', self.heater_max_power,
+        imax = config.getfloat('pid_integral_max', self.heater.get_max_power(),
                                minval=0.)
         self.temp_integ_max = 0.
         if self.Ki:
@@ -205,7 +204,7 @@ class ControlPID:
         co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd*temp_deriv
         #logging.debug("pid: %f@%.3f -> diff=%f deriv=%f err=%f integ=%f co=%d",
         #    temp, read_time, temp_diff, temp_deriv, temp_err, temp_integ, co)
-        bounded_co = max(0., min(self.heater_max_power, co))
+        bounded_co = max(0., min(self.heater.get_max_power(), co))
         self.heater.set_pwm(read_time, bounded_co)
         # Store state for next measurement
         self.prev_temp = temp
@@ -217,6 +216,17 @@ class ControlPID:
         temp_diff = target_temp - smoothed_temp
         return (abs(temp_diff) > PID_SETTLE_DELTA
                 or abs(self.prev_temp_deriv) > PID_SETTLE_SLOPE)
+
+
+######################################################################
+# Power limiter class which just returns a constant
+######################################################################
+
+class SimplePowerLimiter:
+    def __init__(self, limit):
+        self.limit = limit
+    def get_power_limit(self):
+        return self.limit
 
 
 ######################################################################

--- a/klippy/extras/power_limiter.py
+++ b/klippy/extras/power_limiter.py
@@ -1,0 +1,70 @@
+# Prevent the whole printer (or subset) using more than a set amount of power.
+#
+# Copyright (C) 2021  Oliver Mattos <oliver@omattos.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+class PowerLimiter:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.printer.register_event_handler("klippy:ready",
+                                            self.handle_ready)
+        self.device_names = [x.strip()
+                             for x in config.get("devices").split(',')]
+        self.device_powers = [float(x)
+                              for x in config.get("device_powers").split(',')]
+        if len(self.device_names) != len(self.device_powers):
+            raise self.printer.config_error(
+                    "You need to specify device powers for all devices!"
+                    "  Try setting device_powers: 100%s" % (
+                    ', 100'*(len(self.devices)-1)))
+
+        self.limit_watts = config.getfloat("limit_watts")
+        if (self.limit_watts > sum(self.device_powers)):
+            raise self.printer.config_error(
+                "limit_watts must be less than all of the device_powers added")
+
+        self.pheaters = self.printer.load_object(config, 'heaters')
+
+    def handle_ready(self):
+        self.devices = [ self.make_PowerLimitedDevice(name, power)
+                         for name, power in
+                         zip(self.device_names, self.device_powers)]
+
+    def make_PowerLimitedDevice(self, name, power):
+        heater = self.pheaters.lookup_heater(name)
+        return PowerLimitedDevice(heater, power, self)
+
+    # Power not in use by any device in this group
+    def get_available_power(self):
+        power_used = sum([x.get_watts_used() for x in self.devices])
+        return self.limit_watts - power_used
+
+    def get_group_size(self):
+        return len(self.devices)
+
+
+class PowerLimitedDevice:
+    def __init__(self, heater, heater_power_watts, group):
+        self.group = group
+        self.heater = heater
+        self.heater_power_watts = heater_power_watts
+        self.upstream_power_limiter = self.heater.power_limiter
+        self.heater.power_limiter = self
+
+    # PWM fraction that should be the maximum allowable right now.
+    def get_power_limit(self):
+        # Let this device use most of it's current usage, plus an even share
+        # of available power.  The long term stable point of this is an
+        # approximately even share between heaters.
+        share_of_available = (self.group.get_available_power()
+                                / self.group.get_group_size())
+        new_limit = ( share_of_available / self.heater_power_watts
+                     + self.heater.last_pwm_value * 0.95)
+        return min(new_limit, self.upstream_power_limiter.get_power_limit())
+
+    def get_watts_used(self):
+        return self.heater.last_pwm_value * self.heater_power_watts
+
+def load_config(config):
+    return PowerLimiter(config)


### PR DESCRIPTION
The power limiter can be defined over any set of heaters, and simply distributes power, up to the defined maximum, on a first-come-first-served basis.

The existing heater_verify functionality is used to abort if there is insufficient group-wide power to keep everything operating during printing.  The main benefit of this change is the bed heater can be used on full power to heat up quicker while the extruder isn't in use. It also means the system can extrude considerably quicker without tripping the power supply.

Overall this change cuts some print times in half.