### PR TITLE
Allow sharing endstop pins with buttons

### DIFF
--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -227,7 +227,8 @@ class PrinterButtons:
         mcu = mcu_name = None
         pin_params_list = []
         for pin in pins:
-            pin_params = ppins.lookup_pin(pin, can_invert=True, can_pullup=True, share_type='endstop')
+            pin_params = ppins.lookup_pin(
+                pin, can_invert=True, can_pullup=True, share_type='endstop')
             if mcu is not None and pin_params['chip'] != mcu:
                 raise ppins.error("button pins must be on same mcu")
             mcu = pin_params['chip']

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -227,7 +227,7 @@ class PrinterButtons:
         mcu = mcu_name = None
         pin_params_list = []
         for pin in pins:
-            pin_params = ppins.lookup_pin(pin, can_invert=True, can_pullup=True)
+            pin_params = ppins.lookup_pin(pin, can_invert=True, can_pullup=True, share_type='endstop')
             if mcu is not None and pin_params['chip'] != mcu:
                 raise ppins.error("button pins must be on same mcu")
             mcu = pin_params['chip']

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -253,7 +253,8 @@ class PrinterPins:
     def setup_pin(self, pin_type, pin_desc, share_type=None):
         can_invert = pin_type in ['endstop', 'digital_out', 'pwm']
         can_pullup = pin_type in ['endstop']
-        pin_params = self.lookup_pin(pin_desc, can_invert, can_pullup, share_type)
+        pin_params = self.lookup_pin(
+            pin_desc, can_invert, can_pullup, share_type)
         return pin_params['chip'].setup_pin(pin_type, pin_params)
     def reset_pin_sharing(self, pin_params):
         share_name = "%s:%s" % (pin_params['chip_name'], pin_params['pin'])

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -250,10 +250,10 @@ class PrinterPins:
         pin_params['share_type'] = share_type
         self.active_pins[share_name] = pin_params
         return pin_params
-    def setup_pin(self, pin_type, pin_desc):
+    def setup_pin(self, pin_type, pin_desc, share_type=None):
         can_invert = pin_type in ['endstop', 'digital_out', 'pwm']
         can_pullup = pin_type in ['endstop']
-        pin_params = self.lookup_pin(pin_desc, can_invert, can_pullup)
+        pin_params = self.lookup_pin(pin_desc, can_invert, can_pullup, share_type)
         return pin_params['chip'].setup_pin(pin_type, pin_params)
     def reset_pin_sharing(self, pin_params):
         share_name = "%s:%s" % (pin_params['chip_name'], pin_params['pin'])

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -344,7 +344,8 @@ class PrinterRail:
             return
         printer = config.get_printer()
         ppins = printer.lookup_object('pins')
-        mcu_endstop = ppins.setup_pin('endstop', config.get('endstop_pin'), share_type='endstop')
+        mcu_endstop = ppins.setup_pin(
+            'endstop', config.get('endstop_pin'), share_type='endstop')
         mcu_endstop.add_stepper(stepper)
         name = stepper.get_name(short=True)
         self.endstops.append((mcu_endstop, name))

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -344,7 +344,7 @@ class PrinterRail:
             return
         printer = config.get_printer()
         ppins = printer.lookup_object('pins')
-        mcu_endstop = ppins.setup_pin('endstop', config.get('endstop_pin'))
+        mcu_endstop = ppins.setup_pin('endstop', config.get('endstop_pin'), share_type='endstop')
         mcu_endstop.add_stepper(stepper)
         name = stepper.get_name(short=True)
         self.endstops.append((mcu_endstop, name))


### PR DESCRIPTION
The intent is to allow an MMU unit to share the manual_stepper endstop
 with a gcode_macro (or filament_switch_sensor) to determine filament
 runout and trigger an automated filament swap, i.e for continual printing
 just swapping spools on runout.

I'm not aware if this is going to cause issues with endstops, merely that
 it works simultaneously, where a stepper can home on the endstop and a
 filament_switch_sensor activates correctly.

There may also be a better way of doing this, but I wasn't able to find
 anyone else talking about the idea