### PR TITLE
gcode_macro: add description property

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -29,8 +29,8 @@ beginning.
 
 ### Add a description to your macro
 
-The help indetify the functionality a short description can be added. To
-do that add `description:` with a short text.
+To help indetify the functionality a short description can be added.
+Add `description:` with a short text to describe the functionality.
 Default is "G-Code macro" if not specified.
 For example:
 

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -29,7 +29,7 @@ beginning.
 
 ### Add a description to your macro
 
-To help indetify the functionality a short description can be added.
+To help identify the functionality a short description can be added.
 Add `description:` with a short text to describe the functionality.
 Default is "G-Code macro" if not specified.
 For example:

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -31,8 +31,8 @@ beginning.
 
 The help indetify the functionality a short description can be added. To
 do that add `description:` with a short text.
-Default is "G-Code macro" if not specified. 
- For example:
+Default is "G-Code macro" if not specified.
+For example:
 
 ```
 [gcode_macro blink_led]

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -27,6 +27,25 @@ Note how the `gcode:` config option always starts at the beginning of
 the line and subsequent lines in the G-Code macro never start at the
 beginning.
 
+### Add a description to your macro
+
+The help indetify the functionality a short description can be added. To
+do that add `description:` with a short text.
+Default is "G-Code macro" if not specified. 
+ For example:
+
+```
+[gcode_macro blink_led]
+description: Blink my_led one time
+gcode:
+  SET_PIN PIN=my_led VALUE=1
+  G4 P2000
+  SET_PIN PIN=my_led VALUE=0
+```
+
+This will be showing is you use the `HELP` command or use the autocomplete
+function.
+
 ### Save/Restore state for G-Code moves
 
 Unfortunately, the G-Code command language can be challenging to use.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1240,6 +1240,9 @@ G-Code macros (one may define any number of sections with a
 #   commands. Care should be taken when overriding commands as it can
 #   cause complex and unexpected results. The default is to not
 #   override an existing G-Code command.
+#description: G-Code macro
+#   This will add a short description used at the HELP command or while
+#   using the auto completion feature. Default "G-Code macro"
 ```
 
 ## [delayed_gcode]

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -120,7 +120,7 @@ class GCodeMacro:
         self.template = gcode_macro.load_template(config, 'gcode')
         self.gcode = printer.lookup_object('gcode')
         self.rename_existing = config.get("rename_existing", None)
-        self.cmd_desc = config.get("description", "G-Code macro")                                                                                                                  
+        self.cmd_desc = config.get("description", "G-Code macro")
         if self.rename_existing is not None:
             if (self.gcode.is_traditional_gcode(self.alias)
                 != self.gcode.is_traditional_gcode(self.rename_existing)):

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -120,6 +120,7 @@ class GCodeMacro:
         self.template = gcode_macro.load_template(config, 'gcode')
         self.gcode = printer.lookup_object('gcode')
         self.rename_existing = config.get("rename_existing", None)
+        self.cmd_desc = config.get("description", "G-Code macro")                                                                                                                  
         if self.rename_existing is not None:
             if (self.gcode.is_traditional_gcode(self.alias)
                 != self.gcode.is_traditional_gcode(self.rename_existing)):
@@ -173,7 +174,6 @@ class GCodeMacro:
         except ValueError as e:
             raise gcmd.error("Unable to parse '%s' as a literal" % (value,))
         self.variables[variable] = literal
-    cmd_desc = "G-Code macro"
     def cmd(self, gcmd):
         if self.in_script:
             raise gcmd.error("Macro %s called recursively" % (self.alias,))


### PR DESCRIPTION
This add a description property to gcode_macro in the same way as used for klipper internal macros. That should help to identify the function of a own macro while using help or the autocomplete function in an console

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com