### PR TITLE
Error in Ultimaker Config File

### DIFF
--- a/config/generic-ultimaker-ultimainboard-v2.cfg
+++ b/config/generic-ultimaker-ultimainboard-v2.cfg
@@ -103,7 +103,7 @@ static_value: 1.0
 [output_pin stepper_xy_current]
 pin: PL5
 pwm: True
-scale: 1.5
+scale: 2.0
 # Max power setting.
 cycle_time: .000030
 hardware_pwm: True
@@ -113,7 +113,7 @@ static_value: 1.200
 [output_pin stepper_z_current]
 pin: PL4
 pwm: True
-scale: 1.5
+scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
 static_value: 1.200
@@ -121,7 +121,7 @@ static_value: 1.200
 [output_pin stepper_e_current]
 pin: PL3
 pwm: True
-scale: 1.5
+scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
 static_value: 1.250


### PR DESCRIPTION
Hi,

This is my first PR so please let me know if I am doing something wrong.

I believe the stepper current scale is incorrect, according to the [Ultimaker 2 Marlin](https://github.com/Ultimaker/Ultimaker2Marlin/blob/8698fb6ad43490ce452d044330f9ca3a17027dfc/Marlin/pins.h#L1221), PWM fully enabled should refer to 2A not 1.5A. 

On an Ultimaker 2, I had issues with steppers skipping with scale: 1.5, which were fixed when I changed to scale: 2.0.

Cheers,