### PR TITLE
Improve ARM Cortex-M control transfer from bootloaders

### DIFF
--- a/src/generic/armcm_boot.c
+++ b/src/generic/armcm_boot.c
@@ -18,49 +18,40 @@ extern uint32_t _data_start, _data_end, _data_flash;
 extern uint32_t _bss_start, _bss_end, _stack_start;
 extern uint32_t _stack_end;
 
-void ResetHandlerC(void);
-
 /****************************************************************
  * Basic interrupt handlers
  ****************************************************************/
 
-// Initial code entry point - invoked by the processor after a reset
-void
-ResetHandler(void)
+static void __noreturn
+reset_handler_stage_two(void)
 {
-    __disable_irq();
+    int i;
 
-    // Explicitly load the stack pointer (for some bootloaders that don't)
-    asm volatile("mov sp, %0\n bx %1"
-                 : : "r"(&_stack_end), "r"(ResetHandlerC));
-}
-
-void
-__noreturn
-ResetHandlerC(void)
-{
     // Clear all enabled user interrupts and user pending interrupts
-    for (uint8_t i=0; i < sizeof(NVIC->ICER)/sizeof(NVIC->ICER[0]); i++) {
+    for (i = 0; i < ARRAY_SIZE(NVIC->ICER); i++) {
         NVIC->ICER[i] = 0xFFFFFFFF;
+        __DSB();
         NVIC->ICPR[i] = 0xFFFFFFFF;
     }
 
     // Reset all user interrupt priorities
-    for (uint8_t i=0; i < sizeof(NVIC->IP)/sizeof(NVIC->IP[0]); i++)
+    for (i = 0; i < ARRAY_SIZE(NVIC->IP); i++)
         NVIC->IP[i] = 0;
 
-    // Reset all system interrupt priorities
-    for (uint8_t i=0; i < sizeof(SCB->SHP)/sizeof(SCB->SHP[0]); i++)
-        SCB->SHP[i] = 0;
+    // Disable SysTick interrupt
+    SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk;
+    __DSB();
 
     // Clear pending pendsv and systick interrupts
     SCB->ICSR = SCB_ICSR_PENDSVCLR_Msk | SCB_ICSR_PENDSTCLR_Msk;
 
-    // Disable SysTick irq (for some bootloaders that don't)
-    SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk;
+    // Reset all system interrupt priorities
+    for (i = 0; i < ARRAY_SIZE(SCB->SHP); i++)
+        SCB->SHP[i] = 0;
 
     __DSB();
     __ISB();
+    __enable_irq();
 
     // Copy global variables from flash to ram
     uint32_t count = (&_data_end - &_data_start) * 4;
@@ -75,12 +66,23 @@ ResetHandlerC(void)
     //__libc_init_array();
 
     // Run the main board specific code
-    __enable_irq();
     armcm_main();
 
     // The armcm_main() call should not return
     for (;;)
         ;
+}
+
+// Initial code entry point - invoked by the processor after a reset
+// Reset interrupts and stack to take control from bootloaders
+void
+ResetHandler(void)
+{
+    __disable_irq();
+
+    // Explicitly load the stack pointer, jump to stage two
+    asm volatile("mov sp, %0\n bx %1"
+                 : : "r"(&_stack_end), "r"(reset_handler_stage_two));
 }
 DECL_ARMCM_IRQ(ResetHandler, -15);
 


### PR DESCRIPTION
Resets stack value in a way that doesn't add hazards in vendor specific main functions.

Resets all user interrupt enables, pending interrupts and interrupt priorities.

First instruction after the reset vector compiles to `CPSID i` to disable interrupts.

May want to consider only compiling in the manual interrupt resets when a bootloader is specified in the `menuconfig`. On M3 and M4 there are 240 interrupt priority registers.

If interrupts are not enabled before jumping to the F0 system bootloader it doesn't work correctly, which is why they are turned back on before calling `armcm_main` instead of letting the klipper system code eventually handle that. I assume other bootloaders may be similar. klipper appears to work fine without it.