### PR TITLE
virtual_sdcard: exact filename match before case insensitive one

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -147,8 +147,10 @@ class VirtualSD:
     def _load_file(self, gcmd, filename, check_subdirs=False):
         files = self.get_file_list(check_subdirs)
         files_by_lower = { fname.lower(): fname for fname, fsize in files }
+        fname = filename
         try:
-            fname = files_by_lower[filename.lower()]
+            if fname not in files:
+                fname = files_by_lower[fname.lower()]
             fname = os.path.join(self.sdcard_dirname, fname)
             f = open(fname, 'rb')
             f.seek(0, os.SEEK_END)


### PR DESCRIPTION
currently, if there are 2 files on the virtual sd card whose names differ only in
case (eg. MyFile.gcode vs myfile.gcode) the actual file that gets loaded is at
best unpredictable.  this patch checks for an exact match before attempting a
case-insensitive one.

Signed-off-by: Andre LeBlanc <andrepleblanc@gmail.com>