### PR TITLE
fix STM32F446 ADC3 bug

### DIFF
--- a/src/stm32/adc.c
+++ b/src/stm32/adc.c
@@ -83,7 +83,7 @@ gpio_adc_setup(uint32_t pin)
     // Determine which ADC block to use
     ADC_TypeDef *adc = ADC1;
     uint32_t adc_base = ADC1_BASE;
-#if CONFIG_MACH_STM32F405 || CONFIG_MACH_STM32F407
+#if CONFIG_MACH_STM32F405 || CONFIG_MACH_STM32F407 || CONFIG_MACH_STM32F446
     if (chan >= 19) {
         // On the STM32F4, some ADC channels are only available from ADC3
         adc = ADC3;


### PR DESCRIPTION
PF3-PF10 on STM32F446ZE can only use ADC3,  So F446 also needs to include ADC3