### PR TITLE
verify_heater: Allow decrease in setpoint without triggering failure.

### DIFF
--- a/klippy/extras/verify_heater.py
+++ b/klippy/extras/verify_heater.py
@@ -28,6 +28,7 @@ class HeaterCheck:
         self.check_gain_time = config.getfloat(
             'check_gain_time', default_gain_time, minval=1.)
         self.approaching_target = self.starting_approach = False
+        self.approaching_from_above = False
         self.last_target = self.goal_temp = self.error = 0.
         self.goal_systime = self.printer.get_reactor().NEVER
         self.check_timer = None
@@ -53,6 +54,8 @@ class HeaterCheck:
                              self.heater_name, target)
             self.approaching_target = self.starting_approach = False
             if temp <= target + self.hysteresis:
+                self.approaching_from_above = False
+            if temp <= target + self.hysteresis or self.approaching_from_above:
                 self.error = 0.
             self.last_target = target
             return eventtime + 1.
@@ -63,6 +66,8 @@ class HeaterCheck:
                 logging.info("Heater %s approaching new target of %.3f",
                              self.heater_name, target)
                 self.approaching_target = self.starting_approach = True
+                if target < temp:
+                    self.approaching_from_above = True
                 self.goal_temp = temp + self.heating_gain
                 self.goal_systime = eventtime + self.check_gain_time
             elif self.error >= self.max_error:


### PR DESCRIPTION
Issue:  If, during a print, I decrease the setpoint temperature from say
60C to say 40C of the heater bed, then by default a critical stop will
be triggered in about 10 seconds.

This is because when the setpoint is changed, the "Target changed - reset
checks" codepath is run. On the next check the "Temperature near target
- reset checks" codepath is run. Each check after that the error number
is incremented until the error exceeds the threshold of 120 and a
critical error is raised.

This fix is to have a logic path for "approaching new setpoint from above",
which will not accumilate error until the target setpoint is reached.

Fixes #3875 

Signed-off-by: Oliver Mattos <oliver@omattos.com>