### PR TITLE
Add support for config file enhanced interpolation

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -3,7 +3,8 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import os, glob, re, time, logging, ConfigParser as configparser, StringIO
+import os, glob, re, time, logging, StringIO
+from backports import configparser
 
 error = configparser.Error
 
@@ -211,7 +212,9 @@ class PrinterConfig:
         self._parse_config_buffer(buffer, filename, fileconfig)
         visited.remove(path)
     def _build_config_wrapper(self, data, filename):
-        fileconfig = configparser.RawConfigParser()
+        fileconfig = configparser.ConfigParser(
+            interpolation=configparser.ExtendedInterpolation(),
+            strict=False)
         self._parse_config(data, filename, fileconfig, set())
         return ConfigWrapper(self.printer, fileconfig, {}, 'printer')
     def _build_config_string(self, config):

--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -6,3 +6,4 @@ cffi==1.12.2
 pyserial==3.4
 greenlet==0.4.15
 Jinja2==2.10.1
+configparser==3.5.0b1


### PR DESCRIPTION
Adds a backported version of `ConfigParser` to enable support for enhanced interpolation of config values. This could be useful to simplify configuration machines that use multiple Z steppers. One value becomes the single source of truth.

An example of how this is used would be (a sample from the Voron 1.8 SKR 1.4 config):
```
[stepper_z]
step_pin: P0.22
dir_pin: P2.11
enable_pin: !P0.21

rotation_distance: 8			
microsteps: 16
full_steps_per_rotation: 200

[stepper_z1]
step_pin: P2.13
dir_pin: P0.11
enable_pin: !P2.12

rotation_distance: ${stepper_z:rotation_distance}
microsteps: ${stepper_z:microsteps}
full_steps_per_rotation: ${stepper_z:full_steps_per_rotation}

```

Concerns:
- This requires a change to `requirements.txt` for klippy. Does that pose a problem for users upgrading with a previously installed pythonenv?
-  `$` becomes a keyword. It isn't in any config examples in the repo and doesn't seem like users would have any reason for it to be within their configs.
