### PR TITLE
config: Add BTT-SKR board for the Creality CR-6SE

### DIFF
--- a/config/printer-creality-cr6se-btt-skr-2021.cfg
+++ b/config/printer-creality-cr6se-btt-skr-2021.cfg
@@ -1,0 +1,160 @@
+# This file contains pin mappings for the BTT-SKR Mainboard on the 2021 Creality CR6-SE.
+# To use this config, during "make menuconfig" select the
+# STM32F103 with a "28KiB bootloader" and with "Use USB for
+# communication" enabled. Also ensure "!PA14" is in the initial pins.
+
+# Flash this firmware by copying "out/klipper.bin" to a SD card and
+# turning on the printer with the card inserted. The firmware
+# filename must be named "firmware.bin".
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PB13
+dir_pin: !PB12
+enable_pin: !PB14
+rotation_distance: 40
+microsteps: 16
+endstop_pin: PC0
+position_min: -5
+position_endstop: -5
+position_max: 235
+homing_speed: 50
+
+[stepper_y]
+step_pin: PB10
+dir_pin: PB2
+enable_pin: !PB11
+rotation_distance: 40
+microsteps: 16
+endstop_pin: PC1
+position_min: -2
+position_endstop: -2
+position_max: 235
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB0
+dir_pin: !PC5
+enable_pin: !PB1
+rotation_distance: 8
+microsteps: 16
+endstop_pin: probe:z_virtual_endstop
+position_min: -1.5
+position_max: 250
+homing_speed: 4
+second_homing_speed: 1
+homing_retract_dist: 2.0
+
+[extruder]
+max_extrude_only_distance: 1000.0
+step_pin: PB3
+dir_pin: !PB4
+enable_pin: !PD2
+rotation_distance: 30.4768
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA0
+control: pid
+# tuned for stock hardware with 200 degree Celsius target
+pid_Kp: 23.08
+pid_Ki: 1.93
+pid_Kd: 68.93
+min_temp: 0
+max_temp: 275
+
+[tmc2209 stepper_x]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 0
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2209 stepper_y]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 1
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2209 stepper_z]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 2
+run_current: 0.580
+hold_current: 0.500
+stealthchop_threshold: 5
+
+[tmc2209 extruder]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 3
+run_current: 0.650
+hold_current: 0.500
+stealthchop_threshold: 5
+
+[heater_bed]
+heater_pin: PC9
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC3
+control: pid
+# tuned for stock hardware with 50 degree Celsius target
+pid_Kp: 63.05
+pid_Ki: 10.48
+pid_Kd: 252.76
+min_temp: 0
+max_temp: 120
+
+[fan]
+pin: PC6
+kick_start_time: 0.5
+
+[controller_fan my_controller_fan]
+pin: PC7
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_stm32f103xe_30FFD5054254353919561557-if00
+restart_method: command
+
+[bed_mesh]
+speed: 50
+horizontal_move_z: 5
+mesh_min: 5,5
+mesh_max: 230,230
+probe_count: 4,4
+
+[safe_z_home]
+home_xy_position: 100,100
+
+# Before printing the PROBE_CALIBRATE command needs to be issued
+# to run the probe calibration procedure, described at
+# docs/Probe_Calibrate.md, to find the correct z_offset.
+[probe]
+pin: PC14
+x_offset: 0.0
+y_offset: 0.0
+z_offset: 0.0
+speed: 2.0
+samples: 5
+
+[filament_switch_sensor filament_sensor]
+pause_on_runout: true
+switch_pin: ^!PC15
+
+[output_pin LED_pin]
+pin: PA13
+
+[static_digital_output daughterboard_communication]
+pins: !PA1
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 500
+max_z_velocity: 5
+max_z_accel: 100


### PR DESCRIPTION
Adds support for the BTT CR-6 after market upgrade board.
This board allows using the USB communication feature (and requires !PA14 in initial pins).
This board also runs the TMC2209 in UART mode and has basically a completely different pinout.
I also added safe_z_home to prevent the printer from trying to home Z at the far edge and crashing (as the nozzle was not over the bed at all)

Note: The PID tuning might not be correct for everyone, as I do run a different nozzle and a flexible bed, not the default glass one.