### PR TITLE
Remove the min_stop_interval check from the micro-controller code

### DIFF
--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -92,9 +92,9 @@ The following configuration sequence is used on AVR chips:
 ```
 PINS arduino
 allocate_oids count=3
-config_stepper oid=0 step_pin=ar29 dir_pin=ar28 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=ar27 dir_pin=ar26 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=ar23 dir_pin=ar22 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=ar29 dir_pin=ar28 invert_step=0
+config_stepper oid=1 step_pin=ar27 dir_pin=ar26 invert_step=0
+config_stepper oid=2 step_pin=ar23 dir_pin=ar22 invert_step=0
 finalize_config crc=0
 ```
 
@@ -114,9 +114,9 @@ results match tests on both a 16Mhz at90usb and a 16Mhz atmega2560).
 The following configuration sequence is used on the Due:
 ```
 allocate_oids count=3
-config_stepper oid=0 step_pin=PB27 dir_pin=PA21 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=PB26 dir_pin=PC30 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=PA21 dir_pin=PC30 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=PB27 dir_pin=PA21 invert_step=0
+config_stepper oid=1 step_pin=PB26 dir_pin=PC30 invert_step=0
+config_stepper oid=2 step_pin=PA21 dir_pin=PC30 invert_step=0
 finalize_config crc=0
 ```
 
@@ -136,9 +136,9 @@ The test was last run on commit `8d4a5c16` with gcc version
 The following configuration sequence is used on the Duet Maestro:
 ```
 allocate_oids count=3
-config_stepper oid=0 step_pin=PC26 dir_pin=PC18 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=PC26 dir_pin=PA8 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=PC26 dir_pin=PB4 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=PC26 dir_pin=PC18 invert_step=0
+config_stepper oid=1 step_pin=PC26 dir_pin=PA8 invert_step=0
+config_stepper oid=2 step_pin=PC26 dir_pin=PB4 invert_step=0
 finalize_config crc=0
 ```
 
@@ -158,10 +158,10 @@ The test was last run on commit `8d4a5c16` with gcc version
 The following configuration sequence is used on the Duet Wifi:
 ```
 allocate_oids count=4
-config_stepper oid=0 step_pin=PD6 dir_pin=PD11 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=PD7 dir_pin=PD12 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=PD8 dir_pin=PD13 min_stop_interval=0 invert_step=0
-config_stepper oid=3 step_pin=PD5 dir_pin=PA1 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=PD6 dir_pin=PD11 invert_step=0
+config_stepper oid=1 step_pin=PD7 dir_pin=PD12 invert_step=0
+config_stepper oid=2 step_pin=PD8 dir_pin=PD13 invert_step=0
+config_stepper oid=3 step_pin=PD5 dir_pin=PA1 invert_step=0
 finalize_config crc=0
 
 ```
@@ -183,9 +183,9 @@ The following configuration sequence is used on the PRU:
 ```
 PINS beaglebone
 allocate_oids count=3
-config_stepper oid=0 step_pin=P8_13 dir_pin=P8_12 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=P8_15 dir_pin=P8_14 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=P8_19 dir_pin=P8_18 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=P8_13 dir_pin=P8_12 invert_step=0
+config_stepper oid=1 step_pin=P8_15 dir_pin=P8_14 invert_step=0
+config_stepper oid=2 step_pin=P8_19 dir_pin=P8_18 invert_step=0
 finalize_config crc=0
 ```
 
@@ -203,9 +203,9 @@ The test was last run on commit `b161a69e` with gcc version `pru-gcc
 The following configuration sequence is used on the STM32F042:
 ```
 allocate_oids count=3
-config_stepper oid=0 step_pin=PA1 dir_pin=PA2 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=PA3 dir_pin=PA2 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=PB8 dir_pin=PA2 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=PA1 dir_pin=PA2 invert_step=0
+config_stepper oid=1 step_pin=PA3 dir_pin=PA2 invert_step=0
+config_stepper oid=2 step_pin=PB8 dir_pin=PA2 invert_step=0
 finalize_config crc=0
 ```
 
@@ -223,9 +223,9 @@ The test was last run on commit `0b0c47c5` with gcc version
 The following configuration sequence is used on the STM32F103:
 ```
 allocate_oids count=3
-config_stepper oid=0 step_pin=PC13 dir_pin=PB5 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=PB3 dir_pin=PB6 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=PA4 dir_pin=PB7 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=PC13 dir_pin=PB5 invert_step=0
+config_stepper oid=1 step_pin=PB3 dir_pin=PB6 invert_step=0
+config_stepper oid=2 step_pin=PA4 dir_pin=PB7 invert_step=0
 finalize_config crc=0
 ```
 
@@ -245,10 +245,10 @@ The test was last run on commit `8d4a5c16` with gcc version
 The following configuration sequence is used on the STM32F4:
 ```
 allocate_oids count=4
-config_stepper oid=0 step_pin=PA5 dir_pin=PB5 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=PB2 dir_pin=PB6 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=PB3 dir_pin=PB7 min_stop_interval=0 invert_step=0
-config_stepper oid=3 step_pin=PB3 dir_pin=PB8 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=PA5 dir_pin=PB5 invert_step=0
+config_stepper oid=1 step_pin=PB2 dir_pin=PB6 invert_step=0
+config_stepper oid=2 step_pin=PB3 dir_pin=PB7 invert_step=0
+config_stepper oid=3 step_pin=PB3 dir_pin=PB8 invert_step=0
 finalize_config crc=0
 ```
 
@@ -280,9 +280,9 @@ using a 168Mhz clock).
 The following configuration sequence is used on the LPC176x:
 ```
 allocate_oids count=3
-config_stepper oid=0 step_pin=P1.20 dir_pin=P1.18 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=P1.21 dir_pin=P1.18 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=P1.23 dir_pin=P1.18 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=P1.20 dir_pin=P1.18 invert_step=0
+config_stepper oid=1 step_pin=P1.21 dir_pin=P1.18 invert_step=0
+config_stepper oid=2 step_pin=P1.23 dir_pin=P1.18 invert_step=0
 finalize_config crc=0
 ```
 
@@ -311,9 +311,9 @@ results were obtained by overclocking an LPC1768 to 120Mhz.
 The following configuration sequence is used on the SAMD21:
 ```
 allocate_oids count=3
-config_stepper oid=0 step_pin=PA27 dir_pin=PA20 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=PB3 dir_pin=PA21 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=PA17 dir_pin=PA21 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=PA27 dir_pin=PA20 invert_step=0
+config_stepper oid=1 step_pin=PB3 dir_pin=PA21 invert_step=0
+config_stepper oid=2 step_pin=PA17 dir_pin=PA21 invert_step=0
 finalize_config crc=0
 ```
 
@@ -334,11 +334,11 @@ micro-controller.
 The following configuration sequence is used on the SAMD51:
 ```
 allocate_oids count=5
-config_stepper oid=0 step_pin=PA22 dir_pin=PA20 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=PA22 dir_pin=PA21 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=PA22 dir_pin=PA19 min_stop_interval=0 invert_step=0
-config_stepper oid=3 step_pin=PA22 dir_pin=PA18 min_stop_interval=0 invert_step=0
-config_stepper oid=4 step_pin=PA23 dir_pin=PA17 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=PA22 dir_pin=PA20 invert_step=0
+config_stepper oid=1 step_pin=PA22 dir_pin=PA21 invert_step=0
+config_stepper oid=2 step_pin=PA22 dir_pin=PA19 invert_step=0
+config_stepper oid=3 step_pin=PA22 dir_pin=PA18 invert_step=0
+config_stepper oid=4 step_pin=PA23 dir_pin=PA17 invert_step=0
 finalize_config crc=0
 ```
 
@@ -365,9 +365,9 @@ micro-controller.
 The following configuration sequence is used on a Raspberry Pi:
 ```
 allocate_oids count=3
-config_stepper oid=0 step_pin=gpio2 dir_pin=gpio3 min_stop_interval=0 invert_step=0
-config_stepper oid=1 step_pin=gpio4 dir_pin=gpio5 min_stop_interval=0 invert_step=0
-config_stepper oid=2 step_pin=gpio6 dir_pin=gpio7 min_stop_interval=0 invert_step=0
+config_stepper oid=0 step_pin=gpio2 dir_pin=gpio3 invert_step=0
+config_stepper oid=1 step_pin=gpio4 dir_pin=gpio5 invert_step=0
+config_stepper oid=2 step_pin=gpio6 dir_pin=gpio7 invert_step=0
 finalize_config crc=0
 ```
 

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,10 @@ All dates in this document are approximate.
 
 # Changes
 
+20210430: The SET_VELOCITY_LIMIT (and M204) command may now set a
+velocity, acceleration, and square_corner_velocity larger than the
+specified values in the config file.
+
 20210325: Support for the `pin_map` config option is deprecated. Use
 the [sample-aliases.cfg](../config/sample-aliases.cfg) file to
 translate to the actual micro-controller pin names. The `pin_map`

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -517,15 +517,13 @@ enabled:
   the given distance (in mm) at the given constant velocity (in
   mm/s). If ACCEL is specified and is greater than zero, then the
   given acceleration (in mm/s^2) will be used; otherwise no
-  acceleration is performed. If acceleration is not performed then it
-  can lead to the micro-controller reporting "No next step" errors
-  (avoid these errors by specifying an ACCEL value or use a very low
-  VELOCITY). No boundary checks are performed; no kinematic updates
-  are made; other parallel steppers on an axis will not be moved. Use
-  caution as an incorrect command could cause damage! Using this
-  command will almost certainly place the low-level kinematics in an
-  incorrect state; issue a G28 afterwards to reset the kinematics.
-  This command is intended for low-level diagnostics and debugging.
+  acceleration is performed. No boundary checks are performed; no
+  kinematic updates are made; other parallel steppers on an axis will
+  not be moved. Use caution as an incorrect command could cause
+  damage! Using this command will almost certainly place the low-level
+  kinematics in an incorrect state; issue a G28 afterwards to reset
+  the kinematics. This command is intended for low-level diagnostics
+  and debugging.
 - `SET_KINEMATIC_POSITION [X=<value>] [Y=<value>] [Z=<value>]`: Force
   the low-level kinematic code to believe the toolhead is at the given
   cartesian position. This is a diagnostic and debugging command; use

--- a/docs/MCU_Commands.md
+++ b/docs/MCU_Commands.md
@@ -138,17 +138,12 @@ This section lists some commonly used config commands.
   sampled at regular interval using the query_analog_in command (see
   below).
 
-* `config_stepper oid=%c step_pin=%c dir_pin=%c min_stop_interval=%u
-  invert_step=%c` : This command creates an internal stepper
-  object. The 'step_pin' and 'dir_pin' parameters specify the step and
-  direction pins respectively; this command will configure them in
-  digital output mode. The 'invert_step' parameter specifies whether a
-  step occurs on a rising edge (invert_step=0) or falling edge
-  (invert_step=1). The 'min_stop_interval' implements a safety
-  feature - it is checked when the micro-controller finishes all moves
-  for a stepper - if it is non-zero it specifies the minimum number of
-  clock ticks since the last step. It is used as a check on the
-  maximum stepper velocity that a stepper may have before stopping.
+* `config_stepper oid=%c step_pin=%c dir_pin=%c invert_step=%c` : This
+  command creates an internal stepper object. The 'step_pin' and
+  'dir_pin' parameters specify the step and direction pins
+  respectively; this command will configure them in digital output
+  mode. The 'invert_step' parameter specifies whether a step occurs on
+  a rising edge (invert_step=0) or falling edge (invert_step=1).
 
 * `config_endstop oid=%c pin=%c pull_up=%c stepper_count=%c` : This
   command creates an internal "endstop" object. It is used to specify

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -12,7 +12,6 @@ class ExtruderStepper:
         stepper_name = config.get_name().split()[1]
         self.extruder_name = config.get('extruder', 'extruder')
         self.stepper = stepper.PrinterStepper(config)
-        self.stepper.set_max_jerk(9999999.9, 9999999.9)
         self.stepper.setup_itersolve('extruder_stepper_alloc')
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -28,7 +28,6 @@ class ManualStepper:
         self.trapq_free_moves = ffi_lib.trapq_free_moves
         self.rail.setup_itersolve('cartesian_stepper_alloc', 'x')
         self.rail.set_trapq(self.trapq)
-        self.rail.set_max_jerk(9999999.9, 9999999.9)
         # Register commands
         stepper_name = config.get_name().split()[1]
         gcode = self.printer.lookup_object('gcode')

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -31,12 +31,6 @@ class CartKinematics:
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
         self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.)
-        # Setup stepper max halt velocity
-        max_halt_velocity = toolhead.get_max_axis_halt()
-        self.rails[0].set_max_jerk(max_halt_velocity, max_accel)
-        self.rails[1].set_max_jerk(max_halt_velocity, max_accel)
-        self.rails[2].set_max_jerk(min(max_halt_velocity, self.max_z_velocity),
-                                   max_accel)
         # Check for dual carriage support
         if config.has_section('dual_carriage'):
             dc_config = config.getsection('dual_carriage')
@@ -46,7 +40,6 @@ class CartKinematics:
             dc_rail.setup_itersolve('cartesian_stepper_alloc', dc_axis)
             for s in dc_rail.get_steppers():
                 toolhead.register_step_generator(s.generate_steps)
-            dc_rail.set_max_jerk(max_halt_velocity, max_accel)
             self.dual_carriage_rails = [
                 self.rails[self.dual_carriage_axis], dc_rail]
             self.printer.lookup_object('gcode').register_command(

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -34,14 +34,6 @@ class CoreXYKinematics:
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
         self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.)
-        # Setup stepper max halt velocity
-        max_halt_velocity = toolhead.get_max_axis_halt()
-        max_xy_halt_velocity = max_halt_velocity * math.sqrt(2.)
-        max_xy_accel = max_accel * math.sqrt(2.)
-        self.rails[0].set_max_jerk(max_xy_halt_velocity, max_xy_accel)
-        self.rails[1].set_max_jerk(max_xy_halt_velocity, max_xy_accel)
-        self.rails[2].set_max_jerk(
-            min(max_halt_velocity, self.max_z_velocity), self.max_z_accel)
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
     def calc_tag_position(self):

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -34,13 +34,6 @@ class CoreXZKinematics:
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
         self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.)
-        # Setup stepper max halt velocity
-        max_halt_velocity = toolhead.get_max_axis_halt()
-        max_xy_halt_velocity = max_halt_velocity * math.sqrt(2.)
-        max_xy_accel = max_accel * math.sqrt(2.)
-        self.rails[0].set_max_jerk(max_xy_halt_velocity, max_xy_accel)
-        self.rails[1].set_max_jerk(max_xy_halt_velocity, max_xy_accel)
-        self.rails[2].set_max_jerk(max_xy_halt_velocity, max_xy_accel)
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
     def calc_tag_position(self):

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -25,15 +25,11 @@ class DeltaKinematics:
         self.rails = [rail_a, rail_b, rail_c]
         config.get_printer().register_event_handler("stepper_enable:motor_off",
                                                     self._motor_off)
-        # Setup stepper max halt velocity
+        # Setup max velocity
         self.max_velocity, self.max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
             'max_z_velocity', self.max_velocity,
             above=0., maxval=self.max_velocity)
-        max_halt_velocity = toolhead.get_max_axis_halt() * SLOW_RATIO
-        max_halt_accel = self.max_accel * SLOW_RATIO
-        for rail in self.rails:
-            rail.set_max_jerk(max_halt_velocity, max_halt_accel)
         # Read radius and arm lengths
         self.radius = radius = config.getfloat('delta_radius', above=0.)
         print_radius = config.getfloat('print_radius', radius, above=0.)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -36,7 +36,6 @@ class PrinterExtruder:
         self.max_e_accel = config.getfloat(
             'max_extrude_only_accel', max_accel * def_max_extrude_ratio
             , above=0.)
-        self.stepper.set_max_jerk(9999999.9, 9999999.9)
         self.max_e_dist = config.getfloat(
             'max_extrude_only_distance', 50., minval=0.)
         self.instant_corner_v = config.getfloat(

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -36,11 +36,6 @@ class PolarKinematics:
         min_z, max_z = self.rails[1].get_range()
         self.axes_min = toolhead.Coord(-max_xy, -max_xy, min_z, 0.)
         self.axes_max = toolhead.Coord(max_xy, max_xy, max_z, 0.)
-        # Setup stepper max halt velocity
-        max_halt_velocity = toolhead.get_max_axis_halt()
-        stepper_bed.set_max_jerk(max_halt_velocity, max_accel)
-        rail_arm.set_max_jerk(max_halt_velocity, max_accel)
-        rail_z.set_max_jerk(max_halt_velocity, max_accel)
     def get_steppers(self):
         return list(self.steppers)
     def calc_tag_position(self):

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -23,13 +23,10 @@ class RotaryDeltaKinematics:
         self.rails = [rail_a, rail_b, rail_c]
         config.get_printer().register_event_handler("stepper_enable:motor_off",
                                                     self._motor_off)
-        # Setup stepper max halt velocity
+        # Read config
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat('max_z_velocity', max_velocity,
                                               above=0., maxval=max_velocity)
-        for rail in self.rails:
-            rail.set_max_jerk(9999999.9, 9999999.9)
-        # Read config
         shoulder_radius = config.getfloat('shoulder_radius', above=0.)
         shoulder_height = config.getfloat('shoulder_height', above=0.)
         a_upper_arm = stepper_configs[0].getfloat('upper_arm_length', above=0.)

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -22,11 +22,6 @@ class WinchKinematics:
             s.setup_itersolve('winch_stepper_alloc', *a)
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        # Setup stepper max halt velocity
-        max_velocity, max_accel = toolhead.get_max_velocity()
-        max_halt_velocity = toolhead.get_max_axis_halt()
-        for s in self.steppers:
-            s.set_max_jerk(max_halt_velocity, max_accel)
         # Setup boundary checks
         acoords = list(zip(*self.anchors))
         self.axes_min = toolhead.Coord(*[min(a) for a in acoords], e=0.)

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -824,7 +824,7 @@ class MCU:
         return False, '%s: %s' % (self._name, stats)
 
 Common_MCU_errors = {
-    ("Timer too close", "No next step"): """
+    ("Timer too close",): """
 This often indicates the host computer is overloaded. Check
 for other processes consuming excessive CPU time, high swap
 usage, disk errors, overheating, unstable voltage, or

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -32,7 +32,6 @@ class MCU_stepper:
         self._dir_pin = dir_pin_params['pin']
         self._invert_dir = dir_pin_params['invert']
         self._mcu_position_offset = self._tag_position = 0.
-        self._min_stop_interval = 0.
         self._reset_cmd_tag = self._get_position_cmd = None
         self._active_callbacks = []
         ffi_main, ffi_lib = chelper.get_ffi()
@@ -56,26 +55,15 @@ class MCU_stepper:
         # Calculate the time it takes to travel a distance with constant accel
         time_offset = start_velocity / accel
         return math.sqrt(2. * dist / accel + time_offset**2) - time_offset
-    def set_max_jerk(self, max_halt_velocity, max_accel):
-        # Calculate the firmware's maximum halt interval time
-        last_step_time = self._dist_to_time(self._step_dist,
-                                            max_halt_velocity, max_accel)
-        second_last_step_time = self._dist_to_time(2. * self._step_dist,
-                                                   max_halt_velocity, max_accel)
-        self._min_stop_interval = second_last_step_time - last_step_time
     def setup_itersolve(self, alloc_func, *params):
         ffi_main, ffi_lib = chelper.get_ffi()
         sk = ffi_main.gc(getattr(ffi_lib, alloc_func)(*params), ffi_lib.free)
         self.set_stepper_kinematics(sk)
     def _build_config(self):
-        max_error = self._mcu.get_max_stepper_error()
-        min_stop_interval = max(0., self._min_stop_interval - max_error)
         self._mcu.add_config_cmd(
             "config_stepper oid=%d step_pin=%s dir_pin=%s"
-            " min_stop_interval=%d invert_step=%d" % (
-                self._oid, self._step_pin, self._dir_pin,
-                self._mcu.seconds_to_clock(min_stop_interval),
-                self._invert_step))
+            " min_stop_interval=0 invert_step=%d" % (
+                self._oid, self._step_pin, self._dir_pin, self._invert_step))
         self._mcu.add_config_cmd("reset_step_clock oid=%d clock=0"
                                  % (self._oid,), on_restart=True)
         step_cmd_tag = self._mcu.lookup_command_tag(
@@ -87,6 +75,7 @@ class MCU_stepper:
         self._get_position_cmd = self._mcu.lookup_query_command(
             "stepper_get_position oid=%c",
             "stepper_position oid=%c pos=%i", oid=self._oid)
+        max_error = self._mcu.get_max_stepper_error()
         ffi_main, ffi_lib = chelper.get_ffi()
         ffi_lib.stepcompress_fill(self._stepqueue,
                                   self._mcu.seconds_to_clock(max_error),
@@ -360,9 +349,6 @@ class PrinterRail:
     def set_trapq(self, trapq):
         for stepper in self.steppers:
             stepper.set_trapq(trapq)
-    def set_max_jerk(self, max_halt_velocity, max_accel):
-        for stepper in self.steppers:
-            stepper.set_max_jerk(max_halt_velocity, max_accel)
     def set_position(self, coord):
         for stepper in self.steppers:
             stepper.set_position(coord)

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -61,8 +61,7 @@ class MCU_stepper:
         self.set_stepper_kinematics(sk)
     def _build_config(self):
         self._mcu.add_config_cmd(
-            "config_stepper oid=%d step_pin=%s dir_pin=%s"
-            " min_stop_interval=0 invert_step=%d" % (
+            "config_stepper oid=%d step_pin=%s dir_pin=%s invert_step=%d" % (
                 self._oid, self._step_pin, self._dir_pin, self._invert_step))
         self._mcu.add_config_cmd("reset_step_clock oid=%d clock=0"
                                  % (self._oid,), on_restart=True)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -217,9 +217,6 @@ class ToolHead:
         self.max_accel_to_decel = self.requested_accel_to_decel
         self.square_corner_velocity = config.getfloat(
             'square_corner_velocity', 5., minval=0.)
-        self.config_max_velocity = self.max_velocity
-        self.config_max_accel = self.max_accel
-        self.config_square_corner_velocity = self.square_corner_velocity
         self.junction_deviation = 0.
         self._calc_junction_deviation()
         # Print time tracking
@@ -560,10 +557,9 @@ class ToolHead:
             'SQUARE_CORNER_VELOCITY', self.square_corner_velocity, minval=0.)
         self.requested_accel_to_decel = gcmd.get_float(
             'ACCEL_TO_DECEL', self.requested_accel_to_decel, above=0.)
-        self.max_velocity = min(max_velocity, self.config_max_velocity)
-        self.max_accel = min(max_accel, self.config_max_accel)
-        self.square_corner_velocity = min(square_corner_velocity,
-                                          self.config_square_corner_velocity)
+        self.max_velocity = max_velocity
+        self.max_accel = max_accel
+        self.square_corner_velocity = square_corner_velocity
         self._calc_junction_deviation()
         msg = ("max_velocity: %.6f\n"
                "max_accel: %.6f\n"
@@ -586,7 +582,7 @@ class ToolHead:
                                   % (gcmd.get_commandline(),))
                 return
             accel = min(p, t)
-        self.max_accel = min(accel, self.config_max_accel)
+        self.max_accel = accel
         self._calc_junction_deviation()
 
 def add_printer_objects(config):

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -539,12 +539,6 @@ class ToolHead:
         self.last_kin_move_time = max(self.last_kin_move_time, kin_time)
     def get_max_velocity(self):
         return self.max_velocity, self.max_accel
-    def get_max_axis_halt(self):
-        # Determine the maximum velocity a cartesian axis could halt
-        # at due to the junction_deviation setting.  The 8.0 was
-        # determined experimentally.
-        return min(self.max_velocity,
-                   math.sqrt(8. * self.junction_deviation * self.max_accel))
     def _calc_junction_deviation(self):
         scv2 = self.square_corner_velocity**2
         self.junction_deviation = scv2 * (math.sqrt(2.) - 1.) / self.max_accel

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -44,7 +44,6 @@ struct stepper {
     struct gpio_out step_pin, dir_pin;
     uint32_t position;
     struct move_queue_head mq;
-    uint32_t min_stop_interval;
     // gcc (pre v6) does better optimization when uint8_t are bitfields
     uint8_t flags : 8;
 };
@@ -53,7 +52,7 @@ enum { POSITION_BIAS=0x40000000 };
 
 enum {
     SF_LAST_DIR=1<<0, SF_NEXT_DIR=1<<1, SF_INVERT_STEP=1<<2, SF_HAVE_ADD=1<<3,
-    SF_LAST_RESET=1<<4, SF_NO_NEXT_CHECK=1<<5, SF_NEED_RESET=1<<6
+    SF_LAST_RESET=1<<4, SF_NEED_RESET=1<<5
 };
 
 // Setup a stepper for the next move in its queue
@@ -62,9 +61,6 @@ stepper_load_next(struct stepper *s, uint32_t min_next_time)
 {
     if (move_queue_empty(&s->mq)) {
         // There is no next move - the queue is empty
-        if (s->interval - s->add < s->min_stop_interval
-            && !(s->flags & SF_NO_NEXT_CHECK))
-            shutdown("No next step");
         s->count = 0;
         return SF_DONE;
     }
@@ -186,16 +182,14 @@ command_config_stepper(uint32_t *args)
     struct stepper *s = oid_alloc(args[0], command_config_stepper, sizeof(*s));
     if (!CONFIG_INLINE_STEPPER_HACK)
         s->time.func = stepper_event;
-    s->flags = args[4] ? SF_INVERT_STEP : 0;
+    s->flags = args[3] ? SF_INVERT_STEP : 0;
     s->step_pin = gpio_out_setup(args[1], s->flags & SF_INVERT_STEP);
     s->dir_pin = gpio_out_setup(args[2], 0);
-    s->min_stop_interval = args[3];
     s->position = -POSITION_BIAS;
     move_queue_setup(&s->mq, sizeof(struct stepper_move));
 }
 DECL_COMMAND(command_config_stepper,
-             "config_stepper oid=%c step_pin=%c dir_pin=%c"
-             " min_stop_interval=%u invert_step=%c");
+             "config_stepper oid=%c step_pin=%c dir_pin=%c invert_step=%c");
 
 // Return the 'struct stepper' for a given stepper oid
 struct stepper *
@@ -223,10 +217,6 @@ command_queue_step(uint32_t *args)
         flags ^= SF_LAST_DIR;
         m->flags |= MF_DIR;
     }
-    flags &= ~SF_NO_NEXT_CHECK;
-    if (m->count == 1 && (m->flags || flags & SF_LAST_RESET))
-        // count=1 moves after a reset or dir change can have small intervals
-        flags |= SF_NO_NEXT_CHECK;
     flags &= ~SF_LAST_RESET;
     if (s->count) {
         s->flags = flags;


### PR DESCRIPTION
The min_stop_interval check was designed to check if the host communication was lost in the middle of a series of stepper moves.  The high-level idea to the check was that the host would never stop moving a stepper while the stepper is moving at a high speed.  If that did occur, it was likely the result of a loss in communication.

However, this check has proved troublesome.  It's not easy to predict the maximum halt velocity for many steppers.  It makes it difficult to tune acceleration, velocity, and cornering speeds at runtime.  There are cases during direction changes that complicate the check.  Etc.  

The end result is that the check has been steadily diluted over the years and I suspect it is now just a burden.

This PR removes the check entirely.  It also changes the toolhead code so that it is possible to configure acceleration, velocity, and square_corner_velocity values greater than what was initially placed in the config file.

@dmbutyugin - fyi.

-Kevin