### PR TITLE
St7920 cmd and sync delay config option

### DIFF
--- a/klippy/extras/display/st7920.py
+++ b/klippy/extras/display/st7920.py
@@ -142,9 +142,8 @@ class ST7920(DisplayBase):
                 for name in ['cs', 'sclk', 'sid']]
         mcu = None
         # Spec says 72us, but faster is possible in practice
-        
-        delay_cmd = config.getfloat('st7920_delay_cmd', .000020, minval=.000020)
-        delay_sync = config.getfloat('st7920_delay_sync', .000045, minval=.000045)
+        delay_cmd = config.getfloat('delay_cmd', .000020, minval=.000020)
+        delay_sync = config.getfloat('delay_sync', .000045, minval=.000045)
         for pin_params in pins:
             if mcu is not None and pin_params['chip'] != mcu:
                 raise ppins.error("st7920 all pins must be on same mcu")

--- a/klippy/extras/display/st7920.py
+++ b/klippy/extras/display/st7920.py
@@ -143,16 +143,16 @@ class ST7920(DisplayBase):
         mcu = None
         
         # Spec says 72us, but faster is possible in practice
-        delay_cmd = config.getfloat('delay_cmd', .000020, minval=.000020)
-        delay_sync = config.getfloat('delay_sync', .000045, minval=.000045)
+        st7920_delay_cmd = config.getfloat('st7920_delay_cmd', .000020, minval=.000020)
+        st7920_delay_sync = config.getfloat('st7920_delay_sync', .000045, minval=.000045)
         
         for pin_params in pins:
             if mcu is not None and pin_params['chip'] != mcu:
                 raise ppins.error("st7920 all pins must be on same mcu")
             mcu = pin_params['chip']
         self.pins = [pin_params['pin'] for pin_params in pins]
-        self.delay_cmd = delay_cmd
-        self.delay_sync = delay_sync
+        self.st7920_delay_cmd = st7920_delay_cmd
+        self.st7920_delay_sync = st7920_delay_sync
         # prepare send functions
         self.mcu = mcu
         self.oid = self.mcu.create_oid()
@@ -167,8 +167,8 @@ class ST7920(DisplayBase):
             "config_st7920 oid=%u cs_pin=%s sclk_pin=%s sid_pin=%s"
             " sync_delay_ticks=%d cmd_delay_ticks=%d" % (
                 self.oid, self.pins[0], self.pins[1], self.pins[2],
-                self.mcu.seconds_to_clock(self.delay_sync),
-                self.mcu.seconds_to_clock(self.delay_cmd)))
+                self.mcu.seconds_to_clock(self.st7920_delay_sync),
+                self.mcu.seconds_to_clock(self.st7920_delay_cmd)))
         cmd_queue = self.mcu.alloc_command_queue()
         self.send_cmds_cmd = self.mcu.lookup_command(
             "st7920_send_cmds oid=%c cmds=%*s", cq=cmd_queue)

--- a/klippy/extras/display/st7920.py
+++ b/klippy/extras/display/st7920.py
@@ -142,15 +142,16 @@ class ST7920(DisplayBase):
                 for name in ['cs', 'sclk', 'sid']]
         mcu = None
         # Spec says 72us, but faster is possible in practice
-        st7920_delay_cmd = config.getfloat('st7920_delay_cmd', .000020, minval=.000020)
-        st7920_delay_sync = config.getfloat('st7920_delay_sync', .000045, minval=.000045)
+        
+        delay_cmd = config.getfloat('st7920_delay_cmd', .000020, minval=.000020)
+        delay_sync = config.getfloat('st7920_delay_sync', .000045, minval=.000045)
         for pin_params in pins:
             if mcu is not None and pin_params['chip'] != mcu:
                 raise ppins.error("st7920 all pins must be on same mcu")
             mcu = pin_params['chip']
         self.pins = [pin_params['pin'] for pin_params in pins]
-        self.st7920_delay_cmd = st7920_delay_cmd
-        self.st7920_delay_sync = st7920_delay_sync
+        self.delay_cmd = delay_cmd
+        self.delay_sync = delay_sync
         # prepare send functions
         self.mcu = mcu
         self.oid = self.mcu.create_oid()
@@ -165,8 +166,8 @@ class ST7920(DisplayBase):
             "config_st7920 oid=%u cs_pin=%s sclk_pin=%s sid_pin=%s"
             " sync_delay_ticks=%d cmd_delay_ticks=%d" % (
                 self.oid, self.pins[0], self.pins[1], self.pins[2],
-                self.mcu.seconds_to_clock(self.st7920_delay_sync),
-                self.mcu.seconds_to_clock(self.st7920_delay_cmd)))
+                self.mcu.seconds_to_clock(self.delay_sync),
+                self.mcu.seconds_to_clock(self.delay_cmd)))
         cmd_queue = self.mcu.alloc_command_queue()
         self.send_cmds_cmd = self.mcu.lookup_command(
             "st7920_send_cmds oid=%c cmds=%*s", cq=cmd_queue)

--- a/klippy/extras/display/st7920.py
+++ b/klippy/extras/display/st7920.py
@@ -141,11 +141,9 @@ class ST7920(DisplayBase):
         pins = [ppins.lookup_pin(config.get(name + '_pin'))
                 for name in ['cs', 'sclk', 'sid']]
         mcu = None
-        
         # Spec says 72us, but faster is possible in practice
         st7920_delay_cmd = config.getfloat('st7920_delay_cmd', .000020, minval=.000020)
         st7920_delay_sync = config.getfloat('st7920_delay_sync', .000045, minval=.000045)
-        
         for pin_params in pins:
             if mcu is not None and pin_params['chip'] != mcu:
                 raise ppins.error("st7920 all pins must be on same mcu")


### PR DESCRIPTION
Necessary to increase the reliability of the st7920 display with certain manufacturer's 3D printers. It is common in Marlin for the manufacturer to have added their own display delay in the form of: #define ST7920_DELAY_1... ST7920_DELAY_3. Adding this as a configurable option will theoretically help increase the reliability of certain displays across various manufacturers.

On the Eryone ER-20, there are some printers which work well with the default delay options, and others which don't. Marlin works well for these printers.

This is a user who used the default config on the ER-20, and was getting really odd LCD issues. We were unsuccessful in solving the issue by getting him to test multiple USB cables and cutting the signal from the 5V pin on the USB cable. None of it worked.
 
![image](https://user-images.githubusercontent.com/7358924/126046379-78ef0abe-d3fe-478b-b5ab-e657059b71ab.png)

Default Marlin for the ER-20 has the following delays configured in the pins file

```
#ifndef ST7920_DELAY_1
  #define ST7920_DELAY_1 DELAY_NS(125)
#endif
#ifndef ST7920_DELAY_2
  #define ST7920_DELAY_2 DELAY_NS(125)
#endif
#ifndef ST7920_DELAY_3
  #define ST7920_DELAY_3 DELAY_NS(125)
#endif
```

We would like to get him to test different LCD delays in Klipper, but that is much easier for less technical users if there it is a configurable option. So we made this change to test to see if it makes a difference and at the very least to set the delays to the same value as stock Eryone ER-20 Marlin.

Signed-off-by: Simon Hawkenson <simon@hawkenson.ca>