### PR TITLE
config:  Ultimaker v2 default config example

### DIFF
--- a/config/printer-ultimaker-2-2020.cfg
+++ b/config/printer-ultimaker-2-2020.cfg
@@ -1,0 +1,159 @@
+# This file contains common pin mappings and set of defaults that work well
+# with the Ultimaker 2 and 2+.
+
+# To use this config, the firmware should be compiled for the
+# AVR atmega2560.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: ar25
+dir_pin: !ar23
+enable_pin: !ar27
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!ar22
+position_endstop: 0
+position_max: 230
+homing_speed: 50.0
+
+[stepper_y]
+step_pin: ar32
+dir_pin: ar33
+enable_pin: !ar31
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!ar26
+position_endstop: 225
+position_max: 225
+homing_speed: 50.0
+
+[stepper_z]
+step_pin: ar35
+dir_pin: !ar36
+enable_pin: !ar34
+microsteps: 16
+rotation_distance: 16
+endstop_pin: ^!ar29
+position_endstop: 215
+position_max: 215
+homing_speed: 20.0
+
+[extruder]
+step_pin: ar42
+dir_pin: ar43
+enable_pin: !ar37
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.400
+filament_diameter: 2.850
+heater_pin: ar2
+sensor_type: PT100 INA826
+sensor_pin: analog8
+#control: pid
+#pid_Kp: 22.2
+#pid_Ki: 1.08
+#pid_Kd: 114
+min_temp: 0
+max_temp: 275
+pressure_advance: 2.2
+
+# Dual extruder support.
+#[extruder1]
+#step_pin: ar49
+#dir_pin: ar47
+#enable_pin: !ar48
+#microsteps: 16
+#rotation_distance: 33.500
+#nozzle_diameter: 0.400
+#filament_diameter: 2.850
+#heater_pin: ar3
+#sensor_type: PT100 INA826
+#sensor_pin: analog9
+#control: pid
+#pid_Kp: 22.2
+#pid_Ki: 1.08
+#pid_Kd: 114
+#min_temp: 0
+#max_temp: 275
+
+[heater_bed]
+heater_pin: ar4
+sensor_type: PT100 INA826
+sensor_pin: analog10
+control: pid
+min_temp: 0
+max_temp: 100
+pid_kp = 33.821
+pid_ki = 0.564
+pid_kd = 507.310
+
+[power_limiter]
+devices: heater_bed,extruder
+device_powers: 150, 50
+limit_watts: 150
+
+[input_shaper]
+shaper_freq_x: 140
+shaper_freq_y: 62
+
+[fan]
+pin: ar7
+
+[mcu]
+serial: /dev/ttyACM0
+pin_map: arduino
+
+[bed_screws]
+screw1: 100,225
+screw2: 0,30
+screw3: 200,30
+
+[printer]
+kinematics: cartesian
+max_velocity: 1000
+max_accel: 5000
+max_accel_to_decel: 7000
+max_z_velocity: 25
+max_z_accel: 30
+square_corner_velocity: 10
+
+[output_pin case_light]
+pin: ar8
+static_value: 1.0
+
+# Motor current settings.
+[output_pin stepper_xy_current]
+pin: ar44
+pwm: True
+scale: 2
+# Max power setting.
+cycle_time: .000030
+hardware_pwm: True
+static_value: 1.200
+# Power adjustment setting.
+
+[output_pin stepper_z_current]
+pin: ar45
+pwm: True
+scale: 2
+cycle_time: .000030
+hardware_pwm: True
+static_value: 1.200
+
+[output_pin stepper_e_current]
+pin: ar46
+pwm: True
+scale: 2
+cycle_time: .000030
+hardware_pwm: True
+static_value: 1.250
+
+[output_pin beeper]
+pin: ar18
+
+[display]
+lcd_type: ssd1306
+encoder_pins: ^ar40, ^ar41
+click_pin: ^!ar19
+reset_pin: ar5


### PR DESCRIPTION
This config is tested working on the Ultimaker v2.  It likley also works
on the Ultimaker v2+.

It requires the power limiting module
(https://github.com/KevinOConnor/klipper/pull/3877) or the system will
power off at random while printing due to being out of power.

Signed-off-by: Oliver Mattos <oliver@omattos.com>