### PR TITLE
Probe & manual_probe: add ability to save babystepping

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -207,6 +207,10 @@ The following standard commands are supported:
   for calibrating a Z position_endstop config setting. See the
   MANUAL_PROBE command for details on the parameters and the
   additional commands available while the tool is active.
+  `Z_ENDSTOP_UPDATE_POSITION`: Take the current Z Gcode offset (aka, 
+  babystepping), and subtract it from the stepper_z endstop_position. 
+  This acts to take a frequently used babystepping value, and "make 
+  it permanent".  Requires a `SAVE_CONFIG` to take effect.
 - `TUNING_TOWER COMMAND=<command> PARAMETER=<name> START=<value>
   FACTOR=<value> [BAND=<value>]`: A tool for tuning a parameter on
   each Z height during a print. The tool will run the given COMMAND
@@ -357,6 +361,10 @@ the [probe calibrate guide](Probe_Calibrate.md)):
   additional commands available while the tool is active. Please note,
   the PROBE_CALIBRATE command uses the speed variable to move in XY direction
   as well as Z.
+`PROBE_UPDATE_OFFSET`: Take the current Z Gcode offset (aka, 
+  babystepping), and subtract if from the probe's z_offset. 
+  This acts to take a frequently used babystepping value, and "make 
+  it permanent".  Requires a `SAVE_CONFIG` to take effect.
 
 ## BLTouch
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -207,9 +207,9 @@ The following standard commands are supported:
   for calibrating a Z position_endstop config setting. See the
   MANUAL_PROBE command for details on the parameters and the
   additional commands available while the tool is active.
-  `Z_ENDSTOP_UPDATE_POSITION`: Take the current Z Gcode offset (aka, 
-  babystepping), and subtract it from the stepper_z endstop_position. 
-  This acts to take a frequently used babystepping value, and "make 
+  `Z_ENDSTOP_UPDATE_POSITION`: Take the current Z Gcode offset (aka,
+  babystepping), and subtract it from the stepper_z endstop_position.
+  This acts to take a frequently used babystepping value, and "make
   it permanent".  Requires a `SAVE_CONFIG` to take effect.
 - `TUNING_TOWER COMMAND=<command> PARAMETER=<name> START=<value>
   FACTOR=<value> [BAND=<value>]`: A tool for tuning a parameter on
@@ -356,14 +356,12 @@ the [probe calibrate guide](Probe_Calibrate.md)):
   section.
 - `PROBE_CALIBRATE [SPEED=<speed>] [<probe_parameter>=<value>]`: Run a
   helper script useful for calibrating the probe's z_offset. See the
-  PROBE command for details on the optional probe parameters. See the
-  MANUAL_PROBE command for details on the SPEED parameter and the
-  additional commands available while the tool is active. Please note,
-  the PROBE_CALIBRATE command uses the speed variable to move in XY direction
-  as well as Z.
-`PROBE_UPDATE_OFFSET`: Take the current Z Gcode offset (aka, 
-  babystepping), and subtract if from the probe's z_offset. 
-  This acts to take a frequently used babystepping value, and "make 
+  PROBE command for details on the optional probe parameters. See
+  the MANUAL_PROBE command for details on the SPEED parameter and the additional commands available while the tool is active. Please note, the PROBE_CALIBRATE command uses the speed variable
+  to move in XY direction as well as Z.
+`PROBE_UPDATE_OFFSET`: Take the current Z Gcode offset (aka,
+  babystepping), and subtract if from the probe's z_offset.
+  This acts to take a frequently used babystepping value, and "make
   it permanent".  Requires a `SAVE_CONFIG` to take effect.
 
 ## BLTouch

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -21,9 +21,9 @@ class ManualProbe:
                 'Z_ENDSTOP_CALIBRATE', self.cmd_Z_ENDSTOP_CALIBRATE,
                 desc=self.cmd_Z_ENDSTOP_CALIBRATE_help)
             self.gcode.register_command(
-                'Z_ENDSTOP_UPDATE_POSITION',
-                self.cmd_Z_ENDSTOP_UPDATE_POSITION,
-                desc=self.cmd_Z_ENDSTOP_UPDATE_POSITION_help)
+                'Z_OFFSET_APPLY_ENDSTOP',
+                self.cmd_Z_OFFSET_APPLY_ENDSTOP,
+                desc=self.cmd_Z_OFFSET_APPLY_ENDSTOP_help)
     def manual_probe_finalize(self, kin_pos):
         if kin_pos is not None:
             self.gcode.respond_info("Z position is %.3f" % (kin_pos[2],))
@@ -43,7 +43,7 @@ class ManualProbe:
     cmd_Z_ENDSTOP_CALIBRATE_help = "Calibrate a Z endstop"
     def cmd_Z_ENDSTOP_CALIBRATE(self, gcmd):
         ManualProbeHelper(self.printer, gcmd, self.z_endstop_finalize)
-    def cmd_Z_ENDSTOP_UPDATE_POSITION(self,gcmd):
+    def cmd_Z_OFFSET_APPLY_ENDSTOP(self,gcmd):
         offset = self.gcode_move.get_status()['homing_origin'].z
         configfile = self.printer.lookup_object('configfile')
         if offset == 0:
@@ -56,7 +56,7 @@ class ManualProbe:
                 "with the above and restart the printer." % (new_calibrate))
             configfile.set('stepper_z', 'position_endstop',
                 "%.3f" % (new_calibrate,))
-    cmd_Z_ENDSTOP_UPDATE_POSITION_help = "Adjust the z endstop_position"
+    cmd_Z_OFFSET_APPLY_ENDSTOP_help = "Adjust the z endstop_position"
 
 # Verify that a manual probe isn't already in progress
 def verify_no_manual_probe(printer):

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -10,6 +10,7 @@ class ManualProbe:
         self.printer = config.get_printer()
         # Register commands
         self.gcode = self.printer.lookup_object('gcode')
+        self.gcode_move = self.printer.load_object(config, "gcode_move")
         self.gcode.register_command('MANUAL_PROBE', self.cmd_MANUAL_PROBE,
                                     desc=self.cmd_MANUAL_PROBE_help)
         zconfig = config.getsection('stepper_z')
@@ -43,8 +44,7 @@ class ManualProbe:
     def cmd_Z_ENDSTOP_CALIBRATE(self, gcmd):
         ManualProbeHelper(self.printer, gcmd, self.z_endstop_finalize)
     def cmd_Z_ENDSTOP_UPDATE_POSITION(self,gcmd):
-        gcode_move = self.printer.lookup_object('gcode_move')
-        offset = gcode_move.base_position[2]
+        offset = self.gcode_move.get_status()['homing_origin'].z
         configfile = self.printer.lookup_object('configfile')
         if offset == 0:
             self.gcode.respond_info("Nothing to do: Z Offset is 0")

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -20,7 +20,8 @@ class ManualProbe:
                 'Z_ENDSTOP_CALIBRATE', self.cmd_Z_ENDSTOP_CALIBRATE,
                 desc=self.cmd_Z_ENDSTOP_CALIBRATE_help)
             self.gcode.register_command(
-                'Z_ENDSTOP_UPDATE_POSITION', self.cmd_Z_ENDSTOP_UPDATE_POSITION, 
+                'Z_ENDSTOP_UPDATE_POSITION',
+                self.cmd_Z_ENDSTOP_UPDATE_POSITION,
                 desc=self.cmd_Z_ENDSTOP_UPDATE_POSITION_help)
     def manual_probe_finalize(self, kin_pos):
         if kin_pos is not None:
@@ -53,8 +54,9 @@ class ManualProbe:
                 "stepper_z: position_endstop: %.3f\n"
                 "The SAVE_CONFIG command will update the printer config file\n"
                 "with the above and restart the printer." % (new_calibrate))
-            configfile.set('stepper_z', 'position_endstop', "%.3f" % (new_calibrate,))
-    cmd_Z_ENDSTOP_UPDATE_POSITION_help = "Adjust the stepper_z endstop_position using the current gcode offset"
+            configfile.set('stepper_z', 'position_endstop',
+                "%.3f" % (new_calibrate,))
+    cmd_Z_ENDSTOP_UPDATE_POSITION_help = "Adjust the z endstop_position"
 
 # Verify that a manual probe isn't already in progress
 def verify_no_manual_probe(printer):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -27,6 +27,7 @@ class PrinterProbe:
         self.multi_probe_pending = False
         self.last_state = False
         self.last_z_result = 0.
+        self.gcode_move = self.printer.load_object(config, "gcode_move")
         # Infer Z position to move to during a probe
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')
@@ -267,8 +268,7 @@ class PrinterProbe:
                                        self.probe_calibrate_finalize)
     def cmd_PROBE_UPDATE_OFFSET(self,gcmd):
         z_offset = self.probe_calibrate_z
-        gcode_move = self.printer.lookup_object('gcode_move')
-        offset = gcode_move.base_position[2]
+        offset = self.gcode_move.get_status()['homing_origin'].z
         configfile = self.printer.lookup_object('configfile')
         if offset == 0:
             self.gcode.respond_info("Nothing to do: Z Offset is 0")

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -279,6 +279,7 @@ class PrinterProbe:
                 "with the above and restart the printer." % (self.name, new_calibrate))
             configfile.set(self.name, 'z_offset', "%.3f" % (new_calibrate,))
     cmd_PROBE_UPDATE_OFFSET_help = "Adjust the probe's z_offset using the current gcode offset"
+
 # Endstop wrapper that enables probe specific features
 class ProbeEndstopWrapper:
     def __init__(self, config):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -70,7 +70,8 @@ class PrinterProbe:
                                     desc=self.cmd_PROBE_CALIBRATE_help)
         self.gcode.register_command('PROBE_ACCURACY', self.cmd_PROBE_ACCURACY,
                                     desc=self.cmd_PROBE_ACCURACY_help)
-        self.gcode.register_command('PROBE_UPDATE_OFFSET', self.cmd_PROBE_UPDATE_OFFSET, 
+        self.gcode.register_command('PROBE_UPDATE_OFFSET',
+                                    self.cmd_PROBE_UPDATE_OFFSET,
                                     desc=self.cmd_PROBE_UPDATE_OFFSET_help)
     def _handle_homing_move_begin(self, hmove):
         if self.mcu_probe in hmove.get_mcu_endstops():
@@ -276,9 +277,10 @@ class PrinterProbe:
             self.gcode.respond_info(
                 "%s: z_offset: %.3f\n"
                 "The SAVE_CONFIG command will update the printer config file\n"
-                "with the above and restart the printer." % (self.name, new_calibrate))
+                "with the above and restart the printer."
+                % (self.name, new_calibrate))
             configfile.set(self.name, 'z_offset', "%.3f" % (new_calibrate,))
-    cmd_PROBE_UPDATE_OFFSET_help = "Adjust the probe's z_offset using the current gcode offset"
+    cmd_PROBE_UPDATE_OFFSET_help = "Adjust the probe's z_offset"
 
 # Endstop wrapper that enables probe specific features
 class ProbeEndstopWrapper:

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -71,9 +71,9 @@ class PrinterProbe:
                                     desc=self.cmd_PROBE_CALIBRATE_help)
         self.gcode.register_command('PROBE_ACCURACY', self.cmd_PROBE_ACCURACY,
                                     desc=self.cmd_PROBE_ACCURACY_help)
-        self.gcode.register_command('PROBE_UPDATE_OFFSET',
-                                    self.cmd_PROBE_UPDATE_OFFSET,
-                                    desc=self.cmd_PROBE_UPDATE_OFFSET_help)
+        self.gcode.register_command('Z_OFFSET_APPLY_PROBE',
+                                    self.cmd_Z_OFFSET_APPLY_PROBE,
+                                    desc=self.cmd_Z_OFFSET_APPLY_PROBE_help)
     def _handle_homing_move_begin(self, hmove):
         if self.mcu_probe in hmove.get_mcu_endstops():
             self.mcu_probe.probe_prepare(hmove)
@@ -266,7 +266,7 @@ class PrinterProbe:
         # Start manual probe
         manual_probe.ManualProbeHelper(self.printer, gcmd,
                                        self.probe_calibrate_finalize)
-    def cmd_PROBE_UPDATE_OFFSET(self,gcmd):
+    def cmd_Z_OFFSET_APPLY_PROBE(self,gcmd):
         z_offset = self.probe_calibrate_z
         offset = self.gcode_move.get_status()['homing_origin'].z
         configfile = self.printer.lookup_object('configfile')
@@ -280,7 +280,7 @@ class PrinterProbe:
                 "with the above and restart the printer."
                 % (self.name, new_calibrate))
             configfile.set(self.name, 'z_offset', "%.3f" % (new_calibrate,))
-    cmd_PROBE_UPDATE_OFFSET_help = "Adjust the probe's z_offset"
+    cmd_Z_OFFSET_APPLY_PROBE_help = "Adjust the probe's z_offset"
 
 # Endstop wrapper that enables probe specific features
 class ProbeEndstopWrapper:


### PR DESCRIPTION
Created two new extended gcodes: PROBE_UPDATE_OFFSET, and Z_ENDSTOP_UPDATE_POSITION
These use the z gcode offset to revise the probe offset, or z endstop position
allowing users to make a frequently used babystepping value permanent without
manual config editing.

Signed-off-by: Ben Eastep <shifting@shifting.ca>