### PR TITLE
bltouch: Throw error if z_offset is not positive

### DIFF
--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -28,7 +28,7 @@ class BLTouchEndstopWrapper:
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
-        self.position_endstop = config.getfloat('z_offset')
+        self.position_endstop = config.getfloat('z_offset', above=0)
         self.stow_on_each_sample = config.getboolean('stow_on_each_sample',
                                                      True)
         self.probe_touch_mode = config.getboolean('probe_with_touch_mode',


### PR DESCRIPTION
I installed klipper for the first time yesterday and struggled with the error shown below:
![before](https://user-images.githubusercontent.com/43967290/121610402-f3548200-ca23-11eb-91ba-b614cf425fe4.png)
Eventually, someone pointed out that my z_offset was negative when it should be positive, which fixed my problem, but it would be nice for any newcomers who encounter this to immediately know the problem as opposed to look around for hours as I did.

This is a very small change, it just adds the "above=0" argument to the getconfig request for the z_offset in the bltouch.py file. With this change, when you attempt to use a negative z_offset you are given this error message as opposed to a unrelated one:
![after](https://user-images.githubusercontent.com/43967290/121610597-6827bc00-ca24-11eb-80fc-4297d7bd1ce0.png)

Signed-off-by: Ryan Zmuda ryanzmuda@gmail.com