### PR TITLE
SDCard update and compilation support for Fysetc S6 and Spider

### DIFF
--- a/config/generic-fysetc-s6-v2.cfg
+++ b/config/generic-fysetc-s6-v2.cfg
@@ -1,8 +1,7 @@
-# This file contains common pin mappings for the Fysetc S6 v2 board.
-# To use this config, the firmware should be compiled for the STM32F446.
-# When calling "menuconfig", enable "extra low-level configuration setup"
-# and select the "12MHz crystal" as clock reference
-# For flashing, write the compiled klipper.bin to memory location 0x08000000
+# This file contains common pin mappings for the Fysetc S6 v2 board.  To use
+# this config, the firmware should be compiled for the STM32F446 with a "64KiB
+# bootloader".  When calling "menuconfig", enable "extra low-level configuration
+# setup" and select the "12MHz crystal" as clock reference.
 
 # See docs/Config_Reference.md for a description of parameters.
 

--- a/config/generic-fysetc-s6.cfg
+++ b/config/generic-fysetc-s6.cfg
@@ -1,8 +1,7 @@
-# This file contains common pin mappings for the Fysetc S6 board.
-# To use this config, the firmware should be compiled for the STM32F446.
-# When calling "menuconfig", enable "extra low-level configuration setup"
-# and select the "12MHz crystal" as clock reference
-# For flashing, write the compiled klipper.bin to memory location 0x08000000
+# This file contains common pin mappings for the Fysetc S6 board.  To use this
+# config, the firmware should be compiled for the STM32F446 with a "64KiB
+# bootloader".  When calling "menuconfig", enable "extra low-level configuration
+# setup" and select the "12MHz crystal" as clock reference.
 
 # See docs/Config_Reference.md for a description of parameters.
 

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -49,6 +49,12 @@ BOARD_DEFS = {
         'mcu': "stm32f407xx",
         'spi_bus': "spi1",
         "cs_pin": "PA4"
+    },
+    'fysetc-spider': {
+        'mcu': "stm32f446xx",
+        'spi_bus': "spi1",
+        "cs_pin": "PA4",
+        "current_firmware_path": "OLD.BIN"
     }
 }
 
@@ -80,6 +86,9 @@ BOARD_ALIASES = {
     'btt-skr-pro-v1.2': BOARD_DEFS['btt-skr-pro'],
     'btt-gtr-v1': BOARD_DEFS['btt-gtr'],
     'mks-robin-e3d': BOARD_DEFS['mks-robin-e3'],
+    'fysetc-spider-v1': BOARD_DEFS['fysetc-spider'],
+    'fysetc-s6-v1.2': BOARD_DEFS['fysetc-spider'],
+    'fysetc-s6-v2': BOARD_DEFS['fysetc-spider']
 }
 
 def list_boards():

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -131,7 +131,7 @@ config STACK_SIZE
 ######################################################################
 
 choice
-    prompt "Bootloader offset" if MACH_STM32F207 || MACH_STM32F407 || MACH_STM32F405 || MACH_STM32F103 || MACH_STM32F070
+    prompt "Bootloader offset" if MACH_STM32F207 || MACH_STM32F407 || MACH_STM32F405 || MACH_STM32F446 || MACH_STM32F103 || MACH_STM32F070
     config STM32_FLASH_START_2000
         bool "8KiB bootloader (stm32duino)" if MACH_STM32F103 || MACH_STM32F070
     config STM32_FLASH_START_5000
@@ -143,7 +143,7 @@ choice
     config STM32_FLASH_START_C000
         bool "48KiB bootloader (MKS Robin Nano V3)" if MACH_STM32F407
     config STM32_FLASH_START_10000
-        bool "64KiB bootloader (Alfawise)" if MACH_STM32F103
+        bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F446
     config STM32_FLASH_START_800
         bool "2KiB bootloader (HID Bootloader)" if MACH_STM32F103
 


### PR DESCRIPTION
The Fysetc S6 and Spider come with an SDCard bootloader. This PR updates Kconfig to allow configuring the correct offset on an STM32F446 to prevent Klipper from overwriting the bootloader. Also new board definitions for `flash-sdcard.sh` are introduced.

This has been tested with an S6 v2 and a Spider v1.