### PR TITLE
gcode_macro - expose math functions to gcode macros

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -4,8 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback, logging, ast, copy
-import jinja2
-
+import jinja2, math
 
 ######################################################################
 # Template handling
@@ -101,6 +100,7 @@ class PrinterGCodeMacro:
             'action_respond_info': self._action_respond_info,
             'action_raise_error': self._action_raise_error,
             'action_call_remote_method': self._action_call_remote_method,
+            'math': math
         }
 
 def load_config(config):


### PR DESCRIPTION
Added python math lib to gcode_macro and exposed it to the templates so functions like sin and cos can be caculated from gcode macros.