### PR TITLE
lpc176x: Hotfix for problem serial communication.

### DIFF
--- a/src/lpc176x/main.c
+++ b/src/lpc176x/main.c
@@ -49,6 +49,13 @@ void
 enable_pclock(uint32_t pclk)
 {
     LPC_SC->PCONP |= 1<<pclk;
+    if (pclk < 16) {
+        uint32_t shift = pclk * 2;
+        LPC_SC->PCLKSEL0 = (LPC_SC->PCLKSEL0 & ~(0x3<<shift)) | (0x1<<shift);
+    } else {
+        uint32_t shift = (pclk - 16) * 2;
+        LPC_SC->PCLKSEL1 = (LPC_SC->PCLKSEL1 & ~(0x3<<shift)) | (0x1<<shift);
+    }
 }
 
 // Return the frequency of the given peripheral clock

--- a/src/lpc176x/serial.c
+++ b/src/lpc176x/serial.c
@@ -61,7 +61,7 @@ serial_init(void)
     // Setup baud
     LPC_UART0->LCR = (1<<7); // set DLAB bit
     enable_pclock(PCLK_UART0);
-    uint32_t pclk = get_pclock_frequency(PCLK_UART0);
+    uint32_t pclk = SystemCoreClock;
     uint32_t div = pclk / (CONFIG_SERIAL_BAUD * 16);
     LPC_UART0->DLL = div & 0xff;
     LPC_UART0->DLM = (div >> 8) & 0xff;


### PR DESCRIPTION
I revert some code from v0.9.1 in particolarity the pclk
because klipper had a bad sync when trying the connection.
Resolve this issue #4125
 
Signed-off-by: Antonio di Giovanni <crashvampiro@msn.com>