### PR TITLE
Add support for the Prusa Mini+ and the Prusa Buddy board

### DIFF
--- a/config/generic-buddy.cfg
+++ b/config/generic-buddy.cfg
@@ -1,0 +1,159 @@
+# This file contains common configurations and pin mappings for the Prusa Buddy
+# board. The LCD is not currently supported by Klipper, so the touchscreen will
+# permanently display the bootloader screen after the Klipper firmware is flashed;
+# use Fluidd, Mainsail, or OctoPrint etc. to control the printer.
+
+# To use this config, the firmware should be compiled for the STM32F407. When
+# running "make menuconfig", enable "extra low-level configuration setup",
+# select the "128KiB + 512 byte offset" bootloader, and USB communication.
+# Connect the printer to your Raspberry Pi using the printer's micro-USB port.
+# If you prefer to remove Prusa's stock bootloader entirely, select the
+# "No bootloader" option.
+
+# When flashing for the first time, you will need to break the "appendix"
+# on the Buddy board, then put the device into DFU mode by moving the jumper
+# on the 3-pin header (older boards) or shorting the 2-pin header (newer boards)
+# and resetting, and finally use "make flash" to install Klipper. Once Klipper is
+# installed, you no longer need the jumper - just use "make flash" which will
+# automatically put the device into DFU mode.
+
+# Note that if you were previously running Prusa firmware, you must fully
+# power cycle the board after flashing. Otherwise, Klipper will be unable to
+# communicate with the TMC2209s due to the abrupt change in the baud rate,
+# and will show this error: "Unable to read tmc uart register IFCNT".
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PD1
+dir_pin: PD0
+enable_pin: !PD3
+microsteps: 16
+rotation_distance: 32
+endstop_pin: tmc2209_stepper_x:virtual_endstop
+position_endstop: 200
+position_min: 0
+position_max: 200
+homing_speed: 50
+homing_retract_dist: 0
+
+[stepper_y]
+step_pin: PD13
+dir_pin: PD12
+enable_pin: !PD14
+microsteps: 16
+rotation_distance: 32
+endstop_pin: tmc2209_stepper_y:virtual_endstop
+position_endstop: 0
+position_min: 0
+position_max: 200
+homing_speed: 50
+homing_retract_dist: 0
+
+[stepper_z]
+step_pin: PD4
+dir_pin: !PD15
+enable_pin: !PD2
+microsteps: 16
+rotation_distance: 4
+endstop_pin: probe:z_virtual_endstop
+position_min: 0
+position_max: 200
+
+[extruder]
+step_pin: PD9
+dir_pin: !PD8
+enable_pin: !PD10
+microsteps: 16
+rotation_distance: 10
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB1
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC0
+control: pid
+pid_Kp: 7
+pid_Ki: 0.5
+pid_Kd: 45
+min_temp: 10
+max_temp: 305
+
+[tmc2209 stepper_x]
+uart_pin: PD5
+uart_address: 1
+diag_pin: ^PE2
+driver_SGTHRS: 130
+run_current: 0.35
+sense_resistor: 0.22
+stealthchop_threshold: 999999
+
+[tmc2209 stepper_y]
+uart_pin: PD5
+uart_address: 3
+diag_pin: ^PE1
+driver_SGTHRS: 130
+run_current: 0.35
+sense_resistor: 0.22
+stealthchop_threshold: 999999
+
+[tmc2209 stepper_z]
+uart_pin: PD5
+uart_address: 0
+diag_pin: ^PE3
+driver_SGTHRS: 100
+run_current: 0.35
+sense_resistor: 0.22
+stealthchop_threshold: 999999
+
+[tmc2209 extruder]
+uart_pin: PD5
+uart_address: 2
+diag_pin: ^PA15
+driver_SGTHRS: 100
+run_current: 0.4
+sense_resistor: 0.22
+
+[heater_bed]
+heater_pin: PB0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA4
+control: pid
+pid_Kp: 120
+pid_Ki: 1.5
+pid_Kd: 600
+min_temp: 10
+max_temp: 110
+
+# Hotend fan.
+[heater_fan hotend_fan]
+pin: PE9
+tachometer_pin: PE14
+
+# Part cooling fan.
+[fan]
+pin: PE11
+tachometer_pin: PE10
+
+# The SuperPINDA has built-in temperature compensation and no thermistor output,
+# so no compensation table is needed. The PINDA thermistor is otherwise on pin PA6.
+[probe]
+pin: PA8
+x_offset: -29
+y_offset: -3
+z_offset: 0
+speed: 6.0
+
+[filament_switch_sensor filament_sensor]
+switch_pin: ^PB4
+pause_on_runout: True
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_stm32f407xx_3100380013504E4E53353420-if00
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 180
+max_accel: 1250
+max_z_velocity: 12
+max_z_accel: 400

--- a/config/printer-prusa-mini-plus-2020.cfg
+++ b/config/printer-prusa-mini-plus-2020.cfg
@@ -1,0 +1,184 @@
+# This file contains common configurations and pin mappings for the Prusa
+# Mini+, which uses the Prusa Buddy board. The printer's LCD is not currently
+# supported by Klipper, so the touchscreen will permanently display the
+# bootloader screen after the Klipper firmware is flashed; use Fluidd, Mainsail,
+# or OctoPrint etc. to control the printer.
+
+# To use this config, the firmware should be compiled for the STM32F407. When
+# running "make menuconfig", enable "extra low-level configuration setup",
+# select the "128KiB + 512 byte offset" bootloader, and USB communication.
+# Connect the printer to your Raspberry Pi using the printer's micro-USB port.
+# If you prefer to remove Prusa's stock bootloader entirely, select the
+# "No bootloader" option.
+
+# When flashing for the first time, you will need to break the "appendix"
+# on the Buddy board, then put the device into DFU mode by moving the jumper
+# on the 3-pin header (older boards) or shorting the 2-pin header (newer boards)
+# and resetting, and finally use "make flash" to install Klipper. Once Klipper is
+# installed, you no longer need the jumper - just use "make flash" which will
+# automatically put the device into DFU mode.
+
+# Note that if you were previously running Prusa firmware, you must fully
+# power cycle the board after flashing. Otherwise, Klipper will be unable to
+# communicate with the TMC2209s due to the abrupt change in the baud rate,
+# and will show this error: "Unable to read tmc uart register IFCNT".
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PD1
+dir_pin: PD0
+enable_pin: !PD3
+microsteps: 16
+rotation_distance: 32  # 200 * 16 / 100
+endstop_pin: tmc2209_stepper_x:virtual_endstop
+position_endstop: 180.4
+position_min: -2
+position_max: 180.4
+homing_speed: 50
+homing_retract_dist: 0
+
+[stepper_y]
+step_pin: PD13
+dir_pin: PD12
+enable_pin: !PD14
+microsteps: 16
+rotation_distance: 32  # 200 * 16 / 100
+endstop_pin: tmc2209_stepper_y:virtual_endstop
+position_endstop: -3
+position_min: -3
+position_max: 180
+homing_speed: 50
+homing_retract_dist: 0
+
+[stepper_z]
+step_pin: PD4
+dir_pin: !PD15
+enable_pin: !PD2
+microsteps: 16
+rotation_distance: 4
+endstop_pin: probe:z_virtual_endstop
+position_min: 0
+position_max: 185
+
+[extruder]
+step_pin: PD9
+dir_pin: !PD8
+enable_pin: !PD10
+microsteps: 16
+rotation_distance: 9.84615  # 200 * 16 / 325
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB1
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC0
+control: pid
+# Prusa's firmware defaults.
+pid_Kp: 7
+pid_Ki: 0.5
+pid_Kd: 45
+min_temp: 10
+max_temp: 305
+
+[tmc2209 stepper_x]
+uart_pin: PD5
+uart_address: 1
+diag_pin: ^PE2
+driver_SGTHRS: 130
+run_current: 0.35
+sense_resistor: 0.22
+stealthchop_threshold: 999999
+
+[tmc2209 stepper_y]
+uart_pin: PD5
+uart_address: 3
+diag_pin: ^PE1
+driver_SGTHRS: 130
+run_current: 0.35
+sense_resistor: 0.22
+stealthchop_threshold: 999999
+
+[tmc2209 stepper_z]
+uart_pin: PD5
+uart_address: 0
+diag_pin: ^PE3
+driver_SGTHRS: 100
+run_current: 0.35
+sense_resistor: 0.22
+stealthchop_threshold: 999999
+
+[tmc2209 extruder]
+uart_pin: PD5
+uart_address: 2
+diag_pin: ^PA15
+driver_SGTHRS: 100
+run_current: 0.4
+sense_resistor: 0.22
+
+[heater_bed]
+heater_pin: PB0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA4
+control: pid
+# Prusa's firmware defaults.
+pid_Kp: 120
+pid_Ki: 1.5
+pid_Kd: 600
+min_temp: 10
+max_temp: 110
+
+# Hotend fan.
+# The stock firmware uses control ranges of PWM 0-50%, RPM 1000-8000.
+# Change fan_speed below to match your preference. Measured speeds:
+#   fan_speed 0.5:  50% PWM = 4000RPM (Prusa stock default speed)
+#   fan_speed 1.0: 100% PWM = 8000RPM (safe but loud)
+[heater_fan hotend_fan]
+pin: PE9
+tachometer_pin: PE14
+fan_speed: 0.5
+
+# Part cooling fan.
+# The stock firmware uses control ranges of PWM 10-50%, RPM 500-5000.
+# To match stock firmware, set the Klipper fan speed to 50%. This speed
+# can be safely increased to 100% for better part cooling. Measured speeds:
+#    50% PWM = 2500RPM (Prusa stock default speed)
+#   100% PWM = 5000RPM (better cooling, still quiet)
+[fan]
+pin: PE11
+tachometer_pin: PE10
+
+# The SuperPINDA has built-in temperature compensation and no thermistor output,
+# so no compensation table is needed here.
+[probe]
+pin: PA8
+x_offset: -29
+y_offset: -3
+z_offset: 0  # set this to your Live Z Offset, but negated (invert the sign)
+speed: 6.0
+
+[safe_z_home]
+home_xy_position: 147.4,21.1
+z_hop: 4
+
+[bed_mesh]
+speed: 100
+horizontal_move_z: 5
+mesh_min: 10,10
+mesh_max: 141,167
+probe_count: 4,4
+
+[filament_switch_sensor filament_sensor]
+switch_pin: ^PB4
+pause_on_runout: True
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_stm32f407xx_3100380013504E4E53353420-if00
+restart_method: command
+
+[printer]
+kinematics: cartesian
+# Prusa firmware defaults.
+max_velocity: 180
+max_accel: 1250
+max_z_velocity: 12
+max_z_accel: 400

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -142,6 +142,8 @@ choice
         bool "32KiB bootloader" if MACH_STM32F207 || MACH_STM32F407 || MACH_STM32F446
     config STM32_FLASH_START_8800
         bool "34KiB bootloader (Chitu v6 Bootloader)" if MACH_STM32F103
+    config STM32_FLASH_START_20200
+        bool "128KiB bootloader with 512 byte offset (Prusa Buddy)" if MACH_STM32F407
     config STM32_FLASH_START_C000
         bool "48KiB bootloader (MKS Robin Nano V3)" if MACH_STM32F407
     config STM32_FLASH_START_10000
@@ -166,6 +168,7 @@ config FLASH_START
     default 0x8008800 if STM32_FLASH_START_8800
     default 0x800C000 if STM32_FLASH_START_C000
     default 0x8010000 if STM32_FLASH_START_10000
+    default 0x8020200 if STM32_FLASH_START_20200
     default 0x8000000
 
 config ARMCM_RAM_VECTORTABLE

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -165,8 +165,10 @@ DICTIONARY stm32f407.dict
 CONFIG ../../config/generic-bigtreetech-gtr.cfg
 CONFIG ../../config/generic-bigtreetech-skr-pro.cfg
 CONFIG ../../config/generic-bigtreetech-skr-2.cfg
+CONFIG ../../config/generic-buddy.cfg
 CONFIG ../../config/generic-flyboard.cfg
 CONFIG ../../config/generic-mks-robin-nano-v3.cfg
+CONFIG ../../config/printer-prusa-mini-plus-2020.cfg
 
 # Printers using the stm32f446
 DICTIONARY stm32f407.dict


### PR DESCRIPTION
The Buddy board will likely be used by the MK4, so has a separate generic config file.