### PR TITLE
changed standard timout gcode

### DIFF
--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -6,7 +6,9 @@
 import logging
 
 DEFAULT_IDLE_GCODE = """
-TURN_OFF_HEATERS
+{% if 'heaters' in printer %}
+   TURN_OFF_HEATERS
+{% endif %}
 M84
 """
 


### PR DESCRIPTION
When using klipper with a machine without heaters (e.g. a plotter) there is an error when the idle timeout is applied: (Unknown command:"TURN_OFF_HEATERS")

This PR fixes this by checking if there are any heaters to turn off.

I tested this with a normal printer and with a machine without heaters.

--fleinze