### PR TITLE
stm32: SPI changes in preparation for ST7789V support

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -103,13 +103,13 @@ class MCU_SPI:
 
 # Helper to setup an spi bus from settings in a config section
 def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
-                        default_speed=100000, share_type=None):
+                        default_speed=100000, share_type=None, use_cs_pin=True):
     # Determine pin from config
     ppins = config.get_printer().lookup_object("pins")
     cs_pin = config.get(pin_option)
     cs_pin_params = ppins.lookup_pin(cs_pin, share_type=share_type)
     pin = cs_pin_params['pin']
-    if pin == 'None':
+    if pin == 'None' or not use_cs_pin:
         ppins.reset_pin_sharing(cs_pin_params)
         pin = None
     # Load bus parameters

--- a/src/stm32/spi.c
+++ b/src/stm32/spi.c
@@ -69,17 +69,15 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
 
     // Enable SPI
     SPI_TypeDef *spi = spi_bus[bus].spi;
-    if (!is_enabled_pclock((uint32_t)spi)) {
-        enable_pclock((uint32_t)spi);
-        gpio_peripheral(spi_bus[bus].miso_pin, spi_bus[bus].function, 1);
-        gpio_peripheral(spi_bus[bus].mosi_pin, spi_bus[bus].function, 0);
-        gpio_peripheral(spi_bus[bus].sck_pin, spi_bus[bus].function, 0);
+    enable_pclock((uint32_t)spi);
+    gpio_peripheral(spi_bus[bus].miso_pin, spi_bus[bus].function, 1);
+    gpio_peripheral(spi_bus[bus].mosi_pin, spi_bus[bus].function, 0);
+    gpio_peripheral(spi_bus[bus].sck_pin, spi_bus[bus].function, 0);
 
-        // Configure CR2 on stm32f0
+    // Configure CR2 on stm32f0
 #if CONFIG_MACH_STM32F0
-        spi->CR2 = SPI_CR2_FRXTH | (7 << SPI_CR2_DS_Pos);
+    spi->CR2 = SPI_CR2_FRXTH | (7 << SPI_CR2_DS_Pos);
 #endif
-    }
 
     // Calculate CR1 register
     uint32_t pclk = get_pclock_frequency((uint32_t)spi);

--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -24,10 +24,14 @@ enable_pclock(uint32_t periph_base)
         uint32_t pos = (periph_base - APB1PERIPH_BASE) / 0x400;
         RCC->APB1ENR |= (1<<pos);
         RCC->APB1ENR;
+        RCC->APB1RSTR |= (1<<pos);
+        RCC->APB1RSTR &= ~(1<<pos);
     } else if (periph_base < AHB1PERIPH_BASE) {
         uint32_t pos = (periph_base - APB2PERIPH_BASE) / 0x400;
         RCC->APB2ENR |= (1<<pos);
         RCC->APB2ENR;
+        RCC->APB2RSTR |= (1<<pos);
+        RCC->APB2RSTR &= ~(1<<pos);
     } else if (periph_base < AHB2PERIPH_BASE) {
         uint32_t pos = (periph_base - AHB1PERIPH_BASE) / 0x400;
         RCC->AHB1ENR |= (1<<pos);


### PR DESCRIPTION
As requested in https://github.com/KevinOConnor/klipper/pull/4374#issuecomment-860868153

* Use APB1RSTR etc. to reset peripherals when enabling them, as we already do for STM32F1.
* Always enable SPI buses and configure GPIOs for them, even if they appear already enabled (e.g. by the bootloader). It's cheap and harmless, and prevents misconfiguration.

Signed-off-by: Matthew Lloyd <github@matthewlloyd.net>