### PR TITLE
Add default display configuration for st7920

### DIFF
--- a/config/generic-mks-robin-e3.cfg
+++ b/config/generic-mks-robin-e3.cfg
@@ -122,5 +122,12 @@ aliases:
     # EXP2 header
     EXP2_1=PB14, EXP2_3=PB11, EXP2_5=PB0,  EXP2_7=PC10,  EXP2_9=<GND>,
     EXP2_2=PB13, EXP2_4=PA15, EXP2_6=PB15, EXP2_8=<RST>, EXP2_10=<NC>
-
-# See the sample-lcd.cfg file for definitions of common LCD displays.
+    
+# Display configuration for the st7920, hooked up to the Ender3-EXP1 port
+#[display]
+#lcd_type: st7920
+#cs_pin: EXP1_4
+#sclk_pin: EXP1_5
+#sid_pin: EXP1_3
+#encoder_pins: ^EXP2_5, ^EXP2_3
+#click_pin: ^!EXP1_1


### PR DESCRIPTION
Default display configuration for st7920 based displays, connected on Ender3-EXP1 port