### PR TITLE
kinematics: Add hybrid-corexy and hybrid-corexz

### DIFF
--- a/config/example-hybrid-corexy.cfg
+++ b/config/example-hybrid-corexy.cfg
@@ -1,0 +1,79 @@
+# This file is an example config file for hybrid corexy style printers also
+# known as Markforged kinematic. One may copy and edit this file to configure
+# a new hybrid corexy printer.
+
+# DO NOT COPY THIS FILE WITHOUT CAREFULLY READING AND UPDATING IT
+# FIRST. Incorrectly configured parameters may cause damage.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PH6
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: hybrid_corexy
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30

--- a/config/example-hybrid-corexz.cfg
+++ b/config/example-hybrid-corexz.cfg
@@ -1,0 +1,79 @@
+# This file is an example config file for hybrid corexz style printers also
+# known as Markforged kinematic. One may copy and edit this file to configure
+# a new hybrid corexy printer.
+
+# DO NOT COPY THIS FILE WITHOUT CAREFULLY READING AND UPDATING IT
+# FIRST. Incorrectly configured parameters may cause damage.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PH6
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: hybrid_corexz
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -82,7 +82,8 @@ The printer section controls high level printer settings.
 [printer]
 kinematics:
 #   The type of printer in use. This option may be one of: cartesian,
-#   corexy, corexz, delta, rotary_delta, polar, winch, or none. This
+#   corexy, corexz, hybrid-codexy, hybrid-corexz, rotary_delta, delta,
+#   polar, winch, or none. This
 #   parameter must be specified.
 max_velocity:
 #   Maximum velocity (in mm/s) of the toolhead (relative to the
@@ -345,6 +346,74 @@ parameters.
 ```
 [printer]
 kinematics: corexz
+max_z_velocity:
+#   This sets the maximum velocity (in mm/s) of movement along the z
+#   axis. The default is to use max_velocity for max_z_velocity.
+max_z_accel:
+#   This sets the maximum acceleration (in mm/s^2) of movement along
+#   the z axis. The default is to use max_accel for max_z_accel.
+
+# The stepper_x section is used to describe the X axis as well as the
+# stepper controlling the X+Z movement.
+[stepper_x]
+
+# The stepper_y section is used to describe the stepper controlling
+# the Y axis.
+[stepper_y]
+
+# The stepper_z section is used to describe the Z axis as well as the
+# stepper controlling the X-Z movement.
+[stepper_z]
+```
+
+## Hybrid-CoreXY Kinematics
+
+See [example-hybrid-corexy.cfg](../config/example-hybrid-corexy.cfg)
+for an example hybrid corexy kinematics config file.
+
+This kinematic is also known as Markforged kinematic.
+
+Only parameters specific to hybrid corexy printers are described here
+see [common kinematic settings](#common-kinematic-settings) for available
+parameters.
+
+```
+[printer]
+kinematics: hybrid_corexy
+max_z_velocity:
+#   This sets the maximum velocity (in mm/s) of movement along the z
+#   axis. The default is to use max_velocity for max_z_velocity.
+max_z_accel:
+#   This sets the maximum acceleration (in mm/s^2) of movement along
+#   the z axis. The default is to use max_accel for max_z_accel.
+
+# The stepper_x section is used to describe the X axis as well as the
+# stepper controlling the X+Z movement.
+[stepper_x]
+
+# The stepper_y section is used to describe the stepper controlling
+# the Y axis.
+[stepper_y]
+
+# The stepper_z section is used to describe the Z axis as well as the
+# stepper controlling the X-Z movement.
+[stepper_z]
+```
+
+## Hybrid-CoreXZ Kinematics
+
+See [example-hybrid-corexz.cfg](../config/example-hybrid-corexz.cfg)
+for an example hybrid corexz kinematics config file.
+
+This kinematic is also known as Markforged kinematic.
+
+Only parameters specific to hybrid corexy printers are described here
+see [common kinematic settings](#common-kinematic-settings) for available
+parameters.
+
+```
+[printer]
+kinematics: hybrid_corexz
 max_z_velocity:
 #   This sets the maximum velocity (in mm/s) of movement along the z
 #   axis. The default is to use max_velocity for max_z_velocity.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -388,15 +388,15 @@ max_z_accel:
 #   the z axis. The default is to use max_accel for max_z_accel.
 
 # The stepper_x section is used to describe the X axis as well as the
-# stepper controlling the X+Z movement.
+# stepper controlling the X-Y movement.
 [stepper_x]
 
 # The stepper_y section is used to describe the stepper controlling
 # the Y axis.
 [stepper_y]
 
-# The stepper_z section is used to describe the Z axis as well as the
-# stepper controlling the X-Z movement.
+# The stepper_z section is used to describe the stepper controlling
+# the Z axis.
 [stepper_z]
 ```
 
@@ -422,15 +422,15 @@ max_z_accel:
 #   the z axis. The default is to use max_accel for max_z_accel.
 
 # The stepper_x section is used to describe the X axis as well as the
-# stepper controlling the X+Z movement.
+# stepper controlling the X-Z movement.
 [stepper_x]
 
 # The stepper_y section is used to describe the stepper controlling
 # the Y axis.
 [stepper_y]
 
-# The stepper_z section is used to describe the Z axis as well as the
-# stepper controlling the X-Z movement.
+# The stepper_z section is used to describe the stepper controlling
+# the Z axis.
 [stepper_z]
 ```
 

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -1,5 +1,4 @@
 # Code for handling the kinematics of hybrid-corexy robots
-# The hybrid-corexy kinematic is also known as Markforged kinematics
 #
 # Copyright (C) 2021  Fabrice Gallet <tircown@gmail.com>
 #
@@ -7,6 +6,7 @@
 import logging
 import stepper
 
+# The hybrid-corexy kinematic is also known as Markforged kinematics
 class HybridCoreXYKinematics:
     def __init__(self, toolhead, config):
         self.printer = config.get_printer()

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -35,12 +35,6 @@ class HybridCoreXYKinematics:
         self.max_z_accel = config.getfloat(
             'max_z_accel', max_accel, above=0., maxval=max_accel)
         self.limits = [(1.0, -1.0)] * 3
-        # Setup stepper max halt velocity
-        max_halt_velocity = toolhead.get_max_axis_halt()
-        self.rails[0].set_max_jerk(max_halt_velocity, max_accel)
-        self.rails[1].set_max_jerk(max_halt_velocity, max_accel)
-        self.rails[2].set_max_jerk(
-            min(max_halt_velocity, self.max_z_velocity), self.max_z_accel)
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
     def calc_tag_position(self):

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -1,0 +1,106 @@
+# Code for handling the kinematics of hybrid-corexy robots
+# The hybrid-corexy kinematic is also known as Markforged kinematics
+#
+# Copyright (C) 2021  Fabrice Gallet <tircown@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+import stepper
+
+class HybridCoreXYKinematics:
+    def __init__(self, toolhead, config):
+        self.printer = config.get_printer()
+        printer_config = config.getsection('printer')
+        # itersolve parameters
+        self.rails = [ stepper.PrinterRail(config.getsection('stepper_x')),
+                       stepper.LookupMultiRail(config.getsection('stepper_y')),
+                       stepper.LookupMultiRail(config.getsection('stepper_z'))]
+        self.rails[2].get_endstops()[0][0].add_stepper(
+            self.rails[0].get_steppers()[0])
+        self.rails[0].setup_itersolve('corexy_stepper_alloc', '-')
+        self.rails[1].setup_itersolve('cartesian_stepper_alloc', 'y')
+        self.rails[2].setup_itersolve('cartesian_stepper_alloc', 'z')
+        ranges = [r.get_range() for r in self.rails]
+        self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
+        self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.)
+        for s in self.get_steppers():
+            s.set_trapq(toolhead.get_trapq())
+            toolhead.register_step_generator(s.generate_steps)
+        self.printer.register_event_handler("stepper_enable:motor_off",
+                                                    self._motor_off)
+        # Setup boundary checks
+        max_velocity, max_accel = toolhead.get_max_velocity()
+        self.max_z_velocity = config.getfloat(
+            'max_z_velocity', max_velocity, above=0., maxval=max_velocity)
+        self.max_z_accel = config.getfloat(
+            'max_z_accel', max_accel, above=0., maxval=max_accel)
+        self.limits = [(1.0, -1.0)] * 3
+        # Setup stepper max halt velocity
+        max_halt_velocity = toolhead.get_max_axis_halt()
+        self.rails[0].set_max_jerk(max_halt_velocity, max_accel)
+        self.rails[1].set_max_jerk(max_halt_velocity, max_accel)
+        self.rails[2].set_max_jerk(
+            min(max_halt_velocity, self.max_z_velocity), self.max_z_accel)
+    def get_steppers(self):
+        return [s for rail in self.rails for s in rail.get_steppers()]
+    def calc_tag_position(self):
+        pos = [rail.get_tag_position() for rail in self.rails]
+        return [pos[0] + pos[1], pos[1], pos[2]]
+    def set_position(self, newpos, homing_axes):
+        for i, rail in enumerate(self.rails):
+            rail.set_position(newpos)
+            if i in homing_axes:
+                self.limits[i] = rail.get_range()
+    def note_z_not_homed(self):
+        # Helper for Safe Z Home
+        self.limits[2] = (1.0, -1.0)
+    def _home_axis(self, homing_state, axis, rail):
+        position_min, position_max = rail.get_range()
+        hi = rail.get_homing_info()
+        homepos = [None, None, None, None]
+        homepos[axis] = hi.position_endstop
+        forcepos = list(homepos)
+        if hi.positive_dir:
+            forcepos[axis] -= 1.5 * (hi.position_endstop - position_min)
+        else:
+            forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
+        # Perform homing
+        homing_state.home_rails([rail], forcepos, homepos)
+    def home(self, homing_state):
+        for axis in homing_state.get_axes():
+            self._home_axis(homing_state, axis, self.rails[axis])
+    def _motor_off(self, print_time):
+        self.limits = [(1.0, -1.0)] * 3
+    def _check_endstops(self, move):
+        end_pos = move.end_pos
+        for i in (0, 1, 2):
+            if (move.axes_d[i]
+                and (end_pos[i] < self.limits[i][0]
+                     or end_pos[i] > self.limits[i][1])):
+                if self.limits[i][0] > self.limits[i][1]:
+                    raise move.move_error("Must home axis first")
+                raise move.move_error()
+    def check_move(self, move):
+        limits = self.limits
+        xpos, ypos = move.end_pos[:2]
+        if (xpos < limits[0][0] or xpos > limits[0][1]
+            or ypos < limits[1][0] or ypos > limits[1][1]):
+            self._check_endstops(move)
+        if not move.axes_d[2]:
+            # Normal XY move - use defaults
+            return
+        # Move with Z - update velocity and accel for slower Z axis
+        self._check_endstops(move)
+        z_ratio = move.move_d / abs(move.axes_d[2])
+        move.limit_speed(
+            self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
+    def get_status(self, eventtime):
+        axes = [a for a, (l, h) in zip("xyz", self.limits) if l <= h]
+        return {
+            'homed_axes': "".join(axes),
+            'axis_minimum': self.axes_min,
+            'axis_maximum': self.axes_max,
+        }
+
+def load_kinematics(toolhead, config):
+    return HybridCoreXYKinematics(toolhead, config)

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -35,12 +35,6 @@ class HybridCoreXZKinematics:
         self.max_z_accel = config.getfloat(
             'max_z_accel', max_accel, above=0., maxval=max_accel)
         self.limits = [(1.0, -1.0)] * 3
-        # Setup stepper max halt velocity
-        max_halt_velocity = toolhead.get_max_axis_halt()
-        self.rails[0].set_max_jerk(max_halt_velocity, max_accel)
-        self.rails[1].set_max_jerk(max_halt_velocity, max_accel)
-        self.rails[2].set_max_jerk(
-            min(max_halt_velocity, self.max_z_velocity), self.max_z_accel)
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
     def calc_tag_position(self):

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -1,5 +1,4 @@
 # Code for handling the kinematics of hybrid-corexz robots
-# The hybrid-corexz kinematic is also known as Markforged kinematics
 #
 # Copyright (C) 2021  Fabrice Gallet <tircown@gmail.com>
 #
@@ -7,6 +6,7 @@
 import logging
 import stepper
 
+# The hybrid-corexz kinematic is also known as Markforged kinematics
 class HybridCoreXZKinematics:
     def __init__(self, toolhead, config):
         self.printer = config.get_printer()

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -1,0 +1,106 @@
+# Code for handling the kinematics of hybrid-corexz robots
+# The hybrid-corexz kinematic is also known as Markforged kinematics
+#
+# Copyright (C) 2021  Fabrice Gallet <tircown@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+import stepper
+
+class HybridCoreXZKinematics:
+    def __init__(self, toolhead, config):
+        self.printer = config.get_printer()
+        printer_config = config.getsection('printer')
+        # itersolve parameters
+        self.rails = [ stepper.PrinterRail(config.getsection('stepper_x')),
+                       stepper.LookupMultiRail(config.getsection('stepper_y')),
+                       stepper.LookupMultiRail(config.getsection('stepper_z'))]
+        self.rails[2].get_endstops()[0][0].add_stepper(
+            self.rails[0].get_steppers()[0])
+        self.rails[0].setup_itersolve('corexz_stepper_alloc', '-')
+        self.rails[1].setup_itersolve('cartesian_stepper_alloc', 'y')
+        self.rails[2].setup_itersolve('cartesian_stepper_alloc', 'z')
+        ranges = [r.get_range() for r in self.rails]
+        self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.)
+        self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.)
+        for s in self.get_steppers():
+            s.set_trapq(toolhead.get_trapq())
+            toolhead.register_step_generator(s.generate_steps)
+        self.printer.register_event_handler("stepper_enable:motor_off",
+                                                    self._motor_off)
+        # Setup boundary checks
+        max_velocity, max_accel = toolhead.get_max_velocity()
+        self.max_z_velocity = config.getfloat(
+            'max_z_velocity', max_velocity, above=0., maxval=max_velocity)
+        self.max_z_accel = config.getfloat(
+            'max_z_accel', max_accel, above=0., maxval=max_accel)
+        self.limits = [(1.0, -1.0)] * 3
+        # Setup stepper max halt velocity
+        max_halt_velocity = toolhead.get_max_axis_halt()
+        self.rails[0].set_max_jerk(max_halt_velocity, max_accel)
+        self.rails[1].set_max_jerk(max_halt_velocity, max_accel)
+        self.rails[2].set_max_jerk(
+            min(max_halt_velocity, self.max_z_velocity), self.max_z_accel)
+    def get_steppers(self):
+        return [s for rail in self.rails for s in rail.get_steppers()]
+    def calc_tag_position(self):
+        pos = [rail.get_tag_position() for rail in self.rails]
+        return [pos[0] + pos[2], pos[1], pos[2]]
+    def set_position(self, newpos, homing_axes):
+        for i, rail in enumerate(self.rails):
+            rail.set_position(newpos)
+            if i in homing_axes:
+                self.limits[i] = rail.get_range()
+    def note_z_not_homed(self):
+        # Helper for Safe Z Home
+        self.limits[2] = (1.0, -1.0)
+    def _home_axis(self, homing_state, axis, rail):
+        position_min, position_max = rail.get_range()
+        hi = rail.get_homing_info()
+        homepos = [None, None, None, None]
+        homepos[axis] = hi.position_endstop
+        forcepos = list(homepos)
+        if hi.positive_dir:
+            forcepos[axis] -= 1.5 * (hi.position_endstop - position_min)
+        else:
+            forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
+        # Perform homing
+        homing_state.home_rails([rail], forcepos, homepos)
+    def home(self, homing_state):
+        for axis in homing_state.get_axes():
+            self._home_axis(homing_state, axis, self.rails[axis])
+    def _motor_off(self, print_time):
+        self.limits = [(1.0, -1.0)] * 3
+    def _check_endstops(self, move):
+        end_pos = move.end_pos
+        for i in (0, 1, 2):
+            if (move.axes_d[i]
+                and (end_pos[i] < self.limits[i][0]
+                     or end_pos[i] > self.limits[i][1])):
+                if self.limits[i][0] > self.limits[i][1]:
+                    raise move.move_error("Must home axis first")
+                raise move.move_error()
+    def check_move(self, move):
+        limits = self.limits
+        xpos, ypos = move.end_pos[:2]
+        if (xpos < limits[0][0] or xpos > limits[0][1]
+            or ypos < limits[1][0] or ypos > limits[1][1]):
+            self._check_endstops(move)
+        if not move.axes_d[2]:
+            # Normal XY move - use defaults
+            return
+        # Move with Z - update velocity and accel for slower Z axis
+        self._check_endstops(move)
+        z_ratio = move.move_d / abs(move.axes_d[2])
+        move.limit_speed(
+            self.max_z_velocity * z_ratio, self.max_z_accel * z_ratio)
+    def get_status(self, eventtime):
+        axes = [a for a, (l, h) in zip("xyz", self.limits) if l <= h]
+        return {
+            'homed_axes': "".join(axes),
+            'axis_minimum': self.axes_min,
+            'axis_maximum': self.axes_max,
+        }
+
+def load_kinematics(toolhead, config):
+    return HybridCoreXZKinematics(toolhead, config)

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -6,6 +6,8 @@ DICTIONARY atmega2560.dict
 CONFIG ../../config/example-cartesian.cfg
 CONFIG ../../config/example-corexy.cfg
 CONFIG ../../config/example-corexz.cfg
+CONFIG ../../config/example-hybrid-corexy.cfg
+CONFIG ../../config/example-hybrid-corexz.cfg
 CONFIG ../../config/example-delta.cfg
 CONFIG ../../config/example-rotary-delta.cfg
 CONFIG ../../config/example-winch.cfg


### PR DESCRIPTION
Add hybrid-corexy kinematics.
Add hybrid-corexz kinematics.
Both are simple carriage version of the kinematics also known as Markforged kinematics.

This follows the issue #3391 and is a revamp of pull request #3609

Signed-off-by: Fabrice GALLET tircown@gmail.com