### PR TITLE
Update printer-flsun-q5-2020.cfg

### DIFF
--- a/config/printer-flsun-q5-2020.cfg
+++ b/config/printer-flsun-q5-2020.cfg
@@ -8,7 +8,7 @@
 
 # Note that the "make flash" command does not work with MKS Robin
 # boards. After running "make", run the following command:
-# ./scripts/update_mks_robin.py out/klipper.bin out/Robin_mini.bin
+# ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano.bin
 # Copy the file out/Robin_nano.bin to an SD card and then restart the
 # printer with that SD card.
 


### PR DESCRIPTION
module: Config file

The MKS Robin Nano v1.2 expects the firmware file to be called `Robin_nano.bin`.

Signed-off-by: Daniel Da Cunha <github@ddc.im>