### PR TITLE
Additional Notes for Creality Board v4.2.2

### DIFF
--- a/config/printer-creality-ender3-2020.cfg
+++ b/config/printer-creality-ender3-2020.cfg
@@ -1,5 +1,5 @@
 # This file contains pin mappings for the stock 2020 Creality Ender 3
-# starting from July 2020. To use this config, during "make menuconfig" 
+# starting from July 2020. To use this config, during "make menuconfig"
 # select the STM32F103 with a "28KiB bootloader" and with "Use USB for
 # communication" disabled. Also, select "Enable extra low-level
 # configuration options" and configure "GPIO pins to set at

--- a/config/printer-creality-ender3-2020.cfg
+++ b/config/printer-creality-ender3-2020.cfg
@@ -1,8 +1,7 @@
 # This file contains pin mappings for the stock 2020 Creality Ender 3
-# Pro with the 32-bit Creality 4.2.2 board. To use this config, during
-# "make menuconfig" select the STM32F103 with a "28KiB bootloader" and
-# with "Use USB for communication" disabled. If these settings do not work
-# you need to do the following. Select "Enable extra low-level
+# starting from July 2020. To use this config, during "make menuconfig" 
+# select the STM32F103 with a "28KiB bootloader" and with "Use USB for
+# communication" disabled. Also, select "Enable extra low-level
 # configuration options" and configure "GPIO pins to set at
 # micro-controller startup" to "!PA14"
 
@@ -96,16 +95,3 @@ max_velocity: 300
 max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
-
-# Pin mappings for BL_T port
-#[bltouch]
-#sensor_pin: ^PB1
-#control_pin: PB0
-
-[display]
-lcd_type: st7920
-cs_pin: PB12
-sclk_pin: PB13
-sid_pin: PB15
-encoder_pins: ^PB14, ^PB10
-click_pin: ^!PB2


### PR DESCRIPTION
This adds further notes to the Ender 3 and Ender 3 Pro configurations that come with the stock v4.2.2 Creality STM Board as of July 2020. 

With this also, the Ender 3 profile now should resemble the Ender 3 V2 Profile because of the board change.

Signed-off-by: Julian Maison-Guillard <jmaisonguillard@gmail.com>