### PR TITLE
Add BIBO2 Touch Printer

### DIFF
--- a/config/printer-bibo2-touch-2020.cfg
+++ b/config/printer-bibo2-touch-2020.cfg
@@ -276,12 +276,34 @@ screw1: 0,90
 screw2: -90,-90
 screw3: 90,-90
 
-
+#####################################################################################
 # BLTouch Config
+#
+# This is wired to the Z+ connector block.
+# White wire goes to bottom pin on the Z+ connector (D19)
+# Black wire goes to middle pin on the Z+ connector (Ground)
+# 
+# Brown wire goes to bottom right of "Servos 1" Block (Ground)
+# Red wire goes to the bottom middle of "Servos 1" Block (5V)
+# Yellow wire goes to the bottom left of the "Servoes 1" Block (D11)
+#
+# You will need to adjust your offsets to match however you mounted the BLTouch
+#
+# In my case, my BLTouch is mounted on the left side of the printhead, 77.5mm away
+# from the tip of E0 (aka the rightmost extruder nozzle). Negative means further left
+#
+# It is directly in line with the two nozzles, which is why the Y-offset is zero.
+#
+# Note that you really have to hook the white wire to one of the endstop connectors,
+# you can't just plug it into any random data pin on the board. The endstop connectors
+# have some extra circuitry between the MCU and the pin to debounce. When I tried
+# hooking the white wire up to a data pin on AUX-2 it didn't work. You really gotta
+# use the endstop pins.
+#####################################################################################
+
 #[bltouch]
 #sensor_pin: ar19
 #control_pin: ar11
-## You will definitly want to change these offsets depending on where you install your bltouch
 #x_offset: -77.5
 #y_offset: 0
 #z_offset: -2.4

--- a/config/printer-bibo2-touch-2020.cfg
+++ b/config/printer-bibo2-touch-2020.cfg
@@ -1,0 +1,301 @@
+#####################################################################################
+# Configuration for BIBO 2 Touch with a MKS GEN L
+# X,Y,Z,E are A4988
+#####################################################################################
+
+[printer]
+kinematics: cartesian
+max_velocity: 350
+max_accel: 350
+max_accel_to_decel: 175
+square_corner_velocity: 5
+max_z_velocity: 16
+max_z_accel: 300
+
+[input_shaper]
+# you may want to adjust these
+shaper_freq_x: 26.8938
+shaper_freq_y: 24.4499
+shaper_type: mzv
+
+#####################################################################################
+
+[stepper_x]
+step_pin: ar54
+dir_pin: ar55
+enable_pin: !ar38
+#step_distance: .01
+rotation_distance: 32
+microsteps: 16
+endstop_pin: !ar2 #^ar3
+position_endstop: 141
+position_min: -107
+position_max: 141
+homing_speed: 50
+
+
+#####################################################################################
+
+[stepper_y]
+step_pin: ar60
+dir_pin: !ar61
+enable_pin: !ar56
+#step_distance: .01
+rotation_distance: 31.76
+microsteps: 16
+endstop_pin: !ar15 #^ar14
+position_endstop: 93
+position_min: -93
+position_max: 93
+homing_speed: 50
+
+#####################################################################################
+
+[stepper_z]
+step_pin: ar46
+dir_pin: ar48
+enable_pin: !ar62
+#step_distance: .0025
+rotation_distance: 7.9584
+microsteps: 16
+# Comment this out if using BLTouch
+endstop_pin: ^!ar18
+# Uncomment this if using BLTouch
+#endstop_pin: probe:z_virtual_endstop
+position_min: -15
+position_max: 150
+homing_retract_dist: 10 # to fix bltouch clone error
+
+#####################################################################################
+ 
+[extruder]
+max_extrude_only_distance: 100
+step_pin: ar26
+dir_pin: ar28
+enable_pin: !ar24
+#step_distance: 0.01068376068
+rotation_distance: 29.40
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+#control: pid
+#pid_kp: 19.469
+#pid_ki: 0.843
+#pid_kd: 112.436
+min_temp: 10
+max_temp: 275
+pressure_advance: 0.055
+#pressure_advance_lookahead_time: 0.05
+max_extrude_cross_section:50
+
+# Script to change back to the main extruder
+[gcode_macro T0]
+gcode:
+    SET_GCODE_OFFSET X=0                        # Clear X offset
+    ACTIVATE_EXTRUDER EXTRUDER=extruder
+
+[extruder1]
+max_extrude_only_distance: 100
+step_pin: ar36
+dir_pin: !ar34
+enable_pin: !ar30
+#step_distance: 0.01068376068
+rotation_distance: 29.40
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: ar7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog15
+#control: pid
+#pid_kp = 19.329
+#pid_ki = 0.826
+#pid_kd = 113.075
+min_temp: 10
+max_temp: 275
+pressure_advance: 0.055
+#pressure_advance_lookahead_time: 0.05
+max_extrude_cross_section:50
+
+
+# Script to activate second extruder
+[gcode_macro T1]
+gcode:
+    SET_GCODE_OFFSET X=33.0                       # Account for different X offset
+    ACTIVATE_EXTRUDER EXTRUDER=extruder1
+
+
+#####################################################################################
+
+[heater_bed]
+heater_pin: ar8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+control = pid
+min_temp: 10
+max_temp: 125
+
+
+
+#####################################################################################
+
+[filament_switch_sensor my_sensor]
+pause_on_runout: True
+#   When set to True, a PAUSE will execute immediately after a runout
+#   is detected. Note that if pause_on_runout is False and the
+#   runout_gcode is omitted then runout detection is disabled. Default
+#   is True.
+runout_gcode: M600
+#   A list of G-Code commands to execute after a filament runout is
+#   detected. See docs/Command_Templates.md for G-Code format. If
+#   pause_on_runout is set to True this G-Code will run after the
+#   PAUSE is complete. The default is not to run any G-Code commands.
+#insert_gcode:
+#   A list of G-Code commands to execute after a filament insert is
+#   detected. See docs/Command_Templates.md for G-Code format. The
+#   default is not to run any G-Code commands, which disables insert
+#   detection.
+#event_delay: 3.0
+#   The minimum amount of time in seconds to delay between events.
+#   Events triggered during this time period will be silently
+#   ignored. The default is 3 seconds.
+#pause_delay: 0.5
+#   The amount of time to delay, in seconds, between the pause command
+#   dispatch and execution of the runout_gcode. It may be useful to
+#   increase this delay if OctoPrint exhibits strange pause behavior.
+#   Default is 0.5 seconds.
+switch_pin: ar4
+#   The pin on which the switch is connected. This parameter must be
+#   provided.
+
+#####################################################################################
+
+[fan]
+pin: ar9
+max_power: 1.0
+
+#####################################################################################
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
+pin_map: arduino
+
+
+######################################################################
+# Filament Change
+######################################################################
+
+# M600: Filament Change. This macro will pause the printer, move the
+# tool to the change position, and retract the filament 50mm. Adjust
+# the retraction settings for your own extruder. After filament has
+# been changed, the print can be resumed from its previous position
+# with the "RESUME" gcode.
+
+[gcode_macro M600]
+default_parameter_X: 141
+default_parameter_Y: 0
+default_parameter_Z: 10
+gcode:
+    SAVE_GCODE_STATE NAME=M600_state
+    PAUSE
+    G91
+    G1 E-.8 F2700
+    G1 Z{Z}
+    G90
+    G1 X{X} Y{Y} F3000
+    G91
+    G1 E-50 F1000
+    RESTORE_GCODE_STATE NAME=M600_state
+
+[gcode_macro M900]
+description: Set the pressure advance
+gcode:
+    SET_PRESSURE_ADVANCE ADVANCE={ params.K|float}
+
+
+[virtual_sdcard]
+path: ~/gcode_files
+
+[display_status]
+
+[pause_resume]
+
+[gcode_macro PAUSE]
+rename_existing: BASE_PAUSE
+# change this if you need more or less extrusion
+variable_extrude: 1.0
+gcode:
+  ##### read E from pause macro #####
+  {% set E = printer["gcode_macro PAUSE"].extrude|float %}
+  ##### set park positon for x and y #####
+  # default is your max posion from your printer.cfg
+  {% set x_park = printer.toolhead.axis_maximum.x|float - 5.0 %}
+  {% set y_park = printer.toolhead.axis_maximum.y|float - 5.0 %}
+  ##### calculate save lift position #####
+  {% set max_z = printer.toolhead.axis_maximum.z|float %}
+  {% set act_z = printer.toolhead.position.z|float %}
+  {% if act_z < (max_z - 2.0) %}
+      {% set z_safe = 2.0 %}
+  {% else %}
+      {% set z_safe = max_z - act_z %}
+  {% endif %}
+  ##### end of definitions #####
+  SAVE_GCODE_STATE NAME=PAUSE_state
+  BASE_PAUSE
+  G91
+  G1 E-{E} F2100
+  G1 Z{z_safe} F900
+  G90
+  G1 X{x_park} Y{y_park} F6000
+
+[gcode_macro RESUME]
+rename_existing: BASE_RESUME
+gcode:
+  ##### read E from pause macro #####
+  {% set E = printer["gcode_macro PAUSE"].extrude|float %}
+  ##### end of definitions #####
+  G91
+  G1 E{E} F2100
+  RESTORE_GCODE_STATE NAME=PAUSE_state
+  BASE_RESUME
+
+[gcode_macro CANCEL_PRINT]
+rename_existing: BASE_CANCEL_PRINT
+gcode:
+  TURN_OFF_HEATERS
+  CLEAR_PAUSE
+  SDCARD_RESET_FILE
+  BASE_CANCEL_PRINT
+
+# Very handy for manual bed leveling!
+[bed_screws]
+screw1: 0,90
+screw2: -90,-90
+screw3: 90,-90
+
+
+# BLTouch Config
+#[bltouch]
+#sensor_pin: ar19
+#control_pin: ar11
+## You will definitly want to change these offsets depending on where you install your bltouch
+#x_offset: -77.5
+#y_offset: 0
+#z_offset: -2.4
+#speed: 5.0
+
+#[safe_z_home]
+#home_xy_position: 77.5,0 # Change coordinates so that the BLTouch probe falls onto the center of the bed
+#speed: 50
+#z_hop: 10
+#z_hop_speed: 5
+
+#[bed_mesh]
+#speed: 120
+#horizontal_move_z: 5
+#mesh_min: -85,-90
+#mesh_max: 60,80
+#probe_count: 6

--- a/config/printer-bibo2-touch-2020.cfg
+++ b/config/printer-bibo2-touch-2020.cfg
@@ -79,6 +79,10 @@ sensor_type: EPCOS 100K B57560G104F
 sensor_pin: analog13
 min_temp: 10
 max_temp: 250
+control: pid
+pid_kp: 19.469
+pid_ki: 0.843
+pid_kd: 112.436
 
 # Script to change back to the main extruder
 [gcode_macro T0]
@@ -100,6 +104,10 @@ sensor_type: EPCOS 100K B57560G104F
 sensor_pin: analog15
 min_temp: 10
 max_temp: 250
+control: pid
+pid_kp: 19.469
+pid_ki: 0.843
+pid_kd: 112.436
 
 # Script to activate second extruder
 [gcode_macro T1]

--- a/config/printer-bibo2-touch-2020.cfg
+++ b/config/printer-bibo2-touch-2020.cfg
@@ -70,7 +70,7 @@ max_extrude_only_distance: 100
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-rotation_distance: 32
+rotation_distance: 29
 microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750
@@ -95,7 +95,7 @@ max_extrude_only_distance: 100
 step_pin: ar36
 dir_pin: !ar34
 enable_pin: !ar30
-rotation_distance: 32
+rotation_distance: 29
 microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750

--- a/config/printer-bibo2-touch-2020.cfg
+++ b/config/printer-bibo2-touch-2020.cfg
@@ -39,7 +39,7 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-rotation_distance: 31.76
+rotation_distance: 32
 microsteps: 16
 endstop_pin: !ar15 #^ar14
 position_endstop: 93
@@ -53,7 +53,7 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-rotation_distance: 7.9584
+rotation_distance: 8
 microsteps: 16
 # Comment this out if using BLTouch
 endstop_pin: ^!ar18
@@ -70,7 +70,7 @@ max_extrude_only_distance: 100
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-rotation_distance: 29.40
+rotation_distance: 32
 microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750
@@ -91,7 +91,7 @@ max_extrude_only_distance: 100
 step_pin: ar36
 dir_pin: !ar34
 enable_pin: !ar30
-rotation_distance: 29.40
+rotation_distance: 32
 microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750

--- a/config/printer-bibo2-touch-2020.cfg
+++ b/config/printer-bibo2-touch-2020.cfg
@@ -24,7 +24,6 @@ shaper_type: mzv
 step_pin: ar54
 dir_pin: ar55
 enable_pin: !ar38
-#step_distance: .01
 rotation_distance: 32
 microsteps: 16
 endstop_pin: !ar2 #^ar3
@@ -40,7 +39,6 @@ homing_speed: 50
 step_pin: ar60
 dir_pin: !ar61
 enable_pin: !ar56
-#step_distance: .01
 rotation_distance: 31.76
 microsteps: 16
 endstop_pin: !ar15 #^ar14
@@ -55,7 +53,6 @@ homing_speed: 50
 step_pin: ar46
 dir_pin: ar48
 enable_pin: !ar62
-#step_distance: .0025
 rotation_distance: 7.9584
 microsteps: 16
 # Comment this out if using BLTouch
@@ -67,13 +64,12 @@ position_max: 150
 homing_retract_dist: 10 # to fix bltouch clone error
 
 #####################################################################################
- 
+
 [extruder]
 max_extrude_only_distance: 100
 step_pin: ar26
 dir_pin: ar28
 enable_pin: !ar24
-#step_distance: 0.01068376068
 rotation_distance: 29.40
 microsteps: 16
 nozzle_diameter: 0.400
@@ -81,15 +77,8 @@ filament_diameter: 1.750
 heater_pin: ar10
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: analog13
-#control: pid
-#pid_kp: 19.469
-#pid_ki: 0.843
-#pid_kd: 112.436
 min_temp: 10
-max_temp: 275
-pressure_advance: 0.055
-#pressure_advance_lookahead_time: 0.05
-max_extrude_cross_section:50
+max_temp: 250
 
 # Script to change back to the main extruder
 [gcode_macro T0]
@@ -102,7 +91,6 @@ max_extrude_only_distance: 100
 step_pin: ar36
 dir_pin: !ar34
 enable_pin: !ar30
-#step_distance: 0.01068376068
 rotation_distance: 29.40
 microsteps: 16
 nozzle_diameter: 0.400
@@ -110,16 +98,8 @@ filament_diameter: 1.750
 heater_pin: ar7
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: analog15
-#control: pid
-#pid_kp = 19.329
-#pid_ki = 0.826
-#pid_kd = 113.075
 min_temp: 10
-max_temp: 275
-pressure_advance: 0.055
-#pressure_advance_lookahead_time: 0.05
-max_extrude_cross_section:50
-
+max_temp: 250
 
 # Script to activate second extruder
 [gcode_macro T1]
@@ -136,7 +116,7 @@ sensor_type: EPCOS 100K B57560G104F
 sensor_pin: analog14
 control = pid
 min_temp: 10
-max_temp: 125
+max_temp: 110
 
 
 
@@ -282,7 +262,7 @@ screw3: 90,-90
 # This is wired to the Z+ connector block.
 # White wire goes to bottom pin on the Z+ connector (D19)
 # Black wire goes to middle pin on the Z+ connector (Ground)
-# 
+#
 # Brown wire goes to bottom right of "Servos 1" Block (Ground)
 # Red wire goes to the bottom middle of "Servos 1" Block (5V)
 # Yellow wire goes to the bottom left of the "Servoes 1" Block (D11)


### PR DESCRIPTION
Added basic configuration for a BIBO2 Touch printer.

Commented out the chunks you'd want if you were setting up a BLTouch probe.

Signed-off-by: Cory R. King <me@coryking.com>