### PR TITLE
pca9533: Enhanded RGB support for the mightyboard

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2585,10 +2585,12 @@ PCA9533 LED support. The PCA9533 is used on the mightyboard.
 #initial_GREEN: 0
 #initial_BLUE: 0
 #initial_WHITE: 0
-#   The PCA9533 only supports 1 or 0. The default is 0. On the
-#   mightyboard, the white led is not populated.
-#   Use GCODE to modify led values after startup.
-#   set_led led=my_pca9533 red=1 green=1 blue=1
+#   The PCA9533 supports any value between 0 and 1. The default is 0 for all leds.
+#   The PCA9533 has one on/off channel and two PWM channels for controlling led brightness
+#   so some combinations of led settings are approximated.
+# . On the mightyboard, the white led is not populated.  Using it may result in odd colors.
+#   Use GCODE to modify led values after startup.  Leds may be controlled individually.
+#   set_led led=my_pca9533 red=1 green=0.3 blue=0.7
 ```
 
 ## [gcode_button]

--- a/klippy/extras/pca9533.py
+++ b/klippy/extras/pca9533.py
@@ -1,12 +1,18 @@
 # Support for the PCA9533 LED driver ic
 #
 # Copyright (C) 2021  Marc-Andre Denis <marcadenis@msn.com>
+#               2021  Dean Cording <dean@cording.id.au>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 from . import bus
 
+PCA9533_PSC0=0b001
+PCA9533_PWM0=0b010
+PCA9533_PSC1=0b011
+PCA9533_PWM1=0b100
 PCA9533_PLS0=0b101
+
 
 class PCA9533:
     def __init__(self, config):
@@ -24,30 +30,45 @@ class PCA9533:
         self.led2 = config.getint("initial_BLUE",0,0,1)
         self.led3 = config.getint("initial_WHITE",0,0,1)
 
-        ls0 = (self.led3<<6) | (self.led2<<4) | (self.led1<<2) | (self.led0)
-
-        self.i2c.i2c_write([PCA9533_PLS0,ls0])
+        self.i2c.i2c_write([PCA9533_PSC0,0])
+        self.i2c.i2c_write([PCA9533_PSC1,0])
+        self.set_leds(self.led0,self.led1,self.led2,self.led3)
     def set_led(self, gcmd):
-        if gcmd.get_float("RED",self.led0,0,1) != 0:
-            self.led0 = 1
-        else:
-            self.led0 = 0
-        if gcmd.get_float("GREEN",self.led1,0,1) != 0:
-            self.led1 = 1
-        else:
-            self.led1 = 0
-        if gcmd.get_float("BLUE",self.led2,0,1) != 0:
-            self.led2 = 1
-        else:
-            self.led2 = 0
-        if gcmd.get_float("WHITE",self.led3,0,1) != 0:
-            self.led3 = 1
-        else:
-            self.led3 = 0
-        ls0 = (self.led3<<6) | (self.led2<<4) | (self.led1<<2) | (self.led0)
+        self.led0 = gcmd.get_float("RED",self.led0,0,1)
+        self.led1 = gcmd.get_float("GREEN",self.led1,0,1)
+        self.led2 = gcmd.get_float("BLUE",self.led2,0,1)
+        self.led3 = gcmd.get_float("WHITE",self.led3,0,1)
 
+        self.set_leds(self.led0,self.led1,self.led2,self.led3)
+
+    def set_leds(self,*leds):
+
+        ls0 = 0
+        pwm0 = 0
+        pwm1 = 0
+
+        for index, led in enumerate(leds):
+            if led == 0:
+                continue
+            if led == 1:
+                ls0 |=  0b01<<(2*index)
+            elif pwm0 == 0:
+                pwm0 = led
+                ls0 |= 0b10<<(2*index)
+            elif pwm1 == 0:
+                pwm1 = led
+                ls0 |= 0b11<<(2*index)
+            elif abs(pwm0 - led) < abs(pwm1 - led):
+                pwm0 = (pwm0 + led) / 2
+                ls0 |= 0b10<<(2*index)
+            else:
+                pwm1 = (pwm1 + led) / 2
+                ls0 |= 0b11<<(2*index)
+            
+
+        self.i2c.i2c_write([PCA9533_PWM0,int(255*pwm0)])
+        self.i2c.i2c_write([PCA9533_PWM1,int(255*pwm1)])
         self.i2c.i2c_write([PCA9533_PLS0,ls0])
-
 
 def load_config_prefix(config):
     return PCA9533(config)


### PR DESCRIPTION
Added ability to set led brightness levels between 0 and 1

Signed-off-by:  Dean Cording <dean@cording.id.au>