### PR TITLE
safe_z_home: Allow home_xy_position to be unspecified.

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1046,7 +1046,7 @@ has to move to the center of the bed before Z can be homed.
 [safe_z_home]
 home_xy_position:
 #   A X,Y coordinate (e.g. 100,100) where the Z homing should be
-#   performed. This parameter must be provided.
+#   performed.
 #speed: 50.0
 #   Speed at which the toolhead is moved to the safe Z home
 #   coordinate. The default is 50 mm/s

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1060,9 +1060,9 @@ home_xy_position:
 #   lifted by z_hop. If z_hop is specified, be sure to home the Z
 #   immediately after any XY home requests so that the Z boundary
 #   checks are accurate. The default is to not implement Z hop.
-#z_hop_speed: 20.0
+#z_hop_speed: 15.0
 #   Speed (in mm/s) at which the Z axis is lifted prior to homing. The
-#   default is 20mm/s.
+#   default is 15mm/s.
 #move_to_previous: False
 #   When set to True, xy are reset to their previous positions after z
 #   homing. The default is False.


### PR DESCRIPTION
This makes `home_xy_position` optional.
This is useful to configure a "z hop" when homing XY (e.g. to avoid bed clips) but still allow Z to be homed anywhere without a specific homed XY position.
I also fixed an incorrect mention of default `z_hop_speed` in docs.