### PR TITLE
spi_flash: Support firmware dictionary validation

### DIFF
--- a/klippy/msgproto.py
+++ b/klippy/msgproto.py
@@ -408,6 +408,8 @@ class MessageParser:
         except Exception as e:
             logging.exception("process_identify error")
             self._error("Error during identify: %s", str(e))
+    def get_raw_data_dictionary(self):
+        return self.raw_identify_data
     def get_version_info(self):
         return self.version, self.build_versions
     def get_messages(self):

--- a/scripts/flash-sdcard.sh
+++ b/scripts/flash-sdcard.sh
@@ -6,6 +6,8 @@
 KLIPPY_ENV="${HOME}/klippy-env/bin/python"
 SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 KLIPPER_BIN="${SRCDIR}/out/klipper.bin"
+KLIPPER_BIN_DEFAULT=$KLIPPER_BIN
+KLIPPER_DICT_DEFAULT="${SRCDIR}/out/klipper.dict"
 SPI_FLASH="${SRCDIR}/scripts/spi_flash/spi_flash.py"
 BAUD_ARG=""
 # Force script to exit if an error occurs
@@ -15,22 +17,23 @@ print_help_message()
 {
     echo "SD Card upload utility for Klipper"
     echo
-    echo "usage: flash_sdcard.sh [-h] [-l] [-b <baud>] [-f <firmware>]"
+    echo "usage: flash_sdcard.sh [-h] [-l] [-b <baud>] [-f <firmware>] [-d <dictionary>]"
     echo "                       <device> <board>"
     echo
     echo "positional arguments:"
-    echo "  <device>        device serial port"
-    echo "  <board>         board type"
+    echo "  <device>          device serial port"
+    echo "  <board>           board type"
     echo
     echo "optional arguments:"
-    echo "  -h              show this message"
-    echo "  -l              list available boards"
-    echo "  -b <baud>       serial baud rate (default is 250000)"
-    echo "  -f <firmware>   path to klipper.bin"
+    echo "  -h                show this message"
+    echo "  -l                list available boards"
+    echo "  -b <baud>         serial baud rate (default is 250000)"
+    echo "  -f <firmware>     path to klipper.bin"
+    echo "  -d <dictionary>   path to klipper.dict for firmware validation"
 }
 
 # Parse command line "optional args"
-while getopts "hlb:f:" arg; do
+while getopts "hlb:f:d:" arg; do
     case $arg in
         h)
             print_help_message
@@ -42,6 +45,7 @@ while getopts "hlb:f:" arg; do
             ;;
         b) BAUD_ARG="-b ${OPTARG}";;
         f) KLIPPER_BIN=$OPTARG;;
+        d) KLIPPER_DICT=$OPTARG;;
     esac
 done
 
@@ -64,6 +68,18 @@ if [ ! -e $DEVICE ]; then
     exit -1
 fi
 
+if [ ! $KLIPPER_DICT ] && [ $KLIPPER_BIN == $KLIPPER_BIN_DEFAULT ] ; then
+    KLIPPER_DICT=$KLIPPER_DICT_DEFAULT
+fi
+
+if [ $KLIPPER_DICT ]; then
+    if [ ! -f $KLIPPER_DICT ]; then
+        echo "No file found at '${KLIPPER_BIN}'"
+        exit -1
+    fi
+    KLIPPER_DICT="-d ${KLIPPER_DICT}"
+fi
+
 # Run Script
 echo "Flashing ${KLIPPER_BIN} to ${DEVICE}"
-${KLIPPY_ENV} ${SPI_FLASH} ${BAUD_ARG} ${DEVICE} ${BOARD} ${KLIPPER_BIN}
+${KLIPPY_ENV} ${SPI_FLASH} ${BAUD_ARG} ${KLIPPER_DICT} ${DEVICE} ${BOARD} ${KLIPPER_BIN}


### PR DESCRIPTION
Updates firmware validation to use a dictionary if provided (or found
when updating from the default out/ directory).

Validation without a dictionary still checks the following (in order):
1. Active firmware's raw dictionary changed after update
2. Checksum of firmware.cur matches expected

Signed-off-by: Justin Schuh <code@justinschuh.com>

This PR depends on #4381. Hopefully I did this right, since it's the first time I've stacked PRs. I would have expected the diff to be against the other PR, but the UI seems to display a much larger diff against master.