### PR TITLE
Add Make Clean Instruction

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -50,7 +50,16 @@ make menuconfig
 ```
 
 Select the appropriate micro-controller and review any other options
-provided. Once configured, run:
+provided.
+
+Once configured, clean up after the configuration script (important!):
+
+```
+make clean
+```
+
+Then build the firmware:
+
 
 ```
 make


### PR DESCRIPTION
Adds the instruction to run `make clean` after `make menuconfig` if `make` will be run afterwards, otherwise the build will fail as described in the issues below.

This behavior is unexpected and confusing, and there is no official documentation or instruction regarding the issue itself <s>nor what must be done to allow the build to continue successfully</s>. This step is shown [in the FAQ, under "How Do I Upgrade"](https://github.com/KevinOConnor/klipper/blob/master/docs/FAQ.md#how-do-i-upgrade-to-the-latest-software) ([thanks @ShohninDmitriy](https://github.com/KevinOConnor/klipper/pull/4415#issuecomment-866246091)) but is not explained, and is still absent from the installation instructions, which currently fail without this step, causing a lot of confusion for people starting out (see the referenced issues at the bottom, and potentially others).

This aims to at least partially resolve this insufficiency by just telling viewers of the installation documentation to simply clean up after `menuconfig` manually.

This should ideally also (or probably only) be resolved in the implementation of the `menuconfig` script, but until that happens, this should suffice and help get people going with a little less hassle than reading through the issues and finding one of the comments with this suggested fix.

Fixes #4409, #3682