### PR TITLE
Palette2, Fix get_status

### DIFF
--- a/klippy/extras/palette2.py
+++ b/klippy/extras/palette2.py
@@ -638,10 +638,12 @@ class Palette2:
 
     def get_status(self, eventtime=None):
         status = {
-            "ping": self.omega_pings[-1],
+            "ping": None,
             "remaining_load_length": self.remaining_load_length,
             "is_splicing": self.is_splicing
         }
+        if self.omega_pings:
+            status["ping"] = self.omega_pings[-1]
         return status
 
 def load_config(config):


### PR DESCRIPTION
Quick fix for a missing null check in `get_status` should address the issue reported here: https://github.com/KevinOConnor/klipper/pull/4057#issuecomment-820093695

Signed-off-by: Clifford Roche <clifford.roche@gmail.com>
