### PR TITLE
Create printer-tronxy-x1-2017.cfg

### DIFF
--- a/config/printer-tronxy-x1-2017.cfg
+++ b/config/printer-tronxy-x1-2017.cfg
@@ -1,0 +1,101 @@
+# This file contains pin mappings for the Tronxy X1 (circa 2017). To
+# use this config, the firmware should be compiled for the AVR atmega1284p.
+
+# Note, a number of Melzi boards are shipped with a bootloader that
+# requires the following command to flash the board:
+# avrdude -p atmega1284p -c arduino -b 57600 -P /dev/ttyUSB0 -U out/klipper.elf.hex
+# If the above command does not work and "make flash" does not work
+# then one may need to flash a bootloader to the board - see the
+# Klipper docs/Bootloaders.md file for more information.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PD7
+dir_pin: PC5
+enable_pin: !PD6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!PC2
+position_endstop: 0
+position_max: 150
+homing_speed: 50
+
+[stepper_y]
+step_pin: PC6
+dir_pin: PC7
+enable_pin: !PD6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!PC3
+position_endstop: 0
+position_max: 150
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB3
+dir_pin: !PB2
+enable_pin: !PA5
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^!PC4
+position_endstop: 0.5
+position_max: 150
+
+[extruder]
+step_pin: PB1
+dir_pin: PB0
+enable_pin: !PD6
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PD5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA7
+control: pid
+pid_Kp: 20.16
+pid_Ki: 1.30
+pid_Kd: 78.02
+min_temp: 1
+max_temp: 230
+
+#[heater_bed]
+#heater_pin: PD4
+#sensor_type: 
+#sensor_pin: PA6
+#control: watermark
+#min_temp: 1
+#max_temp: 80
+
+[fan]
+pin: PB4
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[display]
+lcd_type: hd44780
+rs_pin: PA3
+e_pin: PA2
+d4_pin: PD2
+d5_pin: PD3
+d6_pin: PC0
+d7_pin: PC1
+up_pin: PA1
+analog_range_up_pin: 9000, 13000
+down_pin: PA1
+analog_range_down_pin: 800, 1300
+click_pin: PA1
+analog_range_click_pin: 2000, 2500
+back_pin: PA1
+analog_range_back_pin: 4500, 5000
+#kill_pin: PA1
+#analog_range_kill_pin: 400, 600


### PR DESCRIPTION
All features and buttons are working with this config. Extruder max_temp has been set to 230C for PTFE hotend toxin safety. Kids are the most common user of this bargain printer.