### PR TITLE
bed_mesh: add support for X/Y offsets

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -430,3 +430,14 @@ probing the "Probe" points will refer to both the tool and nozzle locations.
 `BED_MESH_CLEAR`
 
 This gcode may be used to clear the internal mesh state.
+
+### Apply X/Y offsets
+
+`BED_MESH_OFFSET [X=<value>] [Y=<value>]`
+
+This is useful for printers with multiple independent extruders, as an offset
+is necessary to produce correct Z adjustment after a tool change.  Offsets
+should be specified relative to the primary extruder.  That is, a positive
+X offset should be specified if the secondary extruder is mounted to the
+right of the primary extruder, and a positive Y offset should be specified
+if the secondary extruder is mounted "behind" the primary extruder.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -434,6 +434,10 @@ The following commands are available when the
   supplied name from persistent memory.  Note that after SAVE or
   REMOVE operations have been run the SAVE_CONFIG gcode must be run
   to make the changes to peristent memory permanent.
+- `BED_MESH_OFFSET [X=<value>] [Y=<value>]`:  Applies X and/or Y
+  offsets to the mesh lookup.  This is useful for printers with
+  independent extruders, as an offset is necessary to produce
+  correct Z adjustment after a tool change.
 
 ## Bed Screws Helper
 

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -93,6 +93,9 @@ class BedMesh:
         self.gcode.register_command(
             'BED_MESH_CLEAR', self.cmd_BED_MESH_CLEAR,
             desc=self.cmd_BED_MESH_CLEAR_help)
+        self.gcode.register_command(
+            'BED_MESH_OFFSET', self.cmd_BED_MESH_OFFSET,
+            desc=self.cmd_BED_MESH_OFFSET_help)
         # Register transform
         gcode_move = self.printer.load_object(config, 'gcode_move')
         gcode_move.set_move_transform(self)
@@ -230,9 +233,20 @@ class BedMesh:
             gcmd.respond_raw("mesh_map_output " + json.dumps(outdict))
         else:
             gcmd.respond_info("Bed has not been probed")
-    cmd_BED_MESH_CLEAR_help = "Clear the Mesh so no z-adjusment is made"
+    cmd_BED_MESH_CLEAR_help = "Clear the Mesh so no z-adjustment is made"
     def cmd_BED_MESH_CLEAR(self, gcmd):
         self.set_mesh(None)
+    cmd_BED_MESH_OFFSET_help = "Add X/Y offsets to the mesh lookup"
+    def cmd_BED_MESH_OFFSET(self, gcmd):
+        if self.z_mesh is not None:
+            offsets = [None, None]
+            for i, axis in enumerate(['X', 'Y']):
+                offsets[i] = gcmd.get_float(axis, None)
+            self.z_mesh.set_mesh_offsets(offsets)
+            gcode_move = self.printer.lookup_object('gcode_move')
+            gcode_move.reset_last_position()
+        else:
+            gcmd.respond_info("No mesh loaded to offset")
 
 
 class BedMeshCalibrate:
@@ -767,6 +781,7 @@ class ZMesh:
         self.probed_matrix = self.mesh_matrix = None
         self.mesh_params = params
         self.avg_z = 0.
+        self.mesh_offsets = [0., 0.]
         logging.debug('bed_mesh: probe/mesh parameters:')
         for key, value in self.mesh_params.items():
             logging.debug("%s :  %s" % (key, value))
@@ -828,6 +843,8 @@ class ZMesh:
             msg = "Mesh X,Y: %d,%d\n" % (self.mesh_x_count, self.mesh_y_count)
             if move_z is not None:
                 msg += "Search Height: %d\n" % (move_z)
+            msg += "Mesh Offsets: X=%.4f, Y=%.4f\n" % (
+                self.mesh_offsets[0], self.mesh_offsets[1])
             msg += "Mesh Average: %.2f\n" % (self.avg_z)
             rng = self.get_z_range()
             msg += "Mesh Range: min=%.4f max=%.4f\n" % (rng[0], rng[1])
@@ -851,6 +868,10 @@ class ZMesh:
         # z step distances
         self.avg_z = round(self.avg_z, 2)
         self.print_mesh(logging.debug)
+    def set_mesh_offsets(self, offsets):
+        for i, o in enumerate(offsets):
+            if o is not None:
+                self.mesh_offsets[i] = o
     def get_x_coordinate(self, index):
         return self.mesh_x_min + self.mesh_x_dist * index
     def get_y_coordinate(self, index):
@@ -858,8 +879,8 @@ class ZMesh:
     def calc_z(self, x, y):
         if self.mesh_matrix is not None:
             tbl = self.mesh_matrix
-            tx, xidx = self._get_linear_index(x, 0)
-            ty, yidx = self._get_linear_index(y, 1)
+            tx, xidx = self._get_linear_index(x + self.mesh_offsets[0], 0)
+            ty, yidx = self._get_linear_index(y + self.mesh_offsets[1], 1)
             z0 = lerp(tx, tbl[yidx][xidx], tbl[yidx][xidx+1])
             z1 = lerp(tx, tbl[yidx+1][xidx], tbl[yidx+1][xidx+1])
             return lerp(ty, z0, z1)


### PR DESCRIPTION
This implements `BED_MESH_OFFSET`, which can be used to apply offsets to the mesh lookup for correct adjustment on printers with multiple extruders.  The offset should be relative to the primary extruder, so generally it should be the additive inverse of the gcode offset.

The first commit in this series contains a minor refactor of how the `fade_target` is handled. The initial offset is no longer pre-calculated when the mesh is set, instead the offset is applied when the final adjustment is calculated.  This made adding the X and Y offsets less confusing.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>.