### PR TITLE
Fixed typo in when comparing `print_stats.state` causing menus to not show up

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -171,7 +171,7 @@ gcode: M24
 
 [menu __main __sdcard __resume]
 type: command
-enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "pause"}
+enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "paused"}
 name: Resume printing
 gcode:
     {% if "pause_resume" in printer %}
@@ -193,7 +193,7 @@ gcode:
 
 [menu __main __sdcard __cancel]
 type: command
-enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "printing" or printer.print_stats.state == "pause")}
+enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "printing" or printer.print_stats.state == "paused")}
 name: Cancel printing
 gcode:
     {% if 'pause_resume' in printer %}


### PR DESCRIPTION
As you can reference in https://github.com/KevinOConnor/klipper/blob/master/klippy/extras/print_stats.py

The state that is set is "paused" not "pause" causing some of the submenus to not show up.