### PR TITLE
heaters: Allow PID parameters to be adjusted at runtime

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -148,6 +148,8 @@ The following standard commands are supported:
   is specified then the toolhead move will be performed with the given
   speed (in mm/s); otherwise the toolhead move will use the restored
   g-code speed.
+- PID HEATER=<config_name> [P=<proportional>] [I=<integral>] [D=<derivative>]
+  [SETTLE_DELTA=<temperature>] : Adjust PID parameters.
 - `PID_CALIBRATE HEATER=<config_name> TARGET=<temperature>
   [WRITE_FILE=1]`: Perform a PID calibration test. The specified
   heater will be enabled until the specified target temperature is


### PR DESCRIPTION
This commit allows for the PID parameters to be adjusted at runtime.
This can be useful when different PID tunings are needed for different
temperatures. For example a heated bed running at 60c vs 100c.

This commit also allows for settle delta to be adjusted which is very
useful during print start macros. And allows settle delta to be loaded
from configuration files.

Signed-off-by: Alexander Wigen <alex@wigen.net>