### PR TITLE
virtual_sdcard: fix case sensitive matching

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -152,10 +152,11 @@ class VirtualSD:
         self._load_file(gcmd, filename)
     def _load_file(self, gcmd, filename, check_subdirs=False):
         files = self.get_file_list(check_subdirs)
+        flist = [f[0] for f in files]
         files_by_lower = { fname.lower(): fname for fname, fsize in files }
         fname = filename
         try:
-            if fname not in files:
+            if fname not in flist:
                 fname = files_by_lower[fname.lower()]
             fname = os.path.join(self.sdcard_dirname, fname)
             f = open(fname, 'rb')


### PR DESCRIPTION
This is minor fix to allow the `virtual_sdcard` to load case sensitive files.  The as the value returned by `get_file_list()` is a tuple, the original check would always evaluate to False.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>