### PR TITLE
config: Specify gear_ratio for Prusa Mini+ extruder

### DIFF
--- a/config/printer-prusa-mini-plus-2020.cfg
+++ b/config/printer-prusa-mini-plus-2020.cfg
@@ -66,7 +66,8 @@ step_pin: PD9
 dir_pin: !PD8
 enable_pin: !PD10
 microsteps: 16
-rotation_distance: 9.84615  # 200 * 16 / 325
+rotation_distance: 29.5385  # (200 * 16 * 3) / 325
+gear_ratio: 3:1
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB1

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -132,7 +132,8 @@ enable_pin:
 #   driver must always be enabled.
 rotation_distance:
 #   Distance (in mm) that the axis travels with one full rotation of
-#   the stepper motor. This parameter must be provided.
+#   the stepper motor (or final gear if gear_ratio is specified).
+#   This parameter must be provided.
 microsteps:
 #   The number of microsteps the stepper motor driver uses. This
 #   parameter must be provided.


### PR DESCRIPTION
Also clarifies the documentation for rotation_distance in the
stepper docs.

Signed-off-by: Matthew Lloyd <github@matthewlloyd.net>