### PR TITLE
Specify ATSAMD sercom explicitly in a samd_sercom config option

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -6,6 +6,9 @@ All dates in this document are approximate.
 
 # Changes
 
+20210703: A `samd_sercom` config section must now specify the sercom
+bus it is configuring via the `sercom` option.
+
 20210612: The `pid_integral_max` config option in heater and
 temperature_fan sections is deprecated.  The option will be removed in
 the near future.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3793,13 +3793,17 @@ i2c_address:
 ## [samd_sercom]
 
 SAMD SERCOM configuration to specify which pins to use on a given
-SERCOM. One may define one section with the "samd_sercom" prefix per
-SERCOM available. Each SERCOM must be configured prior to using it as
-SPI or I2C peripheral. Place this config section above any other
-section that makes use of SPI or I2C buses.
+SERCOM. One may define any number of sections with a "samd_sercom"
+prefix. Each SERCOM must be configured prior to using it as SPI or I2C
+peripheral. Place this config section above any other section that
+makes use of SPI or I2C buses.
 
 ```
-[samd_sercom sercom0]
+[samd_sercom my_sercom]
+sercom:
+#   The name of the sercom bus to configure in the micro-controller.
+#   Available names are "sercom0", "sercom1", etc.. This parameter
+#   must be provided.
 tx_pin:
 #   MOSI pin for SPI communication, or SDA (data) pin for I2C
 #   communication. The pin must have a valid pinmux configuration

--- a/klippy/extras/samd_sercom.py
+++ b/klippy/extras/samd_sercom.py
@@ -7,8 +7,8 @@
 class SamdSERCOM:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.name = config.get_name().split()[1]
 
+        self.sercom = config.get("sercom")
         self.tx_pin = config.get("tx_pin")
         self.rx_pin = config.get("rx_pin", None)
         self.clk_pin = config.get("clk_pin")
@@ -18,15 +18,15 @@ class SamdSERCOM:
         self.mcu = tx_pin_params['chip']
         self.mcu.add_config_cmd(
             "set_sercom_pin bus=%s sercom_pin_type=tx pin=%s" % (
-                self.name, tx_pin_params['pin']))
+                self.sercom, tx_pin_params['pin']))
 
         clk_pin_params = ppins.lookup_pin(self.clk_pin)
         if self.mcu is not clk_pin_params['chip']:
-           raise ppins.error("%s: SERCOM pins must be on same mcu" % (
-                    config.get_name(),))
+            raise ppins.error("%s: SERCOM pins must be on same mcu" % (
+                config.get_name(),))
         self.mcu.add_config_cmd(
             "set_sercom_pin bus=%s sercom_pin_type=clk pin=%s" % (
-                self.name, clk_pin_params['pin']))
+                self.sercom, clk_pin_params['pin']))
 
         if self.rx_pin:
             rx_pin_params = ppins.lookup_pin(self.rx_pin)
@@ -35,7 +35,7 @@ class SamdSERCOM:
                     config.get_name(),))
             self.mcu.add_config_cmd(
                 "set_sercom_pin bus=%s sercom_pin_type=rx pin=%s" % (
-                    self.name, rx_pin_params['pin']))
+                    self.sercom, rx_pin_params['pin']))
 
 def load_config_prefix(config):
     return SamdSERCOM(config)


### PR DESCRIPTION
The current setup doesn't make it possible to configure multiple samd sercom instances on multiple micro-controllers.  This updates the code to make it possible, but it does make a non-backwards compatible change (for those users using a samd_sercom config).

@FHeilmann - FYI.

-Kevin