### PR TITLE
Update generic-bigtreetech-skr-2.cfg

### DIFF
--- a/config/generic-bigtreetech-skr-2.cfg
+++ b/config/generic-bigtreetech-skr-2.cfg
@@ -12,11 +12,13 @@
 # Note: The initial revision of this board has a flaw that can cause
 # damage to itself and other boards. Be sure to verify the board is
 # not impacted by this flaw before using it.
+# See the following link for more information:
+# https://docs.google.com/document/d/1IeKgfE2WIDjqH1fx5Yg7n1FOHVwhDFmDlZ-7QMlOEV0/edit?fbclid=IwAR2C08blcj-n2OIn2bAAzp0HBsOXjyxAex5Mft9HWQ30yx3eu4dJ4VlRkX8
 
 [stepper_x]
-step_pin: PE2
-dir_pin: PE1
-enable_pin: !PE3
+step_pin: PD5
+dir_pin: !PD4
+enable_pin: !PD6
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PC1
@@ -25,9 +27,9 @@ position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: PD5
-dir_pin: !PD4
-enable_pin: !PD6
+step_pin: PE2
+dir_pin: PE1
+enable_pin: !PE3
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PC3
@@ -37,12 +39,18 @@ homing_speed: 50
 
 [stepper_z]
 step_pin: PA15
-dir_pin: PA8
+dir_pin: !PA8
 enable_pin: !PD1
 microsteps: 16
 rotation_distance: 40
+# Disable to use BLTouch
 endstop_pin: ^PC0
+# Disable to use BLTouch
 position_endstop: 0.5
+# Enable to use BLTouch
+# endstop_pin: probe:z_virtual_endstop
+# Enable to use BLTouch
+# position_min: -5
 position_max: 200
 
 [extruder]
@@ -148,3 +156,30 @@ aliases:
 #uart_pin: PD12
 #run_current: 0.600
 #diag_pin:
+
+#########################
+# BLTouch configuration #
+#########################
+
+# Replace the values (except the pins) with the ones specific to your printer
+
+# [safe_z_home]
+# home_xy_position: 150.7, 137
+# speed: 100
+# z_hop: 10
+# z_hop_speed: 5
+
+# [bltouch]
+# sensor_pin: ^PE4
+# control_pin: PE5
+# x_offset: -20.7
+# y_offset: -7
+# z_offset: 2.4
+# speed: 3.0
+
+# [bed_mesh]
+# speed: 100
+# mesh_min: 10, 10
+# mesh_max: 239, 239
+# algorithm: bicubic
+# probe_count: 5,5


### PR DESCRIPTION
Updated SKR2 configuration following my install. Some of the pins have been changed. The original SKR 2 config didn't work -  the axes were inverted.