### PR TITLE
New feature: Min_power for fans

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2209,6 +2209,12 @@ pin:
 #   Time (in seconds) to run the fan at full speed when either first
 #   enabling or increasing it by more than 50% (helps get the fan
 #   spinning). The default is 0.100 seconds.
+#min_power: 0.0
+#   The minimum input speed which will power the fan (expressed as a
+#   value from 0.0 to 1.0). When a speed lower than min_power is
+#   requested the fan will instead be set to this speed.
+#   This setting may be used to prevent fan stalls.
+#   The default is 0.0.
 #off_below: 0.0
 #   The minimum input speed which will power the fan (expressed as a
 #   value from 0.0 to 1.0). When a speed lower than off_below is
@@ -2239,6 +2245,7 @@ a shutdown_speed equal to max_power.
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
+#min_power:
 #off_below:
 #   See the "fan" section for a description of the above parameters.
 #heater: extruder
@@ -2272,6 +2279,7 @@ watched component.
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
+#min_power:
 #off_below:
 #   See the "fan" section for a description of the above parameters.
 #fan_speed: 1.0
@@ -2312,6 +2320,7 @@ additional information.
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
+#min_power:
 #off_below:
 #   See the "fan" section for a description of the above parameters.
 #sensor_type:
@@ -2357,6 +2366,7 @@ with the SET_FAN_SPEED
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
+#min_power:
 #off_below:
 #   See the "fan" section for a description of the above parameters.
 ```

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -13,10 +13,9 @@ class Fan:
         self.last_fan_time = 0.
         # Read config
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
-        self.kick_start_time = config.getfloat('kick_start_time', 0.1,
-                                               minval=0.)
-        self.off_below = config.getfloat('off_below', default=0.,
-                                         minval=0., maxval=1.)
+        self.kick_start_time = config.getfloat('kick_start_time', 0.1, minval=0.)
+        self.off_below = config.getfloat('off_below', default=0., minval=0., maxval =1.)
+        self.min_power = config.getfloat('min_power', default=0., minval=0., maxval =1.)
         cycle_time = config.getfloat('cycle_time', 0.010, above=0.)
         hardware_pwm = config.getboolean('hardware_pwm', False)
         shutdown_speed = config.getfloat(
@@ -34,6 +33,8 @@ class Fan:
     def get_mcu(self):
         return self.mcu_fan.get_mcu()
     def set_speed(self, print_time, value):
+        if value < self.min_power:
+            value = self.min_power
         if value < self.off_below:
             value = 0.
         value = max(0., min(self.max_power, value * self.max_power))

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -13,9 +13,12 @@ class Fan:
         self.last_fan_time = 0.
         # Read config
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
-        self.kick_start_time = config.getfloat('kick_start_time', 0.1, minval=0.)
-        self.off_below = config.getfloat('off_below', default=0., minval=0., maxval =1.)
-        self.min_power = config.getfloat('min_power', default=0., minval=0., maxval =1.)
+        self.kick_start_time = config.getfloat('kick_start_time', 0.1,
+                                               minval=0.)
+        self.off_below = config.getfloat('off_below', default=0.,
+                                         minval=0., maxval=1.)
+        self.min_power = config.getfloat('min_power', default=0.,
+                                         minval=0., maxval =1.)
         cycle_time = config.getfloat('cycle_time', 0.010, above=0.)
         hardware_pwm = config.getboolean('hardware_pwm', False)
         shutdown_speed = config.getfloat(


### PR DESCRIPTION
module: Minimum power for fans, anything below will be pulled up

An alternative to off_below, min_power raises the fan speeds of commands below min_power up to min_power.
This ensures the fan will always run when commanded to.

Signed-off-by: Tobias Weiß t.weiss@bk.ru