### PR TITLE
config: Enable PID for bed heater in printer-fokoos-odin5-f3-2021.cfg

### DIFF
--- a/config/printer-fokoos-odin5-f3-2021.cfg
+++ b/config/printer-fokoos-odin5-f3-2021.cfg
@@ -120,7 +120,12 @@ max_temp: 275
 heater_pin: PA0
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC0
-control: watermark
+control: pid
+# Tuned at 60C.
+pid_kp = 58.214
+pid_ki = 1.075
+pid_kd = 788.077
+
 min_temp: 5
 max_temp: 150
 

--- a/config/printer-fokoos-odin5-f3-2021.cfg
+++ b/config/printer-fokoos-odin5-f3-2021.cfg
@@ -122,9 +122,9 @@ sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC0
 control: pid
 # Tuned at 60C.
-pid_kp = 58.214
-pid_ki = 1.075
-pid_kd = 788.077
+pid_kp: 58.214
+pid_ki: 1.075
+pid_kd: 788.077
 
 min_temp: 5
 max_temp: 150


### PR DESCRIPTION
Signed-off-by: Matthew Lloyd <github@matthewlloyd.net>

I neither hear nor see mechanical relays and PWM control seems to be working well.