### PR TITLE
Fix extruder1 step_pin in Robin Nano V2 example

### DIFF
--- a/config/generic-mks-robin-nano-v2.cfg
+++ b/config/generic-mks-robin-nano-v2.cfg
@@ -63,7 +63,7 @@ min_temp: 0
 max_temp: 250
 
 #[extruder1]
-#step_pin: PA6
+#step_pin: PD15
 #dir_pin: !PA1
 #enable_pin: !PA3
 #heater_pin: PB0


### PR DESCRIPTION
extruder1 `step_pin` was set incorrectly in MKS Robin Nano V2 example config.
Complete pin map can be found [here](https://github.com/makerbase-mks/MKS-Robin-Nano-V2.X/wiki/Wiring_Pinout_and_Size#pin-map).