### PR TITLE
Deprecate pid_integral_max config option

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,10 @@ All dates in this document are approximate.
 
 # Changes
 
+20210612: The `pid_integral_max` config option in heater and
+temperature_fan sections is deprecated.  The option will be removed in
+the near future.
+
 20210503: The gcode_macro `default_parameter_<name>` config option is
 deprecated.  Use the `params` pseudo-variable to access macro
 parameters.  Other methods for accessing macro parameters will be

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -714,9 +714,6 @@ pid_Ki:
 pid_Kd:
 #   Kd is the "derivative" constant for the pid. This parameter must
 #   be provided for PID heaters.
-#pid_integral_max:
-#   The maximum "windup" the integral term may accumulate. The default
-#   is to use the same value as max_power.
 #max_delta: 2.0
 #   On 'watermark' controlled heaters this is the number of degrees in
 #   Celsius above the target temperature before disabling the heater
@@ -1989,7 +1986,6 @@ temperature.
 #pid_Kp:
 #pid_Ki:
 #pid_Kd:
-#pid_integral_max:
 #pwm_cycle_time:
 #min_temp:
 #max_temp:
@@ -2429,7 +2425,6 @@ additional information.
 #pid_Ki:
 #pid_Kd:
 #pid_deriv_time:
-#pid_integral_max:
 #max_delta:
 #min_temp:
 #max_temp:


### PR DESCRIPTION
This is a proposal to deprecate the pid_integral_max config option.  I've never seen this option customized and I can't think of a situation where it would make sense to customize it.  So, I think it would be better to simplify the documentation by removing it.  (The feature would still be present, but it would always use its current default.)

-Kevin
