### PR TITLE
Draft: menu: add `MENU_SHOW` G-code

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3224,6 +3224,9 @@ lcd_type:
 #   Name of the main menu section to show when clicking the encoder
 #   on the home screen. The defaults is __main, and this shows the
 #   the default menus as defined in klippy/extras/display/menu.cfg
+#menu_root_long_click:
+#   Name of the main menu section to show when the encoder is long
+#   clicked on the home screen. The defaults is to use menu_root.
 #menu_reverse_navigation:
 #   When enabled it will reverse up and down directions for list
 #   navigation. The default is False. This parameter is optional.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -224,6 +224,8 @@ The following standard commands are supported:
   e.g. `[display_data <group> <elementname>]` and switch between them
   using this extended gcode command. If DISPLAY is not specified it
   defaults to "display" (the primary display).
+- `MENU_SHOW ITEM=<item> [ROOT=0|1]`: Show a menu item on top of currently
+  shown menu. If `ROOT=1` is specified it will replace a current tree.
 - `SET_IDLE_TIMEOUT [TIMEOUT=<timeout>]`:  Allows the user to set the
   idle timeout (in seconds).
 - `RESTART`: This will cause the host software to reload its config

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -712,6 +712,9 @@ class MenuManager:
         # register itself for printer callbacks
         self.printer.add_object('menu', self)
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
+        # register gcode
+        self.gcode.register_command("MENU_SHOW", self.cmd_MENU_SHOW,
+                                    desc=self.cmd_MENU_SHOW_help)
         # register for key events
         menu_keys.MenuKeys(config, self.key_event)
         # Load local config file in same directory as current module
@@ -748,29 +751,24 @@ class MenuManager:
     def send_event(self, event, *args):
         return self.printer.send_event("menu:" + str(event), *args)
 
+    cmd_MENU_SHOW_help = "Show menu on a screen"
+    def cmd_MENU_SHOW(self, gcmd):
+        menuitem = self.lookup_menuitem(gcmd.get('ITEM'))
+
+        if self.is_running() and not gcmd.get_int('ROOT', 0):
+            self.stack_push(menuitem)
+        else:
+            curtime = self.printer.get_reactor().monotonic()
+            self.stack_root(menuitem, curtime)
+
     def is_running(self):
         return self.running
 
     def begin(self, eventtime, event):
-        self.menustack = []
-        self.timer = 0
-
-        container = self.root
         if event == 'long_click' and self.root_long_click != None:
-            container = self.root_long_click
-
-        if isinstance(container, MenuContainer):
-            # send begin event
-            self.send_event('begin', self)
-            self.update_context(eventtime)
-            if isinstance(container, MenuContainer):
-                container.init_selection()
-            self.stack_push(container)
-            self.running = True
-            return
-        elif self.root is not None:
-            logging.error("Invalid root, menu stopped!")
-        self.running = False
+            self.stack_root(self.root_long_click, eventtime)
+        else:
+            self.stack_root(self.root, eventtime)
 
     def get_status(self, eventtime):
         return {
@@ -803,6 +801,27 @@ class MenuManager:
             'exit': self._action_exit
         }
 
+    def stack_root(self, container, eventtime):
+        top = self.stack_peek()
+        if top is not None:
+            if isinstance(top, MenuList):
+                top.run_script('leave')
+
+        self.menustack = []
+
+        if isinstance(container, MenuContainer):
+            # send begin event
+            self.send_event('begin', self)
+            self.update_context(eventtime)
+            if isinstance(container, MenuContainer):
+                container.init_selection()
+            self.stack_push(container)
+            self.running = True
+            return
+        elif self.root is not None:
+            logging.error("Invalid root, menu stopped!")
+        self.running = False
+
     def stack_push(self, container):
         if not isinstance(container, MenuContainer):
             raise error("Wrong type, expected MenuContainer")
@@ -816,6 +835,7 @@ class MenuManager:
         if not container.is_editing():
             container.update_items()
             container.init_selection()
+        self.timer = 0
         self.menustack.append(container)
 
     def stack_pop(self, update=True):

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -698,7 +698,9 @@ class MenuManager:
         self.gcode_queue = []
         self.context = {}
         self.root = None
+        self.root_long_click = None
         self._root = config.get('menu_root', '__main')
+        self._root_long_click = config.get('menu_root_long_click', self._root)
         self.cols, self.rows = self.display.get_dimensions()
         self.timeout = config.getint('menu_timeout', 0)
         self.timer = 0
@@ -718,6 +720,9 @@ class MenuManager:
         self.load_menuitems(config)
         # Load menu root
         self.root = self.lookup_menuitem(self._root)
+        # Load long click menu
+        if self._root_long_click != self._root:
+            self.root_long_click = self.lookup_menuitem(self._root_long_click)
         # send init event
         self.send_event('init', self)
 
@@ -746,16 +751,21 @@ class MenuManager:
     def is_running(self):
         return self.running
 
-    def begin(self, eventtime):
+    def begin(self, eventtime, event):
         self.menustack = []
         self.timer = 0
-        if isinstance(self.root, MenuContainer):
+
+        container = self.root
+        if event == 'long_click' and self.root_long_click != None:
+            container = self.root_long_click
+
+        if isinstance(container, MenuContainer):
             # send begin event
             self.send_event('begin', self)
             self.update_context(eventtime)
-            if isinstance(self.root, MenuContainer):
-                self.root.init_selection()
-            self.stack_push(self.root)
+            if isinstance(container, MenuContainer):
+                container.init_selection()
+            self.stack_push(container)
             self.running = True
             return
         elif self.root is not None:
@@ -1023,7 +1033,7 @@ class MenuManager:
             self.press(event)
         else:
             # lets start and populate the menu items
-            self.begin(eventtime)
+            self.begin(eventtime, event)
 
     def key_event(self, key, eventtime):
         if key == 'click':


### PR DESCRIPTION
This allows to open a custom menu on top of a current one.

Usage pattern:
- `filament sensor` shows a preheat menu to automatically load filament

Example:

```ini
[filament_switch_sensor fsensor]
pause_on_runout: True
insert_gcode:
    MENU_SHOW ITEM=__load_filament

[menu __load_filament]
type: list
name: Load Filament

[menu __load_filament __pla]
type: command
enable: {('extruder' in printer) and ('heater_bed' in printer)}
name: PLA 200/60
gcode:
    M140 S60
    M104 S200
    LOAD_FILAMENT

[menu __load_filament __petg]
type: command
enable: {('extruder' in printer) and ('heater_bed' in printer)}
name: PETG 215/60
gcode:
    M140 S60
    M104 S215
    LOAD_FILAMENT
```

This is baed on https://github.com/KevinOConnor/klipper/pull/4336, due to changing a similar parts of codebase.