### PR TITLE
config: Added configuration file for FLSUN QQ-S delta printer

### DIFF
--- a/config/printer-flsun-qqs-2020.cfg
+++ b/config/printer-flsun-qqs-2020.cfg
@@ -68,7 +68,7 @@ endstop_pin: PC4
 microsteps: 16
 
 [probe]
-pin: PA11
+pin: !PA11
 x_offset: 0
 y_offset: 0
 z_offset: 10

--- a/config/printer-flsun-qqs-2020.cfg
+++ b/config/printer-flsun-qqs-2020.cfg
@@ -1,0 +1,152 @@
+# This file contains common configurations and pin mappings
+# for the Flsun QQ-S using the MKS Robin Nano board.
+#
+# To use this config, the firmware should be compiled for the
+# STM32F103. When running "make menuconfig", enable "extra low-level
+# configuration setup", select the 28KiB bootloader, and serial (on
+# USART3 PB11/PB10) communication.
+
+# Note that the "make flash" command does not work with MKS Robin
+# boards. After running "make", run the following command:
+# ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano.bin
+# Copy the file out/Robin_nano.bin to an SD card and then restart the
+# printer with that SD card.
+
+# Mesh bed leveling is also added, but commented out. Only enable it if
+# running the PROBE_ACCURACY command outputs a range value < 0.025 mm
+
+# There is a BL Touch as well as a Filament Sensor section commented out
+# at the end of this config, which doesn't come stock with the QQ-S.
+
+# For instructions on how to install either of these components,
+# follow this guide: https://github.com/CobraPi/Klipper-Firmware-FLSUN-QQ-S-Pro
+
+# Note that an offset probe is not recommended on delta printers due to
+# effector tilt. In order to use it successfully to create a useable bed mesh
+# you need to run the enhanced delta calibration:
+# https://www.klipper3d.org/Delta_Calibrate.html
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+baud: 250000
+
+[printer]
+kinematics: delta
+max_velocity: 500
+max_accel: 2000
+max_z_velocity: 200
+minimum_z_position: -5
+
+[stepper_a]
+step_pin: PE3
+dir_pin: PE2
+enable_pin: !PE4
+rotation_distance: 32
+endstop_pin: PA15
+microsteps: 16
+homing_speed: 60
+position_endstop: 370
+arm_length: 280.0
+
+[stepper_b]
+step_pin: PE0
+dir_pin: PB9
+enable_pin: !PE1
+rotation_distance: 32
+endstop_pin: PA12
+microsteps: 16
+
+[stepper_c]
+step_pin: PB5
+dir_pin: PB4
+enable_pin: !PB8
+rotation_distance: 32
+endstop_pin: PC4
+microsteps: 16
+
+[probe]
+pin: PA11
+x_offset: 0
+y_offset: 0
+z_offset: 10
+samples: 3
+samples_results: average
+sample_retract_dist: 5
+
+[delta_calibrate]
+radius: 120
+horizontal_move_z: 10
+
+[extruder]
+step_pin: PD6
+dir_pin: !PD3
+enable_pin: !PB3
+rotation_distance: 9
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC3
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC1
+control: pid
+pid_Kp: 14.529
+pid_Ki: 0.557
+pid_Kd: 94.802
+min_extrude_temp: 180
+min_temp: 0
+max_temp: 260
+
+[heater_bed]
+heater_pin: PA0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC0
+control: pid
+pid_Kp: 325.10
+pid_Ki: 63.35
+pid_Kd: 417.10
+min_temp: 0
+max_temp: 150
+
+[fan]
+pin: PB1
+kick_start_time: 0.200
+
+#######################################################################
+# Optional: Bed mesh leveling - only use if the PROBE_ACCURACY
+#                               command outputs a range value < 0.025 mm
+#######################################################################
+
+#[bed_mesh]
+#speed: 50
+#horizontal_move_z: 5
+#mesh_radius: 100
+#mesh_origin: 0,0
+#round_probe_count: 5
+#algorithm: lagrange
+
+#######################################################################
+# Optional: End-stop style filament sensor
+#######################################################################
+
+#[filament_switch_sensor Filament]
+#pause_on_runout: True
+#switch_pin: PA4
+
+#######################################################################
+# Optional: BL Touch Probe - comment out [probe] section if using this
+#######################################################################
+
+#[bltouch]
+#sensor_pin: PA11
+#control_pin: PA8
+#stow_on_each_sample: True
+#set_output_mode: 5V
+#x_offset: 3
+#y_offset: -36
+#z_offset: -2.3
+#samples: 3
+#sample_retract_dist: 5
+#samples_result: average


### PR DESCRIPTION
Took the time to test these settings with every possible permutation of features: 

- stock printer with stock probe
- stock printer with stock probe and filament sensor
- printer with BL touch
- printer with BL touch and filament sensor

I've found these values to work particularly well for this printer. I noticed that there's a config for the flsun Q5 but not the QQ-S