### PR TITLE
Periodically check TMC drivers for errors

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,11 @@ All dates in this document are approximate.
 
 # Changes
 
+20210227: TMC stepper motor drivers in UART or SPI mode are now
+queried once per second whenever they are enabled - if the driver can
+not be contacted or if the driver reports an error, then Klipper will
+transition to a shutdown state.
+
 20210219: The `rpi_temperature` module has been renamed to
 `temperature_host`.  Replace any occurrences of `sensor_type:
 rpi_temperature` with `sensor_type: temperature_host`.  The path to

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -153,20 +153,21 @@ class TMCCommandHelper:
                                      minval=0., maxval=max_current)
         hold_current = gcmd.get_float('HOLDCURRENT', None,
                                       above=0., maxval=max_current)
-        if run_current is None and hold_current is None:
-            # Query only
-            if prev_hold_current is None:
-                gcmd.respond_info("Run Current: %0.2fA" % (prev_run_current,))
-            else:
-                gcmd.respond_info("Run Current: %0.2fA Hold Current: %0.2fA"
-                                  % (prev_run_current, prev_hold_current))
-            return
-        if run_current is None:
-            run_current = prev_run_current
-        if hold_current is None:
-            hold_current = prev_hold_current
-        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
-        ch.set_current(run_current, hold_current, print_time)
+        if run_current is not None or hold_current is not None:
+            if run_current is None:
+                run_current = prev_run_current
+            if hold_current is None:
+                hold_current = prev_hold_current
+            toolhead = self.printer.lookup_object('toolhead')
+            print_time = toolhead.get_last_move_time()
+            ch.set_current(run_current, hold_current, print_time)
+            prev_run_current, prev_hold_current, max_current = ch.get_current()
+        # Report values
+        if prev_hold_current is None:
+            gcmd.respond_info("Run Current: %0.2fA" % (prev_run_current,))
+        else:
+            gcmd.respond_info("Run Current: %0.2fA Hold Current: %0.2fA"
+                              % (prev_run_current, prev_hold_current))
     # Stepper enable/disable via comms
     def _do_enable(self, print_time, is_enable):
         toff_val = 0

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -74,6 +74,7 @@ SignedFields = ["CUR_A", "CUR_B", "sgt"]
 FieldFormatters = {
     "I_scale_analog":   (lambda v: "1(ExtVREF)" if v else ""),
     "shaft":            (lambda v: "1(Reverse)" if v else ""),
+    "reset":            (lambda v: "1(Reset)" if v else ""),
     "drv_err":          (lambda v: "1(ErrorShutdown!)" if v else ""),
     "uv_cp":            (lambda v: "1(Undervoltage!)" if v else ""),
     "VERSION":          (lambda v: "%#x" % v),

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -241,7 +241,8 @@ class TMC2130:
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
         current_helper = TMCCurrentHelper(config, self.mcu_tmc)
-        cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
+        cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper,
+                                         clear_gstat=False)
         cmdhelper.setup_register_dump(ReadRegisters)
         # Setup basic register values
         mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -188,13 +188,13 @@ class TMC2208:
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields)
         # Register commands
-        cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc)
+        current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
+        cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
         # Setup basic register values
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
-        tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         self.get_microsteps = mh.get_microsteps
         self.get_phase = mh.get_phase

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -62,13 +62,13 @@ class TMC2209:
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
-        cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc)
+        current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
+        cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         # Setup basic register values
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
-        tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         self.get_microsteps = mh.get_microsteps
         self.get_phase = mh.get_phase

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -1,11 +1,11 @@
 # TMC2660 configuration
 #
 # Copyright (C) 2018-2019  Florian Heilmann <Florian.Heilmann@gmx.net>
-# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-from . import bus, tmc
+from . import bus, tmc, tmc2130
 
 Registers = {
     "DRVCONF": 0xE, "SGCSCONF": 0xC, "SMARTEN": 0xA,
@@ -59,66 +59,53 @@ Fields["DRVCONF"] = {
 
 Fields["READRSP@RDSEL0"] = {
     "SG": 0x01,
-    "OT": 0x01 << 1,
-    "OTPW": 0x01 << 2,
-    "S2GA": 0x01 << 3,
-    "S2GB": 0x01 << 4,
-    "OLA": 0x01 << 5,
-    "OLB": 0x01 << 6,
-    "STST": 0x01 << 7,
+    "ot": 0x01 << 1,
+    "otpw": 0x01 << 2,
+    "s2ga": 0x01 << 3,
+    "s2gb": 0x01 << 4,
+    "ola": 0x01 << 5,
+    "olb": 0x01 << 6,
+    "stst": 0x01 << 7,
     "MSTEP": 0x3ff << 10
 }
 
 Fields["READRSP@RDSEL1"] = {
     "SG": 0x01,
-    "OT": 0x01 << 1,
-    "OTPW": 0x01 << 2,
-    "S2GA": 0x01 << 3,
-    "S2GB": 0x01 << 4,
-    "OLA": 0x01 << 5,
-    "OLB": 0x01 << 6,
-    "STST": 0x01 << 7,
+    "ot": 0x01 << 1,
+    "otpw": 0x01 << 2,
+    "s2ga": 0x01 << 3,
+    "s2gb": 0x01 << 4,
+    "ola": 0x01 << 5,
+    "olb": 0x01 << 6,
+    "stst": 0x01 << 7,
     "SG@RDSEL1": 0x3ff << 10
 }
 
 Fields["READRSP@RDSEL2"] = {
     "SG": 0x01,
-    "OT": 0x01 << 1,
-    "OTPW": 0x01 << 2,
-    "S2GA": 0x01 << 3,
-    "S2GB": 0x01 << 4,
-    "OLA": 0x01 << 5,
-    "OLB": 0x01 << 6,
-    "STST": 0x01 << 7,
+    "ot": 0x01 << 1,
+    "otpw": 0x01 << 2,
+    "s2ga": 0x01 << 3,
+    "s2gb": 0x01 << 4,
+    "ola": 0x01 << 5,
+    "olb": 0x01 << 6,
+    "stst": 0x01 << 7,
     "SG@RDSEL2": 0x1f << 15,
     "SE": 0x1f << 10
 }
 
 SignedFields = ["SGT"]
 
-FieldFormatters = {
-    "MRES": (lambda v: "%d(%dusteps)" % (v, 0x100 >> v)),
-    "DEDGE": (lambda v:
-        "1(Both Edges Active)" if v else "0(Only Rising Edge active)"),
-    "intpol": (lambda v: "1(On)" if v else "0(Off)"),
-    "toff": (lambda v: ("%d" % v) if v else "0(Driver Disabled!)"),
+FieldFormatters = dict(tmc2130.FieldFormatters)
+FieldFormatters.update({
+    "DEDGE": (lambda v: "1(Both Edges Active!)" if v else ""),
     "CHM": (lambda v: "1(constant toff)" if v else "0(spreadCycle)"),
     "SFILT": (lambda v: "1(Filtered mode)" if v else "0(Standard mode)"),
     "VSENSE": (lambda v: "%d(%dmV)" % (v, 165 if v else 305)),
-    "SDOFF": (lambda v: "1(Step/Dir disabled" if v else "0(Step/dir enabled)"),
-    "DISS2G": (lambda v: "%d(Short to GND protection %s)" % (v,
-                                          "disabled" if v else "enabled")),
-    "MSTEP": (lambda v: "%d(%d, OA1 %s OA2)" % (v, v & 0xff,
-                                                "<=" if v & 0x100 else "=>")),
-    "SG": (lambda v: "%d(%s)" % (v, "Stall!" if v else "No Stall!")),
-    "OT": (lambda v: "1(Overtemp shutdown!)" if v else ""),
-    "OTPW": (lambda v: "1(Overtemp warning!)" if v else ""),
-    "S2GA": (lambda v: "1(Short to GND Coil A!)" if v else ""),
-    "S2GB": (lambda v: "1(Short to GND Coil B!)" if v else ""),
-    "OLA": (lambda v: "1(Open Load Coil A at slow speed!)" if v else ""),
-    "OLB": (lambda v: "1(Open Load Coil B at slow speed!)" if v else ""),
-    "STST": (lambda v: "1(Standstill detected!)" if v else ""),
-}
+    "SDOFF": (lambda v: "1(Step/Dir disabled!)" if v else ""),
+    "DISS2G": (lambda v: "%d(Short to GND disabled!)" if v else ""),
+    "SG": (lambda v: "1(Stall!)" if v else ""),
+})
 
 
 ######################################################################

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -272,31 +272,35 @@ class TMC5160CurrentHelper:
         if not globalscaler:
             globalscaler = 256
         bits = self.fields.get_field(field_name)
-        current = (globalscaler * (bits + 1) * VREF
-                   / (256. * 32. * math.sqrt(2.) * self.sense_resistor))
-        return round(current, 2)
-    cmd_SET_TMC_CURRENT_help = "Set the current of a TMC driver"
-    def cmd_SET_TMC_CURRENT(self, gcmd):
-        run_current = gcmd.get_float('CURRENT', None,
-                                     minval=0., maxval=MAX_CURRENT)
-        hold_current = gcmd.get_float('HOLDCURRENT', None,
-                                      above=0., maxval=MAX_CURRENT)
-        if run_current is None and hold_current is None:
-            # Query only
-            run_current = self._calc_current_from_field("IRUN")
-            hold_current = self._calc_current_from_field("IHOLD")
-            gcmd.respond_info("Run Current: %0.2fA Hold Current: %0.2fA"
-                              % (run_current, hold_current))
-            return
-        if run_current is None:
-            run_current = self._calc_current_from_field("IRUN")
-        if hold_current is None:
-            hold_current = self._calc_current_from_field("IHOLD")
-        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
+        return (globalscaler * (bits + 1) * VREF
+                / (256. * 32. * math.sqrt(2.) * self.sense_resistor))
+    def get_current(self):
+        run_current = self._calc_current_from_field("IRUN")
+        hold_current = self._calc_current_from_field("IHOLD")
+        return run_current, hold_current, MAX_CURRENT
+    def set_current(self, run_current, hold_current, print_time):
         irun, ihold = self._calc_current(run_current, hold_current)
         self.fields.set_field("IHOLD", ihold)
         val = self.fields.set_field("IRUN", irun)
         self.mcu_tmc.set_register("IHOLD_IRUN", val, print_time)
+    cmd_SET_TMC_CURRENT_help = "Set the current of a TMC driver"
+    def cmd_SET_TMC_CURRENT(self, gcmd):
+        prev_run_current, prev_hold_current, max_current = self.get_current()
+        run_current = gcmd.get_float('CURRENT', None,
+                                     minval=0., maxval=max_current)
+        hold_current = gcmd.get_float('HOLDCURRENT', None,
+                                      above=0., maxval=max_current)
+        if run_current is None and hold_current is None:
+            # Query only
+            gcmd.respond_info("Run Current: %0.2fA Hold Current: %0.2fA"
+                              % (prev_run_current, prev_hold_current))
+            return
+        if run_current is None:
+            run_current = prev_run_current
+        if hold_current is None:
+            hold_current = prev_hold_current
+        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
+        self.set_current(run_current, hold_current, print_time)
 
 
 ######################################################################

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -215,11 +215,6 @@ Fields["TSTEP"] = {
 SignedFields = ["CUR_A", "CUR_B", "sgt", "XACTUAL", "VACTUAL", "PWM_SCALE_AUTO"]
 
 FieldFormatters = dict(tmc2130.FieldFormatters)
-FieldFormatters.update({
-    "reset":            (lambda v: "1(reset)" if v else ""),
-    "drv_err":          (lambda v: "1(ErrorShutdown!)" if v else ""),
-    "uv_cp":            (lambda v: "1(Undervoltage!)" if v else ""),
-})
 
 
 ######################################################################

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -358,18 +358,20 @@ class RetryAsyncCommand:
             query_time = self.reactor.monotonic()
             if query_time > first_query_time + self.TIMEOUT_TIME:
                 self.serial.register_response(None, self.name, self.oid)
-                raise error("Timeout on wait for '%s' response" % (self.name,))
+                raise serialhdl.error("Timeout on wait for '%s' response"
+                                      % (self.name,))
             self.serial.raw_send(cmd, minclock, minclock, cmd_queue)
 
 # Wrapper around query commands
 class CommandQueryWrapper:
     def __init__(self, serial, msgformat, respformat, oid=None,
-                 cmd_queue=None, is_async=False):
+                 cmd_queue=None, is_async=False, error=serialhdl.error):
         self._serial = serial
         self._cmd = serial.get_msgparser().lookup_command(msgformat)
         serial.get_msgparser().lookup_command(respformat)
         self._response = respformat.split()[0]
         self._oid = oid
+        self._error = error
         self._xmit_helper = serialhdl.SerialRetryCommand
         if is_async:
             self._xmit_helper = RetryAsyncCommand
@@ -383,7 +385,7 @@ class CommandQueryWrapper:
         try:
             return xh.get_response(cmd, self._cmd_queue, minclock, reqclock)
         except serialhdl.error as e:
-            raise error(str(e))
+            raise self._error(str(e))
 
 # Wrapper around command sending
 class CommandWrapper:
@@ -688,7 +690,7 @@ class MCU:
     def lookup_query_command(self, msgformat, respformat, oid=None,
                              cq=None, is_async=False):
         return CommandQueryWrapper(self._serial, msgformat, respformat, oid,
-                                   cq, is_async)
+                                   cq, is_async, self._printer.command_error)
     def try_lookup_command(self, msgformat):
         try:
             return self.lookup_command(msgformat)


### PR DESCRIPTION
There are several high-level changes in this PR:
1. Every enabled TMC stepper is now polled once per second to see if the driver reports an error (eg, over-current or over-temp).  If the driver reports an error (or can not be contacted) then a shutdown is invoked.
2. TMC temperature warnings are also checked once per second.  Warnings are written to the log.
3. The full initialization sequence is now sent every time the driver is enabled.
4. It is no longer an error if a TMC2208/TMC2209 driver is not available on startup.  This may simplify setups where motor power is externally controlled.  If the software cant contact the driver when it is actually enabled, then a shutdown will be invoked.
5. The SET_TMC_CURRENT command has been refactored.

The above changes apply to all of the tmc drivers (tmc2130, tmc2208, tmc2209, tmc2660, and tmc5610).  However, I do not have all of those drivers to test.

Help with testing would is appreciated.

-Kevin