### PR TITLE
docs: Fix M300 beeper example.

### DIFF
--- a/config/sample-macros.cfg
+++ b/config/sample-macros.cfg
@@ -72,9 +72,7 @@ value: 0
 shutdown_value: 0
 #   Disable at emergency shutdown (no PWM would be available anyway).
 cycle_time: 0.001
-#   PWM frequency : 0.001 = 1ms will give a base tone of 1kHz
-scale: 1000
-#   PWM parameter will be in the range of (0-1000 Hz).
+#   Default PWM frequency : 0.001 = 1ms will give a tone of 1kHz
 #   Although not pitch perfect.
 
 [gcode_macro M300]
@@ -83,7 +81,7 @@ gcode:
     {% set S = params.S|default(1000)|int %}
     # Use a 10ms duration is P is omitted.
     {% set P = params.P|default(100)|int %}
-    SET_PIN PIN=BEEPER_pin VALUE={S}
+    SET_PIN PIN=BEEPER_pin VALUE=0.5 CYCLE_TIME={ 1.0/S if S > 0 else 1 }
     G4 P{P}
     SET_PIN PIN=BEEPER_pin VALUE=0
 


### PR DESCRIPTION
The M300 example macro now sets the PWM cycle time to generate the requested
frequency. 'scale' did not have the desired effect. Duty cycle is now
fixed at 0.5. All S parameter values less than 1 generate a 1Hz 'tone'
to avoid division-by-zero.

Signed-off-by: Stefan Holst <mail@s-holst.de>