### PR TITLE
Fix rotary encoder handling - resurrection of #730

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3183,6 +3183,12 @@ lcd_type:
 #encoder_pins:
 #   The pins connected to encoder. 2 pins must be provided when using
 #   encoder. This parameter must be provided when using menu.
+#steps_per_detent:
+#   The steps per detent defines if your are dealing with a half-stepping 
+#   encoder or a full stepping encoder. Allowed values are 4 (half-stepping) or
+#   2 (full stepping)  
+#   The default is 4
+
 #click_pin:
 #   The pin connected to 'enter' button or encoder 'click'. This
 #   parameter must be provided when using menu. The presence of an

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3187,8 +3187,7 @@ lcd_type:
 #   The steps per detent defines if your are dealing with a half-stepping 
 #   encoder or a full stepping encoder. Allowed values are 4 (half-stepping) or
 #   2 (full stepping)  
-#   The default is 4
-
+#   The default is 2.
 #click_pin:
 #   The pin connected to 'enter' button or encoder 'click'. This
 #   parameter must be provided when using menu. The presence of an

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3184,9 +3184,9 @@ lcd_type:
 #   The pins connected to encoder. 2 pins must be provided when using
 #   encoder. This parameter must be provided when using menu.
 #steps_per_detent:
-#   The steps per detent defines if your are dealing with a half-stepping 
+#   The steps per detent defines if your are dealing with a half-stepping
 #   encoder or a full stepping encoder. Allowed values are 4 (half-stepping) or
-#   2 (full stepping)  
+#   2 (full stepping)
 #   The default is 2.
 #click_pin:
 #   The pin connected to 'enter' button or encoder 'click'. This

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -214,12 +214,11 @@ class RotaryEncoder:
 
     def encoder_callback(self, eventtime, state):
         es = ENCODER_STATES[self.encoder_state & 0xf][state & 0x3]
-        logging.debug(
-            "encoder_callback: self.encoder_state='%0x', state='%0x', es='%0x'" % (
-            self.encoder_state, state, es,))
-        logging.debug(
-            "  cw_masked='%0x', ccw_masked='%0x'" % (
-            es & self.cw_mask, es & self.ccw_mask,))
+        logging.info(
+            "encoder_callback: self.encoder_state='%0x', state='%0x', es='%0x'"
+            % (self.encoder_state, state, es,))
+        logging.info("cw_masked='%0x', ccw_masked='%0x'"
+                     % (es & self.cw_mask, es & self.ccw_mask,))
         self.encoder_state = es
         if (es & self.cw_mask):
             self.cw_callback(eventtime)

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -198,7 +198,7 @@ ENCODER_STATES = (
 
 
 class RotaryEncoder:
-    def __init__(self, cw_callback, ccw_callback, steps_per_detent=4):
+    def __init__(self, cw_callback, ccw_callback, steps_per_detent=2):
         self.cw_callback = cw_callback
         self.ccw_callback = ccw_callback
         self.encoder_state = R_START

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -5,13 +5,13 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 
-
 ######################################################################
 # Button state tracking
 ######################################################################
 
 QUERY_TIME = .002
 RETRANSMIT_COUNT = 50
+
 
 class MCU_buttons:
     def __init__(self, printer, mcu):
@@ -23,6 +23,7 @@ class MCU_buttons:
         self.invert = self.last_button = 0
         self.ack_cmd = None
         self.ack_count = 0
+
     def setup_buttons(self, pins, callback):
         mask = 0
         shift = len(self.pin_list)
@@ -32,6 +33,7 @@ class MCU_buttons:
             mask |= 1 << len(self.pin_list)
             self.pin_list.append((pin_params['pin'], pin_params['pullup']))
         self.callbacks.append((mask, shift, callback))
+
     def build_config(self):
         if not self.pin_list:
             return
@@ -54,6 +56,7 @@ class MCU_buttons:
                 self.invert), is_init=True)
         self.mcu.register_response(self.handle_buttons_state,
                                    "buttons_state", self.oid)
+
     def handle_buttons_state(self, params):
         # Expand the message ack_count from 8-bit
         ack_count = self.ack_count
@@ -74,6 +77,7 @@ class MCU_buttons:
         for nb in new_buttons:
             self.reactor.register_async_callback(
                 (lambda e, s=self, b=nb: s.handle_button(e, b)))
+
     def handle_button(self, eventtime, button):
         button ^= self.invert
         changed = button ^ self.last_button
@@ -91,6 +95,7 @@ ADC_REPORT_TIME = 0.015
 ADC_DEBOUNCE_TIME = 0.025
 ADC_SAMPLE_TIME = 0.001
 ADC_SAMPLE_COUNT = 6
+
 
 class MCU_ADC_buttons:
     def __init__(self, printer, pin, pullup):
@@ -134,7 +139,7 @@ class MCU_ADC_buttons:
 
         # button debounce check & new button pressed
         if ((read_time - self.last_debouncetime) >= ADC_DEBOUNCE_TIME
-            and self.last_button == btn and self.last_pressed != btn):
+                and self.last_button == btn and self.last_pressed != btn):
             # release last_pressed
             if self.last_pressed is not None:
                 self.call_button(self.last_pressed, False)
@@ -158,38 +163,39 @@ class MCU_ADC_buttons:
 # Rotary encoder handler https://github.com/brianlow/Rotary
 # Copyright 2011 Ben Buxton (bb@cactii.net).
 # Licenced under the GNU GPL Version 3.
-R_START     = 0x0
-R_CCW_A     = 0x1
-R_CW_A      = 0x2
-R_MID       = 0x3
-R_CW_B      = 0x4
-R_CCW_B     = 0x5
+R_START = 0x0
+R_CCW_A = 0x1
+R_CW_A = 0x2
+R_MID = 0x3
+R_CW_B = 0x4
+R_CCW_B = 0x5
 
-R_DIR_CW_4  = 0x0010
+R_DIR_CW_4 = 0x0010
 R_DIR_CCW_4 = 0x0020
-R_DIR_CW_2  = 0x0100
+R_DIR_CW_2 = 0x0100
 R_DIR_CCW_2 = 0x0200
 
-R_MSK_CW_4  = 0x0010
+R_MSK_CW_4 = 0x0010
 R_MSK_CCW_4 = 0x0020
-R_MSK_CW_2  = 0x0110
+R_MSK_CW_2 = 0x0110
 R_MSK_CCW_2 = 0x0220
 
 # Use modified half step state table, allowing user-selectable steps per direction pulse
 ENCODER_STATES = (
-  # R_START
-  (R_MID,               R_CW_A,     R_CCW_A,    R_START),
-  # R_CCW_A
-  (R_MID | R_DIR_CCW_2, R_START,    R_CCW_A,    R_START),
-  # R_CW_A
-  (R_MID | R_DIR_CW_2,  R_CW_A,     R_START,    R_START),
-  # R_MID
-  (R_MID,               R_CCW_B,    R_CW_B,     R_START),
-  # R_CW_B
-  (R_MID,               R_MID,      R_CW_B,     R_START | R_DIR_CW_4),
-  # R_CCW_B
-  (R_MID,               R_CCW_B,    R_MID,      R_START | R_DIR_CCW_4),
+    # R_START
+    (R_MID, R_CW_A, R_CCW_A, R_START),
+    # R_CCW_A
+    (R_MID | R_DIR_CCW_2, R_START, R_CCW_A, R_START),
+    # R_CW_A
+    (R_MID | R_DIR_CW_2, R_CW_A, R_START, R_START),
+    # R_MID
+    (R_MID, R_CCW_B, R_CW_B, R_START),
+    # R_CW_B
+    (R_MID, R_MID, R_CW_B, R_START | R_DIR_CW_4),
+    # R_CCW_B
+    (R_MID, R_CCW_B, R_MID, R_START | R_DIR_CCW_4),
 )
+
 
 class RotaryEncoder:
     def __init__(self, cw_callback, ccw_callback, steps_per_detent=4):
@@ -203,14 +209,17 @@ class RotaryEncoder:
             self.cw_mask = R_MSK_CW_2
             self.ccw_mask = R_MSK_CCW_2
         else:
-            raise ppins.error("%d steps per detent not supported" % steps_per_detent)
+            raise ppins.error(
+                "%d steps per detent not supported" % steps_per_detent)
 
     def encoder_callback(self, eventtime, state):
         es = ENCODER_STATES[self.encoder_state & 0xf][state & 0x3]
         logging.debug(
-                "encoder_callback: self.encoder_state='%0x', state='%0x', es='%0x'" % (self.encoder_state, state, es,))
+            "encoder_callback: self.encoder_state='%0x', state='%0x', es='%0x'" % (
+            self.encoder_state, state, es,))
         logging.debug(
-                "  cw_masked='%0x', ccw_masked='%0x'" % (es & self.cw_mask, es & self.ccw_mask,))
+            "  cw_masked='%0x', ccw_masked='%0x'" % (
+            es & self.cw_mask, es & self.ccw_mask,))
         self.encoder_state = es
         if (es & self.cw_mask):
             self.cw_callback(eventtime)
@@ -228,17 +237,21 @@ class PrinterButtons:
         self.printer.load_object(config, 'query_adc')
         self.mcu_buttons = {}
         self.adc_buttons = {}
+
     def register_adc_button(self, pin, min_val, max_val, pullup, callback):
         adc_buttons = self.adc_buttons.get(pin)
         if adc_buttons is None:
             self.adc_buttons[pin] = adc_buttons = MCU_ADC_buttons(
                 self.printer, pin, pullup)
         adc_buttons.setup_button(min_val, max_val, callback)
+
     def register_adc_button_push(self, pin, min_val, max_val, pullup, callback):
         def helper(eventtime, state, callback=callback):
             if state:
                 callback(eventtime)
+
         self.register_adc_button(pin, min_val, max_val, pullup, helper)
+
     def register_buttons(self, pins, callback):
         # Parse pins
         ppins = self.printer.lookup_object('pins')
@@ -254,18 +267,23 @@ class PrinterButtons:
         # Register pins and callback with the appropriate MCU
         mcu_buttons = self.mcu_buttons.get(mcu_name)
         if (mcu_buttons is None
-            or len(mcu_buttons.pin_list) + len(pin_params_list) > 8):
+                or len(mcu_buttons.pin_list) + len(pin_params_list) > 8):
             self.mcu_buttons[mcu_name] = mcu_buttons = MCU_buttons(
                 self.printer, mcu)
         mcu_buttons.setup_buttons(pin_params_list, callback)
-    def register_rotary_encoder(self, pin1, pin2, cw_callback, ccw_callback, steps_per_detent):
+
+    def register_rotary_encoder(self, pin1, pin2, cw_callback, ccw_callback,
+                                steps_per_detent):
         re = RotaryEncoder(cw_callback, ccw_callback, steps_per_detent)
         self.register_buttons([pin1, pin2], re.encoder_callback)
+
     def register_button_push(self, pin, callback):
         def helper(eventtime, state, callback=callback):
             if state:
                 callback(eventtime)
+
         self.register_buttons([pin], helper)
+
 
 def load_config(config):
     return PrinterButtons(config)

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -180,7 +180,8 @@ R_MSK_CCW_4 = 0x0020
 R_MSK_CW_2 = 0x0110
 R_MSK_CCW_2 = 0x0220
 
-# Use modified half step state table, allowing user-selectable steps per direction pulse
+# Use modified half step state table,
+# allowing user-selectable steps per direction pulse
 ENCODER_STATES = (
     # R_START
     (R_MID, R_CW_A, R_CCW_A, R_START),

--- a/klippy/extras/display/menu_keys.py
+++ b/klippy/extras/display/menu_keys.py
@@ -17,6 +17,8 @@ class MenuKeys:
         buttons = self.printer.load_object(config, "buttons")
         # Register rotary encoder
         encoder_pins = config.get('encoder_pins', None)
+        self.encoder_steps_per_detent = config.getchoice(
+            'encoder_steps_per_detent', {'2': 2, '4': 4}, '4')
         if encoder_pins is not None:
             try:
                 pin1, pin2 = encoder_pins.split(',')
@@ -24,7 +26,8 @@ class MenuKeys:
                 raise config.error("Unable to parse encoder_pins")
             buttons.register_rotary_encoder(pin1.strip(), pin2.strip(),
                                             self.encoder_cw_callback,
-                                            self.encoder_ccw_callback)
+                                            self.encoder_ccw_callback,
+                                            self.encoder_steps_per_detent)
         self.encoder_fast_rate = config.getfloat('encoder_fast_rate',
                                                  .030, above=0.)
         self.last_encoder_cw_eventtime = 0

--- a/klippy/extras/display/menu_keys.py
+++ b/klippy/extras/display/menu_keys.py
@@ -18,7 +18,7 @@ class MenuKeys:
         # Register rotary encoder
         encoder_pins = config.get('encoder_pins', None)
         self.encoder_steps_per_detent = config.getchoice(
-            'encoder_steps_per_detent', {'2': 2, '4': 4}, '4')
+            'encoder_steps_per_detent', {'2': 2, '4': 4}, '2')
         if encoder_pins is not None:
             try:
                 pin1, pin2 = encoder_pins.split(',')


### PR DESCRIPTION
Original fix from @nickbrennan01

This feature supports half-stepping rotary encoders and encoders with inverted
inputs (like Velleman K8800).

Requires an additional config entry in [display] section:
  encoder_steps_per_detent: 2|4

encoder_steps_per_detent = 2: "regular" encoder
encoder_steps_per_detent = 4: half-stepping encoder

Signed-off-by: Juergen Orschiedt juorschiedt@gmail.com