### PR TITLE
thermocouple: max31865: attempt to recover from faults

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2034,6 +2034,17 @@ sensor_pin:
 #   The above parameters control the sensor parameters of MAX31865
 #   chips. The defaults for each parameter are next to the parameter
 #   name in the above list.
+#rtd_consecutive_fault_limit: 0
+#   The above paramter controls Klipper's retry behavior when
+#   handling faults raised by the MAX31865. When set to a value
+#   greater than 0, Klipper will ignore consecutive failures up
+#   to the limit, each time resetting the MAX31865 with initial
+#   configuration parameters. A successful measurement resets
+#   this counter. This can help with sensors in noisy electrical
+#   environments. Only set this if you're having problems with
+#   sporadic firmware shutdowns due to thermocouple failures, and
+#   do not set this too high (e.x. <= 5-10). Setting this too high
+#   could lead to thermal runaway.
 ```
 
 ## BMP280/BME280/BME680 temperature sensor


### PR DESCRIPTION
I'm running a PT1000 attached to an Adafruit Max31865 board, and
struggled with noise from rapid extruder movements pushing the
voltage just outside of what the max31685 board expects. Even running
my RTD's wires outside the printer (a Voron 2.4) only helped somewhat.
Given that rapid movements (like (de)?retractions) are momentary, I
figured that ignoring the error and trying again would be sufficient to
continue on successfully.

When `rtd_consecutive_fault_limit` (default: 0, as it is implicitly today)
is set to a value greater than 0, all faults raised by the max31685 will be
ignored, logged, and the max31865 re-initialized using the original
configuration. Once the max consecutive failures are reached, both the 
firmware and host shut down as is the current behavior. Failures return
the last known good temperature value. The firmware is responsible for
tracking the overall failure count (and resetting said count when a
successful measurement is performed), with the failure count being sent
back to the host along with each response. The host performs the reset
of the max31865 board by re-sending the initial configuration command
(which includes the fault reset bit). Simply resetting the fault bit isn't
enough, as it doesn't automatically sample and you end up with the same
temperature value with Klipper none the wiser.

This is currently only implemented for the Max31865, as that's the only
board I own currently. The code in this PR has ~50 hours of print time, and
recovered from dozens of events. The log looks a little like this:

```
Max31865: recovered from fault (consecutive_faults=1, consecutive_fault_limit=3): Overvoltage or undervoltage fault
#output: thermocouple fault detected, consecutive faults: 1, allowed faults: 3
#output: thermocouple fault recovered, resetting fault count
```

when operating.

Signed-off-by: Michael Rose <elementation@gmail.com>