### PR TITLE
extruder: expose `can_extrude` flag based on temperature

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -130,6 +130,8 @@ The following information is available for heater objects such as
   the given heater.
 - `power`: The last setting of the PWM pin (a value between 0.0 and
   1.0) associated with the heater.
+- `can_extrude`: If extruder can extrude (defined by `min_extrude_temp`),
+  available only for [extruder](Config_Reference.md#extruder)
 
 # heaters
 

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -91,6 +91,7 @@ class PrinterExtruder:
         self.pressure_advance_smooth_time = smooth_time
     def get_status(self, eventtime):
         return dict(self.heater.get_status(eventtime),
+                    can_extrude=self.heater.can_extrude,
                     pressure_advance=self.pressure_advance,
                     smooth_time=self.pressure_advance_smooth_time)
     def get_name(self):


### PR DESCRIPTION
Sometimes an automated filament load is implemented,
but extruder might not always extrude filament due to temperature constraints.

This adds a flag to check if this operation is possible.

Example usage:

```ini
[gcode_macro LOAD_FILAMENT]
gcode:
    {% if printer.extruder.can_extrude %}
    M117 Loading Filament...
    SAVE_GCODE_STATE NAME=__filament__load
    M83
    G1 E70 F400
    G1 E25 F200
    M400
    RESTORE_GCODE_STATE NAME=__filament__load
    M117 Load Complete
    {% else %}
    M117 Cannot auto-load (MIN TEMP)
    {% endif %}
    UPDATE_DELAYED_GCODE ID=clear_display DURATION=5
```