### PR TITLE
docs: Make sure SPI is enabeld

### DIFF
--- a/docs/RPi_microcontroller.md
+++ b/docs/RPi_microcontroller.md
@@ -25,6 +25,10 @@ sudo cp "./scripts/klipper-mcu-start.sh" /etc/init.d/klipper_mcu
 sudo update-rc.d klipper_mcu defaults
 ```
 
+Enabling SPI
+============
+Make sure the Linux SPI driver is enabled by running sudo raspi-config and enabling SPI under the "Interfacing options" menu.
+
 Building the micro-controller code
 ==================================
 


### PR DESCRIPTION
Module: Documentation

Whilst this line is in Measuring_Resonances.md, it's causing some confusion for users and it should be in the RPi Microcontoller guide because not all RPi users are measuring resonances, and SPI appears to be a hard requirement for the RPi mcu

Signed-off-by: Rowland Straylight rowlandstraylight@gmail.com