### PR TITLE
menu: fix for #3968

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -471,7 +471,7 @@ name: Temperature
 
 [menu __main __temp __hotend0_target]
 type: input
-enable: {'extruder' in printer}
+enable: {('extruder' in printer) and ('extruder' in printer.heaters.available_heaters)}
 name: {"Ex0:%3.0f (%4.0f)" % (menu.input, printer.extruder.temperature)}
 input: {printer.extruder.target}
 input_min: 0
@@ -481,7 +481,7 @@ gcode: M104 T0 S{'%.0f' % menu.input}
 
 [menu __main __temp __hotend1_target]
 type: input
-enable: {'extruder1' in printer}
+enable: {('extruder1' in printer) and ('extruder1' in printer.heaters.available_heaters)}
 name: {"Ex1:%3.0f (%4.0f)" % (menu.input, printer.extruder1.temperature)}
 input: {printer.extruder1.target}
 input_min: 0


### PR DESCRIPTION
For the menu hotend targets, also check available heaters.
It'll solve a crash when using shared heaters.

Signed-off-by: Janar Sööt <janar.soot@gmail.com>