### PR TITLE
Aarch64 Arch Linux install script

### DIFF
--- a/scripts/install-arch-aarch64.sh
+++ b/scripts/install-arch-aarch64.sh
@@ -121,6 +121,12 @@ verify_ready()
         echo "This script is only compatabile with aarch64-based installations"
         exit -1
     fi
+
+    if ! which sudo > /dev/null 2>&1; then 
+        echo "Sudo is not installed, please install Sudo and add user to sudoers list."
+        exit -1
+    fi
+
 }
 
 # Force script to exit if an error occurs

--- a/scripts/install-arch-aarch64.sh
+++ b/scripts/install-arch-aarch64.sh
@@ -89,7 +89,7 @@ WantedBy=multi-user.target
 Type=simple
 User=$KLIPPER_USER
 RemainAfterExit=yes
-ExecStart=${PYTHONDIR}/bin/python ${SRCDIR}/klippy/klippy.py ${CONFIGDIR}/printer.cfg -l ${KLIPPER_LOG}
+ExecStart=${PYTHONDIR}/bin/python ${SRCDIR}/klippy/klippy.py ${CONFIGDIR}/printer.cfg -l ${KLIPPER_LOG} -a /tmp/klippy_uds
 EOF
 # Use systemctl to enable the klipper systemd service script
     sudo systemctl enable klipper.service

--- a/scripts/install-arch-aarch64.sh
+++ b/scripts/install-arch-aarch64.sh
@@ -46,7 +46,7 @@ install_packages()
     # Install desired packages
     report_status "Installing packages..."
     paru -S --needed ${PKGLIST}
-     
+
     # Install ARM build package. PKGBUILD recompresses it, so this takes a *LONG* time
     # even on a Pi 4
     report_status "Installing arm-none-eabi-gcc. This will take some time..."
@@ -122,7 +122,7 @@ verify_ready()
         exit -1
     fi
 
-    if ! which sudo > /dev/null 2>&1; then 
+    if ! which sudo > /dev/null 2>&1; then
         echo "Sudo is not installed, please install Sudo and add user to sudoers list."
         exit -1
     fi

--- a/scripts/install-arch-aarch64.sh
+++ b/scripts/install-arch-aarch64.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# This script installs Klipper on an aarch64 Arch Linux system
+
+PYTHONDIR="${HOME}/klippy-env"
+SYSTEMDDIR="/etc/systemd/system"
+CONFIGDIR="${HOME}/klipper_config"
+KLIPPER_USER=$USER
+KLIPPER_GROUP=$KLIPPER_USER
+
+# Step 1: Install Paru to handle AUR builds
+install_paru()
+{
+    # Packages needed to install Paru
+    PKGLIST="git base-devel"
+
+    # Install desired packages
+     report_status "Installing Paru dependencies..."
+
+     sudo pacman -S --needed ${PKGLIST}
+
+     # Clone paru-bin
+     git clone https://aur.archlinux.org/paru-bin.git
+
+     # Install Paru
+     report_status "Installing Paru..."
+     cd ~/paru-bin
+     makepkg -si
+
+     # Remove git repo
+     cd ~
+     sudo rm -rf paru-bin
+}
+
+# Step 2: Install Packages
+install_packages()
+{
+    # Packages for python cffi
+    PKGLIST="python2-virtualenv libffi"
+    # kconfig requirements
+    PKGLIST="${PKGLIST} ncurses"
+    # hub-ctrl
+    PKGLIST="${PKGLIST} libusb"
+    # AVR chip installation and building
+    PKGLIST="${PKGLIST} avrdude avr-gcc avr-binutils avr-libc"
+
+    # Install desired packages
+    report_status "Installing packages..."
+    paru -S --needed ${PKGLIST}
+     
+    # Install ARM build package. PKGBUILD recompresses it, so this takes a *LONG* time
+    # even on a Pi 4
+    report_status "Installing arm-none-eabi-gcc. This will take some time..."
+    paru -S gcc-arm-none-eabi-bin
+
+    # Install stm32flash. Paru will warn about incompatable architecture, but aarch64 is backwards
+    # compatabile, so this works fine.
+    report_status "Installing stm32flash. Please ignore incompatability error warning"
+    paru -S stm32flash
+}
+
+# Step 2: Create python virtual environment
+create_virtualenv()
+{
+    report_status "Updating python virtual environment..."
+
+    # Create virtualenv if it doesn't already exist
+    [ ! -d ${PYTHONDIR} ] && virtualenv2 ${PYTHONDIR}
+
+    # Install/update dependencies
+    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
+}
+
+# Step 3: Install startup script
+install_script()
+{
+# Create systemd service file
+    KLIPPER_LOG=/tmp/klippy.log
+    report_status "Installing system start script..."
+    sudo /bin/sh -c "cat > $SYSTEMDDIR/klipper.service" << EOF
+#Systemd service file for klipper
+[Unit]
+Description=Starts klipper on startup
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+User=$KLIPPER_USER
+RemainAfterExit=yes
+ExecStart=${PYTHONDIR}/bin/python ${SRCDIR}/klippy/klippy.py ${CONFIGDIR}/printer.cfg -l ${KLIPPER_LOG}
+EOF
+# Use systemctl to enable the klipper systemd service script
+    sudo systemctl enable klipper.service
+    report_status "Make sure to add $KLIPPER_USER to the user group controlling your serial printer port"
+    report_status "On Arch use sudo usermod -aG uucp $KLIPPER_USER"
+}
+
+# Step 4: Start host software
+start_software()
+{
+    report_status "Launching Klipper host software..."
+    sudo systemctl start klipper
+}
+
+# Helper functions
+report_status()
+{
+    echo -e "\n\n###### $1"
+}
+
+verify_ready()
+{
+    if [ "$EUID" -eq 0 ]; then
+        echo "This script must not run as root"
+        exit -1
+    fi
+
+    if [[ "$(uname -m)" != "aarch64" ]]; then
+        echo "This script is only compatabile with aarch64-based installations"
+        exit -1
+    fi
+}
+
+# Force script to exit if an error occurs
+set -e
+
+# Find SRCDIR from the pathname of this script
+SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+
+# Run installation steps defined above
+verify_ready
+install_paru
+install_packages
+create_virtualenv
+install_script
+start_software

--- a/scripts/install-arch-aarch64.sh
+++ b/scripts/install-arch-aarch64.sh
@@ -50,12 +50,12 @@ install_packages()
     # Install ARM build package. PKGBUILD recompresses it, so this takes a *LONG* time
     # even on a Pi 4
     report_status "Installing arm-none-eabi-gcc. This will take some time..."
-    paru -S --skip-review gcc-arm-none-eabi-bin
+    paru -S --skipreview gcc-arm-none-eabi-bin
 
     # Install stm32flash. Paru will warn about incompatable architecture, but aarch64 is backwards
     # compatabile, so this works fine.
     report_status "Installing stm32flash. Please ignore incompatability error warning"
-    paru -S --skip-review stm32flash
+    paru -S --skipreview stm32flash
 }
 
 # Step 2: Create python virtual environment

--- a/scripts/install-arch-aarch64.sh
+++ b/scripts/install-arch-aarch64.sh
@@ -19,7 +19,7 @@ install_paru()
      sudo pacman -S --needed ${PKGLIST}
 
      # Clone paru-bin
-     git clone https://aur.archlinux.org/paru-bin.git
+     git clone https://aur.archlinux.org/paru-bin.git ~/paru-bin
 
      # Install Paru
      report_status "Installing Paru..."
@@ -50,12 +50,12 @@ install_packages()
     # Install ARM build package. PKGBUILD recompresses it, so this takes a *LONG* time
     # even on a Pi 4
     report_status "Installing arm-none-eabi-gcc. This will take some time..."
-    paru -S gcc-arm-none-eabi-bin
+    paru -S --skip-review gcc-arm-none-eabi-bin
 
     # Install stm32flash. Paru will warn about incompatable architecture, but aarch64 is backwards
     # compatabile, so this works fine.
     report_status "Installing stm32flash. Please ignore incompatability error warning"
-    paru -S stm32flash
+    paru -S --skip-review stm32flash
 }
 
 # Step 2: Create python virtual environment

--- a/scripts/install-arch.sh
+++ b/scripts/install-arch.sh
@@ -86,6 +86,11 @@ verify_ready()
         echo "This script must not run as root"
         exit -1
     fi
+
+    if [[ "$(uname -m)" != "x86_64" ]]; then
+        echo "This script is only compatabile with x86_64 installations"
+        exit -1
+    fi
 }
 
 # Force script to exit if an error occurs


### PR DESCRIPTION
module: Install Scripts

Klipper install script for Arch Linux Aarch64 (raspberry pi 3b+/4 or equivalent).

I've written a klipper install script for aarch64 Arch linux that I'd like to share in case someone else finds it useful. I've tested this and verified that it installs klipper successfully. The only issue is that I only have a BTT SKR 1.4 available to test firmware flashing. I've verified that it builds the binary correctly and that flashing the firmware via `./scripts/flash-sdcard.sh` works correctly, but I am unable to test the functionality for any ST or AVR boards.

I am unsure if this is useful, but figured I'd offer it and let the maintainers decide.

Signed-off-by: Christopher Conroy <battloid.kouji@gmail.com>