### PR TITLE
Deprecate pin_map config option

### DIFF
--- a/config/example-cartesian.cfg
+++ b/config/example-cartesian.cfg
@@ -8,46 +8,46 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_max: 200
 
 [stepper_y]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 200
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar18
+endstop_pin: ^PD3
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.500
 filament_diameter: 3.500
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -56,16 +56,15 @@ min_temp: 0
 max_temp: 210
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 110
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian

--- a/config/example-corexy.cfg
+++ b/config/example-corexy.cfg
@@ -8,48 +8,48 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar18
+endstop_pin: ^PD3
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -58,19 +58,18 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: corexy

--- a/config/example-corexz.cfg
+++ b/config/example-corexz.cfg
@@ -7,48 +7,48 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar18
+endstop_pin: ^PD3
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -57,19 +57,18 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: corexz

--- a/config/example-delta.cfg
+++ b/config/example-delta.cfg
@@ -7,43 +7,43 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_a]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar2
+endstop_pin: ^PE4
 homing_speed: 50
 position_endstop: 297.05
 arm_length: 333.0
 
 [stepper_b]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar15
+endstop_pin: ^PJ0
 
 [stepper_c]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar19
+endstop_pin: ^PD2
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -52,16 +52,15 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: delta

--- a/config/example-polar.cfg
+++ b/config/example-polar.cfg
@@ -7,44 +7,44 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_bed]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 gear_ratio: 80:16
 
 [stepper_arm]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 300
 position_max: 300
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar18
+endstop_pin: ^PD3
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -53,19 +53,18 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: polar

--- a/config/example-rotary-delta.cfg
+++ b/config/example-rotary-delta.cfg
@@ -7,44 +7,44 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_a]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 gear_ratio: 107.000:16, 60:16
-endstop_pin: ^ar2
+endstop_pin: ^PE4
 homing_speed: 50
 position_endstop: 252
 upper_arm_length: 170.000
 lower_arm_length: 320.000
 
 [stepper_b]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 gear_ratio: 107.000:16, 60:16
-endstop_pin: ^ar15
+endstop_pin: ^PJ0
 
 [stepper_c]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 gear_ratio: 107.000:16, 60:16
-endstop_pin: ^ar19
+endstop_pin: ^PD2
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -53,16 +53,15 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: rotary_delta

--- a/config/example-winch.cfg
+++ b/config/example-winch.cfg
@@ -11,9 +11,9 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_a]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
 anchor_x: 0
@@ -21,9 +21,9 @@ anchor_y: -2000
 anchor_z: -100
 
 [stepper_b]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
 anchor_x: 2000
@@ -31,9 +31,9 @@ anchor_y: 1000
 anchor_z: -100
 
 [stepper_c]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 40
 anchor_x: -2000
@@ -41,9 +41,9 @@ anchor_y: 1000
 anchor_z: -100
 
 [stepper_d]
-step_pin: ar36
-dir_pin: ar34
-enable_pin: !ar30
+step_pin: PC1
+dir_pin: PC3
+enable_pin: !PC7
 microsteps: 16
 rotation_distance: 40
 anchor_x: 0
@@ -51,16 +51,16 @@ anchor_y: 0
 anchor_z: 3000
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -69,16 +69,15 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: winch

--- a/config/generic-cramps.cfg
+++ b/config/generic-cramps.cfg
@@ -11,46 +11,46 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: P8_13
-dir_pin: P8_12
-enable_pin: !P9_14
+step_pin: gpio0_23
+dir_pin: gpio1_12
+enable_pin: !gpio1_18
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^P8_8
+endstop_pin: ^gpio2_3
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: P8_15
-dir_pin: P8_14
-enable_pin: !P9_14
+step_pin: gpio1_15
+dir_pin: gpio0_26
+enable_pin: !gpio1_18
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^P8_10
+endstop_pin: ^gpio2_4
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: P8_19
-dir_pin: P8_18
-enable_pin: !P9_14
+step_pin: gpio0_22
+dir_pin: gpio2_1
+enable_pin: !gpio1_18
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^P9_13
+endstop_pin: ^gpio0_31
 position_endstop: 0
 position_max: 200
 
 [extruder]
-step_pin: P9_16
-dir_pin: P9_12
-enable_pin: !P9_14
+step_pin: gpio1_19
+dir_pin: gpio1_28
+enable_pin: !gpio1_18
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: P9_15
+heater_pin: gpio1_16
 sensor_type: EPCOS 100K B57560G104F
 pullup_resistor: 2000
 sensor_pin: host:analog5
@@ -62,7 +62,7 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: P8_11
+heater_pin: gpio1_13
 sensor_type: EPCOS 100K B57560G104F
 pullup_resistor: 2000
 sensor_pin: host:analog4
@@ -71,11 +71,10 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: P9_41
+pin: gpio0_20
 
 [mcu]
 serial: /dev/rpmsg_pru30
-pin_map: beaglebone
 
 [mcu host]
 serial: /tmp/klipper_host_mcu
@@ -88,6 +87,6 @@ max_z_velocity: 5
 max_z_accel: 100
 
 [output_pin machine_enable]
-pin: P9_23
+pin: gpio1_17
 value: 1
 shutdown_value: 0

--- a/config/generic-gt2560.cfg
+++ b/config/generic-gt2560.cfg
@@ -5,49 +5,49 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar25
-dir_pin: ar23
-enable_pin: !ar27
+step_pin: PA3
+dir_pin: PA1
+enable_pin: !PA5
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar22
+endstop_pin: ^PA0
 position_endstop: 0
 position_max: 200
 homing_speed: 30
 
 [stepper_y]
-step_pin: ar31
-dir_pin: ar33
-enable_pin: !ar29
+step_pin: PC6
+dir_pin: PC4
+enable_pin: !PA7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar26
+endstop_pin: ^PA4
 position_endstop: 0
 position_max: 200
 homing_speed: 30
 
 [stepper_z]
-step_pin: ar37
-dir_pin: !ar39
-enable_pin: !ar35
+step_pin: PC0
+dir_pin: !PG2
+enable_pin: !PC2
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar30
+endstop_pin: ^PC7
 position_endstop: 0
 position_max: 200
 position_min: 0.0
 
 [extruder]
-step_pin: ar43
-dir_pin: ar45
-enable_pin: !ar41
+step_pin: PL6
+dir_pin: PL4
+enable_pin: !PG0
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.4
 filament_diameter: 1.750
-heater_pin: ar2
+heater_pin: PE4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog8
+sensor_pin: PK0
 min_temp: 0
 max_temp: 250
 control: pid
@@ -56,9 +56,9 @@ pid_ki: 1.774
 pid_kd: 125.159
 
 [heater_bed]
-heater_pin: ar4
+heater_pin: PG5
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog10
+sensor_pin: PK2
 min_temp: 0
 max_temp: 120
 control: pid
@@ -67,11 +67,10 @@ pid_ki: 2.898
 pid_kd: 342.787
 
 [fan]
-pin: ar7
+pin: PH4
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -82,11 +81,11 @@ max_z_accel: 500
 
 [display]
 lcd_type: hd44780
-rs_pin: ar20
-e_pin: ar17
-d4_pin: ar16
-d5_pin: ar21
-d6_pin: ar5
-d7_pin: ar6
-encoder_pins: ^ar42, ^ar40
-click_pin: ^!ar19
+rs_pin: PD1
+e_pin: PH0
+d4_pin: PH1
+d5_pin: PD0
+d6_pin: PE3
+d7_pin: PH3
+encoder_pins: ^PL7, ^PG1
+click_pin: ^!PD2

--- a/config/generic-radds.cfg
+++ b/config/generic-radds.cfg
@@ -4,55 +4,55 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-# Temp sensor pins: analog0..analog4
-# Mosfet Pins: ar7 (Heatbed), ar8, ar9, ar11, ar12, ar13
+# Temp sensor pins: PA16..PA6
+# Mosfet Pins: PC23 (Heatbed), PC22, PC21, PD7, PD8, PB27
 
 [stepper_x]
-step_pin: ar24
-dir_pin: ar23
-enable_pin: ar26
+step_pin: PA15
+dir_pin: PA14
+enable_pin: PD1
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar28
-#endstop_pin: ^ar34
+endstop_pin: ^PD3
+#endstop_pin: ^PC2
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar17
-dir_pin: !ar16
-enable_pin: ar22
+step_pin: PA12
+dir_pin: !PA13
+enable_pin: PB26
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar30
-#endstop_pin: ^ar36
+endstop_pin: ^PD9
+#endstop_pin: ^PC4
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar2
-dir_pin: ar3
-enable_pin: ar15
+step_pin: PB25
+dir_pin: PC28
+enable_pin: PD5
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar32
-#endstop_pin: ^ar38
+endstop_pin: ^PD10
+#endstop_pin: ^PC6
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
-step_pin: analog7
-dir_pin: analog6
-enable_pin: analog8
+step_pin: PA2
+dir_pin: PA3
+enable_pin: PB17
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar13
+heater_pin: PB27
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog0
+sensor_pin: PA16
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -61,32 +61,31 @@ min_temp: 0
 max_temp: 250
 
 #[extruder1]
-#step_pin:           analog10
-#dir_pin:            analog9
-#enable_pin:         analog11
+#step_pin:           PB19
+#dir_pin:            PB18
+#enable_pin:         PB20
 
 #[extruder2]
-#step_pin:           ar51
-#dir_pin:            ar53
-#enable_pin:         ar49
+#step_pin:           PC12
+#dir_pin:            PB14
+#enable_pin:         PC14
 
 [heater_bed]
-heater_pin: ar7
+heater_pin: PC23
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog1
+sensor_pin: PA24
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar9
+pin: PC21
 
 #[heater_fan nozzle_cooling_fan]
-#pin: ar8
+#pin: PC22
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -98,18 +97,18 @@ max_z_accel: 100
 # "RepRapDiscount 2004 Smart Controller" type displays
 #[display]
 #lcd_type: hd44780
-#rs_pin: ar42
-#e_pin: ar43
-#d4_pin: ar44
-#d5_pin: ar45
-#d6_pin: ar46
-#d7_pin: ar47
-#encoder_pins: ^ar52, ^ar50
-#click_pin: ^!ar48
+#rs_pin: PA19
+#e_pin: PA20
+#d4_pin: PC19
+#d5_pin: PC18
+#d6_pin: PC17
+#d7_pin: PC16
+#encoder_pins: ^PB21, ^PC13
+#click_pin: ^!PC15
 
 # "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
 #[display]
 #lcd_type: st7920
-#cs_pin: ar42
-#sclk_pin: ar44
-#sid_pin: ar43
+#cs_pin: PA19
+#sclk_pin: PC19
+#sid_pin: PA20

--- a/config/generic-ramps.cfg
+++ b/config/generic-ramps.cfg
@@ -1,55 +1,55 @@
 # This file contains common pin mappings for RAMPS (v1.3 and later)
 # boards. RAMPS boards typically use a firmware compiled for the AVR
-# atmega2560 (though other AVR chips are also possible).
+# atmega2560 (though the atmega1280 is also possible).
 
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar3
-#endstop_pin: ^ar2
+endstop_pin: ^PE5
+#endstop_pin: ^PE4
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar14
-#endstop_pin: ^ar15
+endstop_pin: ^PJ1
+#endstop_pin: ^PJ0
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar18
-#endstop_pin: ^ar19
+endstop_pin: ^PD3
+#endstop_pin: ^PD2
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -58,27 +58,26 @@ min_temp: 0
 max_temp: 250
 
 #[extruder1]
-#step_pin: ar36
-#dir_pin: ar34
-#enable_pin: !ar30
-#heater_pin: ar9
-#sensor_pin: analog15
+#step_pin: PC1
+#dir_pin: PC3
+#enable_pin: !PC7
+#heater_pin: PH6
+#sensor_pin: PK7
 #...
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -91,12 +90,12 @@ max_z_accel: 100
 [board_pins]
 aliases:
     # Common EXP1 header found on many "all-in-one" ramps clones
-    EXP1_1=ar37, EXP1_3=ar17, EXP1_5=ar23, EXP1_7=ar27, EXP1_9=<GND>,
-    EXP1_2=ar35, EXP1_4=ar16, EXP1_6=ar25, EXP1_8=ar29, EXP1_10=<5V>,
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
     # EXP2 header
-    EXP2_1=ar50, EXP2_3=ar31, EXP2_5=ar33, EXP2_7=ar49, EXP2_9=<GND>,
-    EXP2_2=ar52, EXP2_4=ar53, EXP2_6=ar51, EXP2_8=ar41, EXP2_10=<RST>
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
     # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
-    # Note, some boards wire: EXP2_8=<RST>, EXP2_10=ar41
+    # Note, some boards wire: EXP2_8=<RST>, EXP2_10=PG0
 
 # See the sample-lcd.cfg file for definitions of common LCD displays.

--- a/config/generic-replicape.cfg
+++ b/config/generic-replicape.cfg
@@ -15,7 +15,6 @@
 
 [mcu]
 serial: /dev/rpmsg_pru30
-pin_map: beaglebone
 
 [mcu host]
 serial: /tmp/klipper_host_mcu
@@ -33,34 +32,34 @@ stepper_e_microstep_mode: 16
 stepper_e_current: 0.5
 
 [stepper_x]
-step_pin: P8_17
-dir_pin: P8_26
+step_pin: gpio0_27
+dir_pin: gpio1_29
 enable_pin: replicape:stepper_x_enable
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^P9_25
+endstop_pin: ^gpio3_21
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: P8_12
-dir_pin: P8_19
+step_pin: gpio1_12
+dir_pin: gpio0_22
 enable_pin: replicape:stepper_y_enable
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^P9_23
+endstop_pin: ^gpio1_17
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: P8_13
-dir_pin: P8_14
+step_pin: gpio0_23
+dir_pin: gpio0_26
 enable_pin: replicape:stepper_z_enable
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^P9_13
+endstop_pin: ^gpio0_31
 position_endstop: 0
 position_max: 200
 
@@ -72,8 +71,8 @@ max_z_velocity: 25
 max_z_accel: 30
 
 [extruder]
-step_pin: P9_12
-dir_pin: P8_15
+step_pin: gpio1_28
+dir_pin: gpio1_15
 enable_pin: replicape:stepper_e_enable
 microsteps: 16
 rotation_distance: 33.500
@@ -101,7 +100,7 @@ max_temp: 130
 pin: replicape:power_fan0
 
 # The alternative servo pins channels on the endstops x2 and y2 can be used
-# via the special relicape pins servo0 (P9_14) and servo1 (P9_16).
+# via the special relicape pins servo0 (gpio1_18) and servo1 (gpio1_19).
 #[servo servo_x2]
 #pin: replicape:servo0
 #   PWM output pin controlling the servo. This parameter must be
@@ -116,16 +115,16 @@ pin: replicape:power_fan0
 [board_pins]
 aliases:
    # step/dir pins
-   X_DIR=P8_26, X_STEP=P8_17, Y_DIR=P8_19, Y_STEP=P8_12, Z_DIR=P8_14, Z_STEP=P8_13,
-   E_DIR=P8_15, E_STEP=P9_12, H_DIR=P8_16, H_STEP=P8_11,
+   X_DIR=gpio1_29, X_STEP=gpio0_27, Y_DIR=gpio0_22, Y_STEP=gpio1_12, Z_DIR=gpio0_26, Z_STEP=gpio0_23,
+   E_DIR=gpio1_15, E_STEP=gpio1_28, H_DIR=gpio1_14, H_STEP=gpio1_13,
    # stepper fault pins
-   FAULT_X=P8_10, FAULT_Y=P8_9, FAULT_Z=P9_24, FAULT_E=P8_18, FAULT_H=P8_8,
+   FAULT_X=gpio2_4, FAULT_Y=gpio2_5, FAULT_Z=gpio0_15, FAULT_E=gpio2_1, FAULT_H=gpio2_3,
    # endstops
-   STOP_X1=P9_25, STOP_X2=P9_11, STOP_Y1=P9_23, STOP_Y2=P9_28, STOP_Z1=P9_13, STOP_Z2=P9_18,
+   STOP_X1=gpio3_21, STOP_X2=gpio0_30, STOP_Y1=gpio1_17, STOP_Y2=gpio3_17, STOP_Z1=gpio0_31, STOP_Z2=gpio0_4,
    # enable steppers (all on one pin)
-   STEPPER_ENABLE=P9_41,
+   STEPPER_ENABLE=gpio0_20,
    # servos
-   SERVO_0=P9_14, SERVO_1=P9_16,
+   SERVO_0=gpio1_18, SERVO_1=gpio1_19,
 
 [board_pins host]
 mcu: host

--- a/config/generic-rumba.cfg
+++ b/config/generic-rumba.cfg
@@ -4,51 +4,51 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar17
-dir_pin: ar16
-enable_pin: !ar48
+step_pin: PH0
+dir_pin: PH1
+enable_pin: !PL1
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar37
-#endstop_pin: ^ar36
+endstop_pin: ^PC0
+#endstop_pin: ^PC1
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar54
-dir_pin: !ar47
-enable_pin: !ar55
+step_pin: PF0
+dir_pin: !PL2
+enable_pin: !PF1
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar35
-#endstop_pin: ^ar34
+endstop_pin: ^PC2
+#endstop_pin: ^PC3
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar57
-dir_pin: ar56
-enable_pin: !ar62
+step_pin: PF3
+dir_pin: PF2
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar33
-#endstop_pin: ^ar32
+endstop_pin: ^PC4
+#endstop_pin: ^PC5
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
-step_pin: ar23
-dir_pin: ar22
-enable_pin: !ar24
+step_pin: PA1
+dir_pin: PA0
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar2
+heater_pin: PE4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog15
+sensor_pin: PK7
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -57,38 +57,37 @@ min_temp: 0
 max_temp: 250
 
 #[extruder1]
-#step_pin: ar26
-#dir_pin: ar25
-#enable_pin: !ar27
-#heater_pin: ar3
-#sensor_pin: analog14
+#step_pin: PA4
+#dir_pin: PA3
+#enable_pin: !PA5
+#heater_pin: PE5
+#sensor_pin: PK6
 #...
 
 #[extruder2]
-#step_pin: ar29
-#dir_pin: ar28
-#enable_pin: !ar39
-#heater_pin: ar6
-#sensor_pin: analog13
+#step_pin: PA7
+#dir_pin: PA6
+#enable_pin: !PG2
+#heater_pin: PH3
+#sensor_pin: PK5
 #...
 
 [heater_bed]
-heater_pin: ar9
+heater_pin: PH6
 sensor_type: NTC 100K beta 3950
-sensor_pin: analog11
+sensor_pin: PK3
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar7
+pin: PH4
 
 #[heater_fan fan1]
-#pin: ar8
+#pin: PH5
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -100,20 +99,20 @@ max_z_accel: 100
 # "RepRapDiscount 2004 Smart Controller" type displays
 #[display]
 #lcd_type: hd44780
-#rs_pin: ar19
-#e_pin: ar42
-#d4_pin: ar18
-#d5_pin: ar38
-#d6_pin: ar41
-#d7_pin: ar40
-#encoder_pins: ^ar11, ^ar12
-#click_pin: ^!ar43
+#rs_pin: PD2
+#e_pin: PL7
+#d4_pin: PD3
+#d5_pin: PD7
+#d6_pin: PG0
+#d7_pin: PG1
+#encoder_pins: ^PB5, ^PB6
+#click_pin: ^!PL6
 
 # "RepRapDiscount 128x64 Full Graphic Smart Controller" type displays
 #[display]
 #lcd_type: st7920
-#cs_pin: ar19
-#sclk_pin: ar18
-#sid_pin: ar42
-#encoder_pins: ^ar11, ^ar12
-#click_pin: ^!ar43
+#cs_pin: PD2
+#sclk_pin: PD3
+#sid_pin: PL7
+#encoder_pins: ^PB5, ^PB6
+#click_pin: ^!PL6

--- a/config/generic-simulavr.cfg
+++ b/config/generic-simulavr.cfg
@@ -8,52 +8,52 @@
 
 [stepper_x]
 # Pins: PA5, PA4, PA1
-step_pin: ar29
-dir_pin: ar28
-enable_pin: ar25
+step_pin: PA5
+dir_pin: PA4
+enable_pin: PA1
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar0
+endstop_pin: ^PB0
 position_min: -0.25
 position_endstop: 0
 position_max: 200
 
 [stepper_y]
 # Pins: PA3, PA2
-step_pin: ar27
-dir_pin: ar26
-enable_pin: ar25
+step_pin: PA3
+dir_pin: PA2
+enable_pin: PA1
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar1
+endstop_pin: ^PB1
 position_min: -0.25
 position_endstop: 0
 position_max: 200
 
 [stepper_z]
 # Pins: PC7, PC6
-step_pin: ar23
-dir_pin: ar22
-enable_pin: ar25
+step_pin: PC7
+dir_pin: PC6
+enable_pin: PA1
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar2
+endstop_pin: ^PB2
 position_min: 0.1
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
 # Pins: PC3, PC2
-step_pin: ar19
-dir_pin: ar18
-enable_pin: ar25
+step_pin: PC3
+dir_pin: PC2
+enable_pin: PA1
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.500
 filament_diameter: 3.500
-heater_pin: ar4
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog7
+sensor_pin: PA7
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -63,19 +63,18 @@ min_extrude_temp: 0
 max_temp: 210
 
 [heater_bed]
-heater_pin: ar3
+heater_pin: PB3
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog0
+sensor_pin: PA0
 control: watermark
 min_temp: 0
 max_temp: 110
 
 [fan]
-pin: ar14
+pin: PD6
 
 [mcu]
 serial: /tmp/pseudoserial
-pin_map: arduino
 
 [printer]
 kinematics: cartesian

--- a/config/generic-ultimaker-ultimainboard-v2.cfg
+++ b/config/generic-ultimaker-ultimainboard-v2.cfg
@@ -5,49 +5,49 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar25
-dir_pin: !ar23
-enable_pin: !ar27
+step_pin: PA3
+dir_pin: !PA1
+enable_pin: !PA5
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar22
+endstop_pin: ^!PA0
 position_endstop: 0
 position_max: 230
 homing_speed: 50.0
 
 [stepper_y]
-step_pin: ar32
-dir_pin: ar33
-enable_pin: !ar31
+step_pin: PC5
+dir_pin: PC4
+enable_pin: !PC6
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar26
+endstop_pin: ^!PA4
 position_endstop: 225
 position_max: 225
 homing_speed: 50.0
 
 [stepper_z]
-step_pin: ar35
-dir_pin: !ar36
-enable_pin: !ar34
+step_pin: PC2
+dir_pin: !PC1
+enable_pin: !PC3
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar29
+endstop_pin: ^!PA7
 position_endstop: 215
 position_max: 215
 homing_speed: 20.0
 
 [extruder]
-step_pin: ar42
-dir_pin: ar43
-enable_pin: !ar37
+step_pin: PL7
+dir_pin: PL6
+enable_pin: !PC0
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 2.850
-heater_pin: ar2
+heater_pin: PE4
 sensor_type: PT100 INA826
-sensor_pin: analog8
+sensor_pin: PK0
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -57,16 +57,16 @@ max_temp: 275
 
 # Dual extruder support.
 #[extruder1]
-#step_pin: ar49
-#dir_pin: ar47
-#enable_pin: !ar48
+#step_pin: PL0
+#dir_pin: PL2
+#enable_pin: !PL1
 #microsteps: 16
 #rotation_distance: 33.500
 #nozzle_diameter: 0.400
 #filament_diameter: 2.850
-#heater_pin: ar3
+#heater_pin: PE5
 #sensor_type: PT100 INA826
-#sensor_pin: analog9
+#sensor_pin: PK1
 #control: pid
 #pid_Kp: 22.2
 #pid_Ki: 1.08
@@ -75,19 +75,18 @@ max_temp: 275
 #max_temp: 275
 
 [heater_bed]
-heater_pin: ar4
+heater_pin: PG5
 sensor_type: PT100 INA826
-sensor_pin: analog10
+sensor_pin: PK2
 control: watermark
 min_temp: 0
 max_temp: 100
 
 [fan]
-pin: ar7
+pin: PH4
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -97,12 +96,12 @@ max_z_velocity: 25
 max_z_accel: 30
 
 [output_pin case_light]
-pin: ar8
+pin: PH5
 static_value: 1.0
 
 # Motor current settings.
 [output_pin stepper_xy_current]
-pin: ar44
+pin: PL5
 pwm: True
 scale: 1.5
 # Max power setting.
@@ -112,7 +111,7 @@ static_value: 1.200
 # Power adjustment setting.
 
 [output_pin stepper_z_current]
-pin: ar45
+pin: PL4
 pwm: True
 scale: 1.5
 cycle_time: .000030
@@ -120,7 +119,7 @@ hardware_pwm: True
 static_value: 1.200
 
 [output_pin stepper_e_current]
-pin: ar46
+pin: PL3
 pwm: True
 scale: 1.5
 cycle_time: .000030

--- a/config/kit-voron2-250mm.cfg
+++ b/config/kit-voron2-250mm.cfg
@@ -30,14 +30,12 @@
 # Mcu for X/Y/E steppers
 serial: /dev/serial/by-id/**INSERT_YOUR_ARDUINO_DEFINITION_HERE**
 #   Obtain definition by "ls -l /dev/serial/by-id/"
-pin_map: arduino
 restart_method: arduino
 
 [mcu z]
 # Mcu for Z steppers
 serial: /dev/serial/by-id/**INSERT_YOUR_ARDUINO_DEFINITION_HERE**
 #   Obtain definition by "ls -l /dev/serial/by-id/"
-pin_map: arduino
 restart_method: arduino
 
 [printer]
@@ -49,14 +47,14 @@ max_z_accel: 350
 
 [stepper_x]
 # B Stepper
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 #   X on mcu_xye
 microsteps: 16
 rotation_distance: 40
 #   80 steps per mm - 1.8 deg - 1/16 microstepping
-endstop_pin: ^ar2
+endstop_pin: ^PE4
 #   X_MAX on mcu_xye
 position_min: 0
 position_endstop: 250
@@ -66,14 +64,14 @@ homing_retract_dist: 5
 
 [stepper_y]
 # A Stepper
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 #   Y on mcu_xye
 microsteps: 16
 rotation_distance: 40
 #   80 steps per mm - 1.8 deg - 1/16 microstepping
-endstop_pin: ^ar15
+endstop_pin: ^PJ0
 #   Y_MAX on mcu_xye
 position_min: 0
 position_endstop: 250
@@ -83,14 +81,14 @@ homing_retract_dist: 5
 
 [stepper_z]
 # Z0 Stepper - Front Left
-step_pin: z:ar54
-dir_pin: !z:ar55
-enable_pin: !z:ar38
+step_pin: z:PF0
+dir_pin: !z:PF1
+enable_pin: !z:PD7
 #   X on mcu_z
 microsteps: 16
 rotation_distance: 8
 #   400 steps per mm - 1.8 deg - 1/16 microstepping
-endstop_pin: ^!z:ar18
+endstop_pin: ^!z:PD3
 #   Z_MIN on mcu_z
 position_endstop: -0.2
 #   Offset (in mm) for nozzle to bed off z switch
@@ -103,9 +101,9 @@ homing_retract_dist: 3.0
 
 [stepper_z1]
 # Z1 Stepper - Rear Left
-step_pin: z:ar60
-dir_pin: z:ar61
-enable_pin: !z:ar56
+step_pin: z:PF6
+dir_pin: z:PF7
+enable_pin: !z:PF2
 #   Y on mcu_z
 microsteps: 16
 rotation_distance: 8
@@ -113,9 +111,9 @@ rotation_distance: 8
 
 [stepper_z2]
 # Z2 Stepper - Rear Right
-step_pin: z:ar46
-dir_pin: !z:ar48
-enable_pin: !z:ar62
+step_pin: z:PL3
+dir_pin: !z:PL1
+enable_pin: !z:PK0
 #   Z on mcu_z
 microsteps: 16
 rotation_distance: 8
@@ -123,18 +121,18 @@ rotation_distance: 8
 
 [stepper_z3]
 # Z3 Stepper - Front Right
-step_pin: z:ar26
-dir_pin: z:ar28
-enable_pin: !z:ar24
+step_pin: z:PA4
+dir_pin: z:PA6
+enable_pin: !z:PA2
 #   E0 on mcu_z
 microsteps: 16
 rotation_distance: 8
 #   400 steps per mm - 1.8 deg - 1/16 microstepping
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 #   E0 on mcu_xye
 microsteps: 16
 rotation_distance: 5.76576
@@ -143,11 +141,11 @@ nozzle_diameter: 0.400
 filament_diameter: 1.750
 max_extrude_only_distance: 780.0
 #   This is set high to allow the load/unload filament macros to run
-heater_pin: ar10
+heater_pin: PB4
 #   D10 on mcu_xye
 max_power: 1.0
 sensor_type: NTC 100K beta 3950
-sensor_pin: analog13
+sensor_pin: PK5
 #   T0 on mcu_xye
 smooth_time: 3.0
 control: pid
@@ -160,7 +158,7 @@ max_temp: 270
 
 [probe]
 # Inductive Probe
-pin: ^z:ar19
+pin: ^z:PD2
 #   Z_MAX on mcu_z
 x_offset: 0.0
 y_offset: 25.0
@@ -173,13 +171,13 @@ sample_retract_dist: 6.0
 
 [fan]
 # Print cooling fan
-pin: ar9
+pin: PH6
 #   D9 on mcu_xye
 kick_start_time: 0.500
 
 [heater_fan hotend_fan]
 # Hotend fan
-pin: z:ar9
+pin: z:PH6
 #   D9 on mcu_z
 kick_start_time: 0.500
 heater: extruder
@@ -187,7 +185,7 @@ heater_temp: 50.0
 
 [heater_fan controller_fan]
 # Controller fan
-pin: z:ar10
+pin: z:PB4
 #   D10 on mcu_z
 kick_start_time: 0.500
 heater: heater_bed
@@ -195,17 +193,17 @@ heater_temp: 45.0
 
 [heater_fan exhaust_fan]
 # Exhaust fan
-pin: z:ar8
+pin: z:PH5
 #   D8 on mcu_z
 kick_start_time: 0.500
 heater: heater_bed
 heater_temp: 60.0
 
 [heater_bed]
-heater_pin: z:ar11
+heater_pin: z:PB5
 #   D11 (servo) on mcu_z
 sensor_type: NTC 100K MGB18-104F39050L32
-sensor_pin: z:analog15
+sensor_pin: z:PK7
 #   T2 on mcu_z
 smooth_time: 3.0
 max_power: 0.75
@@ -247,14 +245,14 @@ horizontal_move_z: 6
 [display]
 # RepRapDiscount 128x64 Full Graphic Smart Controller
 lcd_type: st7920
-cs_pin: z:ar16
-sclk_pin: z:ar23
-sid_pin: z:ar17
+cs_pin: z:PH1
+sclk_pin: z:PA1
+sid_pin: z:PH0
 #   LCD connector on mcu_z
 menu_timeout: 40
-encoder_pins: ^z:ar33, ^z:ar31
-click_pin: ^!z:ar35
-kill_pin: ^!z:ar41
+encoder_pins: ^z:PC4, ^z:PC6
+click_pin: ^!z:PC2
+kill_pin: ^!z:PG0
 
 
 ###   Macros   ###

--- a/config/kit-zav3d-2019.cfg
+++ b/config/kit-zav3d-2019.cfg
@@ -26,12 +26,12 @@
 
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_max: 200
 homing_speed: 50
@@ -39,25 +39,25 @@ homing_speed: 50
 # The stepper_y section is used to describe the Y axis as well as the
 # stepper controlling the X-Y movement.
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 ## Configuration with Z Endstop, without Probe tool like BLTOUCH or others.
 #[stepper_z]
-#step_pin: ar46
-#dir_pin: ar48
-#enable_pin: !ar62
+#step_pin: PL3
+#dir_pin: PL1
+#enable_pin: !PK0
 #microsteps: 16
 #rotation_distance: 8
 ## I used Z_MAX_ENDSTOP
-#endstop_pin: ^ar19
+#endstop_pin: ^PD2
 ## More about z-calibration is here https://vk.com/topic-107680682_34101598
 #position_endstop: 235
 #position_max: 235
@@ -66,9 +66,9 @@ homing_speed: 50
 ## Configuration for Bltouch probe tool.
 ## Read more about BLTOUCH here https://www.klipper3d.org/BLTouch.html
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
 position_min: -3
@@ -78,16 +78,16 @@ endstop_pin: probe:z_virtual_endstop
 ## Configuration with PID Calibration.
 ## Read more here https://www.klipper3d.org/Config_checks.html
 [extruder]
-step_pin: ar26
-dir_pin: !ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: !PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 13.5744
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 min_temp: 0
 max_temp: 250
 control: pid
@@ -98,9 +98,9 @@ pid_kd: 151.598
 ## Configuration with PID Calibration.
 ## Read more here https://www.klipper3d.org/Config_checks.html
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 min_temp: 0
 max_temp: 130
 control: pid
@@ -109,11 +109,10 @@ pid_ki: 1.822
 pid_kd: 741.600
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: corexy
@@ -123,8 +122,8 @@ max_z_velocity: 25
 max_z_accel: 30
 
 [bltouch]
-sensor_pin: ^ar18
-control_pin: ar7
+sensor_pin: ^PD3
+control_pin: PH4
 x_offset: 39
 y_offset: 11
 z_offset: 0.9

--- a/config/printer-adimlab-2018.cfg
+++ b/config/printer-adimlab-2018.cfg
@@ -4,50 +4,50 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar25
-dir_pin: !ar23
-enable_pin: !ar27
+step_pin: PA3
+dir_pin: !PA1
+enable_pin: !PA5
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar22
+endstop_pin: ^!PA0
 position_min: -5
 position_endstop: -5
 position_max: 310
 homing_speed: 30.0
 
 [stepper_y]
-step_pin: ar32
-dir_pin: !ar33
-enable_pin: !ar31
+step_pin: PC5
+dir_pin: !PC4
+enable_pin: !PC6
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar26
+endstop_pin: ^!PA4
 position_endstop: 0
 position_max: 310
 homing_speed: 30.0
 
 [stepper_z]
-step_pin: ar35
-dir_pin: ar36
-enable_pin: !ar34
+step_pin: PC2
+dir_pin: PC1
+enable_pin: !PC3
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!ar29
+endstop_pin: ^!PA7
 position_endstop: 0.0
 position_max: 400
 homing_speed: 5.0
 
 [extruder]
-step_pin: ar42
-dir_pin: ar43
-enable_pin: !ar37
+step_pin: PL7
+dir_pin: PL6
+enable_pin: !PC0
 microsteps: 16
 rotation_distance: 34.557
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar2
+heater_pin: PE4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog8
+sensor_pin: PK0
 control: pid
 pid_Kp: 15.717
 pid_Ki: 0.569
@@ -56,9 +56,9 @@ min_temp: 0
 max_temp: 245
 
 [heater_bed]
-heater_pin: ar4
+heater_pin: PG5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog10
+sensor_pin: PK2
 control: pid
 pid_Kp: 74.883
 pid_Ki: 1.809
@@ -75,7 +75,6 @@ check_gain_time: 120
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -85,7 +84,7 @@ max_z_velocity: 10
 max_z_accel: 60
 
 [output_pin stepper_xy_current]
-pin: ar44
+pin: PL5
 pwm: True
 scale: 2.0
 cycle_time: .000030
@@ -93,7 +92,7 @@ hardware_pwm: True
 static_value: 1.3
 
 [output_pin stepper_z_current]
-pin: ar45
+pin: PL4
 pwm: True
 scale: 2.0
 cycle_time: .000030
@@ -101,7 +100,7 @@ hardware_pwm: True
 static_value: 1.3
 
 [output_pin stepper_e_current]
-pin: ar46
+pin: PL3
 pwm: True
 scale: 2.0
 cycle_time: .000030
@@ -110,15 +109,15 @@ static_value: 1.25
 
 [display]
 lcd_type: st7920
-cs_pin: ar20
-sclk_pin: ar14
-sid_pin: ar15
-encoder_pins: ^ar41, ^ar40
-click_pin: ^!ar19
+cs_pin: PD1
+sclk_pin: PJ1
+sid_pin: PJ0
+encoder_pins: ^PG0, ^PG1
+click_pin: ^!PD2
 
-# The filament runout sensor (on pin ar24) is not currently supported
+# The filament runout sensor (on pin PA2) is not currently supported
 # in Klipper.
 
 [output_pin case_light]
-pin: ar7
+pin: PH4
 value: 1

--- a/config/printer-anycubic-4max-2018.cfg
+++ b/config/printer-anycubic-4max-2018.cfg
@@ -4,51 +4,51 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar3
+endstop_pin: ^!PE5
 position_min: -2
 position_endstop: -2
 position_max: 205
 homing_speed: 60.0
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar14
+endstop_pin: ^!PJ1
 position_endstop: 0
 position_max: 215
 homing_speed: 60.0
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!ar18
+endstop_pin: ^!PD3
 position_endstop: 0.5
 position_max: 305
 homing_speed: 8.0
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.133
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 max_extrude_only_distance: 2000
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_kp: 27.725
 pid_ki: 1.224
@@ -57,9 +57,9 @@ min_temp: 0
 max_temp: 300
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_kp: 73.735
 pid_ki: 1.437
@@ -68,12 +68,11 @@ min_temp: 0
 max_temp: 110
 
 [fan]
-pin: ar9
+pin: PH6
 kick_start_time: 1.0
 
 [mcu]
 serial: /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -83,23 +82,23 @@ max_z_velocity: 40
 max_z_accel: 60
 
 [heater_fan extruder_fan]
-pin: ar44
+pin: PL5
 
 [heater_fan stepstick_fan]
-pin: ar7
+pin: PH4
 kick_start_time: 1.0
 
 [display]
 lcd_type: st7920
-cs_pin: ar16
-sclk_pin: ar23
-sid_pin: ar17
-encoder_pins: ^ar31, ^ar33
-click_pin: ^!ar35
-kill_pin: ^!ar41
+cs_pin: PH1
+sclk_pin: PA1
+sid_pin: PH0
+encoder_pins: ^PC6, ^PC4
+click_pin: ^!PC2
+kill_pin: ^!PG0
 
 [filament_switch_sensor e0_sensor]
-switch_pin: ar19
+switch_pin: PD2
 
 [gcode_macro START_PRINT]
 gcode:

--- a/config/printer-anycubic-i3-mega-2017.cfg
+++ b/config/printer-anycubic-i3-mega-2017.cfg
@@ -7,58 +7,58 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar3
+endstop_pin: ^!PE5
 position_min: -5
 position_endstop: -5
 position_max: 210
 homing_speed: 30.0
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar42
+endstop_pin: ^!PL7
 position_endstop: 0
 position_max: 210
 homing_speed: 30.0
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!ar18
+endstop_pin: ^!PD3
 position_endstop: 0.0
 position_max: 205
 homing_speed: 5.0
 
 [stepper_z1]
-step_pin: ar36
-dir_pin: ar34
-enable_pin: !ar30
+step_pin: PC1
+dir_pin: PC3
+enable_pin: !PC7
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!ar43
+endstop_pin: ^!PL6
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 34.557
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 15.717
 pid_Ki: 0.569
@@ -67,12 +67,12 @@ min_temp: 0
 max_temp: 245
 
 [heater_fan extruder_fan]
-pin: ar44
+pin: PL5
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp: 74.883
 pid_Ki: 1.809
@@ -81,11 +81,10 @@ min_temp: 0
 max_temp: 110
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -95,4 +94,4 @@ max_z_velocity: 10
 max_z_accel: 60
 
 [heater_fan stepstick_fan]
-pin: ar7
+pin: PH4

--- a/config/printer-anycubic-kossel-2016.cfg
+++ b/config/printer-anycubic-kossel-2016.cfg
@@ -8,12 +8,12 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_a]
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar2
+endstop_pin: ^PE4
 homing_speed: 60
 # The next parameter needs to be adjusted for
 # your printer. You may want to start with 280
@@ -23,32 +23,32 @@ position_endstop: 273.0
 arm_length: 229.4
 
 [stepper_b]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar15
+endstop_pin: ^PJ0
 
 [stepper_c]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar19
+endstop_pin: ^PD2
 
 [extruder]
-step_pin: ar26
-dir_pin: !ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: !PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 35.165
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 25.349
 pid_Ki: 1.216
@@ -58,23 +58,22 @@ min_temp: 0
 max_temp: 275
 
 #[heater_bed]
-#heater_pin: ar8
+#heater_pin: PH5
 #sensor_type: EPCOS 100K B57560G104F
-#sensor_pin: analog14
+#sensor_pin: PK6
 #control: watermark
 #min_temp: 0
 #max_temp: 130
 
 [fan]
-pin: ar9
+pin: PH6
 kick_start_time: 0.200
 
 [heater_fan extruder_cooler_fan]
-pin: ar44
+pin: PL5
 
 [mcu]
 serial: /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0
-pin_map: arduino
 
 [printer]
 kinematics: delta
@@ -102,12 +101,12 @@ timeout: 360
 # "RepRapDiscount 2004 Smart Controller" type displays
 [display]
 lcd_type: hd44780
-rs_pin: ar16
-e_pin: ar17
-d4_pin: ar23
-d5_pin: ar25
-d6_pin: ar27
-d7_pin: ar29
-encoder_pins: ^ar31, ^ar33
-click_pin: ^!ar35
-kill_pin: ^!ar41
+rs_pin: PH1
+e_pin: PH0
+d4_pin: PA1
+d5_pin: PA3
+d6_pin: PA5
+d7_pin: PA7
+encoder_pins: ^PC6, ^PC4
+click_pin: ^!PC2
+kill_pin: ^!PG0

--- a/config/printer-anycubic-kossel-plus-2017.cfg
+++ b/config/printer-anycubic-kossel-plus-2017.cfg
@@ -8,12 +8,12 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_a]
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar2
+endstop_pin: ^PE4
 homing_speed: 60
 # The next parameter needs to be adjusted for
 # your printer. You may want to start with 280
@@ -23,32 +23,32 @@ position_endstop: 295.6
 arm_length: 269.0
 
 [stepper_b]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar15
+endstop_pin: ^PJ0
 
 [stepper_c]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar19
+endstop_pin: ^PD2
 
 [extruder]
-step_pin: ar26
-dir_pin: !ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: !PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.333
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 25.349
 pid_Ki: 1.216
@@ -58,9 +58,9 @@ min_temp: 0
 max_temp: 275
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_kp: 73.517
 pid_ki: 1.132
@@ -69,21 +69,20 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar9
+pin: PH6
 kick_start_time: 0.200
 
 [heater_fan extruder_cooler_fan]
-pin: ar44
+pin: PL5
 
 # if you want to use your probe for DELTA_CALIBRATE you will need that
 #[probe]
-#pin: ^ar18
+#pin: ^PD3
 #z_offset: 15.9
 #samples: 3
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: delta
@@ -105,12 +104,12 @@ radius: 115
 # "RepRapDiscount 2004 Smart Controller" type displays
 [display]
 lcd_type: hd44780
-rs_pin: ar16
-e_pin: ar17
-d4_pin: ar23
-d5_pin: ar25
-d6_pin: ar27
-d7_pin: ar29
-encoder_pins: ^ar31, ^ar33
-click_pin: ^!ar35
-kill_pin: ^!ar41
+rs_pin: PH1
+e_pin: PH0
+d4_pin: PA1
+d5_pin: PA3
+d6_pin: PA5
+d7_pin: PA7
+encoder_pins: ^PC6, ^PC4
+click_pin: ^!PC2
+kill_pin: ^!PG0

--- a/config/printer-creality-cr10s-2017.cfg
+++ b/config/printer-creality-cr10s-2017.cfg
@@ -4,48 +4,48 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_max: 300
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 300
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar18
+endstop_pin: ^PD3
 position_endstop: 0
 position_max: 400
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -54,9 +54,9 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp: 690.34
 pid_Ki: 111.47
@@ -65,11 +65,10 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -80,8 +79,8 @@ max_z_accel: 100
 
 [display]
 lcd_type: st7920
-cs_pin: ar16
-sclk_pin: ar23
-sid_pin: ar17
-encoder_pins: ^ar33, ^ar31
-click_pin: ^!ar35
+cs_pin: PH1
+sclk_pin: PA1
+sid_pin: PH0
+encoder_pins: ^PC4, ^PC6
+click_pin: ^!PC2

--- a/config/printer-longer-lk4-pro-2019.cfg
+++ b/config/printer-longer-lk4-pro-2019.cfg
@@ -5,34 +5,34 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar3
+endstop_pin: ^!PE5
 position_endstop: 0
 position_max: 235
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar14
+endstop_pin: ^!PJ1
 position_endstop: 0
 position_max: 235
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!ar35
+endstop_pin: ^!PC2
 # Uncomment for BLTouch
 # endstop_pin: probe:z_virtual_endstop
 position_endstop: 0.5
@@ -55,8 +55,8 @@ position_max: 250
 # According this follow mapping :
 # https://arduiblog.com/2020/06/22/installation-dun-bltouch-sur-lalfawise-u30-pro/
 # & see "Branchement" paragraph & picture
-# sensor_pin: ^ar35
-# control_pin: ar7
+# sensor_pin: ^PC2
+# control_pin: PH4
 # If you use this fang : https://www.thingiverse.com/thing:3603067
 # you can use this follow values for x & y offset
 # x_offset: -28
@@ -70,16 +70,16 @@ position_max: 250
 # probe_count: 4,3
 
 [extruder]
-step_pin: ar26
-dir_pin: !ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: !PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 34.5576
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -88,22 +88,21 @@ min_temp: 0
 max_temp: 250
 
 [filament_switch_sensor filament_sensor]
-switch_pin: ^!ar2
+switch_pin: ^!PE4
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian

--- a/config/printer-micromake-d1-2016.cfg
+++ b/config/printer-micromake-d1-2016.cfg
@@ -5,43 +5,43 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_a]
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^ar2
+endstop_pin: ^PE4
 homing_speed: 100
 position_endstop: 319.5
 arm_length: 217.0
 
 [stepper_b]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^ar15
+endstop_pin: ^PJ0
 
 [stepper_c]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^ar19
+endstop_pin: ^PD2
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 20.067
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -51,11 +51,10 @@ max_temp: 250
 max_extrude_only_distance: 100.0
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyACM0
-pin_map: arduino
 
 [printer]
 kinematics: delta
@@ -68,16 +67,16 @@ delta_radius: 95
 radius: 80
 
 #[probe]
-#pin: ^!ar18
+#pin: ^!PD3
 
 [display]
 lcd_type: hd44780
-rs_pin: ar16
-e_pin: ar17
-d4_pin: ar23
-d5_pin: ar25
-d6_pin: ar27
-d7_pin: ar29
-encoder_pins: ^ar31, ^ar33
-click_pin: ^!ar35
-kill_pin: ^!ar41
+rs_pin: PH1
+e_pin: PH0
+d4_pin: PA1
+d5_pin: PA3
+d6_pin: PA5
+d7_pin: PA7
+encoder_pins: ^PC6, ^PC4
+click_pin: ^!PC2
+kill_pin: ^!PG0

--- a/config/printer-sovol-sv01-2020.cfg
+++ b/config/printer-sovol-sv01-2020.cfg
@@ -5,48 +5,48 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_max: 300
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 255
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar18
+endstop_pin: ^PD3
 position_endstop: 0
 position_max: 300
 
 [extruder]
-step_pin: ar26
-dir_pin: !ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: !PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 7.680
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 31.147
 pid_Ki: 2.076
@@ -55,9 +55,9 @@ min_temp: 0
 max_temp: 265
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp: 72.174
 pid_Ki: 1.816
@@ -66,15 +66,14 @@ min_temp: 0
 max_temp: 110
 
 [filament_switch_sensor my_sensor]
-switch_pin: ar2
+switch_pin: PE4
 pause_on_runout: True
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -85,8 +84,8 @@ max_z_accel: 100
 
 [display]
 lcd_type: st7920
-cs_pin: ar16
-sclk_pin: ar23
-sid_pin: ar17
-encoder_pins: ^ar33, ^ar31
-click_pin: ^!ar35
+cs_pin: PH1
+sclk_pin: PA1
+sid_pin: PH0
+encoder_pins: ^PC4, ^PC6
+click_pin: ^!PC2

--- a/config/printer-sunlu-s8-2020.cfg
+++ b/config/printer-sunlu-s8-2020.cfg
@@ -1,53 +1,53 @@
 # This file contains pin mappings for the SUNLU S8 v1.01 (circa 2020), which
 # is a modified RAMPS v1.3 board. To use this config, the firmware should be
 # compiled for the AVR atmega2560. The following pins are available for
-# expansion (e.g. ABL): ^ar19 (Z+ endstop), ar4, ar5, ar6, ar11
+# expansion (e.g. ABL): ^PD2 (Z+ endstop), PG5, PE3, PH3, PB5
 
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar3
+endstop_pin: ^!PE5
 position_endstop: 0
 position_max: 310
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar14
+endstop_pin: ^!PJ1
 position_endstop: 0
 position_max: 310
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!ar18
+endstop_pin: ^!PD3
 position_endstop: 0.5
 position_max: 400
 
 [extruder]
-step_pin: ar26
-dir_pin: !ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: !PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 33.280
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_kp: 25.588
 pid_ki: 1.496
@@ -57,12 +57,12 @@ max_temp: 250
 
 [filament_switch_sensor runout]
 pause_on_runout: True
-switch_pin: ^ar2
+switch_pin: ^PE4
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_kp: 74.786
 pid_ki: 0.766
@@ -77,14 +77,13 @@ max_temp: 110
 check_gain_time: 240
 
 [fan]
-pin: ar9
+pin: PH6
 
 [heater_fan fan1]
-pin: ar7
+pin: PH4
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -95,11 +94,11 @@ max_z_accel: 100
 
 [display]
 lcd_type: st7920
-cs_pin: ar16
-sclk_pin: ar23
-sid_pin: ar17
-encoder_pins: ^ar33, ^ar31
-click_pin: ^!ar35
+cs_pin: PH1
+sclk_pin: PA1
+sid_pin: PH0
+encoder_pins: ^PC4, ^PC6
+click_pin: ^!PC2
 
 [output_pin beeper]
-pin: ar37
+pin: PC0

--- a/config/printer-tevo-flash-2018.cfg
+++ b/config/printer-tevo-flash-2018.cfg
@@ -8,33 +8,33 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: !ar3
+endstop_pin: !PE5
 position_endstop: -13
 position_min: -13
 position_max: 235
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: !ar14
+endstop_pin: !PJ1
 position_endstop: -3
 position_min: -3
 position_max: 235
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
 position_max: 250
@@ -42,24 +42,24 @@ endstop_pin: probe:z_virtual_endstop
 position_min: -2
 
 [stepper_z1]
-step_pin: ar36
-dir_pin: ar34
-enable_pin: !ar30
+step_pin: PC1
+dir_pin: PC3
+enable_pin: !PC7
 microsteps: 16
 rotation_distance: 8
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 gear_ratio: 50:17
 rotation_distance: 22.598
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 18.547
 pid_Ki: 0.788
@@ -68,9 +68,9 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp: 38.824
 pid_Ki: 0.539
@@ -79,14 +79,13 @@ min_temp: 0
 max_temp: 70
 
 [heater_fan my_nozzle_fan]
-pin: ar7
+pin: PH4
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -97,15 +96,15 @@ max_z_accel: 100
 
 [display]
 lcd_type: uc1701
-cs_pin: ar25
-a0_pin: ar27
-encoder_pins: ^!ar31, ^!ar33
-click_pin: ^!ar35
-kill_pin: ar64
+cs_pin: PA3
+a0_pin: PA5
+encoder_pins: ^!PC6, ^!PC4
+click_pin: ^!PC2
+kill_pin: PK2
 
 [bltouch]
-sensor_pin: ar18
-control_pin: ar11
+sensor_pin: PD3
+control_pin: PB5
 x_offset: 0
 y_offset: 18
 z_offset: 1.64

--- a/config/printer-tevo-tarantula-pro-2020.cfg
+++ b/config/printer-tevo-tarantula-pro-2020.cfg
@@ -8,58 +8,58 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar3
+endstop_pin: ^!PE5
 position_endstop: -2
 position_max: 220
 position_min: -2
 homing_speed: 25.0
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar14
+endstop_pin: ^!PJ1
 position_endstop: 0
 position_max: 220
 homing_speed: 25.0
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!ar18
+endstop_pin: ^!PD3
 position_endstop: 0
 position_max: 200
 
 # Enable for dual-z addon
 #[stepper_z1]
-#step_pin: ar36
-#dir_pin: ar34
-#enable_pin: !ar30
+#step_pin: PC1
+#dir_pin: PC3
+#enable_pin: !PC7
 #microsteps: 16
 #rotation_distance: 8
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 7.904
 nozzle_diameter: 0.400
 filament_diameter: 1.75
 
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.5
 pid_Ki: 1.78
@@ -68,19 +68,18 @@ min_temp: 0
 max_temp: 220
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: watermark
 min_temp: 0
 max_temp: 110
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -90,13 +89,13 @@ max_z_velocity: 50
 max_z_accel: 100
 
 [heater_fan nozzle_fan]
-pin: ar7
+pin: PH4
 
 [display]
 lcd_type: uc1701
-cs_pin: ar25
-a0_pin: ar27
-encoder_pins: ^!ar31, ^!ar33
-click_pin: ^!ar35
-kill_pin: !ar41
+cs_pin: PA3
+a0_pin: PA5
+encoder_pins: ^!PC6, ^!PC4
+click_pin: ^!PC2
+kill_pin: !PG0
 menu_reverse_navigation: true

--- a/config/printer-velleman-k8200-2013.cfg
+++ b/config/printer-velleman-k8200-2013.cfg
@@ -7,52 +7,52 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: !ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar63
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK1
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^ar18
+endstop_pin: ^PD3
 position_endstop: 0.5
 # Set position_max to 200 if you have the original Z-axis setup.
 position_max: 250
 
 [extruder]
-step_pin: ar26
+step_pin: PA4
 # Remove the "!" from dir_pin if you have an original extruder
-dir_pin: !ar28
-enable_pin: !ar24
+dir_pin: !PA6
+enable_pin: !PA2
 # You will have to calculate your own rotation_distance.
 # This is for the belted extruder https://www.thingiverse.com/thing:339928
 microsteps: 16
 rotation_distance: 4.266
 nozzle_diameter: 0.400
 filament_diameter: 2.85
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 21.503
 pid_Ki: 1.103
@@ -61,9 +61,9 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: ar9
+heater_pin: PH6
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp: 75.283
 pid_Ki: 0.588
@@ -72,12 +72,11 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: ar8
+pin: PH5
 kick_start_time: 0.500
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -89,11 +88,11 @@ max_z_accel: 100
 # The LCD is untested - "RepRapDiscount 2004 Smart Controller" displays
 #[display]
 #lcd_type: hd44780
-#rs_pin: ar27
-#e_pin: ar29
-#d4_pin: ar37
-#d5_pin: ar35
-#d6_pin: ar33
-#d7_pin: ar31
-#encoder_pins: ^ar16, ^ar17
-#click_pin: ^!ar23
+#rs_pin: PA5
+#e_pin: PA7
+#d4_pin: PC0
+#d5_pin: PC2
+#d6_pin: PC4
+#d7_pin: PC6
+#encoder_pins: ^PH1, ^PH0
+#click_pin: ^!PA1

--- a/config/printer-wanhao-duplicator-9-2018.cfg
+++ b/config/printer-wanhao-duplicator-9-2018.cfg
@@ -5,31 +5,31 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar61
-dir_pin: !ar62
-enable_pin: !ar60
+step_pin: PF7
+dir_pin: !PK0
+enable_pin: !PF6
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar54
+endstop_pin: ^!PF0
 position_endstop: 0
 position_max: 295
 homing_speed: 30.0
 
 [stepper_y]
-step_pin: ar64
-dir_pin: ar65
-enable_pin: !ar2
+step_pin: PK2
+dir_pin: PK3
+enable_pin: !PE4
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar24
+endstop_pin: ^!PA2
 position_endstop: 0
 position_max: 290
 homing_speed: 30.0
 
 [stepper_z]
-step_pin: ar67
-dir_pin: ar69
-enable_pin: !ar66
+step_pin: PK5
+dir_pin: PK7
+enable_pin: !PK4
 microsteps: 16
 rotation_distance: 8
 endstop_pin: probe:z_virtual_endstop
@@ -37,16 +37,16 @@ position_max: 370
 position_min: -0.99
 
 [extruder]
-step_pin: ar58
-dir_pin: ar59
-enable_pin: !ar57
+step_pin: PF4
+dir_pin: PF5
+enable_pin: !PF3
 microsteps: 16
 rotation_distance: 31.936
 nozzle_diameter: 0.4
 filament_diameter: 1.75
-heater_pin: ar4
+heater_pin: PG5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog1
+sensor_pin: PF1
 control: pid
 pid_Kp: 33.41
 pid_Ki: 1.47
@@ -55,9 +55,9 @@ min_temp: 0
 max_temp: 315
 
 [heater_bed]
-heater_pin: ar3
+heater_pin: PE5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp: 64.095903
 pid_Ki: 1.649830
@@ -66,10 +66,10 @@ min_temp: 0
 max_temp: 120
 
 [fan]
-pin: ar5
+pin: PE3
 
 [probe]
-pin: !ar6
+pin: !PH3
 x_offset: 27
 y_offset: 3
 z_offset: 1.4
@@ -80,7 +80,6 @@ samples_result: average
 
 [mcu]
 serial: /dev/ttyUSB0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian

--- a/config/printer-wanhao-duplicator-i3-mini-2017.cfg
+++ b/config/printer-wanhao-duplicator-i3-mini-2017.cfg
@@ -7,48 +7,48 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: ar22
-dir_pin: !ar23
-enable_pin: !ar57
+step_pin: PA0
+dir_pin: !PA1
+enable_pin: !PF3
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar19
+endstop_pin: ^!PD2
 position_endstop: 120
 position_max: 120
 homing_speed: 30.0
 
 [stepper_y]
-step_pin: ar25
-dir_pin: ar26
-enable_pin: !ar24
+step_pin: PA3
+dir_pin: PA4
+enable_pin: !PA2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!ar18
+endstop_pin: ^!PD3
 position_endstop: 0
 position_max: 135
 homing_speed: 30.0
 
 [stepper_z]
-step_pin: ar29
-dir_pin: ar39
-enable_pin: !ar28
+step_pin: PA7
+dir_pin: PG2
+enable_pin: !PA6
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!ar38
+endstop_pin: ^!PD7
 position_endstop: 0.5
 position_max: 100
 
 [extruder]
-step_pin: ar55
-dir_pin: !ar56
-enable_pin: !ar54
+step_pin: PF1
+dir_pin: !PF2
+enable_pin: !PF0
 microsteps: 16
 rotation_distance: 34.043
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: ar4
+heater_pin: PG5
 sensor_type: NTC 100K MGB18-104F39050L32
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -57,11 +57,10 @@ min_temp: 1
 max_temp: 265
 
 [fan]
-pin: ar12
+pin: PB6
 
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -72,9 +71,9 @@ max_z_accel: 100
 
 [display]
 lcd_type: uc1701
-cs_pin: ar41
-a0_pin: ar40
-rst_pin: ar27
-click_pin: ^!ar5
-encoder_pins: ^ar3, ^ar2
-kill_pin: ar64
+cs_pin: PG0
+a0_pin: PG1
+rst_pin: PA5
+click_pin: ^!PE3
+encoder_pins: ^PE5, ^PE4
+kill_pin: PK2

--- a/config/sample-aliases.cfg
+++ b/config/sample-aliases.cfg
@@ -1,0 +1,128 @@
+# This file contains common board aliases for Arduino (and similar)
+# boards.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+# Arduino aliases for atmega168/328/328p boards
+[board_pins arduino-standard]
+aliases:
+    ar0=PD0, ar1=PD1, ar2=PD2, ar3=PD3, ar4=PD4,
+    ar5=PD5, ar6=PD6, ar7=PD7, ar8=PB0, ar9=PB1,
+    ar10=PB2, ar11=PB3, ar12=PB4, ar13=PB5, ar14=PC0,
+    ar15=PC1, ar16=PC2, ar17=PC3, ar18=PC4, ar19=PC5,
+    analog0=PC0, analog1=PC1, analog2=PC2, analog3=PC3, analog4=PC4,
+    analog5=PC5, analog6=PE0, analog7=PE1
+
+# Arduino aliases for atmega2560/1280 (Arduino mega) boards
+[board_pins arduino-mega]
+aliases:
+    ar0=PE0, ar1=PE1, ar2=PE4, ar3=PE5, ar4=PG5,
+    ar5=PE3, ar6=PH3, ar7=PH4, ar8=PH5, ar9=PH6,
+    ar10=PB4, ar11=PB5, ar12=PB6, ar13=PB7, ar14=PJ1,
+    ar15=PJ0, ar16=PH1, ar17=PH0, ar18=PD3, ar19=PD2,
+    ar20=PD1, ar21=PD0, ar22=PA0, ar23=PA1, ar24=PA2,
+    ar25=PA3, ar26=PA4, ar27=PA5, ar28=PA6, ar29=PA7,
+    ar30=PC7, ar31=PC6, ar32=PC5, ar33=PC4, ar34=PC3,
+    ar35=PC2, ar36=PC1, ar37=PC0, ar38=PD7, ar39=PG2,
+    ar40=PG1, ar41=PG0, ar42=PL7, ar43=PL6, ar44=PL5,
+    ar45=PL4, ar46=PL3, ar47=PL2, ar48=PL1, ar49=PL0,
+    ar50=PB3, ar51=PB2, ar52=PB1, ar53=PB0, ar54=PF0,
+    ar55=PF1, ar56=PF2, ar57=PF3, ar58=PF4, ar59=PF5,
+    ar60=PF6, ar61=PF7, ar62=PK0, ar63=PK1, ar64=PK2,
+    ar65=PK3, ar66=PK4, ar67=PK5, ar68=PK6, ar69=PK7,
+    analog0=PF0, analog1=PF1, analog2=PF2, analog3=PF3, analog4=PF4,
+    analog5=PF5, analog6=PF6, analog7=PF7, analog8=PK0, analog9=PK1,
+    analog10=PK2, analog11=PK3, analog12=PK4, analog13=PK5, analog14=PK6,
+    analog15=PK7,
+    # Marlin adds these additional aliases
+    ml70=PG4, ml71=PG3, ml72=PJ2, ml73=PJ3, ml74=PJ7,
+    ml75=PJ4, ml76=PJ5, ml77=PJ6, ml78=PE2, ml79=PE6,
+    ml80=PE7, ml81=PD4, ml82=PD5, ml83=PD6, ml84=PH2,
+    ml85=PH7
+
+# Aliases for atmega644p (Sanguino boards)
+[board_pins sanguino]
+aliases:
+    ar0=PB0, ar1=PB1, ar2=PB2, ar3=PB3, ar4=PB4,
+    ar5=PB5, ar6=PB6, ar7=PB7, ar8=PD0, ar9=PD1,
+    ar10=PD2, ar11=PD3, ar12=PD4, ar13=PD5, ar14=PD6,
+    ar15=PD7, ar16=PC0, ar17=PC1, ar18=PC2, ar19=PC3,
+    ar20=PC4, ar21=PC5, ar22=PC6, ar23=PC7, ar24=PA0,
+    ar25=PA1, ar26=PA2, ar27=PA3, ar28=PA4, ar29=PA5,
+    ar30=PA6, ar31=PA7,
+    analog0=PA0, analog1=PA1, analog2=PA2, analog3=PA3, analog4=PA4,
+    analog5=PA5, analog6=PA6, analog7=PA7
+
+# Aliases for atsam3x8e (Arduino Due boards)
+[board_pins arduino-due]
+aliases:
+    ar0=PA8, ar1=PA9, ar2=PB25, ar3=PC28, ar4=PA29,
+    ar5=PC25, ar6=PC24, ar7=PC23, ar8=PC22, ar9=PC21,
+    ar10=PA28, ar11=PD7, ar12=PD8, ar13=PB27, ar14=PD4,
+    ar15=PD5, ar16=PA13, ar17=PA12, ar18=PA11, ar19=PA10,
+    ar20=PB12, ar21=PB13, ar22=PB26, ar23=PA14, ar24=PA15,
+    ar25=PD0, ar26=PD1, ar27=PD2, ar28=PD3, ar29=PD6,
+    ar30=PD9, ar31=PA7, ar32=PD10, ar33=PC1, ar34=PC2,
+    ar35=PC3, ar36=PC4, ar37=PC5, ar38=PC6, ar39=PC7,
+    ar40=PC8, ar41=PC9, ar42=PA19, ar43=PA20, ar44=PC19,
+    ar45=PC18, ar46=PC17, ar47=PC16, ar48=PC15, ar49=PC14,
+    ar50=PC13, ar51=PC12, ar52=PB21, ar53=PB14, ar54=PA16,
+    ar55=PA24, ar56=PA23, ar57=PA22, ar58=PA6, ar59=PA4,
+    ar60=PA3, ar61=PA2, ar62=PB17, ar63=PB18, ar64=PB19,
+    ar65=PB20, ar66=PB15, ar67=PB16, ar68=PA1, ar69=PA0,
+    ar70=PA17, ar71=PA18, ar72=PC30, ar73=PA21, ar74=PA25,
+    ar75=PA26, ar76=PA27, ar77=PA28, ar78=PB23,
+    analog0=PA16, analog1=PA24, analog2=PA23, analog3=PA22, analog4=PA6,
+    analog5=PA4, analog6=PA3, analog7=PA2, analog8=PB17, analog9=PB18,
+    analog10=PB19, analog11=PB20
+
+# Aliases for Adafruit GrandCentral boards (samd51)
+[board_pins adafruit-grandcentral]
+aliases:
+    ar0=PB25, ar1=PB24, ar2=PC18, ar3=PC19, ar4=PC20,
+    ar5=PC21, ar6=PD20, ar7=PD21, ar8=PB18, ar9=PB2,
+    ar10=PB22, ar11=PB23, ar12=PB0, ar13=PB1, ar14=PB16,
+    ar15=PB17, ar16=PC22, ar17=PC23, ar18=PB12, ar19=PB13,
+    ar20=PB20, ar21=PB21, ar22=PD12, ar23=PA15, ar24=PC17,
+    ar25=PC16, ar26=PA12, ar27=PA13, ar28=PA14, ar29=PB19,
+    ar30=PA23, ar31=PA22, ar32=PA21, ar33=PA20, ar34=PA19,
+    ar35=PA18, ar36=PA17, ar37=PA16, ar38=PB15, ar39=PB14,
+    ar40=PC13, ar41=PC12, ar42=PC15, ar43=PC14, ar44=PC11,
+    ar45=PC10, ar46=PC6, ar47=PC7, ar48=PC4, ar49=PC5,
+    ar50=PD11, ar51=PD8, ar52=PD9, ar53=PD10, ar54=PA2,
+    ar55=PA5, ar56=PB3, ar57=PC0, ar58=PC1, ar59=PC2,
+    ar60=PC3, ar61=PB4, ar62=PB5, ar63=PB6, ar64=PB7,
+    ar65=PB8, ar66=PB9, ar67=PA4, ar68=PA6, ar69=PA7,
+    analog0=PA2, analog1=PA5, analog2=PB3, analog3=PC0, analog4=PC1,
+    analog5=PC2, analog6=PC3, analog7=PB4, analog8=PB5, analog9=PB6,
+    analog10=PB7, analog11=PB8, analog12=PB9, analog13=PA4, analog14=PA6,
+    analog15=PA7
+
+# Aliases for Beaglebone boards
+[board_pins beaglebone]
+aliases:
+    P8_3=gpio1_6, P8_4=gpio1_7, P8_5=gpio1_2,
+    P8_6=gpio1_3, P8_7=gpio2_2, P8_8=gpio2_3,
+    P8_9=gpio2_5, P8_10=gpio2_4, P8_11=gpio1_13,
+    P8_12=gpio1_12, P8_13=gpio0_23, P8_14=gpio0_26,
+    P8_15=gpio1_15, P8_16=gpio1_14, P8_17=gpio0_27,
+    P8_18=gpio2_1, P8_19=gpio0_22, P8_20=gpio1_31,
+    P8_21=gpio1_30, P8_22=gpio1_5, P8_23=gpio1_4,
+    P8_24=gpio1_1, P8_25=gpio1_0, P8_26=gpio1_29,
+    P8_27=gpio2_22, P8_28=gpio2_24, P8_29=gpio2_23,
+    P8_30=gpio2_25, P8_31=gpio0_10, P8_32=gpio0_11,
+    P8_33=gpio0_9, P8_34=gpio2_17, P8_35=gpio0_8,
+    P8_36=gpio2_16, P8_37=gpio2_14, P8_38=gpio2_15,
+    P8_39=gpio2_12, P8_40=gpio2_13, P8_41=gpio2_10,
+    P8_42=gpio2_11, P8_43=gpio2_8, P8_44=gpio2_9,
+    P8_45=gpio2_6, P8_46=gpio2_7, P9_11=gpio0_30,
+    P9_12=gpio1_28, P9_13=gpio0_31, P9_14=gpio1_18,
+    P9_15=gpio1_16, P9_16=gpio1_19, P9_17=gpio0_5,
+    P9_18=gpio0_4, P9_19=gpio0_13, P9_20=gpio0_12,
+    P9_21=gpio0_3, P9_22=gpio0_2, P9_23=gpio1_17,
+    P9_24=gpio0_15, P9_25=gpio3_21, P9_26=gpio0_14,
+    P9_27=gpio3_19, P9_28=gpio3_17, P9_29=gpio3_15,
+    P9_30=gpio3_16, P9_31=gpio3_14, P9_41=gpio0_20,
+    P9_42=gpio3_20, P9_43=gpio0_7, P9_44=gpio3_18,
+    P9_33=AIN4, P9_35=AIN6, P9_36=AIN5, P9_37=AIN2,
+    P9_38=AIN3, P9_39=AIN0, P9_40=AIN1

--- a/config/sample-multi-mcu.cfg
+++ b/config/sample-multi-mcu.cfg
@@ -9,61 +9,58 @@
 # are connected to the main micro-controller.
 [mcu]
 serial: /dev/serial/by-path/platform-3f980000.usb-usb-0:1.2:1.0-port0
-pin_map: arduino
 
 # The "zboard" micro-controller will be used to control the Z axis.
 [mcu zboard]
 serial: /dev/serial/by-path/platform-3f980000.usb-usb-0:1.3:1.0-port0
-pin_map: arduino
 
 # The "auxboard" micro-controller will be used to control the heaters.
 [mcu auxboard]
 serial: /dev/serial/by-path/platform-3f980000.usb-usb-0:1.4:1.0-port0
-pin_map: arduino
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: zboard:ar46
-dir_pin: zboard:ar48
-enable_pin: !zboard:ar62
+step_pin: zboard:PL3
+dir_pin: zboard:PL1
+enable_pin: !zboard:PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^zboard:ar18
+endstop_pin: ^zboard:PD3
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
-step_pin: auxboard:ar26
-dir_pin: auxboard:ar28
-enable_pin: !auxboard:ar24
+step_pin: auxboard:PA4
+dir_pin: auxboard:PA6
+enable_pin: !auxboard:PA2
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: auxboard:ar10
+heater_pin: auxboard:PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: auxboard:analog13
+sensor_pin: auxboard:PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -72,15 +69,15 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: auxboard:ar8
+heater_pin: auxboard:PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: auxboard:analog14
+sensor_pin: auxboard:PK6
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: auxboard:ar9
+pin: auxboard:PH6
 
 [printer]
 kinematics: cartesian

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,11 @@ All dates in this document are approximate.
 
 # Changes
 
+20210325: Support for the `pin_map` config option is deprecated. Use
+the [sample-aliases.cfg](../config/sample-aliases.cfg) file to
+translate to the actual micro-controller pin names. The `pin_map`
+config option will be removed in the near future.
+
 20210313: Klipper's support for micro-controllers that communicate
 with CAN bus has changed. If using CAN bus then all micro-controllers
 must be reflashed and the [Klipper configuration must be

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3659,8 +3659,9 @@ example.
 revision:
 #   The replicape hardware revision. Currently only revision "B3" is
 #   supported. This parameter must be provided.
-#enable_pin: !P9_41
-#   The replicape global enable pin. The default is !P9_41.
+#enable_pin: !gpio0_20
+#   The replicape global enable pin. The default is !gpio0_20 (aka
+#   P9_41).
 host_mcu:
 #   The name of the mcu config section that communicates with the
 #   Klipper "linux process" mcu instance. This parameter must be

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -13,11 +13,6 @@ Klipper and choosing an initial config file.
 Many config options require the name of a micro-controller pin.
 Klipper uses the hardware names for these pins - for example `PA4`.
 
-For AVR micro-controllers one may also use an Arduino alias (such as
-"ar29" or "analog3"). In order to use Arduino names, the `pin_map`
-variable in the `[mcu]` section must be present and have a value of
-`arduino`.
-
 Pin names may be preceded by `!` to indicate that a reverse polarity
 should be used (eg, trigger on low instead of high).
 
@@ -49,9 +44,6 @@ serial:
 #canbus_interface:
 #   If using a device connected to a CAN bus then this sets the CAN
 #   network interface to use. The default is 'can0'.
-#pin_map:
-#   This option may be used to enable Arduino pin name aliases. The
-#   default is to not enable the aliases.
 #restart_method:
 #   This controls the mechanism the host will use to reset the
 #   micro-controller. The choices are 'arduino', 'cheetah', 'rpi_usb',

--- a/docs/Example_Configs.md
+++ b/docs/Example_Configs.md
@@ -82,8 +82,8 @@ directory](../config/).
       170` as that is already the default value.
    7. Where possible, lines should not exceed 80 columns.
 7. Do not use any deprecated features in the example config file. The
-   `step_distance` parameter is deprecated and should not be in any
-   example config file.
+   `step_distance` and `pin_map` parameters are deprecated and should
+   not be in any example config file.
 8. Do not disable a default safety system in an example config file.
    For example, a config should not specify a custom
    `max_extrude_cross_section`. Do not enable debugging features. For

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -333,22 +333,17 @@ details.
 
 ### How do I convert a Marlin pin number to a Klipper pin name?
 
-Short answer: In some cases one can use Klipper's `pin_map: arduino`
-feature. Otherwise, for "digital" pins, one method is to search for
-the requested pin in Marlin's fastio header files. The Atmega2560 and
-Atmega1280 chips use
-[fastio_1280.h](https://github.com/MarlinFirmware/Marlin/blob/1.1.9/Marlin/fastio_1280.h),
-while the Atmega644p and Atmega1284p chips use
-[fastio_644.h](https://github.com/MarlinFirmware/Marlin/blob/1.1.9/Marlin/fastio_644.h).
-For example, if you are looking to translate Marlin's digital pin
-number 23 on an atmega2560 then one could find the following line in
-Marlin's fastio_1280.h file:
-```
-#define DIO23_PIN PINA1
-```
-The `DIO23` indicates the line is for Marlin's pin 23 and the `PINA1`
-indicates the pin uses the hardware name of `PA1`. Klipper uses the
-hardware names (eg, `PA1`).
+Short answer: A mapping is available in the
+[sample-aliases.cfg](../config/sample-aliases.cfg) file. Use that file
+as a guide to finding the actual micro-controller pin names. (It is
+also possible to copy the relevant
+[board_pins](Config_Reference.md#board_pins) config section into your
+config file and use the aliases in your config, but it is preferable
+to translate and use the actual micro-controller pin names.) Note that
+the sample-aliases.cfg file uses pin names that start with the prefix
+"ar" instead of "D" (eg, Arduino pin `D23` is Klipper alias `ar23`)
+and the prefix "analog" instead of "A" (eg, Arduino pin `A14` is
+Klipper alias `analog14`).
 
 Long answer: Klipper uses the standard pin names defined by the
 micro-controller. On the Atmega chips these hardware pins have names
@@ -362,22 +357,8 @@ In particular the Arduino pin numbers frequently don't translate to
 the same hardware names. For example, `D21` is `PD0` on one common
 Arduino board, but is `PC7` on another common Arduino board.
 
-In order to support 3d printers based on real Arduino boards, Klipper
-supports the Arduino pin aliases. This feature is enabled by adding
-`pin_map: arduino` to the [mcu] section of the config file. When these
-aliases are enabled, Klipper understands pin names that start with the
-prefix "ar" (eg, Arduino pin `D23` is Klipper alias `ar23`) and the
-prefix "analog" (eg, Arduino pin `A14` is Klipper alias `analog14`).
-Klipper does not use the Arduino names directly because we feel a name
-like D7 is too easily confused with the hardware name PD7.
-
-Marlin primarily follows the Arduino pin numbering scheme.  However,
-Marlin supports a few chips that Arduino does not support and in some
-cases it supports pins that Arduino boards do not expose. In these
-cases, Marlin chose their own pin numbering scheme. Klipper does not
-support these custom pin numbers - check Marlin's fastio headers (see
-above) to translate these pin numbers to their standard hardware
-names.
+To avoid this confusion, the core Klipper code uses the standard pin
+names defined by the micro-controller.
 
 ### Do I have to wire my device to a specific type of micro-controller pin?
 

--- a/klippy/extras/replicape.py
+++ b/klippy/extras/replicape.py
@@ -167,7 +167,7 @@ class Replicape:
         config.getchoice('revision', revisions)
         self.host_mcu = mcu.get_printer_mcu(printer, config.get('host_mcu'))
         # Setup enable pin
-        enable_pin = config.get('enable_pin', '!P9_41')
+        enable_pin = config.get('enable_pin', '!gpio0_20')
         self.mcu_pwm_enable = ppins.setup_pin('digital_out', enable_pin)
         self.mcu_pwm_enable.setup_max_duration(0.)
         self.mcu_pwm_start_value = self.mcu_pwm_shutdown_value = False


### PR DESCRIPTION
This PR is a proposal to deprecate the `pin_map` config option.  After this change all configs would need to use the standard micro-controller pin names.  The common "arduino aliases" would no longer be supported.

Due to the impact of this change, I would first deprecate the pin_map - that is, upon applying this change, the documentation and all the examples would be removed, but existing configs will continue to work.  Around six months later I would remove the actual `pin_map` config option and anyone who has not converted would be required to convert at that time.

The arduino aliases are arcane and confusing.  Almost all new boards use ARM processors that, thankfully, don't use these confusing aliases.  Having the older boards with the aliases while all the new boards don't adds to the confusion.

In order to facilitate the transition, I've added a config/sample-aliases.cfg file that shows all the aliases.  One can use that as a guide to convert, or one can cut-and-paste that file into their printer.cfg file to add the aliases locally to their config.

It may be the case that we do want aliases to help users better understand their config.  However, I think something like PR #3671 is a better way to use aliases than the arduino aliases.

-Kevin