### PR TITLE
TMC2209: config internal_Rsense

### DIFF
--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -214,6 +214,7 @@ class TMC2208:
         set_config_field(config, "pwm_autograd", True)
         set_config_field(config, "PWM_REG", 8)
         set_config_field(config, "PWM_LIM", 12)
+        set_config_field(config, "internal_Rsense", 0)
     def read_translate(self, reg_name, val):
         if reg_name == "IOIN":
             drv_type = self.fields.get_field("SEL_A", val)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -89,6 +89,7 @@ class TMC2209:
         set_config_field(config, "PWM_REG", 8)
         set_config_field(config, "PWM_LIM", 12)
         set_config_field(config, "SGTHRS", 0)
+        set_config_field(config, "internal_Rsense", 0)
 
 def load_config_prefix(config):
     return TMC2209(config)


### PR DESCRIPTION
added the field config for configurating  a TMC2208/2209 for internalRDS

Used to configure the driver for RDSon mode.
To use internal current mesurement instead of external resistors


Signed of by Oliver Walter <oli1111@web.de>