### PR TITLE
config: Add motor power output pin to SKR2 config

### DIFF
--- a/config/generic-bigtreetech-skr-2.cfg
+++ b/config/generic-bigtreetech-skr-2.cfg
@@ -84,6 +84,10 @@ pin: PB7
 #[heater_fan fan2]
 #pin: PB5
 
+[output_pin motor_power]
+pin: PC13
+value: 1
+
 [mcu]
 serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00
 


### PR DESCRIPTION
The SKR2 shuts off power to the TMC drivers and most FETs unless the motor power pin is pulled high. This is supposed to act as a safety feature. In the context of klipper the absence of this output pin will cause motor movement to fail, since the MCU can't communicate with the drivers if motor power is not applied. This PR fixes that issue.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>