### PR TITLE
RGB support for the mightyboard

### DIFF
--- a/config/generic-mightyboard.cfg
+++ b/config/generic-mightyboard.cfg
@@ -130,3 +130,11 @@ click_pin: ^PJ0
 back_pin: ^PJ2
 up_pin: ^PJ4
 down_pin: ^PJ3
+
+[pca9533 led_strip]
+#set_led led=led_strip red=1 green=1 blue=1
+i2c_bus: twi
+i2c_address: 98
+initial_RED: 1
+initial_GREEN: 1
+initial_BLUE: 1

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2471,6 +2471,24 @@ clock_pin:
 #initial_BLUE: 0.0
 #   See the "neopixel" section for information on these parameters.
 ```
+## [PCA9533]
+PCA9533 LED support. The PCA9533 is used on the mightyboard.
+
+```
+[pca9533 my_pca9533]
+#i2c_bus:
+#    The i2c peripheral, "twi" on the atmega
+#i2c_address: 98
+#    The i2c address, 98 or 99
+#initial_RED: 1
+#initial_GREEN: 1
+#initial_BLUE: 1
+#initial_WHITE: 1
+#    The PCA9533 only supports 1 or 0, any other values will be considered as 1.
+#    On the mightyboard, the white led is not populated.
+#    Use GCODE to modify led values after startup.
+#    set_led led=my_pca9533 red=1 green=1 blue=1
+```
 
 ## [gcode_button]
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2476,15 +2476,19 @@ PCA9533 LED support. The PCA9533 is used on the mightyboard.
 
 ```
 [pca9533 my_pca9533]
-#i2c_bus:
-#    The i2c peripheral, "twi" on the atmega
 #i2c_address: 98
-#    The i2c address, 98 or 99
+#   The i2c address that the chip is using on the i2c bus. The default
+#   is 98 for the PCA9533/1, 99 for the PCA9533/2.
+#i2c_mcu:
+#i2c_bus:
+#i2c_speed:
+#   See the "common I2C settings" section for a description of the
+#   above parameters.
 #initial_RED: 1
 #initial_GREEN: 1
 #initial_BLUE: 1
 #initial_WHITE: 1
-#    The PCA9533 only supports 1 or 0, any other values will be considered as 1.
+#    The PCA9533 only supports 1 or 0, any other values will be considered as 1. The default is 0.
 #    On the mightyboard, the white led is not populated.
 #    Use GCODE to modify led values after startup.
 #    set_led led=my_pca9533 red=1 green=1 blue=1

--- a/klippy/extras/pca9533.py
+++ b/klippy/extras/pca9533.py
@@ -1,4 +1,4 @@
-# Support for HD44780 (20x4 text) LCD displays
+# Support for the PCA9533 LED driver ic
 #
 # Copyright (C) 2021  Marc-Andre Denis <marcadenis@msn.com>
 #
@@ -11,24 +11,18 @@ PCA9533_PLS0=0b101
 class PCA9533:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.i2c = bus.MCU_I2C_from_config(config)
-        i2c_addr = self.i2c.get_i2c_address()
+        self.i2c = bus.MCU_I2C_from_config(config, default_addr=98)
+        #i2c_addr = self.i2c.get_i2c_address()
 
+        name = config.get_name().split()[1]
         self.gcode = self.printer.lookup_object('gcode')
-        self.gcode.register_command("SET_LED",self.set_led)
+        self.gcode.register_mux_command("SET_LED","LED",name,self.set_led,
+            desc="Set the color of an LED")
 
-        self.led0 = 0
-        if config.getfloat("initial_RED",0,0,1) != 0:
-            self.led0 = 1
-        self.led1 = 0
-        if config.getfloat("initial_GREEN",0,0,1) != 0:
-            self.led1 = 1
-        self.led2 = 0
-        if config.getfloat("initial_BLUE",0,0,1) != 0:
-            self.led2 = 1
-        self.led3 = 0
-        if config.getfloat("initial_WHITE",0,0,1) != 0:
-            self.led3 = 1
+        self.led0 = config.getint("initial_RED",0,0,1)
+        self.led1 = config.getint("initial_GREEN",0,0,1)
+        self.led2 = config.getint("initial_BLUE",0,0,1)
+        self.led3 = config.getint("initial_WHITE",0,0,1)
 
         ls0 = (self.led3<<6) | (self.led2<<4) | (self.led1<<2) | (self.led0)
 

--- a/klippy/extras/pca9533.py
+++ b/klippy/extras/pca9533.py
@@ -1,0 +1,59 @@
+# Support for HD44780 (20x4 text) LCD displays
+#
+# Copyright (C) 2021  Marc-Andre Denis <marcadenis@msn.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+from . import bus
+
+PCA9533_PLS0=0b101
+
+class PCA9533:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.i2c = bus.MCU_I2C_from_config(config)
+        i2c_addr = self.i2c.get_i2c_address()
+
+        self.gcode = self.printer.lookup_object('gcode')
+        self.gcode.register_command("SET_LED",self.set_led)
+
+        self.led0 = 0
+        if config.getfloat("initial_RED",0,0,1) != 0:
+            self.led0 = 1
+        self.led1 = 0
+        if config.getfloat("initial_GREEN",0,0,1) != 0:
+            self.led1 = 1
+        self.led2 = 0
+        if config.getfloat("initial_BLUE",0,0,1) != 0:
+            self.led2 = 1
+        self.led3 = 0
+        if config.getfloat("initial_WHITE",0,0,1) != 0:
+            self.led3 = 1
+
+        ls0 = (self.led3<<6) | (self.led2<<4) | (self.led1<<2) | (self.led0)
+
+        self.i2c.i2c_write([PCA9533_PLS0,ls0])
+    def set_led(self, gcmd):
+        if gcmd.get_float("RED",self.led0,0,1) != 0:
+            self.led0 = 1
+        else:
+            self.led0 = 0
+        if gcmd.get_float("GREEN",self.led1,0,1) != 0:
+            self.led1 = 1
+        else:
+            self.led1 = 0
+        if gcmd.get_float("BLUE",self.led2,0,1) != 0:
+            self.led2 = 1
+        else:
+            self.led2 = 0
+        if gcmd.get_float("WHITE",self.led3,0,1) != 0:
+            self.led3 = 1
+        else:
+            self.led3 = 0
+        ls0 = (self.led3<<6) | (self.led2<<4) | (self.led1<<2) | (self.led0)
+
+        self.i2c.i2c_write([PCA9533_PLS0,ls0])
+
+
+def load_config_prefix(config):
+    return PCA9533(config)


### PR DESCRIPTION
Add support for the pca9533 led driver ic.

Signed-off-by: Marc-André Denis marcadenis@msn.com