### PR TITLE
More options for lower fan speed bounds

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2209,6 +2209,12 @@ pin:
 #   Time (in seconds) to run the fan at full speed when either first
 #   enabling or increasing it by more than 50% (helps get the fan
 #   spinning). The default is 0.100 seconds.
+#min_power: 0.0
+#   The minimum input speed which will power the fan (expressed as a
+#   value from 0.0 to 1.0). When a speed lower than min_power is
+#   requested the fan will instead be set to this speed.
+#   This setting may be used to prevent fan stalls.
+#   The default is 0.0.
 #off_below: 0.0
 #   The minimum input speed which will power the fan (expressed as a
 #   value from 0.0 to 1.0). When a speed lower than off_below is
@@ -2222,6 +2228,11 @@ pin:
 #   input speed which reliably drives the fan without stalls. Set
 #   off_below to the duty cycle corresponding to this value (for
 #   example, 12% -> 0.12) or slightly higher.
+#power_scaling: False
+#   Instead of only scaling to max_power, requested fan speeds will
+#   also scale to min_power. This setting may be used to allow similar
+#   cooling performance over different fans on different printers with
+#   the same fan speed commands. The default is False.
 ```
 
 ## [heater_fan]
@@ -2239,7 +2250,9 @@ a shutdown_speed equal to max_power.
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
+#min_power:
 #off_below:
+#power_scaling:
 #   See the "fan" section for a description of the above parameters.
 #heater: extruder
 #   Name of the config section defining the heater that this fan is
@@ -2272,7 +2285,9 @@ watched component.
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
+#min_power:
 #off_below:
+#power_scaling:
 #   See the "fan" section for a description of the above parameters.
 #fan_speed: 1.0
 #   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
@@ -2312,7 +2327,9 @@ additional information.
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
+#min_power:
 #off_below:
+#power_scaling:
 #   See the "fan" section for a description of the above parameters.
 #sensor_type:
 #sensor_pin:
@@ -2357,7 +2374,9 @@ with the SET_FAN_SPEED
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
+#min_power:
 #off_below:
+#power_scaling:
 #   See the "fan" section for a description of the above parameters.
 ```
 

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -17,6 +17,9 @@ class Fan:
                                                minval=0.)
         self.off_below = config.getfloat('off_below', default=0.,
                                          minval=0., maxval=1.)
+        self.min_power = config.getfloat('min_power', default=0.,
+                                         minval=0., maxval =1.)
+        self.power_scaling = config.getboolean('power_scaling', False)
         cycle_time = config.getfloat('cycle_time', 0.010, above=0.)
         hardware_pwm = config.getboolean('hardware_pwm', False)
         shutdown_speed = config.getfloat(
@@ -34,6 +37,10 @@ class Fan:
     def get_mcu(self):
         return self.mcu_fan.get_mcu()
     def set_speed(self, print_time, value):
+        if value and self.power_scaling:
+            value = value * (self.max_power - self.min_power) + self.min_power
+        if value and value < self.min_power:
+            value = self.min_power
         if value < self.off_below:
             value = 0.
         value = max(0., min(self.max_power, value * self.max_power))

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -41,6 +41,14 @@ class ForceMove:
             ffi_lib.cartesian_stepper_alloc('x'), ffi_lib.free)
         # Register commands
         gcode = self.printer.lookup_object('gcode')
+        
+        self.ignore_homing_kinematics_list = ['cartesian', 'corexy', 'corexz']
+        self.kin_name = config.getsection('printer').get('kinematics')
+        if config.getboolean('ignore_homing', False):
+            if self.kin_name not in self.ignore_homing_kinematics_list:
+                raise self.printer.config_error(
+                    "ignore_homing invalid for %s" % (self.kin_name,))
+        
         gcode.register_command('STEPPER_BUZZ', self.cmd_STEPPER_BUZZ,
                                desc=self.cmd_STEPPER_BUZZ_help)
         if config.getboolean("enable_force_move", False):

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -27,8 +27,8 @@ class CartKinematics:
                                               above=0., maxval=max_velocity)
         self.max_z_accel = config.getfloat('max_z_accel', max_accel,
                                            above=0., maxval=max_accel)
-        self.no_homing = config.getsection('force_move').getboolean(
-            'no_homing', False)
+        self.ignore_homing = config.getsection('force_move').getboolean(
+            'ignore_homing', False)
         self.limits = [(1.0, -1.0)] * 3
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
@@ -110,9 +110,10 @@ class CartKinematics:
     def check_move(self, move):
         limits = self.limits
         xpos, ypos = move.end_pos[:2]
-        if not self.no_homing and (xpos < limits[0][0] or xpos > limits[0][1]
+        if not self.ignore_homing and (
+            xpos < limits[0][0] or xpos > limits[0][1]
             or ypos < limits[1][0] or ypos > limits[1][1]):
-            self._check_endstops(move)
+                self._check_endstops(move)
         if not move.axes_d[2]:
             # Normal XY move - use defaults
             return

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -27,6 +27,8 @@ class CartKinematics:
                                               above=0., maxval=max_velocity)
         self.max_z_accel = config.getfloat('max_z_accel', max_accel,
                                            above=0., maxval=max_accel)
+        self.no_homing = config.getsection('force_move').getboolean(
+            'no_homing', False)
         self.limits = [(1.0, -1.0)] * 3
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
@@ -108,7 +110,7 @@ class CartKinematics:
     def check_move(self, move):
         limits = self.limits
         xpos, ypos = move.end_pos[:2]
-        if (xpos < limits[0][0] or xpos > limits[0][1]
+        if not self.no_homing and (xpos < limits[0][0] or xpos > limits[0][1]
             or ypos < limits[1][0] or ypos > limits[1][1]):
             self._check_endstops(move)
         if not move.axes_d[2]:

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -30,8 +30,8 @@ class CoreXYKinematics:
             'max_z_velocity', max_velocity, above=0., maxval=max_velocity)
         self.max_z_accel = config.getfloat(
             'max_z_accel', max_accel, above=0., maxval=max_accel)
-        self.no_homing = config.getsection('force_move').getboolean(
-            'no_homing', False)
+        self.ignore_homing = config.getsection('force_move').getboolean(
+            'ignore_homing', False)
         self.limits = [(1.0, -1.0)] * 3
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
@@ -87,9 +87,10 @@ class CoreXYKinematics:
     def check_move(self, move):
         limits = self.limits
         xpos, ypos = move.end_pos[:2]
-        if not self.no_homing and (xpos < limits[0][0] or xpos > limits[0][1]
+        if not self.ignore_homing and (
+            xpos < limits[0][0] or xpos > limits[0][1]
             or ypos < limits[1][0] or ypos > limits[1][1]):
-            self._check_endstops(move)
+                self._check_endstops(move)
         if not move.axes_d[2]:
             # Normal XY move - use defaults
             return

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -30,6 +30,8 @@ class CoreXYKinematics:
             'max_z_velocity', max_velocity, above=0., maxval=max_velocity)
         self.max_z_accel = config.getfloat(
             'max_z_accel', max_accel, above=0., maxval=max_accel)
+        self.no_homing = config.getsection('force_move').getboolean(
+            'no_homing', False)
         self.limits = [(1.0, -1.0)] * 3
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
@@ -85,7 +87,7 @@ class CoreXYKinematics:
     def check_move(self, move):
         limits = self.limits
         xpos, ypos = move.end_pos[:2]
-        if (xpos < limits[0][0] or xpos > limits[0][1]
+        if not self.no_homing and (xpos < limits[0][0] or xpos > limits[0][1]
             or ypos < limits[1][0] or ypos > limits[1][1]):
             self._check_endstops(move)
         if not move.axes_d[2]:

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -30,6 +30,8 @@ class CoreXZKinematics:
             'max_z_velocity', max_velocity, above=0., maxval=max_velocity)
         self.max_z_accel = config.getfloat(
             'max_z_accel', max_accel, above=0., maxval=max_accel)
+        self.no_homing = config.getsection('force_move').getboolean(
+            'no_homing', False)
         self.limits = [(1.0, -1.0)] * 3
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
@@ -84,7 +86,7 @@ class CoreXZKinematics:
     def check_move(self, move):
         limits = self.limits
         xpos, ypos = move.end_pos[:2]
-        if (xpos < limits[0][0] or xpos > limits[0][1]
+        if not self.no_homing and (xpos < limits[0][0] or xpos > limits[0][1]
             or ypos < limits[1][0] or ypos > limits[1][1]):
             self._check_endstops(move)
         if not move.axes_d[2]:

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -30,8 +30,8 @@ class CoreXZKinematics:
             'max_z_velocity', max_velocity, above=0., maxval=max_velocity)
         self.max_z_accel = config.getfloat(
             'max_z_accel', max_accel, above=0., maxval=max_accel)
-        self.no_homing = config.getsection('force_move').getboolean(
-            'no_homing', False)
+        self.ignore_homing = config.getsection('force_move').getboolean(
+            'ignore_homing', False)
         self.limits = [(1.0, -1.0)] * 3
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
@@ -86,9 +86,10 @@ class CoreXZKinematics:
     def check_move(self, move):
         limits = self.limits
         xpos, ypos = move.end_pos[:2]
-        if not self.no_homing and (xpos < limits[0][0] or xpos > limits[0][1]
+        if not self.ignore_homing and (
+            xpos < limits[0][0] or xpos > limits[0][1]
             or ypos < limits[1][0] or ypos > limits[1][1]):
-            self._check_endstops(move)
+                self._check_endstops(move)
         if not move.axes_d[2]:
             # Normal XY move - use defaults
             return


### PR DESCRIPTION
module: Modify fan behavior on lower power bounds

Adds two options to fans to change how they operate at lower requested speeds.
min_power is an alternative to off_below. Fans speeds above 0 and below min_power are raised to min_power to ensure the fan keeps running after the kick_start_time.

With power_scaling set to True, the requested fan speeds (e.g. from M106 S0 to M106 S255 for the part cooling fan) will be scaled from min_power to max_power instead.

Signed-off-by: Tobias Weiß <t.weiss@bk.ru>