### PR TITLE
config: EXP2 header pin correction for Robin Nano 3 config example

### DIFF
--- a/config/generic-mks-robin-nano-v3.cfg
+++ b/config/generic-mks-robin-nano-v3.cfg
@@ -103,7 +103,7 @@ aliases:
     EXP1_2=PE13, EXP1_4=PC6,  EXP1_6=PE15, EXP1_8=PD10, EXP1_10=<5V>,
     # EXP2 header
     EXP2_1=PA6, EXP2_3=PE8, EXP2_5=PE11, EXP2_7=PE12,  EXP2_9=<GND>,
-    EXP2_2=PA5, EXP2_4=PE0, EXP2_6=PE10, EXP2_8=<RST>, EXP2_10=<3.3v>
+    EXP2_2=PA5, EXP2_4=PE10, EXP2_6=PA7, EXP2_8=<RST>, EXP2_10=<3.3v>
     # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "ssp1"
 
 # See the sample-lcd.cfg file for definitions of common LCD displays.


### PR DESCRIPTION
According to [Robin Nano v3 pinout](https://github.com/makerbase-mks/MKS-Robin-Nano-V3.X/blob/main/hardware/MKS%20Robin%20Nano%20V3.0_003/MKS%20Robin%20Nano%20V3.0_003%20PIN.pdf) the correct pins for:
- EXP2_4 is PE10
- EXP2_6 is PA7

Signed-off-by: Oleksii Zelivianskyi <alexeyzel@gmail.com>