### PR TITLE
bed_mesh: Allow rectangular beds with probe_count of 2.

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -54,7 +54,7 @@ probe_count: 5,3
   3 points along the Y axis, for a total of 15 probed points.  Note that
   if you wanted a square grid, for example 3x3, this could be specified
   as a single integer value that is used for both axes, ie `probe_count: 3`.
-  Note that a mesh requires a minimum probe_count of 3 along each axis.
+  Note that a mesh requires a minimum probe_count of 2 along each axis.
 
 The illustration below demonstrates how the `mesh_min`, `mesh_max`, and
 `probe_count` options are used to generate probe points.  The arrows indicate

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -387,7 +387,7 @@ class BedMeshCalibrate:
         else:
             # rectangular
             x_cnt, y_cnt = parse_pair(
-                config, ('probe_count', '3'), check=False, cast=int, minval=3)
+                config, ('probe_count', '3'), check=False, cast=int, minval=2)
             min_x, min_y = parse_pair(config, ('mesh_min',))
             max_x, max_y = parse_pair(config, ('mesh_max',))
             if max_x <= min_x or max_y <= min_y:


### PR DESCRIPTION
A printer of mine has an inductive probe over a flat glass bed.
The probe does not detect the glass but I've strategically placed squares of aluminum tape so a bed mesh can be generated to examine/adjust/compensate for the tilt of the glass.

![image](https://user-images.githubusercontent.com/1768214/116486169-94abbe00-a852-11eb-99db-d13ccb9fba68.png)

The seemingly arbitrary minimum `probe_count` of 3 would have required me to place 5 more pieces of aluminum tape including one in the very center.

One might think I should be using [bed_**tilt**] in this situation but because of the probe's temperature bias I must use a dedicated z endstop with bed_mesh's `relative_reference_index` feature.

`[bed_tilt]` doesn't seem to have an equivalent to `relative_reference_index` short of manually editing the `z_adjust` value, which, as far as I can tell, can not be done in a macro.

I've simply changed config loading to allow a `probe_count` of 2 and everything seems to be working.
It's still "using" lagrange interpolation apparently.
Maybe the `algorithm` option should be forbidden with a probe_count of 2?

Relevant section of my config:
```
[bed_mesh]
speed: 150
horizontal_move_z: 5
mesh_min: 35,9
mesh_max: 242, 238
probe_count: 2,2
mesh_pps: 0,0
fade_start: 1.0
fade_end: 10.0
relative_reference_index: 0
```

Everything seems to be working, though the mention of "lagrange" should maybe be removed?
![image](https://user-images.githubusercontent.com/1768214/116487610-fd486a00-a855-11eb-860d-175f5227ed30.png)
![image](https://user-images.githubusercontent.com/1768214/116487562-de49d800-a855-11eb-902b-ec2409cdab47.png)