### PR TITLE
Fix offset, mesh limits, add screw tilt adjust

### DIFF
--- a/config/printer-creality-ender6-2020.cfg
+++ b/config/printer-creality-ender6-2020.cfg
@@ -65,17 +65,29 @@ position_max: 400
 # [bltouch]                               # enable for BLTouch
 # sensor_pin: ^PB1
 # control_pin: PB0
-# x_offset: 20.7
-# y_offset: 7
+# x_offset: -20.7
+# y_offset: -7
 # z_offset: 2.4
 # speed: 3.0
 
 # [bed_mesh]                              # enable for BLTouch
 # speed: 100
 # mesh_min: 10, 10
-# mesh_max: 250, 250
+# mesh_max: 229.3, 243
 # algorithm: bicubic
 # probe_count: 5,5
+
+[screws_tilt_adjust]
+screw1: 53, 232
+screw1_name: nw
+screw2: 243, 232
+screw2_name: ne
+screw3: 243, 41
+screw3_name: se
+screw4: 53, 41
+screw4_name: sw
+speed: 50
+screw_thread: CW-M3
 
 [extruder]
 max_extrude_only_distance: 1000.0


### PR DESCRIPTION
Reversed the probe offset direction to account for the coordinate system
Included the offset in the mesh limits, as otherwise ABL will not work
Added in the screw locations for guided bed levelling