### PR TITLE
Add 16KiB bootloader option for STM32F103

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -156,7 +156,7 @@ choice
     config STM32_FLASH_START_800
         bool "2KiB bootloader (HID Bootloader)" if MACH_STM32F103
     config STM32_FLASH_START_4000
-        bool "16KiB bootloader (HID Bootloader)" if MACH_STM32F207 || MACH_STM32F401 || MACH_STM32F405 || MACH_STM32F407
+        bool "16KiB bootloader (HID Bootloader)" if MACH_STM32F207 || MACH_STM32F401 || MACH_STM32F405 || MACH_STM32F407 || MACH_STM32F103
 
     config STM32_FLASH_START_0000
         bool "No bootloader"


### PR DESCRIPTION
The Eryone ER-20 is a STM32F103 based 3D printer which ships with a 16KiB bootloader. Their official version of Marlin starts at 0x08004000.

This can be seen here. https://github.com/Eryone/STM32/blob/master/Marlin_ER20/buildroot/share/PlatformIO/scripts/eryone_mini_STM32f103.py

Fixed signoff issue with previous pull request: https://github.com/KevinOConnor/klipper/pull/4476