### PR TITLE
fan: Add tachometer support

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2222,6 +2222,19 @@ pin:
 #   input speed which reliably drives the fan without stalls. Set
 #   off_below to the duty cycle corresponding to this value (for
 #   example, 12% -> 0.12) or slightly higher.
+#tachometer_pin:
+#   Tachometer input pin for monitoring fan speed. A pullup is generally
+#   required. This parameter is optional.
+#tachometer_ppr: 2
+#   When tachometer_pin is specified, this is the number of pulses per
+#   revolution of the tachometer signal. For a BLDC fan this is
+#   normally half the number of poles. The default is 2.
+#tachometer_poll_interval: 0.0015
+#   When tachometer_pin is specified, this is the polling period of the
+#   tachometer pin, in seconds. The default is 0.0015, which is fast
+#   enough for fans below 10000 RPM at 2 PPR. This must be smaller than
+#   30/(tachometer_ppr*rpm), with some margin, where rpm is the
+#   maximum speed (in RPM) of the fan.
 ```
 
 ## [heater_fan]
@@ -2240,6 +2253,9 @@ a shutdown_speed equal to max_power.
 #hardware_pwm:
 #kick_start_time:
 #off_below:
+#tachometer_pin:
+#tachometer_ppr:
+#tachometer_poll_interval:
 #   See the "fan" section for a description of the above parameters.
 #heater: extruder
 #   Name of the config section defining the heater that this fan is
@@ -2273,6 +2289,9 @@ watched component.
 #hardware_pwm:
 #kick_start_time:
 #off_below:
+#tachometer_pin:
+#tachometer_ppr:
+#tachometer_poll_interval:
 #   See the "fan" section for a description of the above parameters.
 #fan_speed: 1.0
 #   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
@@ -2313,6 +2332,9 @@ additional information.
 #hardware_pwm:
 #kick_start_time:
 #off_below:
+#tachometer_pin:
+#tachometer_ppr:
+#tachometer_poll_interval:
 #   See the "fan" section for a description of the above parameters.
 #sensor_type:
 #sensor_pin:
@@ -2358,6 +2380,9 @@ with the SET_FAN_SPEED
 #hardware_pwm:
 #kick_start_time:
 #off_below:
+#tachometer_pin:
+#tachometer_ppr:
+#tachometer_poll_interval:
 #   See the "fan" section for a description of the above parameters.
 ```
 

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import pulse_counter
 
 FAN_MIN_TIME = 0.100
 
@@ -11,6 +12,7 @@ class Fan:
         self.printer = config.get_printer()
         self.last_fan_value = 0.
         self.last_fan_time = 0.
+        self.rpm = None
         # Read config
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
         self.kick_start_time = config.getfloat('kick_start_time', 0.1,
@@ -28,9 +30,14 @@ class Fan:
         self.mcu_fan.setup_cycle_time(cycle_time, hardware_pwm)
         shutdown_power = max(0., min(self.max_power, shutdown_speed))
         self.mcu_fan.setup_start_value(0., shutdown_power)
+
+        # Setup tachometer
+        self.tachometer = FanTachometer(config)
+
         # Register callbacks
         self.printer.register_event_handler("gcode:request_restart",
                                             self._handle_request_restart)
+
     def get_mcu(self):
         return self.mcu_fan.get_mcu()
     def set_speed(self, print_time, value):
@@ -54,8 +61,34 @@ class Fan:
                                               self.set_speed(pt, value)))
     def _handle_request_restart(self, print_time):
         self.set_speed(print_time, 0.)
+
     def get_status(self, eventtime):
-        return {'speed': self.last_fan_value}
+        tachometer_status = self.tachometer.get_status(eventtime)
+        return {
+            'speed': self.last_fan_value,
+            'rpm': tachometer_status['rpm'],
+        }
+
+class FanTachometer:
+    def __init__(self, config):
+        printer = config.get_printer()
+        self._freq_counter = None
+
+        pin = config.get('tachometer_pin', None)
+        if pin is not None:
+            self.ppr = config.getint('tachometer_ppr', 2, minval=1)
+            poll_time = config.getfloat('tachometer_poll_interval',
+                                        0.0015, above=0.)
+            sample_time = 1.
+            self._freq_counter = pulse_counter.FrequencyCounter(
+                printer, pin, sample_time, poll_time)
+
+    def get_status(self, eventtime):
+        if self._freq_counter:
+            rpm = self._freq_counter.frequency * 30. / self.ppr
+        else:
+            rpm = None
+        return {'rpm': rpm}
 
 class PrinterFan:
     def __init__(self, config):

--- a/klippy/extras/pulse_counter.py
+++ b/klippy/extras/pulse_counter.py
@@ -1,0 +1,79 @@
+# Support for GPIO input edge counters
+#
+# Copyright (C) 2021  Adrian Keet <arkeet@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+class MCU_counter:
+    def __init__(self, printer, pin, sample_time, poll_time):
+        ppins = printer.lookup_object('pins')
+        pin_params = ppins.lookup_pin(pin, can_pullup=True)
+        self._mcu = pin_params['chip']
+        self._oid = self._mcu.create_oid()
+        self._pin = pin_params['pin']
+        self._pullup = pin_params['pullup']
+        self._poll_time = poll_time
+        self._sample_time = sample_time
+        self._callback = None
+        self._last_count = 0
+        self._mcu.register_config_callback(self.build_config)
+
+    def build_config(self):
+        self._mcu.add_config_cmd("config_counter oid=%d pin=%s pull_up=%d"
+            % (self._oid, self._pin, self._pullup))
+        clock = self._mcu.get_query_slot(self._oid)
+        poll_ticks = self._mcu.seconds_to_clock(self._poll_time)
+        sample_ticks = self._mcu.seconds_to_clock(self._sample_time)
+        self._mcu.add_config_cmd(
+            "query_counter oid=%d clock=%d poll_ticks=%d sample_ticks=%d"
+            % (self._oid, clock, poll_ticks, sample_ticks), is_init=True)
+        self._mcu.register_response(self._handle_counter_state,
+                                    "counter_state", self._oid)
+
+    # Callback is called periodically every sample_time
+    def setup_callback(self, cb):
+        self._callback = cb
+
+    def _handle_counter_state(self, params):
+        clock = self._mcu.clock32_to_clock64(params['time'])
+        time = self._mcu.clock_to_print_time(clock)
+
+        count_clock = self._mcu.clock32_to_clock64(params['count_time'])
+        count_time = self._mcu.clock_to_print_time(count_clock)
+
+        # handle 32-bit counter overflow
+        last_count = self._last_count
+        delta_count = (params['count'] - last_count) & 0xffffffff
+        count = last_count + delta_count
+        self._last_count = count
+
+        if self._callback is not None:
+            self._callback(time, count, count_time)
+
+class FrequencyCounter:
+    def __init__(self, printer, pin, sample_time, poll_time):
+        self._callback = None
+        self._last_time = self._last_count = None
+        self._freq = 0.
+        self._counter = MCU_counter(printer, pin, sample_time, poll_time)
+        self._counter.setup_callback(self._counter_callback)
+
+    def _counter_callback(self, time, count, count_time):
+        if self._last_time is None:  # First sample
+            self._last_time = time
+        else:
+            delta_time = count_time - self._last_time
+            if delta_time > 0:
+                self._last_time = count_time
+                delta_count = count - self._last_count
+                self._freq = delta_count / delta_time
+            else:  # No counts since last sample
+                self._last_time = time
+                self._freq = 0.
+            if self._callback is not None:
+                self._callback(time, self._freq)
+        self._last_count = count
+
+    @property
+    def frequency(self):
+        return self._freq

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,4 +7,4 @@ src-$(CONFIG_HAVE_GPIO_SPI) += spicmds.c thermocouple.c
 src-$(CONFIG_HAVE_GPIO_I2C) += i2ccmds.c
 src-$(CONFIG_HAVE_GPIO_HARD_PWM) += pwmcmds.c
 src-$(CONFIG_HAVE_GPIO_BITBANGING) += lcd_st7920.c lcd_hd44780.c buttons.c \
-    tmcuart.c spi_software.c neopixel.c sensor_adxl345.c
+    tmcuart.c spi_software.c neopixel.c sensor_adxl345.c pulse_counter.c

--- a/src/pulse_counter.c
+++ b/src/pulse_counter.c
@@ -1,0 +1,99 @@
+// Commands for counting edges on GPIO input pins
+//
+// Copyright (C) 2021  Adrian Keet <arkeet@gmail.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "basecmd.h" // oid_alloc
+#include "board/gpio.h" // struct gpio_in
+#include "board/irq.h" // irq_disable
+#include "board/misc.h" // timer_read_time
+#include "command.h" // DECL_COMMAND
+#include "sched.h" // DECL_TASK
+
+struct counter {
+    struct timer timer;
+    uint32_t poll_ticks;
+    uint32_t sample_ticks, next_sample_time;
+    uint32_t count, last_count_time;
+    uint8_t flags;
+    struct gpio_in pin;
+};
+
+enum {
+    CF_PENDING = 1,
+};
+
+static struct task_wake counter_wake;
+
+static uint_fast8_t
+counter_event(struct timer *timer)
+{
+    struct counter *c = container_of(timer, struct counter, timer);
+
+    uint32_t time = c->timer.waketime;
+    uint8_t last_value = c->count & 1;
+    uint8_t value = gpio_in_read(c->pin);
+    if (last_value != value) {
+        c->count++;
+        c->last_count_time = time;
+    }
+    // useful invariant: c->count & 1 == value
+
+    if (timer_is_before(c->next_sample_time, time)) {
+        c->flags |= CF_PENDING;
+        c->next_sample_time = time + c->sample_ticks;
+        sched_wake_task(&counter_wake);
+    }
+
+    c->timer.waketime += c->poll_ticks;
+    return SF_RESCHEDULE;
+}
+
+void
+command_config_counter(uint32_t *args)
+{
+    struct counter *c = oid_alloc(
+        args[0], command_config_counter, sizeof(*c));
+    c->pin = gpio_in_setup(args[1], args[2]);
+    c->timer.func = counter_event;
+}
+DECL_COMMAND(command_config_counter,
+             "config_counter oid=%c pin=%u pull_up=%c");
+
+void
+command_query_counter(uint32_t *args)
+{
+    struct counter *c = oid_lookup(args[0], command_config_counter);
+    sched_del_timer(&c->timer);
+    c->timer.waketime = args[1];
+    c->poll_ticks = args[2];
+    c->sample_ticks = args[3];
+    c->next_sample_time = c->timer.waketime; // sample immediately
+    sched_add_timer(&c->timer);
+}
+DECL_COMMAND(command_query_counter,
+             "query_counter oid=%c clock=%u poll_ticks=%u sample_ticks=%u");
+
+void
+counter_task(void)
+{
+    if (!sched_check_wake(&counter_wake))
+        return;
+
+    uint8_t oid;
+    struct counter *c;
+    foreach_oid(oid, c, command_config_counter) {
+        if (!(c->flags & CF_PENDING))
+            continue;
+        irq_disable();
+        uint32_t time = c->timer.waketime - c->poll_ticks;
+        uint32_t count = c->count;
+        uint32_t count_time = c->last_count_time;
+        c->flags &= ~CF_PENDING;
+        irq_enable();
+        sendf("counter_state oid=%c time=%u count=%u count_time=%u",
+              oid, time, count, count_time);
+    }
+}
+DECL_TASK(counter_task);


### PR DESCRIPTION
In response to https://github.com/KevinOConnor/klipper/issues/3771

This adds two new config options for fans: 'tachometer_pin' to specify
the GPIO pin, and 'min_rpm' to ensure that the fan is spinning fast
enough (and shutdown otherwise). The rpm is also exposed in get_status
for command templates and the api server.

There is a new mcu object for a generic edge counter, which repeatedly
polls a GPIO pin and periodically reports the count to the host.