### PR TITLE
Add support for STM32F072 (used in the TurboCAN board)

### DIFF
--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -66,9 +66,9 @@ class PrinterTemperatureMCU:
             ('samd21', self.config_samd21), ('samd51', self.config_samd51),
             ('stm32f1', self.config_stm32f1), ('stm32f2', self.config_stm32f2),
             ('stm32f4', self.config_stm32f4),
-            ('stm32f042', self.config_stm32f042),
+            ('stm32f042', self.config_stm32f0x2),
             ('stm32f070', self.config_stm32f070),
-            ('stm32f072', self.config_stm32f070),
+            ('stm32f072', self.config_stm32f0x2),
             ('', self.config_unknown)]
         for name, func in cfg_funcs:
             if self.mcu_type.startswith(name):
@@ -123,7 +123,7 @@ class PrinterTemperatureMCU:
         cal_adc_110 = self.read16(addr2) / 4095.
         self.slope = (110. - 30.) / (cal_adc_110 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
-    def config_stm32f042(self):
+    def config_stm32f0x2(self):
         self.config_stm32f4(addr1=0x1FFFF7B8, addr2=0x1FFFF7C2)
     def config_stm32f070(self):
         self.slope = 3.3 / -.004300

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -68,6 +68,7 @@ class PrinterTemperatureMCU:
             ('stm32f4', self.config_stm32f4),
             ('stm32f042', self.config_stm32f042),
             ('stm32f070', self.config_stm32f070),
+            ('stm32f072', self.config_stm32f070),
             ('', self.config_unknown)]
         for name, func in cfg_funcs:
             if self.mcu_type.startswith(name):

--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -244,6 +244,7 @@ MCUTYPES = {
     'sam3': flash_atsam3, 'sam4': flash_atsam4, 'samd': flash_atsamd,
     'lpc176': flash_lpc176x, 'stm32f103': flash_stm32f1,
     'stm32f4': flash_stm32f4, 'stm32f042': flash_stm32f4,
+    'stm32f072': flash_stm32f4
 }
 
 

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -55,6 +55,9 @@ choice
     config MACH_STM32F070
         bool "STM32F070"
         select MACH_STM32F0
+    config MACH_STM32F072
+        bool "STM32F072"
+        select MACH_STM32F0
 endchoice
 
 config MACH_STM32F0
@@ -73,13 +76,14 @@ config HAVE_STM32_USBOTG
     default y if MACH_STM32F2 || MACH_STM32F4
 config HAVE_STM32_CANBUS
     bool
-    default y if MACH_STM32F1 || MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F042
+    default y if MACH_STM32F1 || MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F042 || MACH_STM32F072
 
 config MCU
     string
     default "stm32f031x6" if MACH_STM32F031
     default "stm32f042x6" if MACH_STM32F042
     default "stm32f070xb" if MACH_STM32F070
+    default "stm32f072xb" if MACH_STM32F072
     default "stm32f103xe" if MACH_STM32F103
     default "stm32f207xx" if MACH_STM32F207
     default "stm32f401xc" if MACH_STM32F401
@@ -102,7 +106,7 @@ config FLASH_SIZE
     hex
     default 0x4000 if MACH_STM32F031
     default 0x8000 if MACH_STM32F042
-    default 0x20000 if MACH_STM32F070
+    default 0x20000 if MACH_STM32F070 || MACH_STM32F072
     default 0x10000 if MACH_STM32F103 # Flash size of stm32f103x8 (64KiB)
     default 0x40000 if MACH_STM32F2 || MACH_STM32F401
     default 0x80000 if MACH_STM32F405 || MACH_STM32F407 || MACH_STM32F429 || MACH_STM32F446
@@ -115,7 +119,7 @@ config RAM_SIZE
     hex
     default 0x1000 if MACH_STM32F031
     default 0x1800 if MACH_STM32F042
-    default 0x4000 if MACH_STM32F070
+    default 0x4000 if MACH_STM32F070 || MACH_STM32F072
     default 0x5000 if MACH_STM32F103 # Ram size of stm32f103x8 (20KiB)
     default 0x20000 if MACH_STM32F207
     default 0x10000 if MACH_STM32F401


### PR DESCRIPTION
See https://github.com/henrikssn/TurboCAN

Temp compensation logic is common across STM32F0: https://techoverflow.net/2015/01/13/reading-stm32f0-internal-temperature-and-voltage-using-chibios/