### PR TITLE
print_stats: add `cancelled` when `CANCEL_PRINT` used

### DIFF
--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -80,7 +80,9 @@ class PauseResume:
         self.is_paused = self.pause_command_sent = False
     def cmd_CANCEL_PRINT(self, gcmd):
         self.cmd_PAUSE(gcmd)
-        if not self.sd_paused:
+        if self.sd_paused:
+            self.v_sd.do_cancel()
+        else:
             gcmd.respond_info("action:cancel")
         self.cmd_CLEAR_PAUSE(gcmd)
 

--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -38,12 +38,14 @@ class PauseResume:
         return {
             'is_paused': self.is_paused
         }
+    def is_sd_active(self):
+        return self.v_sd is not None and self.v_sd.is_active()
     def send_pause_command(self):
         # This sends the appropriate pause command from an event.  Note
         # the difference between pause_command_sent and is_paused, the
         # module isn't officially paused until the PAUSE gcode executes.
         if not self.pause_command_sent:
-            if self.v_sd is not None and self.v_sd.is_active():
+            if self.is_sd_active():
                 # Printing from virtual sd, run pause command
                 self.sd_paused = True
                 self.v_sd.do_pause()
@@ -79,8 +81,7 @@ class PauseResume:
     def cmd_CLEAR_PAUSE(self, gcmd):
         self.is_paused = self.pause_command_sent = False
     def cmd_CANCEL_PRINT(self, gcmd):
-        self.cmd_PAUSE(gcmd)
-        if self.sd_paused:
+        if self.is_sd_active() or self.sd_paused:
             self.v_sd.do_cancel()
         else:
             gcmd.respond_info("action:cancel")

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -41,11 +41,15 @@ class PrintStats:
             self._update_filament_usage(curtime)
         if self.state != "error":
             self.state = "paused"
-    def note_error(self, message):
-        self.state = "error"
-        self.error_message = message
     def note_complete(self):
-        self.state = "complete"
+        self._note_finish("complete")
+    def note_error(self, message):
+        self._note_finish("error", message)
+    def note_cancel(self):
+        self._note_finish("canceled")
+    def _note_finish(self, state, error_message = None):
+        self.state = state
+        self.error_message = error_message
         eventtime = self.reactor.monotonic()
         self.total_duration = eventtime - self.print_start_time
         if self.filament_used < 0.0000001:

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -46,7 +46,7 @@ class PrintStats:
     def note_error(self, message):
         self._note_finish("error", message)
     def note_cancel(self):
-        self._note_finish("canceled")
+        self._note_finish("cancelled")
     def _note_finish(self, state, error_message = None):
         self.state = state
         self.error_message = error_message

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -47,7 +47,7 @@ class PrintStats:
         self._note_finish("error", message)
     def note_cancel(self):
         self._note_finish("cancelled")
-    def _note_finish(self, state, error_message = None):
+    def _note_finish(self, state, error_message = ""):
         self.state = state
         self.error_message = error_message
         eventtime = self.reactor.monotonic()


### PR DESCRIPTION
Before this change, a `CANCEL_PRINT` would set a `print_stats` to `paused`
that would later be workaround-ed with `moonraker`/`fluidd`/`mainsail` to re-define
`CANCEL_PRINT` to transition to `standby` and forcefully unload file.

This adds a proper `canceled` state. This additonally closes a file
from a `virtual_sdcard` context for `canceled`/`error`, as such state is no longer
resumable from this point.

This removes workarounds needed by `fluidd`/`mainsail` as previously they would ask to:
- https://docs.fluidd.xyz/configuration/initial_setup#cancel_print
- https://docs.mainsail.xyz/necessary-configuration#for-pause--resume--cancel-functionality
- https://github.com/Arksine/moonraker/blob/master/moonraker/components/history.py#L191
- manually call `CLEAR_PAUSE` to mark `pause_resume` as not paused before the call to `SDCARD_RESET_FILE`
- manually call `SDCARD_RESET_FILE` to reset `print_stats` to `standby` and close file in `virtual_sdcard` context
- used a workaround to discover `canceled` state by looking at `print_stats` transition from `paused/printing` to `standby`

This removes all the above workarounds, as either generic `CANCEL_PRINT` can be used, or can be extended with `TURN_OFF_HEATERS`.

This connected with https://github.com/KevinOConnor/klipper/pull/4364/files, does provide a clear distinction about `virtual_sdcard` holding information of currently loaded file, `print_state` holding information about the most recent print result.

Related:
- https://github.com/Arksine/moonraker/pull/176

Signed-off-by: Kamil Trzcinski <ayufan@ayufan.eu>