### PR TITLE
virtual_sdcard: add `file_path` and `file_size` to `status`

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -306,7 +306,9 @@ The following information is available in the
 - `is_active`: Returns True if a print from file is currently active.
 - `progress`: An estimate of the current print progress (based of file
   size and file position).
+- `file_path`: A full path to the file of currently loaded file.
 - `file_position`: The current position (in bytes) of an active print.
+- `file_size`: The file size (in bytes) of currently loaded file.
 
 # webhooks
 

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -165,7 +165,7 @@ name: SD Card
 
 [menu __main __sdcard __start]
 type: command
-enable: {('virtual_sdcard' in printer) and (printer.print_stats.state == "standby" or printer.print_stats.state == "error" or printer.print_stats.state == "complete")}
+enable: {('virtual_sdcard' in printer) and printer.virtual_sdcard.file_path}
 name: Start printing
 gcode: M24
 

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -79,12 +79,22 @@ class VirtualSD:
                 logging.exception("virtual_sdcard get_file_list")
                 raise self.gcode.error("Unable to get file list")
     def get_status(self, eventtime):
-        progress = 0.
+        return {
+            'file_path': self.file_path(),
+            'progress': self.progress(),
+            'is_active': self.is_active(),
+            'file_position': self.file_position,
+            'file_size': self.file_size,
+        }
+    def file_path(self):
+        if self.current_file:
+            return self.current_file.name
+        return None
+    def progress(self):
         if self.file_size:
-            progress = float(self.file_position) / self.file_size
-        is_active = self.is_active()
-        return {'progress': progress, 'is_active': is_active,
-                'file_position': self.file_position}
+            return float(self.file_position) / self.file_size
+        else:
+            return 0.
     def is_active(self):
         return self.work_timer is not None
     def do_pause(self):


### PR DESCRIPTION
This provides a comprehensive information if currently we have a file loaded.

Previously:

- we used `print_stats` to know if something is loaded, which is not always correct nor true
- this provides a clear information if a `virtual-sdcard` file is loaded and currently printing
- provides a clear purpose of `v-sd` to track a file progress, `print_stats` to track print progress (which might be coming from manual stream of commands [not yet possible])

Signed-off-by: Kamil Trzcinski <ayufan@ayufan.eu>