### PR TITLE
Create printer-tevo-tarantula-pro2020-orange.cfg

### DIFF
--- a/config/printer-tevo-tarantula-pro2020-orange.cfg
+++ b/config/printer-tevo-tarantula-pro2020-orange.cfg
@@ -1,0 +1,120 @@
+# Support for the orange Tevo Tarantula Pro (aka Homers Odysseus - 2020 Model). 
+# To use this config, the firmware should be compiled for the LPC1768 (100MHz).
+# with USB and bootloader active setting.
+# Note that this config file is for the "new orange" Tarantula Pro, with a
+# MKS SGen_L 1.0 32-bit board.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[mcu]
+serial: /dev/ttyACM0
+baud: 250000
+
+[printer]
+kinematics: cartesian
+max_velocity: 200
+max_accel: 2000
+max_z_velocity: 25
+max_z_accel: 100
+
+[stepper_x]
+step_pin: P2.2
+dir_pin: P2.3
+enable_pin: !P2.1
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !P1.29  # ^P1.28 for X-max
+position_endstop: 0
+position_max: 320
+homing_speed: 50
+
+[stepper_y]
+step_pin: P0.19
+dir_pin: !P0.20
+enable_pin: !P2.8
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !P1.27  # ^P1.26 for Y-max
+position_endstop: 0
+position_max: 300
+homing_speed: 50
+
+[stepper_z]
+step_pin: P0.22
+dir_pin: !P2.11
+enable_pin: !P0.21
+microsteps: 16
+rotation_distance: 8
+endstop_pin: !P1.25  # ^P1.24 for Z-max
+position_endstop: 0.5
+position_max: 400
+
+[extruder]
+step_pin: P2.13
+dir_pin: !P0.11
+enable_pin: !P2.12
+microsteps: 16
+rotation_distance: 7.87469
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: P2.7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P0.23
+#control: pid
+#pid_Kp: 22.2
+#pid_Ki: 1.08
+#pid_Kd: 114
+min_temp: 0
+max_temp: 260
+
+[heater_bed]
+heater_pin: P2.5
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: P0.24
+#control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: P2.4
+
+########################################
+# FAN for automatic Hotend cooling
+########################################
+[heater_fan nozzle_fan]
+pin: P2.6
+heater: extruder
+heater_temp: 50.0
+#fan_speed: 1.0
+
+########################################
+# MKS Mini 12864 Display (stock)
+########################################
+[display]
+lcd_type: uc1701
+cs_pin = P0.17
+a0_pin: EXP1_7
+contrast: 40
+encoder_pins: ^EXP2_5, ^EXP2_3
+click_pin: ^!EXP1_2
+spi_software_miso_pin = P0.8
+spi_software_mosi_pin = P0.9
+spi_software_sclk_pin = P0.7
+
+[output_pin beeper]
+pin: EXP1_1
+
+########################################
+# EXP1 / EXP2 (display) pins
+########################################
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=P1.31, EXP1_3=P0.18, EXP1_5=P0.15, EXP1_7=P1.0,  EXP1_9=<GND>,
+    EXP1_2=P1.30, EXP1_4=P0.16, EXP1_6=P0.17, EXP1_8=P1.22, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=P0.8, EXP2_3=P3.25, EXP2_5=P3.26, EXP2_7=P0.27, EXP2_9=<GND>,
+    EXP2_2=P0.7, EXP2_4=P0.28, EXP2_6=P0.9,  EXP2_8=<RST>, EXP2_10=<NC>
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "ssp1"
+
+########################################

--- a/config/printer-tevo-tarantula-pro2020-orange.cfg
+++ b/config/printer-tevo-tarantula-pro2020-orange.cfg
@@ -25,7 +25,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: !P1.29  # ^P1.28 for X-max
 position_endstop: 0
-position_max: 320
+position_max: 245
 homing_speed: 50
 
 [stepper_y]
@@ -36,7 +36,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: !P1.27  # ^P1.26 for Y-max
 position_endstop: 0
-position_max: 300
+position_max: 200
 homing_speed: 50
 
 [stepper_z]
@@ -47,7 +47,7 @@ microsteps: 16
 rotation_distance: 8
 endstop_pin: !P1.25  # ^P1.24 for Z-max
 position_endstop: 0.5
-position_max: 400
+position_max: 275
 
 [extruder]
 step_pin: P2.13


### PR DESCRIPTION
Stock printer configuration for Tevo Tarantula Pro -> Homers Odysseus (Orange Model from 2020)