### PR TITLE
Draft: Replicate Prusa MK3 hotbed silencer

### DIFF
--- a/src/avr/bed_timer.c
+++ b/src/avr/bed_timer.c
@@ -1,0 +1,39 @@
+#include "autoconf.h" // CONFIG_MACH_atmega644p
+#include "gpio.h" // gpio_out_write
+
+#define STEPS 16
+#define DUTY_CYCLE (256/STEPS)
+
+ISR(TIMER0_OVF_vect)
+{
+	if (OCR0B + DUTY_CYCLE >= 255) {
+		OCR0B = 255;
+		TIMSK0 &= ~(1 << TOIE0);
+	} else {
+		OCR0B += DUTY_CYCLE;
+	}
+}
+
+void timer0_restart(uint8_t val)
+{
+	TCNT0 = 0;
+	OCR0B = DUTY_CYCLE - 1;
+	// Fast Mode + Inverted mode
+	if (val) {
+		// HIGH
+		TCCR0A = (1 << WGM01) | (1 << WGM00) | (1 << COM0B1);
+	} else {
+		// LOW
+		TCCR0A = (1 << WGM01) | (1 << WGM00) | (1 << COM0B1) | (1 << COM0B0);
+	}
+	// Pre-scaler to 1, or 62.5kHz
+	TCCR0B = (1 << CS00);
+	// Enable TIMER0_OVF_vect interrupt
+	TIMSK0 |= (1 << TOIE0);
+}
+
+void timer0_stop()
+{
+	TCCR0A = 0;
+	TIMSK0 &= ~(1 << TOIE0);
+}


### PR DESCRIPTION
Prusa MK3 have this nosiy problem of clicking bed when switching.

Prusa fixed that to some extent by introducing a 62.5kHz increasing duty cycle on switching.
It was well documented in https://blog.prusaprinters.org/dev-diary-2-how-we-made-the-heatbed-silent_30946/.

This PR does:

- makes problem of clicky bed go away
- replicate what Prusa does in their's firmware
- does it in a much simpler form retaining soft PWM behavior
- this generates a `STEPS` amount of `ISR` for each edge change at 62.5kHz, exactly how the mentioning blog post does (significantly better, as Prusa uses ISR on regular intervals either be 62.5kHz or 7.8kHz)
- it was validated using `simavr` and with osciloscope

Problems:

- I have no idea how best integrate this. This likely makes sense as a compile-type of behavior
- It is hardcoded to PG5 a heatbed PIN
