### PR TITLE
workflows: Fix typos related to STM32F446

### DIFF
--- a/test/configs/stm32f446.config
+++ b/test/configs/stm32f446.config
@@ -1,3 +1,3 @@
-# Base config file for STM32F407 ARM processor
+# Base config file for STM32F446 ARM processor
 CONFIG_MACH_STM32=y
 CONFIG_MACH_STM32F446=y

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -174,7 +174,7 @@ CONFIG ../../config/generic-prusa-buddy.cfg
 CONFIG ../../config/printer-prusa-mini-plus-2020.cfg
 
 # Printers using the stm32f446
-DICTIONARY stm32f407.dict
+DICTIONARY stm32f446.dict
 CONFIG ../../config/generic-fysetc-s6.cfg
 CONFIG ../../config/generic-fysetc-s6-v2.cfg
 CONFIG ../../config/generic-fysetc-spider.cfg


### PR DESCRIPTION
Fixes 2 occurrences where the STM32F407 was in a place specific to the STM32F446

One commit was...
Signed-off-by: Charles Pickering <charles.pickering@live.com>