### PR TITLE
Fixes clk Init for STM32F401 boards w odd crystals, eg. 25Mhz

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -164,7 +164,7 @@ choice
     config STM32_CLOCK_REF_16M
         bool "16 MHz crystal"
     config STM32_CLOCK_REF_25M
-        bool "25 MHz crystal"    
+        bool "25 MHz crystal"
     config STM32_CLOCK_REF_INTERNAL
         bool "Internal clock"
 endchoice

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -116,7 +116,7 @@ config STACK_SIZE
     default 512
 
 choice
-    prompt "Bootloader offset" if MACH_STM32F207 || MACH_STM32F407 || MACH_STM32F405 || MACH_STM32F103 || MACH_STM32F070
+    prompt "Bootloader offset" if MACH_STM32F207 || MACH_STM32F407 || MACH_STM32F405 || MACH_STM32F103 || MACH_STM32F070 || MACH_STM32F401
     config STM32_FLASH_START_2000
         bool "8KiB bootloader (stm32duino)" if MACH_STM32F103 || MACH_STM32F070
     config STM32_FLASH_START_5000
@@ -133,7 +133,7 @@ choice
     config STM32_FLASH_START_8000
         bool "32KiB bootloader (SKR-PRO or TFT35-V3.0)" if MACH_STM32F207 || MACH_STM32F407
     config STM32_FLASH_START_4000
-        bool "16KiB bootloader (HID Bootloader)" if MACH_STM32F207 || MACH_STM32F405 || MACH_STM32F407
+        bool "16KiB bootloader (HID Bootloader)" if MACH_STM32F207 || MACH_STM32F405 || MACH_STM32F407 || MACH_STM32F401
 
     config STM32_FLASH_START_0000
         bool "No bootloader"
@@ -163,11 +163,14 @@ choice
         bool "12 MHz crystal"
     config STM32_CLOCK_REF_16M
         bool "16 MHz crystal"
+    config STM32_CLOCK_REF_25M
+        bool "25 MHz crystal"    
     config STM32_CLOCK_REF_INTERNAL
         bool "Internal clock"
 endchoice
 config CLOCK_REF_FREQ
     int
+    default 25000000 if STM32_CLOCK_REF_25M
     default 16000000 if STM32_CLOCK_REF_16M
     default 12000000 if STM32_CLOCK_REF_12M
     default 1 if STM32_CLOCK_REF_INTERNAL

--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -151,11 +151,13 @@ enable_clock_stm32f40x(void)
 #if CONFIG_MACH_STM32F405 || CONFIG_MACH_STM32F407 || CONFIG_MACH_STM32F401
 
 #if CONFIG_MACH_STM32F405 || CONFIG_MACH_STM32F407
-    uint32_t pll_base = 2000000, pll_freq = CONFIG_CLOCK_FREQ * 2, pllcfgr, pll_p_clk_divisor = 0x0; 
+    uint32_t pll_base = 2000000, pll_freq = CONFIG_CLOCK_FREQ * 2, pllcfgr;
+    uint32_t pll_p_clk_divisor = 0x0;
 #endif
 
 #if  CONFIG_MACH_STM32F401
-    uint32_t pll_base = 1000000, pll_freq = CONFIG_CLOCK_FREQ * 4, pllcfgr, pll_p_clk_divisor = 0x1;
+    uint32_t pll_base = 1000000, pll_freq = CONFIG_CLOCK_FREQ * 4, pllcfgr;
+    uint32_t pll_p_clk_divisor = 0x1;
 #endif
 
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {


### PR DESCRIPTION
Previous clock initialization used 2Mhz as the PLL base freq.
This would mean that for an ODD crystal such as 25MHZ the
PLL_M divisor would be calculated as 12 (from 12.5).
This sets the PLL base freq to 1M allowing proper divison.
In addition fixes the following for STM32F401--
- Changes pll_freq to CONFIG_CLOCK_FREQ * 4
- Adds a 25Mhz crystal option to the KConfig
- Changes FREQ_PREIPH to CONFIG_CLOCK / 2

Why?
- STM32F401 is capped at 84Mhz and peripheral clock
can go upto 42Mhz
- There are many board designs out there that
(for some reason) use 25Mhz, this would avoid
undue frustration for folks who design their boards
based of those designs. 

Clock initialization for stm32f405 and stm32f407 (and other mcus) 
is not affected.  I don't want to touch something I have no way of testing.