### PR TITLE
Changes in tune menu according to #4023

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -101,8 +101,8 @@ name: Tune
 type: input
 name: Speed: {'%3d' % (menu.input*100)}%
 input: {printer.gcode_move.speed_factor}
-input_min: 0
-input_max: 2
+input_min: 0.01
+input_max: 5
 input_step: 0.01
 realtime: True
 gcode:
@@ -112,7 +112,7 @@ gcode:
 type: input
 name: Flow: {'%3d' % (menu.input*100)}%
 input: {printer.gcode_move.extrude_factor}
-input_min: 0
+input_min: 0.01
 input_max: 2
 input_step: 0.01
 realtime: True


### PR DESCRIPTION
- Set 1% as input minimum for speed and flow
- Increase speed maximum from 200% to 500%

Signed-off-by: Janar Sööt <janar.soot@gmail.com>