### PR TITLE
sync_heater and sync_extruder

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -165,9 +165,18 @@ The following standard commands are supported:
 - `SET_HEATER_TEMPERATURE HEATER=<heater_name> [TARGET=<target_temperature>]`:
   Sets the target temperature for a heater. If a target temperature is
   not supplied, the target is 0.
+- `SYNC_HEATER_TEMPERATURE HEATER=<heater_name> [TO=<heater_name>]
+  [OFFSET_TEMP=<value>]`: Synchronize heaters temperatures with an optional
+  offset. The follower heater will reach the offsetted temperature prior to the
+  synchronisation is active. To unsynchronize an heater, omits the TO parameter.
 - `ACTIVATE_EXTRUDER EXTRUDER=<config_name>`: In a printer with
   multiple extruders this command is used to change the active
   extruder.
+- `SYNC_EXTRUDER EXTRUDER=<config_name> [TO=<config_name>] [OFFSET_TEMP=<value>]`:
+  Synchronize extruders heaters and steppers with an optional offset applied
+  to the temperature. The follower extruder will reach the offsetted temperature
+  prior to the synchronisation is active. To unsynchronize an extruder, omits
+  the TO parameter.
 - `SET_PRESSURE_ADVANCE [EXTRUDER=<config_name>] [ADVANCE=<pressure_advance>]
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -146,6 +146,7 @@ The following information is available for heater objects such as
   1.0) associated with the heater.
 - `can_extrude`: If extruder can extrude (defined by `min_extrude_temp`),
   available only for [extruder](Config_Reference.md#extruder)
+- `sync_heaters`: The list of synchronised heaters with the given heater
 
 # heaters
 

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -114,12 +114,13 @@ class Heater:
         with self.lock:
             self.target_temp = degrees
     def set_temp(self, degrees):
-        if self.sync_heaters_master is None:
-            self._set_temp(degrees)
-            for sync_heater in self.sync_heaters:
-                offset = self.sync_heaters[sync_heater]
-                sync_degrees = 0. if degrees <= 0. else max(degrees + offset, 0.)
-                sync_heater._set_temp(sync_degrees)
+        if self.sync_heaters_master is not None:
+            return
+        self._set_temp(degrees)
+        for sync_heater in self.sync_heaters:
+            offset = self.sync_heaters[sync_heater]
+            sync_degrees = 0. if degrees <= 0. else max(degrees + offset, 0.)
+            sync_heater._set_temp(sync_degrees)
     def get_temp(self, eventtime):
         print_time = self.mcu_pwm.get_mcu().estimated_print_time(eventtime) - 5.
         with self.lock:
@@ -203,7 +204,7 @@ class Heater:
         heater = pheaters.lookup_heater(name_heater, None)
         if heater is not None:
             heater.sync_heater(self, offset_temp)
-            gcmd.respond_info("Heater '%s' is now synchronized with '%s'" 
+            gcmd.respond_info("Heater '%s' is now synchronized with '%s'"
                         % (self.name, heater.get_name(),))
         else:
             raise gcmd.error("Heater '%s' not found" % name_heater)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -233,7 +233,7 @@ class PrinterExtruder:
         else:
             extruder_master.sync_stepper(self.stepper)
             extruder_master.get_heater().sync_heater(heater, offset_temp)
-            gcmd.respond_info("Extruder '%s' now synchronized with '%s'" 
+            gcmd.respond_info("Extruder '%s' now synchronized with '%s'"
                         % (self.name, name_master,))
 
 # Dummy extruder class used when a printer has no extruder at all

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -74,6 +74,9 @@ class PrinterExtruder:
         gcode.register_mux_command("SET_EXTRUDER_STEP_DISTANCE", "EXTRUDER",
                                    self.name, self.cmd_SET_E_STEP_DISTANCE,
                                    desc=self.cmd_SET_E_STEP_DISTANCE_help)
+        gcode.register_mux_command("SYNC_EXTRUDER", "EXTRUDER",
+                                   self.name, self.cmd_SYNC_EXTRUDER,
+                                   desc=self.cmd_SYNC_EXTRUDER_help)
     def update_move_time(self, flush_time):
         self.trapq_free_moves(self.trapq, flush_time)
     def _set_pressure_advance(self, pressure_advance, smooth_time):
@@ -213,6 +216,25 @@ class PrinterExtruder:
         toolhead.flush_step_generation()
         toolhead.set_extruder(self, self.stepper.get_commanded_position())
         self.printer.send_event("extruder:activate_extruder")
+    cmd_SYNC_EXTRUDER_help = "Synchronize extruders heaters and motors"
+    def cmd_SYNC_EXTRUDER(self, gcmd):
+        offset_temp = gcmd.get_float('OFFSET_TEMP', 0.)
+        name_master = gcmd.get('TO', None)
+        heater = self.get_heater()
+        if name_master == self.name or name_master is None:
+            # unsync
+            self.sync_stepper(self.stepper)
+            heater.sync_heater(heater)
+            gcmd.respond_info("Extruder '%s' is now unsynchronized" % self.name)
+            return
+        extruder_master = self.printer.lookup_object(name_master, None)
+        if extruder_master is None:
+            gcmd.error("'%s' is not a valid extruder." % (name_master,))
+        else:
+            extruder_master.sync_stepper(self.stepper)
+            extruder_master.get_heater().sync_heater(heater, offset_temp)
+            gcmd.respond_info("Extruder '%s' now synchronized with '%s'" 
+                        % (self.name, name_master,))
 
 # Dummy extruder class used when a printer has no extruder at all
 class DummyExtruder:


### PR DESCRIPTION
Add the ability to synchronize heaters temperatures with an optional offset.
Add the ability to synchronize extruders steppers and heaters with an optional offset.

This PR prepares duplication/mirror modes for IDEX printers. Even if this code is fully functional the PR is mainly for discussion about the best way to synchronize the extruders. Heaters synchronisation can eventually be used for big heatbed that use multiple heatpads.

Signed-off-by: Fabrice GALLET tircown@gmail.com