### PR TITLE
config: generic crealiy v4.2.7 LCD

### DIFF
--- a/config/generic-creality-v4.2.7.cfg
+++ b/config/generic-creality-v4.2.7.cfg
@@ -90,3 +90,11 @@ max_velocity: 300
 max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
+
+[display]
+lcd_type: st7920
+cs_pin: PB12
+sclk_pin: PB13
+sid_pin: PB15
+encoder_pins: ^PB14, ^PB10
+click_pin: ^!PB2


### PR DESCRIPTION
Following this comment https://github.com/KevinOConnor/klipper/issues/3477#issuecomment-764695855 here is a pull request adding the LCD pins for the Creality v4.2.7 board to the example config. All credits to @er9xuser.