### PR TITLE
gcode_macro: Disallow whitespace in macro name

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -115,7 +115,7 @@ class GCodeMacro:
     def __init__(self, config):
         if len(config.get_name().split()) > 2:
             raise config.error(
-                    "Name of section '%s' contains illegal whitespace" 
+                    "Name of section '%s' contains illegal whitespace"
                     % (config.get_name()))
         name = config.get_name().split()[1]
         self.alias = name.upper()

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -113,6 +113,10 @@ def load_config(config):
 
 class GCodeMacro:
     def __init__(self, config):
+        if len(config.get_name().split() > 2):
+            raise config.error(
+                    "Name of section '%s' contains illegal whitespace" 
+                    % (config.get_name()))
         name = config.get_name().split()[1]
         self.alias = name.upper()
         self.printer = printer = config.get_printer()

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -113,7 +113,7 @@ def load_config(config):
 
 class GCodeMacro:
     def __init__(self, config):
-        if len(config.get_name().split() > 2):
+        if len(config.get_name().split()) > 2:
             raise config.error(
                     "Name of section '%s' contains illegal whitespace" 
                     % (config.get_name()))


### PR DESCRIPTION
This change disallows additional spaces in `gcode_macro` names.

Specifying a gcode macro block like `[gcode_macro MACRO NAME]` does not cause errors or warnings, until the user attempts to use the macro, (at which point the macro will be available under `MACRO` instead). This change simply checks whether the section header contains additional spaces, and raises an error if it does.

Signed-off-by: Florian Heilmann <Florian.Heilmann@gmx.net