### PR TITLE
Ignore files created by PyCharm IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ out
 .config
 .config.old
 klippy/.version
+
+# Ignore files created by PyCharm
+venv/
+.idea/


### PR DESCRIPTION
module: .gitignore

Ignore any files created by the PyCharm IDE when used to work on Klipper codebase. This is simply a QOL change so that one doesn't need to wade through tons of virtual environment and settings files to find the code changes to be committed.

Signed-off-by: Christopher Conroy <cbc02009@gmail.com>