### PR TITLE
docs: Clarification to SET_GCODE_OFFSET command

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -131,7 +131,9 @@ The following standard commands are supported:
   effect on the next absolute G-Code move that specifies the given
   axis). If "MOVE_SPEED" is specified then the toolhead move will be
   performed with the given speed (in mm/s); otherwise the toolhead
-  move will use the last specified G-Code speed.
+  move will use the last specified G-Code speed. To see the current
+  offset, the "GET_POSITION" command will return it under the `gcode 
+  homing` result.
 - `SAVE_GCODE_STATE [NAME=<state_name>]`: Save the current
   g-code coordinate parsing state. Saving and restoring the g-code
   state is useful in scripts and macros. This command saves the


### PR DESCRIPTION
This may seem like a pointless change, (Code_Overview.md 
describes where to read the offset value), but I thought
it would be helpful to mention it here as well since this is the 
section that tells you how to use SET_GCODE_OFFSET. Hopefully
my comment isn't too simplistic - on the Code_Overview.md page, 
it says: `The SET_GCODE_OFFSET command can alter this value.`
The way that's written, I cannot tell whether the SET_GCODE_OFFSET is
the **only** way to change "gcode homing".

Signed-off-by: John Pariseau <simplymail@ururk.com>