### PR TITLE
extruder: Implement non-linear extrusion

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -113,6 +113,8 @@ defs_kin_extruder = """
     struct stepper_kinematics *extruder_stepper_alloc(void);
     void extruder_set_smooth_time(struct stepper_kinematics *sk
         , double smooth_time);
+    void extruder_set_nonlinear(struct stepper_kinematics *sk, double a
+        , double b);
 """
 
 defs_kin_shaper = """

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -174,6 +174,9 @@ itersolve_generate_steps(struct stepper_kinematics *sk, double flush_time)
                                                             , flush_time);
                     if (ret)
                         return ret;
+
+                    if (sk->post_move_cb)
+                        sk->post_move_cb(sk, pm);
                     pm = list_next_entry(pm, node);
                 } while (pm != m);
             }
@@ -207,6 +210,9 @@ itersolve_generate_steps(struct stepper_kinematics *sk, double flush_time)
             if (flush_time + sk->gen_steps_pre_active <= move_end)
                 return 0;
         }
+
+        if (sk->post_move_cb)
+            sk->post_move_cb(sk, m);
         m = list_next_entry(m, node);
     }
 }

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -11,6 +11,7 @@ struct stepper_kinematics;
 struct move;
 typedef double (*sk_calc_callback)(struct stepper_kinematics *sk, struct move *m
                                    , double move_time);
+typedef void (*sk_post_move)(struct stepper_kinematics *sk, struct move *m);
 typedef void (*sk_post_callback)(struct stepper_kinematics *sk);
 struct stepper_kinematics {
     double step_dist, commanded_pos;
@@ -22,6 +23,7 @@ struct stepper_kinematics {
     double gen_steps_pre_active, gen_steps_post_active;
 
     sk_calc_callback calc_position_cb;
+    sk_post_move post_move_cb;
     sk_post_callback post_cb;
 };
 

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -210,7 +210,11 @@ class PrinterExtruder:
     def cmd_SET_NONLINEAR_EXTRUSION(self, gcmd):
         a = gcmd.get_float('A', self.nonlinear_a)
         b = gcmd.get_float('B', self.nonlinear_b)
+
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.flush_step_generation()
         self._set_nonlinear_extrusion(a, b)
+
         msg = ("a: %.6f\n"
                "b: %.6f"
                % (a, b))

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -45,6 +45,11 @@ class PrinterExtruder:
         pressure_advance = config.getfloat('pressure_advance', 0., minval=0.)
         smooth_time = config.getfloat('pressure_advance_smooth_time',
                                       0.040, above=0., maxval=.200)
+
+        self.nonlinear_a = self.nonlinear_b = 0.
+        nonlinear_a = config.getfloat('nonlinear_a', 0.)
+        nonlinear_b = config.getfloat('nonlinear_b', 0.)
+
         # Setup iterative solver
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
@@ -56,7 +61,9 @@ class PrinterExtruder:
         self.stepper.set_trapq(self.trapq)
         toolhead.register_step_generator(self.stepper.generate_steps)
         self.extruder_set_smooth_time = ffi_lib.extruder_set_smooth_time
+        self.extruder_set_nonlinear = ffi_lib.extruder_set_nonlinear
         self._set_pressure_advance(pressure_advance, smooth_time)
+        self._set_nonlinear_extrusion(nonlinear_a, nonlinear_b)
         # Register commands
         gcode = self.printer.lookup_object('gcode')
         if self.name == 'extruder':
@@ -66,6 +73,9 @@ class PrinterExtruder:
             gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER", None,
                                        self.cmd_default_SET_PRESSURE_ADVANCE,
                                        desc=self.cmd_SET_PRESSURE_ADVANCE_help)
+        gcode.register_mux_command("SET_NONLINEAR_EXTRUSION", "EXTRUDER",
+                                   self.name, self.cmd_SET_NONLINEAR_EXTRUSION,
+                                   desc=self.cmd_SET_NONLINEAR_EXTRUSION_help)
         gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER",
                                    self.name, self.cmd_SET_PRESSURE_ADVANCE,
                                    desc=self.cmd_SET_PRESSURE_ADVANCE_help)
@@ -90,6 +100,10 @@ class PrinterExtruder:
         self.extruder_set_smooth_time(self.sk_extruder, new_smooth_time)
         self.pressure_advance = pressure_advance
         self.pressure_advance_smooth_time = smooth_time
+    def _set_nonlinear_extrusion(self, a, b):
+        self.extruder_set_nonlinear(self.sk_extruder, a, b)
+        self.nonlinear_a = a
+        self.nonlinear_b = b
     def get_status(self, eventtime):
         return dict(self.heater.get_status(eventtime),
                     pressure_advance=self.pressure_advance,
@@ -190,6 +204,16 @@ class PrinterExtruder:
         msg = ("pressure_advance: %.6f\n"
                "pressure_advance_smooth_time: %.6f"
                % (pressure_advance, smooth_time))
+        self.printer.set_rollover_info(self.name, "%s: %s" % (self.name, msg))
+        gcmd.respond_info(msg, log=False)
+    cmd_SET_NONLINEAR_EXTRUSION_help = "Set nonlinear extrusion parameters"
+    def cmd_SET_NONLINEAR_EXTRUSION(self, gcmd):
+        a = gcmd.get_float('A', self.nonlinear_a)
+        b = gcmd.get_float('B', self.nonlinear_b)
+        self._set_nonlinear_extrusion(a, b)
+        msg = ("a: %.6f\n"
+               "b: %.6f"
+               % (a, b))
         self.printer.set_rollover_info(self.name, "%s: %s" % (self.name, msg))
         gcmd.respond_info(msg, log=False)
     cmd_SET_E_STEP_DISTANCE_help = "Set extruder step distance"


### PR DESCRIPTION
This allows klipper to compensate for slippage in the extruder at high back-pressures.
When enabled through SET_NONLINEAR_EXTRUSION, or nonlinear_a/b in the configuration,
the actual extrusion velocity will be modified to v(t) + A*v(t)^2 + B*v(t)^3
where v(t) is the requested velocity, and A/B the provided parameters.

This is similar to RepRap's M592 command, except correctly applied to accelerating moves
rather than simply scaling the distance of the entire move based on its average velocity.

This PR isn't really ready yet, but I need comments from someone more familiar with the kinetics code. I'm not totally sure if the way the additional extrusion from previous moves is applied onto future moves is okay, or if there's a better way to do it.

Also, unlike M592, this is currently being applied to extruder-only moves, which will screw up retractions (but makes testing easier)