### PR TITLE
Fix klipper_mcu causing klippy to die

### DIFF
--- a/klippy/chelper/serialqueue.c
+++ b/klippy/chelper/serialqueue.c
@@ -573,7 +573,10 @@ input_event(struct serialqueue *sq, double eventtime)
     int ret = read(sq->serial_fd, &sq->input_buf[sq->input_pos]
                    , sizeof(sq->input_buf) - sq->input_pos);
     if (ret <= 0) {
-        report_errno("read", ret);
+        if(ret < 0)
+            report_errno("read", ret);
+        else
+            errorf("Got EOF when reading from device");
         pollreactor_do_exit(&sq->pr);
         return;
     }


### PR DESCRIPTION
When `klippy` requests a `FIRMWARE_RESTART` from `klipper_mcu` the open pseudo-TTY between them is closed and a `SIGHUP` gets sent to `klippy` which subsequently kills it. This is the cause of #3981.

Here I've added a `SIGHUP` handler that simply ignores the signal, but that seems like throwing the baby out with the bathwater, as it will stop `klippy` from dying if run from e.g. a terminal which is then closed(instead of properly killed e.g. with `Ctrl-C`/`SIGINT`). I'd love suggestions on how to better handle this, if relevant, before merging this.

I've been scouring over the kernel code for `devpts` and from I've been able to tell it's not possible to disable this behavior of sending a `SIGHUP` so we need to somehow handle this situation ourselves.

I also did a quick change in `serialqueue.c` to stop it from outputting errors like `Got error 0 in read: (0)Success`.