### PR TITLE
controller_fan: Add "stepper" config option

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2374,7 +2374,7 @@ a shutdown_speed equal to max_power.
 
 Controller cooling fan (one may define any number of sections with a
 "controller_fan" prefix). A "controller fan" is a fan that will be
-enabled whenever its associated heater or any configured stepper
+enabled whenever its associated heater or its associated stepper
 driver is active. The fan will stop whenever an idle_timeout is
 reached to ensure no overheating will occur after deactivating a
 watched component.
@@ -2405,10 +2405,12 @@ watched component.
 #   will be set to when a heater or stepper driver was active and
 #   before the idle_timeout is reached. The default is fan_speed.
 #heater:
-#   Name of the config section defining the heater that this fan is
-#   associated with. If a comma separated list of heater names is
-#   provided here, then the fan will be enabled when any of the given
-#   heaters are enabled. The default is "extruder".
+#stepper:
+#   Name of the config section defining the heater/stepper that this fan
+#   is associated with. If a comma separated list of heater/stepper names
+#   is provided here, then the fan will be enabled when any of the given
+#   heaters/steppers are enabled. Extruder steppers cannot be used here.
+#   The default heater is "extruder", the default stepper is all of them.
 ```
 
 ## [temperature_fan]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2409,8 +2409,8 @@ watched component.
 #   Name of the config section defining the heater/stepper that this fan
 #   is associated with. If a comma separated list of heater/stepper names
 #   is provided here, then the fan will be enabled when any of the given
-#   heaters/steppers are enabled. Extruder steppers cannot be used here.
-#   The default heater is "extruder", the default stepper is all of them.
+#   heaters/steppers are enabled. The default heater is "extruder", the
+#   default stepper is all of them.
 ```
 
 ## [temperature_fan]

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -11,6 +11,9 @@ class ControllerFan:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
+        self.steppers_to_monitor = config.get("stepper", "")
         self.stepper_names = []
         self.stepper_enable = self.printer.load_object(config, 'stepper_enable')
         self.printer.load_object(config, 'heaters')
@@ -24,12 +27,21 @@ class ControllerFan:
         self.heater_name = config.get("heater", "extruder")
         self.last_on = self.idle_timeout
         self.last_speed = 0.
+    def handle_connect(self):
+        steppers = [n.strip() for n in self.steppers_to_monitor.split(',')]
+        kin = self.printer.lookup_object('toolhead').get_kinematics()
+        all_steppers = [s.get_name() for s in kin.get_steppers()]
+        if steppers == [""]:
+            self.stepper_names = all_steppers
+            return
+        if not all(x in all_steppers for x in steppers):
+            raise self.printer.config_error(
+                "One or more of these steppers are unknown: %s" % (steppers))
+        self.stepper_names = steppers
     def handle_ready(self):
         pheaters = self.printer.lookup_object('heaters')
         self.heaters = [pheaters.lookup_heater(n.strip())
                         for n in self.heater_name.split(',')]
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        self.stepper_names = [s.get_name() for s in kin.get_steppers()]
         reactor = self.printer.get_reactor()
         reactor.register_timer(self.callback, reactor.monotonic()+PIN_MIN_TIME)
     def get_status(self, eventtime):

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -35,7 +35,8 @@ class ControllerFan:
             return
         if not all(x in all_steppers for x in steppers):
             raise self.printer.config_error(
-                "One or more of these steppers are unknown: %s (valid steppers are: %s)"
+                ("One or more of these steppers are unknown: "
+                 "%s (valid steppers are: %s)")
                 % (steppers, ", ".join(all_steppers)))
         self.stepper_names = steppers
     def handle_ready(self):

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -29,7 +29,8 @@ class ControllerFan:
         self.last_speed = 0.
     def handle_connect(self):
         steppers = [n.strip() for n in self.steppers_to_monitor.split(',')]
-        all_steppers = [s.get_name() for s in self.stepper_enable.get_steppers()]
+        all_steppers = [s.get_name()
+                        for s in self.stepper_enable.get_steppers()]
         if steppers == [""]:
             self.stepper_names = all_steppers
             return

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -29,14 +29,14 @@ class ControllerFan:
         self.last_speed = 0.
     def handle_connect(self):
         steppers = [n.strip() for n in self.steppers_to_monitor.split(',')]
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        all_steppers = [s.get_name() for s in kin.get_steppers()]
+        all_steppers = [s.get_name() for s in self.stepper_enable.get_steppers()]
         if steppers == [""]:
             self.stepper_names = all_steppers
             return
         if not all(x in all_steppers for x in steppers):
             raise self.printer.config_error(
-                "One or more of these steppers are unknown: %s" % (steppers))
+                "One or more of these steppers are unknown: %s (valid steppers are: %s)"
+                % (steppers, ", ".join(all_steppers)))
         self.stepper_names = steppers
     def handle_ready(self):
         pheaters = self.printer.lookup_object('heaters')

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -121,6 +121,8 @@ class PrinterStepperEnable:
         if name not in self.enable_lines:
             raise self.printer.config_error("Unknown stepper '%s'" % (name,))
         return self.enable_lines[name]
+    def get_steppers(self):
+        return [e.stepper for e in self.enable_lines.values()]
 
 def load_config(config):
     return PrinterStepperEnable(config)


### PR DESCRIPTION
Allows contoller_fan sections to monitor only certain steppers instead of
all of them, similar to how heaters are currently handled. The default is
to monitor all steppers except extruders for backwards compatibility. Note
that this module (accidentally?) never actually monitored extruder
steppers.