### PR TITLE
neopixel: add a get_status() method

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -346,3 +346,12 @@ The following information is available in the `z_tilt` object (this
 object is available if z_tilt is defined):
 - `applied`: True if the z-tilt leveling process has been run and completed
   successfully.
+
+# neopixel / dotstar
+The following information is available for each `[neopixel led_name]` and
+`[dotstar led_name]` defined in printer.cfg:
+- `color_data`:  An array of objects, with each object containing the RGBW
+  values for a led in the chain.  Note that not all configurations will contain
+  a white value.  Each value is represented as a float from 0 to 1.  For
+  example, the blue value of the second neopixel in a chain could be accessed
+  at `printer["neopixel <config_name>"].colordata[1].B`.

--- a/klippy/extras/dotstar.py
+++ b/klippy/extras/dotstar.py
@@ -82,6 +82,15 @@ class PrinterDotstar:
         else:
             #Send update now (so as not to wake toolhead and reset idle_timeout)
             lookahead_bgfunc(None)
+    def get_status(self, eventtime):
+        cdata = []
+        for i in range(self.chain_count):
+            idx = (i + 1) * 4
+            cdata.append(
+                {k: round(v / 255., 4) for k, v in
+                 zip("BGR", self.color_data[idx+1:idx+4])}
+            )
+        return {'color_data': cdata}
 
 def load_config_prefix(config):
     return PrinterDotstar(config)

--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -136,6 +136,16 @@ class PrinterNeoPixel:
         else:
             #Send update now (so as not to wake toolhead and reset idle_timeout)
             lookahead_bgfunc(None)
+    def get_status(self, eventtime):
+        cdata = []
+        elem_size = len(self.color_order)
+        for i in range(self.chain_count):
+            idx = i * elem_size
+            cdata.append(
+                {k: round(v / 255., 4) for k, v in
+                 zip(self.color_order, self.color_data[idx:idx+elem_size])}
+            )
+        return {'color_data': cdata}
 
 def load_config_prefix(config):
     return PrinterNeoPixel(config)


### PR DESCRIPTION
This request adds a get_status() method for both the neopixel and dotstar modules.  Status will return a `color_data` field that contains a list of RGB(W) values for each led in the chain.  For example, fetching the red value for the first led in a chain might look like the following:
```
printer["neopixel my_led"].colordata[0].R
```

This is primarily useful for clients that wish to provide a UI for changing LED settings, however it could have some use for templates as well.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>