### PR TITLE
stm32f1: reset peripherals in enable_pcclock()

### DIFF
--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -21,10 +21,14 @@ enable_pclock(uint32_t periph_base)
         uint32_t pos = (periph_base - APB1PERIPH_BASE) / 0x400;
         RCC->APB1ENR |= (1<<pos);
         RCC->APB1ENR;
+        RCC->APB1RSTR |= (1<<pos);
+        RCC->APB1RSTR &= ~(1<<pos);
     } else if (periph_base < AHBPERIPH_BASE) {
         uint32_t pos = (periph_base - APB2PERIPH_BASE) / 0x400;
         RCC->APB2ENR |= (1<<pos);
         RCC->APB2ENR;
+        RCC->APB2RSTR |= (1<<pos);
+        RCC->APB2RSTR &= ~(1<<pos);
     } else {
         uint32_t pos = (periph_base - AHBPERIPH_BASE) / 0x400;
         RCC->AHBENR |= (1<<pos);


### PR DESCRIPTION
Hi Kevin, as previously discussed this patch resets the peripheral in `enable_pcclock`.  This fixes hardware SPI on the BTT SKR Mini (and its derivatives), where the stock bootloader does not properly disable SPI after use.

SIgned-off-by:  Eric Callahan <arksine.code@gmail.com>