### PR TITLE
ds18b20: Segmentation fault on 64bit Raspbery PI.

### DIFF
--- a/src/linux/sensor_ds18b20.c
+++ b/src/linux/sensor_ds18b20.c
@@ -138,7 +138,7 @@ command_config_ds18b20(uint32_t *args)
 {
     // Open kernel port
     uint8_t serial_len = args[1];
-    uint8_t *serial = (void*)(size_t)args[2];
+    uint8_t *serial = command_decode_ptr(args[2]);
     if (memchr(serial, '/', serial_len))
         goto fail1;
     char fname[56];


### PR DESCRIPTION
Fixes
```
Program received signal SIGSEGV, Segmentation fault.
#0  __memchr_generic () at ../sysdeps/aarch64/multiarch/../memchr.S:89
#1  0x0000aaaaaaaac7f0 in command_config_ds18b20 (args=0xffffffffcd30, args@entry=<error reading variable: Cannot access memory at address 0xb692a5472eb6a570>) at src/linux/sensor_ds18b20.c:142
#2  0x0000aaaaaaab2d84 in command_dispatch (msglen=29 '\035', buf=<optimized out>) at src/command.c:322
#3  command_find_and_dispatch (buf_len=<optimized out>, pop_count=<synthetic pointer>, buf=<optimized out>) at src/command.c:340
#4  command_find_and_dispatch (pop_count=<synthetic pointer>, buf_len=29 '\035', buf=<optimized out>) at src/command.c:335
#5  console_task () at src/linux/console.c:165
#6  ctr_run_taskfuncs () at out/compile_time_request.c:74
#7  run_tasks () at src/sched.c:246
#8  0x0000aaaaaaab2e70 in sched_main () at src/sched.c:344
#9  0x0000aaaaaaaac598 in main (argc=<optimized out>, argv=<optimized out>) at src/linux/main.c:95
```