### PR TITLE
bed_mesh:  lookup the toolhead object in "handle_connect"

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -59,6 +59,8 @@ class BedMesh:
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:ready",
                                             self.handle_ready)
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
         self.last_position = [0., 0., 0., 0.]
         self.bmc = BedMeshCalibrate(config, self)
         self.z_mesh = None
@@ -90,8 +92,9 @@ class BedMesh:
         # Register transform
         gcode_move = self.printer.load_object(config, 'gcode_move')
         gcode_move.set_move_transform(self)
-    def handle_ready(self):
+    def handle_connect(self):
         self.toolhead = self.printer.lookup_object('toolhead')
+    def handle_ready(self):
         self.bmc.print_generated_points(logging.info)
         self.pmgr.initialize()
     def set_mesh(self, mesh):


### PR DESCRIPTION
This is a bugfix that resolves #4129.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>