### PR TITLE
TMC driver improvements

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -351,10 +351,9 @@ class TMCVirtualPinHelper:
         reg = self.fields.lookup_register("en_pwm_mode", None)
         if reg is None:
             self.en_pwm = not self.fields.get_field("en_spreadCycle")
-            self.pwmthrs = self.fields.get_field("TPWMTHRS")
         else:
             self.en_pwm = self.fields.get_field("en_pwm_mode")
-            self.pwmthrs = 0
+        self.pwmthrs = self.fields.get_field("TPWMTHRS")
         self.coolthrs = self.fields.get_field("TCOOLTHRS")
         self.printer.register_event_handler("homing:homing_move_begin",
                                             self.handle_homing_move_begin)
@@ -374,6 +373,8 @@ class TMCVirtualPinHelper:
             self.mcu_tmc.set_register("GCONF", gconf_val)
         else:
             # On earlier drivers, "stealthchop" must be disabled
+            tp_val = self.fields.set_field("TPWMTHRS", 0xfffff)
+            self.mcu_tmc.set_register("TPWMTHRS", tp_val)
             self.fields.set_field("en_pwm_mode", 0)
             gconf_val = self.fields.set_field(self.diag_pin_field, 1)
             self.mcu_tmc.set_register("GCONF", gconf_val)
@@ -388,6 +389,8 @@ class TMCVirtualPinHelper:
             self.mcu_tmc.set_register("TPWMTHRS", tp_val)
             val = self.fields.set_field("en_spreadCycle", not self.en_pwm)
         else:
+            tp_val = self.fields.set_field("TPWMTHRS", self.pwmthrs)
+            self.mcu_tmc.set_register("TPWMTHRS", tp_val)
             self.fields.set_field("en_pwm_mode", self.en_pwm)
             val = self.fields.set_field(self.diag_pin_field, 0)
         self.mcu_tmc.set_register("GCONF", val)

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -482,3 +482,42 @@ def TMCcoolStepHelper(config, mcu_tmc, tmc_freq):
         'coolStep_min_velocity_threshold', None, minval=0.)
     fields.set_field("TCOOLTHRS",
         TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, 0))
+
+
+class TMCHomingCurrentHelper:
+    def __init__(self, config, mcu_tmc, current_helper):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.mcu_tmc = mcu_tmc
+        self.current_helper = current_helper
+        self.run_current = 0
+        self.hold_current = 0
+        self.homing_current = config.getfloat(
+            'homing_current', None, minval=0.)
+        self.printer.register_event_handler("homing:home_rails_begin",
+                                            self.handle_home_rails_begin)
+        self.printer.register_event_handler("homing:home_rails_end",
+                                            self.handle_home_rails_end)
+
+    def handle_home_rails_begin(self, homing, rails):
+        if self.homing_current is None:
+            return
+        names = [stepper.get_name() for rail in rails
+            for stepper in rail.get_steppers()]
+        if self.name not in names:
+            return
+        logging.info("homing_begin for %s", self.name)
+        self.run_current, self.hold_current, max_current = (
+            self.current_helper.get_current())
+        self.current_helper.set_current(
+            self.homing_current, self.homing_current, None)
+    def handle_home_rails_end(self, homing, rails):
+        if self.homing_current is None:
+            return
+        names = [stepper.get_name() for rail in rails
+            for stepper in rail.get_steppers()]
+        if self.name not in names:
+            return
+        logging.info("homing_end for %s", self.name)
+        self.current_helper.set_current(
+            self.run_current, self.hold_current, None)

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -333,6 +333,7 @@ class TMCVirtualPinHelper:
         self.mcu_endstop = None
         self.en_pwm = False
         self.pwmthrs = 0
+        self.tcoolthrs = 0
         # Register virtual_endstop pin
         name_parts = config.get_name().split()
         ppins = self.printer.lookup_object("pins")
@@ -354,6 +355,7 @@ class TMCVirtualPinHelper:
         else:
             self.en_pwm = self.fields.get_field("en_pwm_mode")
             self.pwmthrs = 0
+        self.coolthrs = self.fields.get_field("TCOOLTHRS")
         self.printer.register_event_handler("homing:homing_move_begin",
                                             self.handle_homing_move_begin)
         self.printer.register_event_handler("homing:homing_move_end",
@@ -368,12 +370,13 @@ class TMCVirtualPinHelper:
             # On "stallguard4" drivers, "stealthchop" must be enabled
             tp_val = self.fields.set_field("TPWMTHRS", 0)
             self.mcu_tmc.set_register("TPWMTHRS", tp_val)
-            val = self.fields.set_field("en_spreadCycle", 0)
+            gconf_val = self.fields.set_field("en_spreadCycle", 0)
+            self.mcu_tmc.set_register("GCONF", gconf_val)
         else:
             # On earlier drivers, "stealthchop" must be disabled
             self.fields.set_field("en_pwm_mode", 0)
-            val = self.fields.set_field(self.diag_pin_field, 1)
-        self.mcu_tmc.set_register("GCONF", val)
+            gconf_val = self.fields.set_field(self.diag_pin_field, 1)
+            self.mcu_tmc.set_register("GCONF", gconf_val)
         tc_val = self.fields.set_field("TCOOLTHRS", 0xfffff)
         self.mcu_tmc.set_register("TCOOLTHRS", tc_val)
     def handle_homing_move_end(self, hmove):
@@ -388,7 +391,7 @@ class TMCVirtualPinHelper:
             self.fields.set_field("en_pwm_mode", self.en_pwm)
             val = self.fields.set_field(self.diag_pin_field, 0)
         self.mcu_tmc.set_register("GCONF", val)
-        tc_val = self.fields.set_field("TCOOLTHRS", 0)
+        tc_val = self.fields.set_field("TCOOLTHRS", self.coolthrs)
         self.mcu_tmc.set_register("TCOOLTHRS", tc_val)
 
 
@@ -423,18 +426,29 @@ class TMCMicrostepHelper:
         mscnt = self.fields.get_field(field_name, reg)
         return 1023 - mscnt, 1024
 
-# Helper to configure "stealthchop" mode
-def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):
+# Helper for calculating TSTEP based values from velocity
+def TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, default_val):
     fields = mcu_tmc.get_fields()
-    en_pwm_mode = False
-    velocity = config.getfloat('stealthchop_threshold', 0., minval=0.)
-    if velocity:
+    if velocity is None:
+        return default_val
+    elif velocity > 0:
         stepper_name = " ".join(config.get_name().split()[1:])
         stepper_config = config.getsection(stepper_name)
         step_dist = stepper.parse_step_distance(stepper_config)
         step_dist_256 = step_dist / (1 << fields.get_field("MRES"))
         threshold = int(tmc_freq * step_dist_256 / velocity + .5)
-        fields.set_field("TPWMTHRS", max(0, min(0xfffff, threshold)))
+        return max(0, min(0xfffff, threshold))
+    else:
+        return 0xfffff
+
+# Helper to configure stealthChop-spreadCycle transition velocity
+def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):
+    fields = mcu_tmc.get_fields()
+    en_pwm_mode = False
+    velocity = config.getfloat('stealthchop_threshold', None, minval=0.)
+    tpwmthrs = TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, 0xfffff)
+    fields.set_field("TPWMTHRS", tpwmthrs)
+    if velocity is not None:
         en_pwm_mode = True
     reg = fields.lookup_register("en_pwm_mode", None)
     if reg is not None:
@@ -442,3 +456,20 @@ def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):
     else:
         # TMC2208 uses en_spreadCycle
         fields.set_field("en_spreadCycle", not en_pwm_mode)
+
+# Helper to configure spreadCycle-highVelocity transition velocity
+# It is also the top speed for coolStep and stallGuard operation
+def TMCTHIGHHelper(config, mcu_tmc, tmc_freq):
+    fields = mcu_tmc.get_fields()
+    velocity = config.getfloat(
+        'high_velocity_threshold', None, minval=0.)
+    fields.set_field("THIGH",
+        TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, 0))
+
+# Helper to configure coolStep and stallGuard lower velocity limit
+def TMCcoolStepHelper(config, mcu_tmc, tmc_freq):
+    fields = mcu_tmc.get_fields()
+    velocity = config.getfloat(
+        'coolStep_min_velocity_threshold', None, minval=0.)
+    fields.set_field("TCOOLTHRS",
+        TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, 0))

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -255,7 +255,7 @@ class TMC2130:
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = MCU_TMC_SPI(config, Registers, self.fields)
         # Allow virtual pins to be created
-        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Register commands
         current_helper = TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -260,6 +260,7 @@ class TMC2130:
         current_helper = TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
         mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         self.get_microsteps = mh.get_microsteps

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -265,19 +265,42 @@ class TMC2130:
         self.get_microsteps = mh.get_microsteps
         self.get_phase = mh.get_phase
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCTHIGHHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCcoolStepHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # CHOPCONF
         set_config_field(config, "toff", 4)
         set_config_field(config, "hstrt", 0)
         set_config_field(config, "hend", 7)
+        set_config_field(config, "fd3", 0)
+        set_config_field(config, "disfdcc", 0)
+        set_config_field(config, "rndtf", 0)
+        set_config_field(config, "chm", 0)
         set_config_field(config, "TBL", 1)
+        set_config_field(config, "vhighfs", 0)
+        set_config_field(config, "vhighchm", 0)
+        set_config_field(config, "sync", 0)
+        set_config_field(config, "diss2g", 0)
+        # COOLCONF
+        set_config_field(config, "semin", 0)
+        set_config_field(config, "seup", 0)
+        set_config_field(config, "semax", 0)
+        set_config_field(config, "sedn", 0)
+        set_config_field(config, "seimin", 0)
+        set_config_field(config, "sgt", 0)
+        set_config_field(config, "sfilt", 0)
+        # IHOLDIRUN
         set_config_field(config, "IHOLDDELAY", 8)
-        set_config_field(config, "TPOWERDOWN", 0)
+        # PWMCONF
         set_config_field(config, "PWM_AMPL", 128)
         set_config_field(config, "PWM_GRAD", 4)
         set_config_field(config, "pwm_freq", 1)
-        set_config_field(config, "pwm_autoscale", True)
-        set_config_field(config, "sgt", 0)
+        set_config_field(config, "pwm_autoscale", 1)
+        set_config_field(config, "pwm_symmetric", 0)
+        set_config_field(config, "freewheel", 0)
+        # TPOWERDOWN
+        set_config_field(config, "TPOWERDOWN", 0)
 
 def load_config_prefix(config):
     return TMC2130(config)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -191,6 +191,7 @@ class TMC2208:
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -201,19 +201,27 @@ class TMC2208:
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
         set_config_field(config, "TBL", 2)
+        set_config_field(config, "diss2g", 0)
+        set_config_field(config, "diss2vs", 0)
+        # IHOLDIRUN
         set_config_field(config, "IHOLDDELAY", 8)
-        set_config_field(config, "TPOWERDOWN", 20)
+        # PWMCONF
         set_config_field(config, "PWM_OFS", 36)
         set_config_field(config, "PWM_GRAD", 14)
         set_config_field(config, "pwm_freq", 1)
-        set_config_field(config, "pwm_autoscale", True)
-        set_config_field(config, "pwm_autograd", True)
+        set_config_field(config, "pwm_autoscale", 1)
+        set_config_field(config, "pwm_autograd", 1)
+        set_config_field(config, "freewheel", 0)
         set_config_field(config, "PWM_REG", 8)
         set_config_field(config, "PWM_LIM", 12)
+        # TPOWERDOWN
+        set_config_field(config, "TPOWERDOWN", 20)
+
     def read_translate(self, reg_name, val):
         if reg_name == "IOIN":
             drv_type = self.fields.get_field("SEL_A", val)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -73,22 +73,38 @@ class TMC2209:
         self.get_microsteps = mh.get_microsteps
         self.get_phase = mh.get_phase
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCcoolStepHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
         set_config_field(config, "TBL", 2)
+        set_config_field(config, "diss2g", 0)
+        set_config_field(config, "diss2vs", 0)
+        # COOLCONF
+        set_config_field(config, "semin", 0)
+        set_config_field(config, "seup", 0)
+        set_config_field(config, "semax", 0)
+        set_config_field(config, "sedn", 0)
+        set_config_field(config, "seimin", 0)
+        # IHOLDIRUN
         set_config_field(config, "IHOLDDELAY", 8)
-        set_config_field(config, "TPOWERDOWN", 20)
+        # PWMCONF
         set_config_field(config, "PWM_OFS", 36)
         set_config_field(config, "PWM_GRAD", 14)
         set_config_field(config, "pwm_freq", 1)
-        set_config_field(config, "pwm_autoscale", True)
-        set_config_field(config, "pwm_autograd", True)
+        set_config_field(config, "pwm_autoscale", 1)
+        set_config_field(config, "pwm_autograd", 1)
+        set_config_field(config, "freewheel", 0)
         set_config_field(config, "PWM_REG", 8)
         set_config_field(config, "PWM_LIM", 12)
+        # TPOWERDOWN
+        set_config_field(config, "TPOWERDOWN", 20)
+        # SGTHRS
         set_config_field(config, "SGTHRS", 0)
+
 
 def load_config_prefix(config):
     return TMC2209(config)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -60,7 +60,7 @@ class TMC2209:
                                       FieldFormatters)
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields, 3)
         # Allow virtual pins to be created
-        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Register commands
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -65,6 +65,7 @@ class TMC2209:
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -229,6 +229,7 @@ class TMC2660:
         current_helper = TMC2660CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # DRVCTRL
         mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         self.get_microsteps = mh.get_microsteps

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -229,7 +229,6 @@ class TMC2660:
         current_helper = TMC2660CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
-
         # DRVCTRL
         mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         self.get_microsteps = mh.get_microsteps
@@ -253,11 +252,9 @@ class TMC2660:
         set_config_field(config, "semax", 0)
         set_config_field(config, "seup", 0)
         set_config_field(config, "semin", 0)
-
         # SGSCONF
         set_config_field(config, "sfilt", 0)
         set_config_field(config, "sgt", 0)
-
         # DRVCONF
         set_config_field(config, "SLPH", 0)
         set_config_field(config, "SLPL", 0)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -211,6 +211,9 @@ Fields["TPWMTHRS"] = {
 Fields["TCOOLTHRS"] = {
     "TCOOLTHRS":                0xfffff << 0
 }
+Fields["THIGH"] = {
+    "THIGH":                    0xfffff << 0
+}
 Fields["TSTEP"] = {
     "TSTEP":                    0xfffff << 0
 }
@@ -299,8 +302,10 @@ class TMC5160:
         self.get_microsteps = mh.get_microsteps
         self.get_phase = mh.get_phase
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
-        #   CHOPCONF
+        tmc.TMCTHIGHHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCcoolStepHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         set_config_field = self.fields.set_config_field
+        # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 2)
@@ -313,17 +318,17 @@ class TMC5160:
         set_config_field(config, "tpfd", 4)
         set_config_field(config, "diss2g", 0)
         set_config_field(config, "diss2vs", 0)
-        #   COOLCONF
-        set_config_field(config, "semin", 0)    # page 52
+        # COOLCONF
+        set_config_field(config, "semin", 0)
         set_config_field(config, "seup", 0)
         set_config_field(config, "semax", 0)
         set_config_field(config, "sedn", 0)
         set_config_field(config, "seimin", 0)
         set_config_field(config, "sgt", 0)
         set_config_field(config, "sfilt", 0)
-        #   IHOLDIRUN
+        # IHOLDIRUN
         set_config_field(config, "IHOLDDELAY", 6)
-        #   PWMCONF
+        # PWMCONF
         set_config_field(config, "PWM_OFS", 30)
         set_config_field(config, "PWM_GRAD", 0)
         set_config_field(config, "pwm_freq", 0)
@@ -332,7 +337,7 @@ class TMC5160:
         set_config_field(config, "freewheel", 0)
         set_config_field(config, "PWM_REG", 4)
         set_config_field(config, "PWM_LIM", 12)
-        #   TPOWERDOWN
+        # TPOWERDOWN
         set_config_field(config, "TPOWERDOWN", 10)
 
 def load_config_prefix(config):

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -292,7 +292,7 @@ class TMC5160:
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields)
         # Allow virtual pins to be created
-        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Register commands
         current_helper = TMC5160CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -299,6 +299,7 @@ class TMC5160:
         current_helper = TMC5160CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
         mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         self.get_microsteps = mh.get_microsteps


### PR DESCRIPTION
This PR improves the usability of TMC drivers with klipper.

The configuration of tmc2130, tmc2208, tmc2209 and tmc5160 was expanded to include more fields that were already there, just not parsed in \_\_init\_\_. Helper functions were made more generic (for `TPWMTHRS`, `TCOOLTHRS` and `THIGH`). More about this is described in the first commit message. As a result, stallGuard homing is more reliable, coolStep can be used and fullstepping at high speeds is possible.

The TMC5160 runtime current update functions were fixed so that `GLOBALSCALER` is updated whenever `IRUN` and `IHOLD` is changed. This is done in the second commit.

The homing current is now independent of the running current. In combination with `TCOOLTHRS`, it helps the homing reliability of tmc2130, tmc2209 and tmc5160 drivers. More about this in both commits.

Homing before and after:
- 0.3A run current, SGT=3, TCOOLTHRS=max (0mm/s): https://photos.app.goo.gl/wKCMmKFDk4c5vZBy7
- 0.3A run current, 0.15/0.18 homing current, SGT=3, TCOOLTHRS=413 (20mm/s) (exactly the same values as in Prusa-Firmware for the MK3S): https://photos.app.goo.gl/NTZsQnqxKvH6brV46
Notice how in the first video the second bump is never attempted (stallguard triggering too early).

Older config files work with this PR without changing anything. Updating the config will make use of the new helper functions.
I'd like some feedback on these changes before I update the config reference as this is the first time I use python code. Be advised that there might be rookie mistakes :P