### PR TITLE
safe_z_home: Always perform z limit checks (fixes #4249)

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1128,11 +1128,8 @@ home_xy_position:
 #   applied to any homing command, even if it doesn't home the Z axis.
 #   If the Z axis is already homed and the current Z position is less
 #   than z_hop, then this will lift the head to a height of z_hop. If
-#   the Z axis is not already homed, then prior to any XY homing
-#   movement the Z axis boundary checks are disabled and the head is
-#   lifted by z_hop. If z_hop is specified, be sure to home the Z
-#   immediately after any XY home requests so that the Z boundary
-#   checks are accurate. The default is to not implement Z hop.
+#   the Z axis is not already homed the head is lifted by z_hop.
+#   The default is to not implement Z hop.
 #z_hop_speed: 20.0
 #   Speed (in mm/s) at which the Z axis is lifted prior to homing. The
 #   default is 20mm/s.


### PR DESCRIPTION
This change causes the z boundary check to always be performed, regardless of the homed status of the Z axis. 

As described in #4249, not doing this can lead to errors if the motors were disabled near z-max (in this case, the zhop is currently performed, which causes out-of-bounds errors and (possibly worse) leaves the z axis in a homed state).


Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net>