### PR TITLE
config: fan pin number correction for Robin Nano 3

### DIFF
--- a/config/generic-mks-robin-nano-v3.cfg
+++ b/config/generic-mks-robin-nano-v3.cfg
@@ -80,7 +80,8 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PB1
+pin: PC14   # fan1
+#pin: PB1 # fan2
 
 [mcu]
 serial: /dev/serial/by-id/usb-Klipper_stm32f407xx_000000000000000000000000-if00


### PR DESCRIPTION
There are two fan pins on Robin Nano 3 and the fan1 pin is PC14, not PB1.
PB1 pin that was in config example is used for the fan2 output.

Signed-off-by: Oleksii Zelivianskyi alexeyzel@gmail.com