### PR TITLE
MKS Robin e3 Config File Update

### DIFF
--- a/config/generic-mks-robin-e3.cfg
+++ b/config/generic-mks-robin-e3.cfg
@@ -38,8 +38,8 @@ position_max: 165
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB7
-dir_pin: !PB6
+step_pin: PB7 #PC14 if using board v1.1
+dir_pin: !PB6 #PC15 if using board v1.1
 enable_pin: !PB8
 microsteps: 16
 rotation_distance: 8


### PR DESCRIPTION
Z stepper was not working on my MKS Robin E3 new Klipper install. I reviewed the MKS documentation (https://github.com/makerbase-mks/MKS-Robin-E3-E3D/blob/master/hardware/MKS%20Robin%20E3%20V1.1_003/MKS%20Robin%20E3%20V1.1_003%20PIN.pdf) and noticed that the  z stepper pinout changed for board version 1.1. This config file update contains comments which note the change to future users. 

Signed-off-by: Eli Hyman eli.hyman@gmail.com