### PR TITLE
Convert linux mcu code to use signal based "irq" handling

### DIFF
--- a/src/linux/Makefile
+++ b/src/linux/Makefile
@@ -7,7 +7,7 @@ src-y += linux/pca9685.c linux/spidev.c linux/analog.c linux/hard_pwm.c
 src-y += linux/i2c.c linux/gpio.c generic/crc16_ccitt.c generic/alloc.c
 src-y += linux/sensor_ds18b20.c
 
-CFLAGS_klipper.elf += -lutil -lpthread
+CFLAGS_klipper.elf += -lutil -lrt -lpthread
 
 flash: $(OUT)klipper.elf
 	@echo "  Flashing"

--- a/src/linux/internal.h
+++ b/src/linux/internal.h
@@ -2,6 +2,7 @@
 #define __LINUX_INTERNAL_H
 // Local definitions for micro-controllers running on linux
 
+#include <signal.h> // sigset_t
 #include <stdint.h> // uint32_t
 #include "autoconf.h" // CONFIG_CLOCK_FREQ
 
@@ -9,7 +10,6 @@
 #define GPIO(PORT, NUM) ((PORT) * MAX_GPIO_LINES + (NUM))
 #define GPIO2PORT(PIN) ((PIN) / MAX_GPIO_LINES)
 #define GPIO2PIN(PIN) ((PIN) % MAX_GPIO_LINES)
-
 
 #define NSECS 1000000000
 #define NSECS_PER_TICK (NSECS / CONFIG_CLOCK_FREQ)
@@ -19,7 +19,7 @@ void report_errno(char *where, int rc);
 int set_non_blocking(int fd);
 int set_close_on_exec(int fd);
 int console_setup(char *name);
-void console_sleep(struct timespec ts);
+void console_sleep(sigset_t *sigset);
 
 // timer.c
 int timer_check_periodic(uint32_t *ts);

--- a/src/linux/internal.h
+++ b/src/linux/internal.h
@@ -23,6 +23,8 @@ void console_sleep(sigset_t *sigset);
 
 // timer.c
 int timer_check_periodic(uint32_t *ts);
+void timer_disable_signals(void);
+void timer_enable_signals(void);
 
 // watchdog.c
 int watchdog_setup(void);

--- a/src/linux/sensor_ds18b20.c
+++ b/src/linux/sensor_ds18b20.c
@@ -163,7 +163,9 @@ command_config_ds18b20(uint32_t *args)
         goto fail4;
 
     pthread_t reader_tid; // Not used
+    timer_disable_signals();
     ret = pthread_create(&reader_tid, NULL, reader_start_routine, d);
+    timer_enable_signals();
     if (ret)
         goto fail5;
 

--- a/src/linux/timer.c
+++ b/src/linux/timer.c
@@ -18,25 +18,22 @@ static struct {
     uint32_t last_read_time;
     // Fields for converting from a systime to ticks
     time_t start_sec;
+    // Flags for tracking irq_enable()/irq_disable()
+    uint32_t can_run_timers, must_wake_timers;
     // Maximum absolute time that can be spent in timer_dispatch()
     uint32_t timer_repeat_until;
-    // Time of next software timer (also used to convert from ticks to systime)
+    // Fields to convert from ticks to systime
     uint32_t next_wake_counter;
     struct timespec next_wake;
+    // Unix signal tracking
+    timer_t t_alarm;
+    sigset_t ss_alarm, ss_sleep;
 } TimerInfo;
 
 
 /****************************************************************
  * Timespec helpers
  ****************************************************************/
-
-// Compare two 'struct timespec' times
-static inline uint8_t
-timespec_is_before(struct timespec ts1, struct timespec ts2)
-{
-    return (ts1.tv_sec < ts2.tv_sec
-            || (ts1.tv_sec == ts2.tv_sec && ts1.tv_nsec < ts2.tv_nsec));
-}
 
 // Convert a 'struct timespec' to a counter value
 static inline uint32_t
@@ -122,8 +119,8 @@ timer_read_time(void)
 void
 timer_kick(void)
 {
-    TimerInfo.next_wake = timespec_read();
-    TimerInfo.next_wake_counter = timespec_to_time(TimerInfo.next_wake);
+    struct itimerspec it = { .it_interval = {0, 0}, .it_value = {0, 1} };
+    timer_settime(TimerInfo.t_alarm, TIMER_ABSTIME, &it, NULL);
 }
 
 #define TIMER_IDLE_REPEAT_TICKS timer_from_us(500)
@@ -172,6 +169,24 @@ timer_dispatch_many(void)
     }
 }
 
+// Invoke timers
+static void
+timer_dispatch(int signal)
+{
+    if (!TimerInfo.can_run_timers) {
+        TimerInfo.must_wake_timers = 1;
+        return;
+    }
+    TimerInfo.can_run_timers = 0;
+    uint32_t next = timer_dispatch_many();
+    TimerInfo.can_run_timers = 1;
+    struct itimerspec it;
+    it.it_interval = (struct timespec){0, 0};
+    TimerInfo.next_wake = it.it_value = timespec_from_time(next);
+    TimerInfo.next_wake_counter = next;
+    timer_settime(TimerInfo.t_alarm, TIMER_ABSTIME, &it, NULL);
+}
+
 // Make sure timer_repeat_until doesn't wrap 32bit comparisons
 void
 timer_task(void)
@@ -184,20 +199,52 @@ timer_task(void)
 }
 DECL_TASK(timer_task);
 
-// Invoke timers
-static void
-timer_dispatch(void)
-{
-    uint32_t next = timer_dispatch_many();
-    TimerInfo.next_wake = timespec_from_time(next);
-    TimerInfo.next_wake_counter = next;
-}
-
 void
 timer_init(void)
 {
-    TimerInfo.start_sec = timespec_read().tv_sec + 1;
+    // Initialize ss_alarm signal set
+    int ret = sigemptyset(&TimerInfo.ss_alarm);
+    if (ret < 0) {
+        report_errno("sigemptyset", ret);
+        return;
+    }
+    ret = sigaddset(&TimerInfo.ss_alarm, SIGALRM);
+    if (ret < 0) {
+        report_errno("sigaddset", ret);
+        return;
+    }
+    // Initialize ss_sleep signal set
+    ret = sigprocmask(0, NULL, &TimerInfo.ss_sleep);
+    if (ret < 0) {
+        report_errno("sigprocmask ss_sleep", ret);
+        return;
+    }
+    ret = sigdelset(&TimerInfo.ss_sleep, SIGALRM);
+    if (ret < 0) {
+        report_errno("sigdelset", ret);
+        return;
+    }
+    // Initialize timespec_to_time() and timespec_from_time()
+    struct timespec curtime = timespec_read();
+    TimerInfo.start_sec = curtime.tv_sec + 1;
+    TimerInfo.next_wake = curtime;
+    TimerInfo.next_wake_counter = timespec_to_time(curtime);
+    // Initialize t_alarm signal based timer
+    ret = timer_create(CLOCK_MONOTONIC, NULL, &TimerInfo.t_alarm);
+    if (ret < 0) {
+        report_errno("timer_create", ret);
+        return;
+    }
+    irq_disable();
+    struct sigaction act = {.sa_handler = timer_dispatch, .sa_flags = SA_RESTART
+                            , .sa_mask = TimerInfo.ss_alarm };
+    ret = sigaction(SIGALRM, &act, NULL);
+    if (ret < 0) {
+        report_errno("sigaction", ret);
+        return;
+    }
     timer_kick();
+    irq_enable();
 }
 DECL_INIT(timer_init);
 
@@ -206,36 +253,65 @@ DECL_INIT(timer_init);
  * Interrupt wrappers
  ****************************************************************/
 
+static void
+timer_force_wakeup(void)
+{
+    TimerInfo.must_wake_timers = 0;
+    timer_kick();
+}
+
 void
 irq_disable(void)
 {
+    barrier();
+    TimerInfo.can_run_timers = 0;
+    barrier();
 }
 
 void
 irq_enable(void)
 {
+    barrier();
+    TimerInfo.can_run_timers = 1;
+    barrier();
+    if (TimerInfo.must_wake_timers)
+        timer_force_wakeup();
 }
 
 irqstatus_t
 irq_save(void)
 {
-    return 0;
+    uint32_t old = TimerInfo.can_run_timers;
+    irq_disable();
+    return old;
 }
 
 void
 irq_restore(irqstatus_t flag)
 {
+    if (flag)
+        irq_enable();
 }
 
 void
 irq_wait(void)
 {
-    console_sleep(TimerInfo.next_wake);
+    // Must atomically enable irqs and check for console activity
+    sigprocmask(SIG_BLOCK, &TimerInfo.ss_alarm, NULL);
+    TimerInfo.can_run_timers = 1;
+    if (TimerInfo.must_wake_timers) {
+        sigprocmask(SIG_UNBLOCK, &TimerInfo.ss_alarm, NULL);
+        timer_force_wakeup();
+        TimerInfo.can_run_timers = 0;
+        barrier();
+        return;
+    }
+    console_sleep(&TimerInfo.ss_sleep);
+    TimerInfo.can_run_timers = 0;
+    sigprocmask(SIG_UNBLOCK, &TimerInfo.ss_alarm, NULL);
 }
 
 void
 irq_poll(void)
 {
-    if (!timespec_is_before(timespec_read(), TimerInfo.next_wake))
-        timer_dispatch();
 }


### PR DESCRIPTION
This converts the linux mcu code to use Unix signals to implement the software timer dispatch.  As discussed in #3387 this can reduce scheduling jitter.  It should also be a little more CPU efficient in general.

@tntclaus - FYI the latest implementation is slightly different than previous iterations of this code.  The latest version should be a bit more CPU efficient as the irq_disable()/irq_enable() code now just sets internal flags.

-Kevin