### PR TITLE
Create printer-prusa-mk3s-2021.cfg

### DIFF
--- a/config/printer-prusa-mk3s-2021.cfg
+++ b/config/printer-prusa-mk3s-2021.cfg
@@ -1,21 +1,21 @@
-# This file contains pin mappings and reasonable defaults for Prusa i3 MK3S 
-# printers. It will work with MK3 (non-S) by selecting the alternative filament 
-# sensor. References to common community mods are included as well. 
+# This file contains pin mappings and reasonable defaults for Prusa i3 MK3S
+# printers. It will work with MK3 (non-S) by selecting the alternative filament
+# sensor. References to common community mods are included as well.
 #
 # Note: The Einsy boards sold by Prusa have defective firmware on the
 # usb-to-serial chip that makes the boards unusable with Klipper through USB.
 # While flashing Klipper firmware must be done over USB, the board can be used
-# via serial with no additional modification. 
+# via serial with no additional modification.
 #
 # To use this config, the firmware should be compiled for the AVR atmega2560.
-# To use via serial, in "make menuconfig" select "Enable extra low-level configuration options" 
-# and select serial1 (the RasPi serial) or serial2 (MMU port on exp3) when making 
+# To use via serial, in "make menuconfig" select "Enable extra low-level configuration options"
+# and select serial1 (the RasPi serial) or serial2 (MMU port on exp3) when making
 # the mcu firmware. See
 # https://reprap.org/mediawiki/images/6/6d/EinsyRambo1.1-connectors-j19-p1-p2-p3.png
-# for pinouts when wiring. 
+# for pinouts when wiring.
 #
 # It is also possible to fix this issue with no ill effect if reverting to non-Klipper
-# firmware. See https://github.com/PrusaOwners/mk3-32u2-firmware 
+# firmware. See https://github.com/PrusaOwners/mk3-32u2-firmware
 # Boards sold by Ultimaker as wel as some clones do not have this problem.
 #
 # See the example.cfg file for a description of all available parameters.
@@ -52,7 +52,7 @@ set_position_z: 0
 
 [gcode_macro G80]
 gcode:
-# G28 #Avoid double homing if using PrusaSlicer or other default gcode. 
+# G28 #Avoid double homing if using PrusaSlicer or other default gcode.
  BED_MESH_CALIBRATE
  G1 X0 Y0 Z0.4 F4000
 
@@ -143,7 +143,7 @@ enable_pin: !PA5
 step_distance: .0025
 endstop_pin: probe:z_virtual_endstop
 #Please update the Z height in the Tram_Z macro below.
-position_max: 200 #This is the MK3S default. 
+position_max: 200 #This is the MK3S default.
 #position_max: 210 #Use this for a stock MK3 non-S, BMG, or Bear extruders for the MK3S.
 position_min: -2
 homing_speed: 13.333
@@ -236,7 +236,7 @@ fan_speed: 1.0
 pin: PH3
 
 [mcu]
-serial: /dev/ttyACM0 #Default to USB,.  
+serial: /dev/ttyACM0 #Default to USB.  
 
 [display]
 lcd_type: hd44780
@@ -256,7 +256,7 @@ max_accel: 1500
 max_z_velocity: 10
 max_z_accel: 200
 
-#MK3S Filament IR Barrier Sensor. 
+#MK3S Filament IR Barrier Sensor.
 [filament_switch_sensor fsensor]
 pause_on_runout: True
 runout_gcode:
@@ -269,7 +269,7 @@ event_delay: 3.0
 pause_delay: 0.01
 switch_pin: !PK0
 
-#MK3 (non-S) Filament Sensor. 
+#MK3 (non-S) Filament Sensor.
 #[pat9125 fsensor]
 #pause_on_runout: True
 #runout_gcode:
@@ -392,7 +392,7 @@ gcode:
 [force_move]
 enable_force_move: TRUE
 
-#This replicates Prusa's calibrate Z funtionality. 
+#This replicates Prusa's calibrate Z funtionality.
 [gcode_macro Tram_Z]
 gcode:
     G28
@@ -400,7 +400,7 @@ gcode:
     G1 Z200 F1000 #Update with Z height. 
     FORCE_MOVE STEPPER=stepper_z Distance=10 Velocity=10
     G28 Z
-    
+
 [virtual_sdcard]
 path: ~/gcode_files
 

--- a/config/printer-prusa-mk3s-2021.cfg
+++ b/config/printer-prusa-mk3s-2021.cfg
@@ -1,0 +1,409 @@
+# This file contains pin mappings and reasonable defaults for Prusa i3 MK3S 
+# printers. It will work with MK3 (non-S) by selecting the alternative filament 
+# sensor. References to common community mods are included as well. 
+#
+# Note: The Einsy boards sold by Prusa have defective firmware on the
+# usb-to-serial chip that makes the boards unusable with Klipper through USB.
+# While flashing Klipper firmware must be done over USB, the board can be used
+# via serial with no additional modification. 
+#
+# To use this config, the firmware should be compiled for the AVR atmega2560.
+# To use via serial, in "make menuconfig" select "Enable extra low-level configuration options" 
+# and select serial1 (the RasPi serial) or serial2 (MMU port on exp3) when making 
+# the mcu firmware. See
+# https://reprap.org/mediawiki/images/6/6d/EinsyRambo1.1-connectors-j19-p1-p2-p3.png
+# for pinouts when wiring. 
+#
+# It is also possible to fix this issue with no ill effect if reverting to non-Klipper
+# firmware. See https://github.com/PrusaOwners/mk3-32u2-firmware 
+# Boards sold by Ultimaker as wel as some clones do not have this problem.
+#
+# See the example.cfg file for a description of all available parameters.
+
+[probe]
+pin: PB4
+x_offset: 24
+y_offset: 5
+z_offset: 0.7 #Put Z-offset from 1st layer calibration baby-steps here.
+speed: 10.0
+samples: 3 #Sampling, primarily for bed mesh. 3 is fine for normal PINDA probes.
+samples_result: average
+
+[bed_mesh]
+speed: 200
+horizontal_move_z: 2
+mesh_min: 35, 6
+mesh_max: 240,198
+probe_count: 7,7
+relative_reference_index: 25 #Generate mesh relative to center post for nylock. 
+mesh_pps: 0,0 #Don't generate interperlated points so our mesh is compatible with nylock calculators like https://pcboy.github.io/g81_relative/
+
+#Home in lower, lefthand corner.
+[homing_override]
+gcode:
+ G1 Z3
+ G28 X0 Y200
+ G1 X1 Y0 F5000
+ G28 Z0
+axes: Z
+set_position_x: 0
+set_position_y: 0
+set_position_z: 0
+
+[gcode_macro G80]
+gcode:
+# G28 #Avoid double homing if using PrusaSlicer or other default gcode. 
+ BED_MESH_CALIBRATE
+ G1 X0 Y0 Z0.4 F4000
+
+[gcode_macro G81]
+gcode:
+ BED_MESH_OUTPUT
+
+[stepper_x]
+step_pin: PC0
+dir_pin: !PL0
+enable_pin: !PA7
+#Step distances for common configurations, 16 tooth and 1.8 degree is Prusa.stock, but many people have 0.9 degree steppers to remove VFAs.
+step_distance: .01 #16 pin tooth wheel, 1.8 degree stepper.
+#step_distance: .0125 #20 tooth drive wheel, 1.8 degree stepper.
+#step_distance: 0.00625 #20 tooth drive wheel. 0.9 degree stepper.
+#step_distance: .005 #16 tooth drive wheel, 0.9 degree stepper.
+endstop_pin: tmc2130_stepper_x:virtual_endstop
+position_endstop: 0
+position_max: 250
+homing_speed: 50
+homing_retract_dist: 0
+
+[tmc2130 stepper_x]
+cs_pin: PG0
+microsteps: 16
+interpolate: True
+run_current: .281738
+hold_current: .281738
+sense_resistor: 0.220
+diag1_pin: !PK2
+driver_IHOLDDELAY: 8
+driver_TPOWERDOWN: 0
+driver_TBL: 2
+driver_TOFF: 3
+driver_HEND: 1
+driver_HSTRT: 5
+driver_PWM_FREQ: 2
+driver_PWM_GRAD: 2
+driver_PWM_AMPL: 230
+driver_PWM_AUTOSCALE: True
+driver_SGT: 3
+
+[stepper_y]
+step_pin: PC1
+dir_pin: PL1
+enable_pin: !PA6
+#Step distances for common configurations, 16 tooth and 1.8 degree is Prusa.stock, but many people have 0.9 degree steppers to remove VFAs.
+step_distance: .01 #16 pin tooth wheel, 1.8 degree stepper.
+#step_distance: .0125 #20 tooth drive wheel, 1.8 degree stepper.
+#step_distance: 0.00625 #20 tooth drive wheel. 0.9 degree stepper.
+#step_distance: .005 #16 tooth drive wheel, 0.9 degree stepper.
+endstop_pin: tmc2130_stepper_y:virtual_endstop
+position_endstop: -4
+position_max: 210
+position_min: -4
+homing_speed: 50
+homing_retract_dist: 0
+
+[tmc2130 stepper_y]
+cs_pin: PG2
+microsteps: 16
+interpolate: True
+run_current: .281738
+hold_current: .281738
+#Run at the same current as X-axis for lower noise, and to keep steppers cooler.
+#This should work, but if Y starts skipping steps, you may need to bump up to Prusa stock. 
+#run_current: .3480291
+#hold_current: .3480291
+sense_resistor: 0.220
+diag1_pin: !PK7
+driver_IHOLDDELAY: 8
+driver_TPOWERDOWN: 0
+driver_TBL: 2
+driver_TOFF: 3
+driver_HEND: 1
+driver_HSTRT: 5
+driver_PWM_FREQ: 2
+driver_PWM_GRAD: 2
+#driver_PWM_AMPL: 235
+driver_PWM_AMPL: 230
+driver_PWM_AUTOSCALE: True
+driver_SGT: 3
+
+[stepper_z]
+step_pin: PC2
+dir_pin: !PL2
+enable_pin: !PA5
+step_distance: .0025
+endstop_pin: probe:z_virtual_endstop
+#Please update the Z height in the Tram_Z macro below.
+position_max: 200 #This is the MK3S default. 
+#position_max: 210 #Use this for a stock MK3 non-S, BMG, or Bear extruders for the MK3S.
+position_min: -2
+homing_speed: 13.333
+
+[tmc2130 stepper_z]
+cs_pin: PK5
+microsteps: 16
+interpolate: True
+run_current: .53033
+hold_current: .53033
+sense_resistor: 0.220
+diag1_pin: !PK6
+driver_IHOLDDELAY: 8
+driver_TPOWERDOWN: 0
+driver_TBL: 2
+driver_TOFF: 3
+driver_HEND: 1
+driver_HSTRT: 5
+driver_PWM_FREQ: 2
+driver_PWM_GRAD: 4
+driver_PWM_AMPL: 200
+driver_PWM_AUTOSCALE: True
+driver_SGT: 4
+
+[extruder]
+step_pin: PC3
+dir_pin: PL6
+enable_pin: !PA4
+step_distance: .0035714 #Stock Prusa or Bear extruder.
+#step_distance: .0012048 #BMG or other 3:1 ratio extruder.
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+# The max extrude cross section is increased for the purge line, but in theory
+# its probably a bad idea to have it this large, as its purpose is to catch
+# poorly sliced objects that extrude too much for small moves.
+max_extrude_cross_section: 50.0
+# Allows to load filament and purge up to 500mm
+max_extrude_only_distance: 500.0
+max_extrude_only_velocity: 120.0
+max_extrude_only_accel: 1250.0
+heater_pin: PE5
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PF0
+control: pid
+pid_Kp: 16.13
+pid_Ki: 1.1625
+pid_Kd: 56.23
+min_temp: 0
+max_temp: 305
+
+[tmc2130 extruder]
+cs_pin: PK4
+microsteps: 32
+interpolate: True
+run_current: .513757
+hold_current: .513757
+sense_resistor: 0.220
+diag1_pin: !PK3
+driver_IHOLDDELAY: 8
+driver_TPOWERDOWN: 0
+driver_TBL: 2
+driver_TOFF: 3
+driver_HEND: 1
+driver_HSTRT: 5
+driver_PWM_FREQ: 2
+driver_PWM_GRAD: 4
+driver_PWM_AMPL: 240
+driver_PWM_AUTOSCALE: True
+driver_SGT: 3
+
+[heater_bed]
+heater_pin: PG5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF2
+control: pid
+pid_Kp: 126.13
+pid_Ki: 4.3
+pid_Kd: 924.76
+min_temp: 0
+max_temp: 125
+
+[heater_fan nozzle_cooling_fan]
+pin: PH5
+heater: extruder
+heater_temp: 50.0
+fan_speed: 1.0
+
+# Part Cooling Fan
+[fan]
+pin: PH3
+
+[mcu]
+serial: /dev/ttyACM0 #Default to USB,.  
+
+[display]
+lcd_type: hd44780
+rs_pin: PD5
+e_pin: PF7
+d4_pin: PF5
+d5_pin: PG4
+d6_pin: PH7
+d7_pin: PG3
+encoder_pins: ^PJ1,^PJ2
+click_pin: ^!PH6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1500
+max_z_velocity: 10
+max_z_accel: 200
+
+#MK3S Filament IR Barrier Sensor. 
+[filament_switch_sensor fsensor]
+pause_on_runout: True
+runout_gcode:
+    M118 Filament Runout Detected
+    M600
+insert_gcode:
+    M118 Filament Load Detected
+    LOAD_FILAMENT
+event_delay: 3.0
+pause_delay: 0.01
+switch_pin: !PK0
+
+#MK3 (non-S) Filament Sensor. 
+#[pat9125 fsensor]
+#pause_on_runout: True
+#runout_gcode:
+# M118 Filament Runout Detected
+#  M600 X250 Y-3 Z10
+#insert_gcode:
+# M118 Filament Load Detected
+#  LOAD_FILAMENT
+#invert_axis: True
+#oq_enable: True
+
+[respond]
+default_type: command
+
+[pause_resume]
+
+# Keeps Debug LED off / not floating
+[static_digital_output debug_led]
+pins: !PB7
+
+[output_pin BEEPER_pin]
+pin: PH2
+pwm: True
+value: 0
+shutdown_value:0
+cycle_time: 0.001
+scale: 1000
+
+[gcode_macro _M300]
+default_parameter_S=1000
+default_parameter_P=100
+gcode:
+    SET_PIN PIN=BEEPER_pin VALUE={S}
+    G4 P{P}
+    SET_PIN PIN=BEEPER_pin VALUE=0
+
+[gcode_macro _M600]
+variable_extr_temp: 0
+default_parameter_X: 100
+default_parameter_Y: 0
+default_parameter_Z: 10
+gcode:
+    PAUSE
+    G91
+    G1 E-.8 F2700
+    G1 Z{Z}
+    G90
+    G1 X{X} Y{Y} F3000
+
+#Load and Unload Macros.
+[gcode_macro LOAD_FILAMENT]
+gcode:
+    M117 Loading Filament...
+    G92 E0.0
+    G91
+    G1 E40 F400
+    G1 E30 F400
+    G1 E25 F200
+    G90
+    G92 E0.0
+    M400
+    M117 Load Complete
+    UPDATE_DELAYED_GCODE ID=clear_display DURATION=5
+
+[gcode_macro UNLOAD_FILAMENT]
+gcode:
+    M117 Unloading Filament...
+    G92 E0.0
+    G91
+    G1 E-45 F5200
+    G1 E-15 F1000
+    G1 E-20 F1000
+    G90
+    G92 E0.0
+    M400
+    M117 Remove Filament Now!
+    M300 S300 P1000
+    UPDATE_DELAYED_GCODE ID=clear_display DURATION=5
+
+[delayed_gcode clear_display]
+initial_duration: 0.
+gcode:
+  M117
+
+[gcode_macro PAUSE]
+rename_existing: BASE_PAUSE
+default_parameter_X: 230   
+default_parameter_Y: 230   
+default_parameter_Z: 10     
+default_parameter_E: 1     
+gcode:
+    SAVE_GCODE_STATE NAME=PAUSE_state
+    BASE_PAUSE
+    G91
+    G1 E-{E} F2100
+    G1 Z{Z}
+    G90
+    G1 X{X} Y{Y} F6000
+
+[gcode_macro RESUME]
+rename_existing: BASE_RESUME
+default_parameter_E: 1   
+gcode:
+    G91
+    G1 E{E} F2100
+    G90
+    RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=1
+    BASE_RESUME
+
+[gcode_macro CANCEL_PRINT]
+rename_existing: BASE_CANCEL_PRINT
+gcode:
+    TURN_OFF_HEATERS
+    CLEAR_PAUSE
+    SDCARD_RESET_FILE
+    BASE_CANCEL_PRINT
+
+[display_status]
+
+[force_move]
+enable_force_move: TRUE
+
+#This replicates Prusa's calibrate Z funtionality. 
+[gcode_macro Tram_Z]
+gcode:
+    G28
+    G1 X125 Y105
+    G1 Z200 F1000 #Update with Z height. 
+    FORCE_MOVE STEPPER=stepper_z Distance=10 Velocity=10
+    G28 Z
+    
+[virtual_sdcard]
+path: ~/gcode_files
+
+#If not using with Octoprint remove the menu.
+#[menu __main __octoprint]
+#type: disabled

--- a/config/printer-prusa-mk3s-2021.cfg
+++ b/config/printer-prusa-mk3s-2021.cfg
@@ -35,7 +35,7 @@ horizontal_move_z: 2
 mesh_min: 35, 6
 mesh_max: 240,198
 probe_count: 7,7
-relative_reference_index: 25 #Generate mesh relative to center post for nylock. 
+relative_reference_index: 25 #Generate mesh relative to center post for nylock.
 mesh_pps: 0,0 #Don't generate interperlated points so our mesh is compatible with nylock calculators like https://pcboy.github.io/g81_relative/
 
 #Home in lower, lefthand corner.
@@ -118,7 +118,7 @@ interpolate: True
 run_current: .281738
 hold_current: .281738
 #Run at the same current as X-axis for lower noise, and to keep steppers cooler.
-#This should work, but if Y starts skipping steps, you may need to bump up to Prusa stock. 
+#This should work, but if Y starts skipping steps, you may need to bump up to Prusa stock.
 #run_current: .3480291
 #hold_current: .3480291
 sense_resistor: 0.220
@@ -236,7 +236,7 @@ fan_speed: 1.0
 pin: PH3
 
 [mcu]
-serial: /dev/ttyACM0 #Default to USB.  
+serial: /dev/ttyACM0 #Default to USB.
 
 [display]
 lcd_type: hd44780
@@ -356,10 +356,10 @@ gcode:
 
 [gcode_macro PAUSE]
 rename_existing: BASE_PAUSE
-default_parameter_X: 230   
-default_parameter_Y: 230   
-default_parameter_Z: 10     
-default_parameter_E: 1     
+default_parameter_X: 230
+default_parameter_Y: 230
+default_parameter_Z: 10
+default_parameter_E: 1
 gcode:
     SAVE_GCODE_STATE NAME=PAUSE_state
     BASE_PAUSE
@@ -371,7 +371,7 @@ gcode:
 
 [gcode_macro RESUME]
 rename_existing: BASE_RESUME
-default_parameter_E: 1   
+default_parameter_E: 1
 gcode:
     G91
     G1 E{E} F2100
@@ -397,7 +397,7 @@ enable_force_move: TRUE
 gcode:
     G28
     G1 X125 Y105
-    G1 Z200 F1000 #Update with Z height. 
+    G1 Z200 F1000 #Update with Z height.
     FORCE_MOVE STEPPER=stepper_z Distance=10 Velocity=10
     G28 Z
 


### PR DESCRIPTION
Example printer.cfg for a Prusa MK3S and MK3.  

It includes macros (I noticed most other examples don't) but some of these are needed 
for the filament sensor as well as to restore the Tram Z/ Calibrate Z functionality. 
I also really wanted something that would work fully out-of-the-box with all Prusa 
default gcode and even with a UI like Mainsail.   

Explicitly put the Prusa USB-to-serial issue note in there as well as workarounds based 
on discord feedback by Arksine. 

My normal config is just this with the appropriate options uncommented for my BMG, 
0.9-degree stepper Prusa, and then my PID, mesh, and IS along with an extra optional 
macro or two I find helpful for UI. 

Explicitly confirmed this file loads without error in latest Klipper.

Based largely off the old example in the PrusaOwners fork. 

Signed-off-by: Scott Knauert <sknauert@apsec.com>