### PR TITLE
Add support for STM32F1 I2C1 alternate pin mapping

### DIFF
--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -17,12 +17,16 @@ struct i2c_info {
     uint8_t scl_pin, sda_pin;
 };
 
-DECL_ENUMERATION_RANGE("i2c_bus", "i2c1", 0, 2);
+DECL_ENUMERATION("i2c_bus", "i2c1", 0);
 DECL_CONSTANT_STR("BUS_PINS_i2c1", "PB6,PB7");
+DECL_ENUMERATION("i2c_bus", "i2c1a", 1);
+DECL_CONSTANT_STR("BUS_PINS_i2c1a", "PB8,PB9");
+DECL_ENUMERATION("i2c_bus", "i2c2", 2);
 DECL_CONSTANT_STR("BUS_PINS_i2c2", "PB10,PB11");
 
 static const struct i2c_info i2c_bus[] = {
     { I2C1, GPIO('B', 6), GPIO('B', 7) },
+    { I2C1, GPIO('B', 8), GPIO('B', 9) },
     { I2C2, GPIO('B', 10), GPIO('B', 11) },
 };
 

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -124,10 +124,16 @@ gpio_peripheral(uint32_t gpio, uint32_t mode, int pullup)
     // way from other STM32s.
     // Code below is emulating a few mappings to work like an STM32F4
     uint32_t func = (mode >> 4) & 0xf;
-    if(( gpio == GPIO('B', 8) || gpio == GPIO('B', 9)) &&
-       func == 9) { // CAN
-        stm32f1_alternative_remap(AFIO_MAPR_CAN_REMAP_Msk,
-                                  AFIO_MAPR_CAN_REMAP_REMAP2);
+    if (gpio == GPIO('B', 8) || gpio == GPIO('B', 9)) {
+        if (func == 9) {
+            // CAN
+            stm32f1_alternative_remap(AFIO_MAPR_CAN_REMAP_Msk,
+                                      AFIO_MAPR_CAN_REMAP_REMAP2);
+        } else if (func == 4) {
+            // I2C1 Alt
+            stm32f1_alternative_remap(AFIO_MAPR_I2C1_REMAP_Msk,
+                                      AFIO_MAPR_I2C1_REMAP);
+        }
     }
     // Add more as needed
 }


### PR DESCRIPTION
This adds support for the alternate pin mapping of I2C1 on PB8/9 in STM32F1 devices