### PR TITLE
module: HTU21D sensor definition fix

### DIFF
--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -108,6 +108,9 @@ class HTU21D:
 
     def setup_callback(self, cb):
         self._callback = cb
+        
+    def get_report_time_delta(self):
+        return self.report_time
 
     def _init_htu21d(self):
         # Device Soft Reset

--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -108,7 +108,7 @@ class HTU21D:
 
     def setup_callback(self, cb):
         self._callback = cb
-        
+
     def get_report_time_delta(self):
         return self.report_time
 


### PR DESCRIPTION
HTU21D sensor class lacked the method `get_report_time_delta` invoked
during watermark control loops. This short fix simply adds that method
in, calling the `self.report_time` attribute created during class
construction.

Fixes issue #4074

Signed-off-by: Jon Sanders <jonsan@gmail.com>