### PR TITLE
stm32: For stm32f0 set OSPEEDR to high-speed

### DIFF
--- a/src/stm32/stm32f0.c
+++ b/src/stm32/stm32f0.c
@@ -84,7 +84,7 @@ gpio_peripheral(uint32_t gpio, uint32_t mode, int pullup)
     regs->MODER = (regs->MODER & ~m_msk) | (mode_bits << m_shift);
     regs->PUPDR = (regs->PUPDR & ~m_msk) | (pup << m_shift);
     regs->OTYPER = (regs->OTYPER & ~(1 << pos)) | (od << pos);
-    regs->OSPEEDR = (regs->OSPEEDR & ~m_msk) | (0x02 << m_shift);
+    regs->OSPEEDR = (regs->OSPEEDR & ~m_msk) | (0x3 << m_shift);
 }
 
 #define USB_BOOT_FLAG_ADDR (CONFIG_RAM_START + CONFIG_RAM_SIZE - 1024)


### PR DESCRIPTION
The hex value 2 matches the x0 rule which
is low speed, use 0x3 instead for high speed.

This helps with long traces or fanout.

Signed-off-by: Curt Meyers <cmeyers@boilerbots.com>