### PR TITLE
Add support for host tracking of the history of stepper motion

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -35,6 +35,10 @@ defs_stepcompress = """
         , int32_t set_next_step_dir_msgtag);
     void stepcompress_free(struct stepcompress *sc);
     int stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock);
+    int stepcompress_set_last_position(struct stepcompress *sc
+        , int64_t last_position);
+    int64_t stepcompress_find_past_position(struct stepcompress *sc
+        , uint64_t clock);
     int stepcompress_queue_msg(struct stepcompress *sc
         , uint32_t *data, int len);
 

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -152,6 +152,10 @@ class PrinterExtruder:
                           move.start_pos[3], 0., 0.,
                           1., pressure_advance, 0.,
                           start_v, cruise_v, accel)
+    def find_past_position(self, print_time):
+        mcu = self.stepper.get_mcu()
+        clock = mcu.print_time_to_clock(print_time)
+        return self.stepper.get_past_commanded_position(clock)
     def cmd_M104(self, gcmd, wait=False):
         # Set Extruder Temperature
         temp = gcmd.get_float('S', 0.)
@@ -220,6 +224,8 @@ class DummyExtruder:
         pass
     def check_move(self, move):
         raise move.move_error("Extrude when no extruder present")
+    def find_past_position(self, print_time):
+        return 0.
     def calc_junction(self, prev_move, move):
         return move.max_cruise_v2
     def get_name(self):


### PR DESCRIPTION
This extends the low-level step compression code to keep a history of `queue_step` commands sent to the micro-controller.  The host can use this information to calculate the position of the stepper motor given a recent time.

This will be useful for filament sensors, as it should allow the host code to obtain the extruder position at the time of a signal from the filament sensor.

This support will also be needed for multi-mcu homing.

@Arksine , @TheJoshW, @mattshepcar - FYI.

-Kevin