### PR TITLE
config: add example config of Biqu B1 Printer, with and without BLTouch

### DIFF
--- a/config/printer-biqu-b1-2020-standard-zstop.cfg
+++ b/config/printer-biqu-b1-2020-standard-zstop.cfg
@@ -1,0 +1,129 @@
+# This file contains common pin mappings for the BIGTREETECH SKR V1.4
+# board. To use this config, the firmware should be compiled for the
+# LPC1768 or LPC1769(Turbo).
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: P2.2
+dir_pin: !P2.6
+enable_pin: !P2.1
+microsteps: 16
+rotation_distance: 39.60
+endstop_pin: !P1.29
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_y]
+step_pin: P0.19
+dir_pin: P0.20
+enable_pin: !P2.8
+microsteps: 16
+rotation_distance: 39.50
+endstop_pin: !P1.28
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_z]
+step_pin: P0.22
+dir_pin: P2.11
+enable_pin: !P0.21
+microsteps: 16
+rotation_distance: 7.76
+endstop_pin: !P1.27
+position_endstop: 0.0
+position_max: 300
+
+[extruder]
+step_pin: P2.13
+dir_pin: !P0.11
+enable_pin: !P2.12
+microsteps: 16
+rotation_distance: 33.333
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: P2.7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P0.24
+#control: pid
+#pid_Kp: 22.2
+#pid_Ki: 1.08
+#pid_Kd: 114
+min_temp: 0
+max_temp: 250
+#pressure_advance: 0.44
+pressure_advance: 0.66
+
+[heater_bed]
+heater_pin: P2.5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P0.25
+#control: pid
+#pid_Kp: 54.027
+#pid_Ki: 0.770
+#pid_Kd: 948.182
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: P2.3
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_lpc1768_0180001102094AAF01A55E5DC52000F5-if00
+
+[printer]
+kinematics: cartesian
+max_velocity: 400
+max_accel: 1000
+max_z_velocity: 10
+max_z_accel: 100
+square_corner_velocity: 5.0
+
+[input_shaper]
+shaper_freq_x: 36.3636
+shaper_freq_y: 66.3900
+shaper_type: mzv
+
+########################################
+# TMC2208 configuration
+########################################
+
+[tmc2208 stepper_x]
+uart_pin: P1.10
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2208 stepper_y]
+uart_pin: P1.9
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2208 stepper_z]
+uart_pin: P1.8
+run_current: 0.650
+hold_current: 0.450
+stealthchop_threshold: 30
+
+[tmc2208 extruder]
+uart_pin: P1.4
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 5
+
+########################################
+# EXP1 / EXP2 (display) pins
+########################################
+
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=P1.30, EXP1_3=P1.18, EXP1_5=P1.20, EXP1_7=P1.22, EXP1_9=<GND>,
+    EXP1_2=P0.28, EXP1_4=P1.19, EXP1_6=P1.21, EXP1_8=P1.23, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=P0.17, EXP2_3=P3.26, EXP2_5=P3.25, EXP2_7=P1.31, EXP2_9=<GND>,
+    EXP2_2=P0.15, EXP2_4=P0.16, EXP2_6=P0.18, EXP2_8=<RST>, EXP2_10=<NC>
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "ssp0"

--- a/config/printer-biqu-b1-2020-with-bltouch.cfg
+++ b/config/printer-biqu-b1-2020-with-bltouch.cfg
@@ -1,0 +1,158 @@
+# This file contains common pin mappings for the BIGTREETECH SKR V1.4
+# board. To use this config, the firmware should be compiled for the
+# LPC1768 or LPC1769(Turbo).
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: P2.2
+dir_pin: !P2.6
+enable_pin: !P2.1
+microsteps: 16
+rotation_distance: 39.60
+endstop_pin: !P1.29
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_y]
+step_pin: P0.19
+dir_pin: P0.20
+enable_pin: !P2.8
+microsteps: 16
+rotation_distance: 39.50
+endstop_pin: !P1.28
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_z]
+step_pin: P0.22
+dir_pin: P2.11
+enable_pin: !P0.21
+microsteps: 16
+rotation_distance: 7.76
+endstop_pin: probe:z_virtual_endstop
+position_min: -5
+position_max: 300
+
+[extruder]
+step_pin: P2.13
+dir_pin: !P0.11
+enable_pin: !P2.12
+microsteps: 16
+rotation_distance: 33.333
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: P2.7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P0.24
+#control: pid
+#pid_Kp: 22.2
+#pid_Ki: 1.08
+#pid_Kd: 114
+min_temp: 0
+max_temp: 250
+#pressure_advance: 0.44
+pressure_advance: 0.66
+
+[heater_bed]
+heater_pin: P2.5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P0.25
+#control: pid
+#pid_Kp: 54.027
+#pid_Ki: 0.770
+#pid_Kd: 948.182
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: P2.3
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_lpc1768_0180001102094AAF01A55E5DC52000F5-if00
+
+[printer]
+kinematics: cartesian
+max_velocity: 400
+max_accel: 1000
+max_z_velocity: 10
+max_z_accel: 100
+square_corner_velocity: 5.0
+
+[bltouch]
+sensor_pin: ^P0.10  # Pull-up (^ symbol) needed in open drain mode
+control_pin: P2.0
+x_offset: -1.5
+y_offset: -34
+z_offset: 1.5
+pin_move_time: 1
+
+[bed_mesh]
+speed: 250
+horizontal_move_z: 8
+mesh_min: 20,10
+mesh_max: 215,200
+probe_count: 5,5
+fade_start: 1.0
+fade_end: 10
+fade_target: 0
+mesh_pps: 2,2
+
+[safe_z_home]
+home_xy_position: 117,117
+speed: 80.0
+z_hop: 10.0
+z_hop_speed: 10.0
+
+[gcode_macro G29]
+gcode:
+    BED_MESH_CALIBRATE
+
+[input_shaper]
+shaper_freq_x: 36.3636
+shaper_freq_y: 66.3900
+shaper_type: mzv
+
+########################################
+# TMC2208 configuration
+########################################
+
+[tmc2208 stepper_x]
+uart_pin: P1.10
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2208 stepper_y]
+uart_pin: P1.9
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2208 stepper_z]
+uart_pin: P1.8
+run_current: 0.650
+hold_current: 0.450
+stealthchop_threshold: 30
+
+[tmc2208 extruder]
+uart_pin: P1.4
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 5
+
+########################################
+# EXP1 / EXP2 (display) pins
+########################################
+
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=P1.30, EXP1_3=P1.18, EXP1_5=P1.20, EXP1_7=P1.22, EXP1_9=<GND>,
+    EXP1_2=P0.28, EXP1_4=P1.19, EXP1_6=P1.21, EXP1_8=P1.23, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=P0.17, EXP2_3=P3.26, EXP2_5=P3.25, EXP2_7=P1.31, EXP2_9=<GND>,
+    EXP2_2=P0.15, EXP2_4=P0.16, EXP2_6=P0.18, EXP2_8=<RST>, EXP2_10=<NC>
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "ssp0"


### PR DESCRIPTION
used both configs on my Biqu B1, works perfectly