### PR TITLE
probe: Add pre-probing move

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1551,6 +1551,18 @@ z_offset:
 #   not obtained in the given number of retries then an error is
 #   reported. The default is zero which causes an error to be reported
 #   on the first sample that exceeds samples_tolerance.
+#preprobe_speed: 0
+#   If set (in mm/s), enables pre-probe moves. Every probing sequence
+#   will start out with a single probing with this speed, after which
+#   the probe will retract a small distance and then the standard
+#   probing sequence (usually done at a slower speed for more accuracy)
+#   will run. Pre-probing does not measure Z height.
+#preprobe_retract_dist:
+#   The distance (in mm) to retract after the pre-probing move, if
+#   enabled. Defaults to the value of sample_retract_dist.
+#preprobe_lift_speed:
+#   The speed (in mm/s) to retract after the pre-probing move, if
+#   enabled. Defaults to the value of lift_speed.
 #activate_gcode:
 #   A list of G-Code commands to execute prior to each probe attempt.
 #   See docs/Command_Templates.md for G-Code format. This may be


### PR DESCRIPTION
Currently when probing, all probing moves happen at the same speed, including the initial probe which may be a much longer move than the subsequent move on multi-sample probing. Even for single-sample probing, picking a slow speed to ensure accuracy can end up resulting in very long probing moves.

This adds "preprobing" moves to the probing code. If enabled, a single probing is performed at a different(usually higher) speed, a small retraction is made, and then the standard probing proceeds as usual. The result of the pre-probe is not part of the determined Z height.

This was implemented already in #1356 (in a slightly different way) but sadly wasn't finished and merged.

Using my standard bed mesh setup:
```
[probe]
...
z_offset: 7.5
speed: 2
samples: 3
samples_tolerance: 0.050
samples_tolerance_retries: 3
sample_retract_dist: 2
preprobe_speed: 20
lift_speed: 20

[bed_mesh]
speed: 400
horizontal_move_z: 12.5 # probe z_offset + 5mm
mesh_min: 15,15
mesh_max: 220,215
probe_count: 5,5
```
I went from 214 to 193 seconds(-9.8%) with no loss in precision for a full bed mesh, and can now reduce my probing speed a lot without suffering from very long bed mesh runs.