### PR TITLE
Deprecate gcode_macro default_parameter_<name> config

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,12 @@ All dates in this document are approximate.
 
 # Changes
 
+20210503: The gcode_macro `default_parameter_<name>` config option is
+deprecated.  Use the `params` pseudo-variable to access macro
+parameters.  Other methods for accessing macro parameters will be
+removed in the near future.  See the [Command Templates
+document](Command_Templates.md#macro-parameters) for examples.
+
 20210430: The SET_VELOCITY_LIMIT (and M204) command may now set a
 velocity, acceleration, and square_corner_velocity larger than the
 specified values in the config file.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1155,16 +1155,6 @@ G-Code macros (one may define any number of sections with a
 #   A list of G-Code commands to execute in place of "my_cmd". See
 #   docs/Command_Templates.md for G-Code format. This parameter must
 #   be provided.
-#default_parameter_<parameter>:
-#   One may define any number of options with a "default_parameter_"
-#   prefix. Use this to define default values for g-code parameters.
-#   For example, if one were to define the macro MY_DELAY with gcode
-#   "G4 P{DELAY}" along with "default_parameter_DELAY = 50" then the
-#   command "MY_DELAY" would evaluate to "G4 P50". To override the
-#   default parameter when calling the command then using
-#   "MY_DELAY DELAY=30" would evaluate to "G4 P30". The default is
-#   to require that all parameters used in the gcode script be
-#   present in the command invoking the macro.
 #variable_<name>:
 #   One may specify any number of options with a "variable_" prefix.
 #   The given variable name will be assigned the given value (parsed


### PR DESCRIPTION
The `default_parameter_NAME` system has always been a bit goofy.  It's a holdover from gcode macros from before the introduction of Jinja2.  The Jinja2 "set" directive is more flexible and easier to understand.

This PR deprecates those config options and encourages using "set" as a replacement.  The change now is just to the documentation - actual support would be removed in around 6 months.

-Kevin