### PR TITLE
Faster "pinup" on BL-Touch

### DIFF
--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -48,9 +48,8 @@ class BLTouchEndstopWrapper:
         mcu.register_config_callback(self._build_config)
         self.mcu_endstop = mcu.setup_pin('endstop', pin_params)
         # output mode
-        self.output_mode = config.getchoice('set_output_mode',
-                                            {'5V': '5V', 'OD': 'OD',
-                                             None: None}, None)
+        omodes = {'5V': '5V', 'OD': 'OD', None: None}
+        self.output_mode = config.getchoice('set_output_mode', omodes, None)
         # Setup for sensor test
         self.next_test_time = 0.
         self.pin_up_not_triggered = config.getboolean(


### PR DESCRIPTION
When probing, the current bltouch code will detect a trigger signal, acknowledge the mcu homing event, and then send a pin_up command.  The "mcu acknowledge" stage may require a few messages to be sent to the micro-controller which normally takes a few milliseconds.  However, in the event of communication errors or delays, it's possible for that process to delay the pin_up command.  As we work on multi-mcu homing (PR #3956) the "mcu acknowledgement" becomes more complex and it increases the risk of a delay.

This PR alters the bltouch code so that it can send the pin_up immediately after a trigger signal.  This should reduce the risk of a delayed pin_up command.

I don't actually own a bltouch, so I can't directly test this code.  Testers would be welcome.  Basic verification that probing continues to work (in both stow_on_retract=False and stow_on_rectract=True modes) should be sufficient.

`cd ~/klipper ; git fetch ; git checkout origin/work-bltouch-20210329 ; sudo service klipper restart`

@FanDjango - FYI.

-Kevin