### PR TITLE
extruder: add E-axis velocity and acceleration limits

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -592,6 +592,11 @@ filament_diameter:
 #   specified then they are calculated to match the limit an XY
 #   printing move with a cross section of 4.0*nozzle_diameter^2 would
 #   have.
+#max_extrude_print_velocity:
+#max_extrude_print_accel:
+#   Maximum velocity (in mm/s) and acceleration (in mm/s^2) of the
+#   extruder motor for print moves. If not specified the limits are
+#   effectively infinite.
 #pressure_advance: 0.0
 #   The amount of raw filament to push into the extruder during
 #   extruder acceleration. An equal amount of filament is retracted

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -181,6 +181,9 @@ The following standard commands are supported:
   result in excessive pressure between extruder and hot end. Do proper
   calibration steps with filament before use. If 'DISTANCE' value is
   not included command will return current step distance.
+- `SET_EXTRUDER_VELOCITY_LIMIT [EXTRUDER=<config_name>]
+  [PRINT_VELOCITY=<value>] [PRINT_ACCEL=<value>]`: Set new values
+  for the extruder velocity/acceleration limits.
 - `SET_STEPPER_ENABLE STEPPER=<config_name> ENABLE=[0|1]`: Enable or
   disable only the given stepper. This is a diagnostic and debugging
   tool and must be used with care. Disabling an axis motor does not


### PR DESCRIPTION
In theory these limits can be achieved by converting to spatial units and imposing the corresponding limit there; however, doing so depends on layer thickness and line width, and is not practical if those vary. Since this needs to be configurable at runtime to be useful (the limits may vary by material, etc.) I've added a new command `SET_EXTRUDER_VELOCITY_LIMIT`, for changing their values. It could also be extended to let the existing (extrude-only move) settings be changed at runtime.

The defaults are made effectively-infinite to avoid any change for users who do not set limits, and I would expect users aiming for maximal print speed to leave at least the acceleration unlimited. However, limiting E-axis acceleration is useful for optimizing extrusion accuracy with pressure advance.
