### PR TITLE
module: Function_Macro, new function adds ability to execute macro fr…

### DIFF
--- a/klippy/extras/function_macro.py
+++ b/klippy/extras/function_macro.py
@@ -3,50 +3,21 @@
 # Copyright (C) 2021  Stefan Verse <verse@amotronics.de>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import traceback, logging, ast, copy
-import jinja2
+import logging
 
-# Wrapper around a Jinja2 template
-class TemplateWrapper:
-    def __init__(self, printer, env, name, script):
-        self.printer = printer
-        self.name = name
-#        function_macro = self.printer.lookup_object('function_macro')
-        try:
-            self.template = env.from_string(script)
-        except Exception as e:
-            msg = "Error loading template '%s': %s" % (
-                 name, traceback.format_exception_only(type(e), e)[-1])
-            logging.exception(msg)
-            raise printer.config_error(msg)
-
-# Main function macro template tracking
 class PrinterFunctionMacro:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.gcode = self.printer.lookup_object('gcode')
-        self.env = jinja2.Environment('{%', '%}', '{', '}')
-        self.scripts = []
-        self.names = []
-    def load_template(self, config, option, default=None, function_name=None):
-        name = "%s:%s" % (config.get_name(), option)
+        self.macro = self.printer.load_object(config, 'macro_list')
+    def load_config(self, config, option, default=None, function_name=None):
         if default is None:
             script = config.get(option)
         else:
             script = config.get(option, default)
-        self.scripts.append(script)
-        self.names.append(function_name)
-        return TemplateWrapper(self.printer, self.env, name, script)
-    def run_macro_from_name(self, function_name):
-        try:
-            index=self.names.index(function_name.upper())
-            self.gcode.run_script_from_command(self.scripts[index].strip())
-        except:
-            return
+        self.macro.add_script(script, function_name)
 
 def load_config(config):
     return PrinterFunctionMacro(config)
-
 
 ######################################################################
 # FUNCTION_MACRO printer object
@@ -58,7 +29,8 @@ class FUNCTION_MACRO:
         self.alias = name.upper()
         self.printer = printer = config.get_printer()
         function_macro = printer.load_object(config, 'function_macro')
-        self.template = function_macro.load_template(config, 'macro',
-                                                     function_name=name.upper())
+        function_macro.load_config(config, 'macro', function_name=name.upper())
+
 def load_config_prefix(config):
     return FUNCTION_MACRO(config)
+

--- a/klippy/extras/function_macro.py
+++ b/klippy/extras/function_macro.py
@@ -1,0 +1,74 @@
+# Add ability to define custom macros mapped to functions
+#
+# Copyright (C) 2021  Stefan Verse <verse@amotronics.de>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback, logging, ast, copy
+import jinja2
+
+# Wrapper around a Jinja2 template
+class TemplateWrapper:
+    def __init__(self, printer, env, name, script):
+        self.printer = printer
+        self.name = name
+#        function_macro = self.printer.lookup_object('function_macro')
+        try:
+            self.template = env.from_string(script)
+        except Exception as e:
+            msg = "Error loading template '%s': %s" % (
+                 name, traceback.format_exception_only(type(e), e)[-1])
+            logging.exception(msg)
+            raise printer.config_error(msg)
+
+# Main function macro template tracking
+class PrinterFunctionMacro:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.env = jinja2.Environment('{%', '%}', '{', '}')
+	self.scripts = []
+	self.names = []
+    def load_template(self, config, option, default=None, function_name=None):
+        name = "%s:%s" % (config.get_name(), option)
+        if default is None:
+            script = config.get(option)
+        else:
+            script = config.get(option, default)
+        self.scripts.append(script)
+        self.names.append(function_name)
+#        for name in self.names:
+#            msg = "Error PrinterFunctionMacro: loading template '%s':'%s'" %(name,script,)
+#            logging.exception(msg)
+        return TemplateWrapper(self.printer, self.env, name, script)
+    def run_macro_from_name(self, function_name):
+        try:
+	    index=self.names.index(function_name.upper())
+#            msg = "Error PrinterFunctionMacro: enter run_macro_from_name %d '%s'" %(index, self.scripts[index],)
+#            logging.exception(msg)
+#            commands = self.scripts[index].split('\n')
+#            for line in commands:
+#                msg = "Error PrinterFunctionMacro: enter run_script_split '%s'" %(line,)
+#                logging.exception(msg)
+#            self.gcode.run_script_from_command(str(self.scripts[index]))
+            self.gcode.run_script_from_command(self.scripts[index].strip())
+        except:
+	    return
+
+def load_config(config):
+    return PrinterFunctionMacro(config)
+
+
+######################################################################
+# FUNCTION_MACRO printer object
+######################################################################
+
+class FUNCTION_MACRO:
+    def __init__(self, config):
+        name = config.get_name().split()[1]
+        self.alias = name.upper()
+        self.printer = printer = config.get_printer()
+        function_macro = printer.load_object(config, 'function_macro')
+        self.template = function_macro.load_template(config, 'macro', function_name=name.upper())
+
+def load_config_prefix(config):
+    return FUNCTION_MACRO(config)

--- a/klippy/extras/function_macro.py
+++ b/klippy/extras/function_macro.py
@@ -33,4 +33,3 @@ class FUNCTION_MACRO:
 
 def load_config_prefix(config):
     return FUNCTION_MACRO(config)
-

--- a/klippy/extras/function_macro.py
+++ b/klippy/extras/function_macro.py
@@ -58,7 +58,7 @@ class FUNCTION_MACRO:
         self.alias = name.upper()
         self.printer = printer = config.get_printer()
         function_macro = printer.load_object(config, 'function_macro')
-        self.template = function_macro.load_template(config, 'macro', 
+        self.template = function_macro.load_template(config, 'macro',
                                                      function_name=name.upper())
 def load_config_prefix(config):
     return FUNCTION_MACRO(config)

--- a/klippy/extras/function_macro.py
+++ b/klippy/extras/function_macro.py
@@ -58,7 +58,7 @@ class FUNCTION_MACRO:
         self.alias = name.upper()
         self.printer = printer = config.get_printer()
         function_macro = printer.load_object(config, 'function_macro')
-        self.template = function_macro.load_template(config, 'macro', function_name=name.upper())
-
+        self.template = function_macro.load_template(config, 'macro', 
+                                                     function_name=name.upper())
 def load_config_prefix(config):
     return FUNCTION_MACRO(config)

--- a/klippy/extras/function_macro.py
+++ b/klippy/extras/function_macro.py
@@ -26,8 +26,8 @@ class PrinterFunctionMacro:
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
         self.env = jinja2.Environment('{%', '%}', '{', '}')
-	self.scripts = []
-	self.names = []
+        self.scripts = []
+        self.names = []
     def load_template(self, config, option, default=None, function_name=None):
         name = "%s:%s" % (config.get_name(), option)
         if default is None:
@@ -36,23 +36,13 @@ class PrinterFunctionMacro:
             script = config.get(option, default)
         self.scripts.append(script)
         self.names.append(function_name)
-#        for name in self.names:
-#            msg = "Error PrinterFunctionMacro: loading template '%s':'%s'" %(name,script,)
-#            logging.exception(msg)
         return TemplateWrapper(self.printer, self.env, name, script)
     def run_macro_from_name(self, function_name):
         try:
-	    index=self.names.index(function_name.upper())
-#            msg = "Error PrinterFunctionMacro: enter run_macro_from_name %d '%s'" %(index, self.scripts[index],)
-#            logging.exception(msg)
-#            commands = self.scripts[index].split('\n')
-#            for line in commands:
-#                msg = "Error PrinterFunctionMacro: enter run_script_split '%s'" %(line,)
-#                logging.exception(msg)
-#            self.gcode.run_script_from_command(str(self.scripts[index]))
+            index=self.names.index(function_name.upper())
             self.gcode.run_script_from_command(self.scripts[index].strip())
         except:
-	    return
+            return
 
 def load_config(config):
     return PrinterFunctionMacro(config)

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -232,7 +232,6 @@ class PrinterHeaters:
         self.sensor_factories = {}
         self.heaters = {}
         self.gcode_id_to_sensor = {}
-        self.gcode_id_to_name = {}
         self.available_heaters = []
         self.available_sensors = []
         self.has_started = False
@@ -256,7 +255,7 @@ class PrinterHeaters:
         sensor = self.setup_sensor(config)
         # Create heater
         self.heaters[heater_name] = heater = Heater(config, sensor, heater_name)
-        self.register_sensor(config, heater, heater_name, gcode_id)
+        self.register_sensor(config, heater, gcode_id)
         self.available_heaters.append(config.get_name())
         return heater
     def get_all_heaters(self):
@@ -278,7 +277,7 @@ class PrinterHeaters:
             raise self.printer.config_error(
                 "Unknown temperature sensor '%s'" % (sensor_type,))
         return self.sensor_factories[sensor_type](config)
-    def register_sensor(self, config, psensor, name, gcode_id=None):
+    def register_sensor(self, config, psensor, gcode_id=None):
         self.available_sensors.append(config.get_name())
         if gcode_id is None:
             gcode_id = config.get('gcode_id', None)
@@ -288,7 +287,6 @@ class PrinterHeaters:
             raise self.printer.config_error(
                 "G-Code sensor id %s already registered" % (gcode_id,))
         self.gcode_id_to_sensor[gcode_id] = psensor
-        self.gcode_id_to_name[gcode_id] = name
     def get_status(self, eventtime):
         return {'available_heaters': self.available_heaters,
                 'available_sensors': self.available_sensors}

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging, threading, traceback
+import logging, threading
 
 
 ######################################################################
@@ -171,8 +171,8 @@ class ControlBangBang:
 # Proportional Integral Derivative (PID) control algo
 ######################################################################
 
-PID_SETTLE_DELTA = 1.5
-PID_SETTLE_SLOPE = .25
+PID_SETTLE_DELTA = 1.
+PID_SETTLE_SLOPE = .1
 
 class ControlPID:
     def __init__(self, heater, config):
@@ -269,7 +269,8 @@ class PrinterHeaters:
     def setup_sensor(self, config):
         modules = ["thermistor", "adc_temperature", "spi_temperature",
                    "bme280", "htu21d", "lm75", "rpi_temperature",
-                   "temperature_mcu"]
+                   "temperature_mcu", "ds18b20"]
+
         for module_name in modules:
             self.printer.load_object(config, module_name)
         sensor_type = config.get('sensor_type')

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging, threading
+import logging, threading, traceback
 
 
 ######################################################################
@@ -16,9 +16,10 @@ AMBIENT_TEMP = 25.
 PID_PARAM_BASE = 255.
 
 class Heater:
-    def __init__(self, config, sensor):
+    def __init__(self, config, sensor, heater_name):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[-1]
+        self.heater_name = heater_name
         # Setup sensor
         self.sensor = sensor
         self.min_temp = config.getfloat('min_temp', minval=KELVIN_TO_CELSIUS)
@@ -85,6 +86,7 @@ class Heater:
             adj_time = min(time_diff * self.inv_smooth_time, 1.)
             self.smoothed_temp += temp_diff * adj_time
             self.can_extrude = (self.smoothed_temp >= self.min_extrude_temp)
+        self.printer.lookup_object('function_macro').run_macro_from_name(self.heater_name+'_temp')
         #logging.debug("temp: %.3f %f = %f", read_time, temp)
     # External commands
     def get_pwm_delay(self):
@@ -168,8 +170,8 @@ class ControlBangBang:
 # Proportional Integral Derivative (PID) control algo
 ######################################################################
 
-PID_SETTLE_DELTA = 1.
-PID_SETTLE_SLOPE = .1
+PID_SETTLE_DELTA = 1.5
+PID_SETTLE_SLOPE = .25
 
 class ControlPID:
     def __init__(self, heater, config):
@@ -178,6 +180,12 @@ class ControlPID:
         self.Kp = config.getfloat('pid_Kp') / PID_PARAM_BASE
         self.Ki = config.getfloat('pid_Ki') / PID_PARAM_BASE
         self.Kd = config.getfloat('pid_Kd') / PID_PARAM_BASE
+        self.Kd_pos = config.getfloat('pid_Kd_pos', 0.) / PID_PARAM_BASE
+        self.Kd_neg = config.getfloat('pid_Kd_neg', 0.) / PID_PARAM_BASE
+        if not self.Kd_pos:
+            self.Kd_pos = self.Kd
+        if not self.Kd_neg:
+            self.Kd_neg = self.Kd
         self.min_deriv_time = heater.get_smooth_time()
         imax = config.getfloat('pid_integral_max', self.heater_max_power,
                                minval=0.)
@@ -202,7 +210,10 @@ class ControlPID:
         temp_integ = self.prev_temp_integ + temp_err * time_diff
         temp_integ = max(0., min(self.temp_integ_max, temp_integ))
         # Calculate output
-        co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd*temp_deriv
+        if temp_deriv>=0:
+            co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd_pos*temp_deriv
+        else:
+            co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd_neg*temp_deriv
         #logging.debug("pid: %f@%.3f -> diff=%f deriv=%f err=%f integ=%f co=%d",
         #    temp, read_time, temp_diff, temp_deriv, temp_err, temp_integ, co)
         bounded_co = max(0., min(self.heater_max_power, co))
@@ -229,6 +240,7 @@ class PrinterHeaters:
         self.sensor_factories = {}
         self.heaters = {}
         self.gcode_id_to_sensor = {}
+        self.gcode_id_to_name = {}
         self.available_heaters = []
         self.available_sensors = []
         self.has_started = False
@@ -251,8 +263,8 @@ class PrinterHeaters:
         # Setup sensor
         sensor = self.setup_sensor(config)
         # Create heater
-        self.heaters[heater_name] = heater = Heater(config, sensor)
-        self.register_sensor(config, heater, gcode_id)
+        self.heaters[heater_name] = heater = Heater(config, sensor, heater_name)
+        self.register_sensor(config, heater, heater_name, gcode_id)
         self.available_heaters.append(config.get_name())
         return heater
     def get_all_heaters(self):
@@ -265,8 +277,7 @@ class PrinterHeaters:
     def setup_sensor(self, config):
         modules = ["thermistor", "adc_temperature", "spi_temperature",
                    "bme280", "htu21d", "lm75", "rpi_temperature",
-                   "temperature_mcu", "ds18b20"]
-
+                   "temperature_mcu"]
         for module_name in modules:
             self.printer.load_object(config, module_name)
         sensor_type = config.get('sensor_type')
@@ -274,7 +285,7 @@ class PrinterHeaters:
             raise self.printer.config_error(
                 "Unknown temperature sensor '%s'" % (sensor_type,))
         return self.sensor_factories[sensor_type](config)
-    def register_sensor(self, config, psensor, gcode_id=None):
+    def register_sensor(self, config, psensor, name, gcode_id=None):
         self.available_sensors.append(config.get_name())
         if gcode_id is None:
             gcode_id = config.get('gcode_id', None)
@@ -284,6 +295,7 @@ class PrinterHeaters:
             raise self.printer.config_error(
                 "G-Code sensor id %s already registered" % (gcode_id,))
         self.gcode_id_to_sensor[gcode_id] = psensor
+        self.gcode_id_to_name[gcode_id] = name
     def get_status(self, eventtime):
         return {'available_heaters': self.available_heaters,
                 'available_sensors': self.available_sensors}

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -62,7 +62,7 @@ class Heater:
         gcode.register_mux_command("SET_HEATER_TEMPERATURE", "HEATER",
                                    self.name, self.cmd_SET_HEATER_TEMPERATURE,
                                    desc=self.cmd_SET_HEATER_TEMPERATURE_help)
-        self.macro = self.printer.lookup_object('function_macro')
+        self.macro = self.printer.lookup_object('macro_list')
     def set_pwm(self, read_time, value):
         if self.target_temp <= 0.:
             value = 0.
@@ -87,7 +87,8 @@ class Heater:
             adj_time = min(time_diff * self.inv_smooth_time, 1.)
             self.smoothed_temp += temp_diff * adj_time
             self.can_extrude = (self.smoothed_temp >= self.min_extrude_temp)
-        self.macro.run_macro_from_name(self.heater_name+'_temp')
+        if self.macro:
+            self.macro.run_macro_from_name(self.heater_name+'_temp')
         #logging.debug("temp: %.3f %f = %f", read_time, temp)
     # External commands
     def get_pwm_delay(self):
@@ -268,7 +269,7 @@ class PrinterHeaters:
     def setup_sensor(self, config):
         modules = ["thermistor", "adc_temperature", "spi_temperature",
                    "bme280", "htu21d", "lm75", "rpi_temperature",
-                   "temperature_mcu", "ds18b20"]
+                   "temperature_mcu"]
 
         for module_name in modules:
             self.printer.load_object(config, module_name)

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -62,7 +62,7 @@ class Heater:
         gcode.register_mux_command("SET_HEATER_TEMPERATURE", "HEATER",
                                    self.name, self.cmd_SET_HEATER_TEMPERATURE,
                                    desc=self.cmd_SET_HEATER_TEMPERATURE_help)
-        self.function_macro = self.printer.lookup_object('function_macro')
+        self.macro = self.printer.lookup_object('function_macro')
     def set_pwm(self, read_time, value):
         if self.target_temp <= 0.:
             value = 0.
@@ -87,7 +87,7 @@ class Heater:
             adj_time = min(time_diff * self.inv_smooth_time, 1.)
             self.smoothed_temp += temp_diff * adj_time
             self.can_extrude = (self.smoothed_temp >= self.min_extrude_temp)
-        self.function_macro.run_macro_from_name(self.heater_name+'_temp')
+        self.macro.run_macro_from_name(self.heater_name+'_temp')
         #logging.debug("temp: %.3f %f = %f", read_time, temp)
     # External commands
     def get_pwm_delay(self):

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -269,7 +269,7 @@ class PrinterHeaters:
     def setup_sensor(self, config):
         modules = ["thermistor", "adc_temperature", "spi_temperature",
                    "bme280", "htu21d", "lm75", "rpi_temperature",
-                   "temperature_mcu"]
+                   "temperature_mcu", "ds18b20"]
 
         for module_name in modules:
             self.printer.load_object(config, module_name)

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -6,7 +6,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, gc, optparse, logging, time, collections, importlib
 import util, reactor, queuelogger, msgproto
-import gcode, configfile, pins, mcu, toolhead, webhooks
+import gcode, configfile, pins, mcu, toolhead, webhooks, macro_list
 
 message_ready = "Printer is ready"
 
@@ -59,7 +59,7 @@ class Printer:
         self.event_handlers = {}
         self.objects = collections.OrderedDict()
         # Init printer components that must be setup prior to config
-        for m in [gcode, webhooks]:
+        for m in [gcode, webhooks, macro_list]:
             m.add_early_printer_objects(self)
     def get_start_args(self):
         return self.start_args

--- a/klippy/macro_list.py
+++ b/klippy/macro_list.py
@@ -12,15 +12,15 @@ class MACRO_LIST:
         self.scripts = []
         self.names = []
         self.names_possible = []
-        self.gcode.register_command("FUNCTION_MACRO_DEFINED", 
+        self.gcode.register_command("FUNCTION_MACRO_DEFINED",
              self.cmd_FUNCTION_MACRO_DEFINED,
              desc=self.cmd_FUNCTION_MACRO_DEFINED_help)
-        self.gcode.register_command("FUNCTION_MACRO_AVAILABLE", 
+        self.gcode.register_command("FUNCTION_MACRO_AVAILABLE",
              self.cmd_FUNCTION_MACRO_AVAILABLE,
              desc=self.cmd_FUNCTION_MACRO_AVAILABLE_help)
     def register_function(self, function_name):
         self.names_possible.append(function_name.upper())
-	return function_name.upper()
+        return function_name.upper()
     def add_script(self, script, function_name):
         self.scripts.append(script)
         self.names.append(function_name.upper())
@@ -38,12 +38,14 @@ class MACRO_LIST:
     def run_macro_from_name(self, function_name):
         index = self.get_index_from_name(function_name)
         self.run_macro_from_index(index)
-    cmd_FUNCTION_MACRO_DEFINED_help = "Show list of registered function_macro names"
+    cmd_FUNCTION_MACRO_DEFINED_help = \
+        "Show list of registered function_macro names"
     def cmd_FUNCTION_MACRO_DEFINED(self, gcmd):
         for name in self.names:
 #            self.gcode.respond_info("function_macro '%s'" % (name))
             self.gcode.respond_info(name)
-    cmd_FUNCTION_MACRO_AVAILABLE_help = "Show list of available function_macro names"
+    cmd_FUNCTION_MACRO_AVAILABLE_help = \
+        "Show list of available function_macro names"
     def cmd_FUNCTION_MACRO_AVAILABLE(self, gcmd):
         for name in self.names_possible :
 #            self.gcode.respond_info("function_macro '%s'" % (name))

--- a/klippy/macro_list.py
+++ b/klippy/macro_list.py
@@ -11,6 +11,16 @@ class MACRO_LIST:
         self.gcode = self.printer.lookup_object('gcode')
         self.scripts = []
         self.names = []
+        self.names_possible = []
+        self.gcode.register_command("FUNCTION_MACRO_DEFINED", 
+             self.cmd_FUNCTION_MACRO_DEFINED,
+             desc=self.cmd_FUNCTION_MACRO_DEFINED_help)
+        self.gcode.register_command("FUNCTION_MACRO_AVAILABLE", 
+             self.cmd_FUNCTION_MACRO_AVAILABLE,
+             desc=self.cmd_FUNCTION_MACRO_AVAILABLE_help)
+    def register_function(self, function_name):
+        self.names_possible.append(function_name.upper())
+	return function_name.upper()
     def add_script(self, script, function_name):
         self.scripts.append(script)
         self.names.append(function_name.upper())
@@ -28,6 +38,16 @@ class MACRO_LIST:
     def run_macro_from_name(self, function_name):
         index = self.get_index_from_name(function_name)
         self.run_macro_from_index(index)
+    cmd_FUNCTION_MACRO_DEFINED_help = "Show list of registered function_macro names"
+    def cmd_FUNCTION_MACRO_DEFINED(self, gcmd):
+        for name in self.names:
+#            self.gcode.respond_info("function_macro '%s'" % (name))
+            self.gcode.respond_info(name)
+    cmd_FUNCTION_MACRO_AVAILABLE_help = "Show list of available function_macro names"
+    def cmd_FUNCTION_MACRO_AVAILABLE(self, gcmd):
+        for name in self.names_possible :
+#            self.gcode.respond_info("function_macro '%s'" % (name))
+            self.gcode.respond_info(name)
 
 def add_early_printer_objects(printer):
     printer.add_object('macro_list',MACRO_LIST(printer))

--- a/klippy/macro_list.py
+++ b/klippy/macro_list.py
@@ -1,0 +1,33 @@
+# Add ability to define custom macros mapped to functions
+#
+# Copyright (C) 2021  Stefan Verse <verse@amotronics.de>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+
+class MACRO_LIST:
+    def __init__(self, printer):
+        self.printer = printer
+        self.gcode = self.printer.lookup_object('gcode')
+        self.scripts = []
+        self.names = []
+    def add_script(self, script, function_name):
+        self.scripts.append(script)
+        self.names.append(function_name.upper())
+    def get_index_from_name(self, function_name):
+        try:
+            return self.names.index(function_name.upper())
+        except:
+            return None
+    def run_macro_from_index(self, index):
+        if index != None:
+            try:
+                self.gcode.run_script_from_command(self.scripts[index].strip())
+            except:
+                return
+    def run_macro_from_name(self, function_name):
+        index = self.get_index_from_name(function_name)
+        self.run_macro_from_index(index)
+
+def add_early_printer_objects(printer):
+    printer.add_object('macro_list',MACRO_LIST(printer))

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -24,7 +24,7 @@ class MCU_endstop:
         self._next_query_print_time = self._end_home_time = 0.
         self._trigger_completion = self._home_completion = None
         self._old_value = None
-        self._function_macro = self._mcu._printer.lookup_object('function_macro')
+        self._macro = self._mcu._printer.lookup_object('function_macro')
     def get_mcu(self):
         return self._mcu
     def add_stepper(self, stepper):
@@ -61,7 +61,7 @@ class MCU_endstop:
                    triggered=True):
         clock = self._mcu.print_time_to_clock(print_time)
         rest_ticks = self._mcu.print_time_to_clock(print_time+rest_time) - clock
-        self._function_macro.run_macro_from_name(self._pin+'_home_start')
+        self._macro.run_macro_from_name(self._pin+'_home_start')
         self._next_query_print_time = print_time + self.RETRY_QUERY
         self._min_query_time = self._reactor.monotonic()
         self._last_sent_time = 0.
@@ -91,12 +91,12 @@ class MCU_endstop:
             did_trigger = self._trigger_completion.wait(eventtime + 0.100)
             if did_trigger is not None:
                 # Homing completed successfully
-                self._function_macro.run_macro_from_name(self._pin+'_home_finish')
+                self._macro.run_macro_from_name(self._pin+'_home_finish')
                 return True
             # Check for timeout
             last = self._mcu.estimated_print_time(self._last_sent_time)
             if last > self._home_end_time or self._mcu.is_shutdown():
-                self._function_macro.run_macro_from_name(self._pin+'_home_fail')
+                self._macro.run_macro_from_name(self._pin+'_home_fail')
                 return False
             # Check for resend
             eventtime = self._reactor.monotonic()
@@ -114,7 +114,7 @@ class MCU_endstop:
         if not self._trigger_completion.test():
             self._trigger_completion.complete(False)
         if did_trigger:
-            self._function_macro.run_macro_from_name(self._pin+'_home_finish')
+            self._macro.run_macro_from_name(self._pin+'_home_finish')
         return did_trigger
     def query_endstop(self, print_time):
         clock = self._mcu.print_time_to_clock(print_time)
@@ -122,11 +122,11 @@ class MCU_endstop:
             return 0
         params = self._query_cmd.send([self._oid], minclock=clock)
         if self._old_value != params['pin_value']:
-            self._function_macro.run_macro_from_name(self._pin+'_change')
+            self._macro.run_macro_from_name(self._pin+'_change')
             if (params['pin_value'] ^ self._invert):
-                self._function_macro.run_macro_from_name(self._pin+'_close')
+                self._macro.run_macro_from_name(self._pin+'_close')
             else:
-                self._function_macro.run_macro_from_name(self._pin+'_open')
+                self._macro.run_macro_from_name(self._pin+'_open')
         self._old_value = params['pin_value']
         return params['pin_value'] ^ self._invert
 

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -24,7 +24,7 @@ class MCU_endstop:
         self._next_query_print_time = self._end_home_time = 0.
         self._trigger_completion = self._home_completion = None
         self._old_value = None
-        self._macro = self._mcu._printer.lookup_object('function_macro')
+        self._macro = self._mcu._printer.lookup_object('macro_list')
     def get_mcu(self):
         return self._mcu
     def add_stepper(self, stepper):
@@ -61,7 +61,8 @@ class MCU_endstop:
                    triggered=True):
         clock = self._mcu.print_time_to_clock(print_time)
         rest_ticks = self._mcu.print_time_to_clock(print_time+rest_time) - clock
-        self._macro.run_macro_from_name(self._pin+'_home_start')
+        if self._macro:
+            self._macro.run_macro_from_name(self._pin+'_home_start')
         self._next_query_print_time = print_time + self.RETRY_QUERY
         self._min_query_time = self._reactor.monotonic()
         self._last_sent_time = 0.
@@ -91,12 +92,14 @@ class MCU_endstop:
             did_trigger = self._trigger_completion.wait(eventtime + 0.100)
             if did_trigger is not None:
                 # Homing completed successfully
-                self._macro.run_macro_from_name(self._pin+'_home_finish')
+                if self._macro:
+                    self._macro.run_macro_from_name(self._pin+'_home_finish')
                 return True
             # Check for timeout
             last = self._mcu.estimated_print_time(self._last_sent_time)
             if last > self._home_end_time or self._mcu.is_shutdown():
-                self._macro.run_macro_from_name(self._pin+'_home_fail')
+                if self._macro:
+                    self._macro.run_macro_from_name(self._pin+'_home_fail')
                 return False
             # Check for resend
             eventtime = self._reactor.monotonic()
@@ -114,7 +117,8 @@ class MCU_endstop:
         if not self._trigger_completion.test():
             self._trigger_completion.complete(False)
         if did_trigger:
-            self._macro.run_macro_from_name(self._pin+'_home_finish')
+            if self._macro:
+                self._macro.run_macro_from_name(self._pin+'_home_finish')
         return did_trigger
     def query_endstop(self, print_time):
         clock = self._mcu.print_time_to_clock(print_time)
@@ -122,11 +126,14 @@ class MCU_endstop:
             return 0
         params = self._query_cmd.send([self._oid], minclock=clock)
         if self._old_value != params['pin_value']:
-            self._macro.run_macro_from_name(self._pin+'_change')
+            if self._macro:
+                self._macro.run_macro_from_name(self._pin+'_change')
             if (params['pin_value'] ^ self._invert):
-                self._macro.run_macro_from_name(self._pin+'_close')
+                if self._macro:
+                    self._macro.run_macro_from_name(self._pin+'_close')
             else:
-                self._macro.run_macro_from_name(self._pin+'_open')
+                if self._macro:
+                    self._macro.run_macro_from_name(self._pin+'_open')
         self._old_value = params['pin_value']
         return params['pin_value'] ^ self._invert
 

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -24,6 +24,7 @@ class MCU_endstop:
         self._next_query_print_time = self._end_home_time = 0.
         self._trigger_completion = self._home_completion = None
         self._old_value = None
+        self._function_macro = self._mcu._printer.lookup_object('function_macro')
     def get_mcu(self):
         return self._mcu
     def add_stepper(self, stepper):
@@ -60,7 +61,7 @@ class MCU_endstop:
                    triggered=True):
         clock = self._mcu.print_time_to_clock(print_time)
         rest_ticks = self._mcu.print_time_to_clock(print_time+rest_time) - clock
-        self._mcu._printer.lookup_object('function_macro').run_macro_from_name(self._pin+'_home_start')
+        self._function_macro.run_macro_from_name(self._pin+'_home_start')
         self._next_query_print_time = print_time + self.RETRY_QUERY
         self._min_query_time = self._reactor.monotonic()
         self._last_sent_time = 0.
@@ -90,12 +91,12 @@ class MCU_endstop:
             did_trigger = self._trigger_completion.wait(eventtime + 0.100)
             if did_trigger is not None:
                 # Homing completed successfully
-                self._mcu._printer.lookup_object('function_macro').run_macro_from_name(self._pin+'_home_finish')
+                self._function_macro.run_macro_from_name(self._pin+'_home_finish')
                 return True
             # Check for timeout
             last = self._mcu.estimated_print_time(self._last_sent_time)
             if last > self._home_end_time or self._mcu.is_shutdown():
-                self._mcu._printer.lookup_object('function_macro').run_macro_from_name(self._pin+'_home_fail')
+                self._function_macro.run_macro_from_name(self._pin+'_home_fail')
                 return False
             # Check for resend
             eventtime = self._reactor.monotonic()
@@ -113,7 +114,7 @@ class MCU_endstop:
         if not self._trigger_completion.test():
             self._trigger_completion.complete(False)
         if did_trigger:
-            self._mcu._printer.lookup_object('function_macro').run_macro_from_name(self._pin+'_home_finish')
+            self._function_macro.run_macro_from_name(self._pin+'_home_finish')
         return did_trigger
     def query_endstop(self, print_time):
         clock = self._mcu.print_time_to_clock(print_time)
@@ -121,11 +122,11 @@ class MCU_endstop:
             return 0
         params = self._query_cmd.send([self._oid], minclock=clock)
         if self._old_value != params['pin_value']:
-            self._mcu._printer.lookup_object('function_macro').run_macro_from_name(self._pin+'_change')
+            self._function_macro.run_macro_from_name(self._pin+'_change')
             if (params['pin_value'] ^ self._invert):
-                self._mcu._printer.lookup_object('function_macro').run_macro_from_name(self._pin+'_close')
+                self._function_macro.run_macro_from_name(self._pin+'_close')
             else:
-                self._mcu._printer.lookup_object('function_macro').run_macro_from_name(self._pin+'_open')
+                self._function_macro.run_macro_from_name(self._pin+'_open')
         self._old_value = params['pin_value']
         return params['pin_value'] ^ self._invert
 

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -25,6 +25,18 @@ class MCU_endstop:
         self._trigger_completion = self._home_completion = None
         self._old_value = None
         self._macro = self._mcu._printer.lookup_object('macro_list')
+        self._endstop_home_start = self._macro.register_function(
+                           "endstop_"+self._pin+'_home_start')
+        self._endstop_home_finish = self._macro.register_function(
+                           "endstop_"+self._pin+'_home_finish')
+        self._endstop_home_fail = self._macro.register_function(
+                           "endstop_"+self._pin+'_home_fail')
+        self._endstop_change = self._macro.register_function(
+                           "endstop_"+self._pin+'_change')
+        self._endstop_close = self._macro.register_function(
+                           "endstop_"+self._pin+'_close')
+        self._endstop_open = self._macro.register_function(
+                           "endstop_"+self._pin+'_open')
     def get_mcu(self):
         return self._mcu
     def add_stepper(self, stepper):
@@ -61,8 +73,7 @@ class MCU_endstop:
                    triggered=True):
         clock = self._mcu.print_time_to_clock(print_time)
         rest_ticks = self._mcu.print_time_to_clock(print_time+rest_time) - clock
-        if self._macro:
-            self._macro.run_macro_from_name(self._pin+'_home_start')
+        self._macro.run_macro_from_name(self._endstop_home_start)
         self._next_query_print_time = print_time + self.RETRY_QUERY
         self._min_query_time = self._reactor.monotonic()
         self._last_sent_time = 0.
@@ -92,14 +103,12 @@ class MCU_endstop:
             did_trigger = self._trigger_completion.wait(eventtime + 0.100)
             if did_trigger is not None:
                 # Homing completed successfully
-                if self._macro:
-                    self._macro.run_macro_from_name(self._pin+'_home_finish')
+                self._macro.run_macro_from_name(self._endstop_home_finish)
                 return True
             # Check for timeout
             last = self._mcu.estimated_print_time(self._last_sent_time)
             if last > self._home_end_time or self._mcu.is_shutdown():
-                if self._macro:
-                    self._macro.run_macro_from_name(self._pin+'_home_fail')
+                self._macro.run_macro_from_name(self._endstop_home_fail)
                 return False
             # Check for resend
             eventtime = self._reactor.monotonic()
@@ -117,8 +126,7 @@ class MCU_endstop:
         if not self._trigger_completion.test():
             self._trigger_completion.complete(False)
         if did_trigger:
-            if self._macro:
-                self._macro.run_macro_from_name(self._pin+'_home_finish')
+            self._macro.run_macro_from_name(self._endstop_home_finish)
         return did_trigger
     def query_endstop(self, print_time):
         clock = self._mcu.print_time_to_clock(print_time)
@@ -126,14 +134,11 @@ class MCU_endstop:
             return 0
         params = self._query_cmd.send([self._oid], minclock=clock)
         if self._old_value != params['pin_value']:
-            if self._macro:
-                self._macro.run_macro_from_name(self._pin+'_change')
+            self._macro.run_macro_from_name(self._endstop_change)
             if (params['pin_value'] ^ self._invert):
-                if self._macro:
-                    self._macro.run_macro_from_name(self._pin+'_close')
+                self._macro.run_macro_from_name(self._endstop_close)
             else:
-                if self._macro:
-                    self._macro.run_macro_from_name(self._pin+'_open')
+                self._macro.run_macro_from_name(self._endstop_open)
         self._old_value = params['pin_value']
         return params['pin_value'] ^ self._invert
 


### PR DESCRIPTION
…om functions by name

function macro is a printer-object that builds lists of macros together with their names from config.
theese macros can be called out of functions just by their names in just one line.
if no macro with this name is in the list, nothing is executed.
typically the functions defines the name of the macro.
for example the heaters.py and mcu.py are modified with this function call.

if you add a heater named extruder to configfile, the coeesponding function_macro gets the name [hester_name]_temp
in this case 'extruder_temp', for a heater named heater_bed the name of the macro would be 'heater_bed_temp'.
You can now define a section
[functionmacro extruder_temp]
macro:
...

the provided macro is executed everytime the extruder temperature is updated.
The macro can consist of a list of gcode commands. If you want to use scripting functionallity of gcode_macro,
just define a gcode_macro and call it in function_macro - means add it to the list of commands

mcu.py is modified to provide function_macro call with the extensions
'_home_start', '_home_finish', '_change', '_close', '_open' to endstops.

if you define a endstop for a stepper in stepper-section with the name P1.2 you can add now function_macro like
'P1.2_change', 'P1.2_close', 'P1.2_open' .....

function_macro is name based and benefits from other names defined in configfile. so the function_macro can match
to other elements used in configfile.
this is the reason, why the class Heater in heaters.py now gets the heater_name, could maybe solved in another way.

the use of macro in well known functions can have unwanted side-effects:
the macro execution consumes computing time and changes runtime behaviour

I even don't know if the function_maco itself could be written smarter - the jinja_stuff means nothing to me.
Please review.

Signed-off-by: Stefan Verse <verse@amotronics.de>