### PR TITLE
New motion_report module

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -189,6 +189,18 @@ The following information is available in
 - `last_stats.<statistics_name>`: Statistics information on the
   micro-controller connection.
 
+## motion_report
+
+The following information is available in the `motion_report` object
+(this object is automatically available if any stepper config section
+is defined):
+- `live_position`: The requested toolhead position interpolated to the
+  current time.
+- `live_velocity`: The requested toolhead velocity (in mm/s) at the
+  current time.
+- `live_extruder_velocity`: The requested extruder velocity (in mm/s)
+  at the current time.
+
 ## output_pin
 
 The following information is available in

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -68,6 +68,13 @@ defs_itersolve = """
 """
 
 defs_trapq = """
+    struct pull_move {
+        double print_time, move_t;
+        double start_v, accel;
+        double start_x, start_y, start_z;
+        double x_r, y_r, z_r;
+    };
+
     void trapq_append(struct trapq *tq, double print_time
         , double accel_t, double cruise_t, double decel_t
         , double start_pos_x, double start_pos_y, double start_pos_z
@@ -76,6 +83,8 @@ defs_trapq = """
     struct trapq *trapq_alloc(void);
     void trapq_free(struct trapq *tq);
     void trapq_finalize_moves(struct trapq *tq, double print_time);
+    int trapq_extract_old(struct trapq *tq, struct pull_move *p, int max
+        , double start_time, double end_time);
 """
 
 defs_kin_cartesian = """

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -75,7 +75,7 @@ defs_trapq = """
         , double start_v, double cruise_v, double accel);
     struct trapq *trapq_alloc(void);
     void trapq_free(struct trapq *tq);
-    void trapq_free_moves(struct trapq *tq, double print_time);
+    void trapq_finalize_moves(struct trapq *tq, double print_time);
 """
 
 defs_kin_cartesian = """

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -83,6 +83,8 @@ defs_trapq = """
     struct trapq *trapq_alloc(void);
     void trapq_free(struct trapq *tq);
     void trapq_finalize_moves(struct trapq *tq, double print_time);
+    void trapq_set_position(struct trapq *tq, double print_time
+        , double pos_x, double pos_y, double pos_z);
     int trapq_extract_old(struct trapq *tq, struct pull_move *p, int max
         , double start_time, double end_time);
 """

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -30,6 +30,12 @@ OTHER_FILES = [
 ]
 
 defs_stepcompress = """
+    struct pull_history_steps {
+        uint64_t first_clock, last_clock;
+        int64_t start_position;
+        int step_count, interval, add;
+    };
+
     struct stepcompress *stepcompress_alloc(uint32_t oid);
     void stepcompress_fill(struct stepcompress *sc, uint32_t max_error
         , uint32_t invert_sdir, int32_t queue_step_msgtag
@@ -42,6 +48,9 @@ defs_stepcompress = """
         , uint64_t clock);
     int stepcompress_queue_msg(struct stepcompress *sc
         , uint32_t *data, int len);
+    int stepcompress_extract_old(struct stepcompress *sc
+        , struct pull_history_steps *p, int max
+        , uint64_t start_clock, uint64_t end_clock);
 
     struct steppersync *steppersync_alloc(struct serialqueue *sq
         , struct stepcompress **sc_list, int sc_num, int move_num);

--- a/klippy/chelper/stepcompress.c
+++ b/klippy/chelper/stepcompress.c
@@ -56,7 +56,7 @@ struct step_move {
 
 #define HISTORY_EXPIRE (30.0)
 
-struct history_move {
+struct history_steps {
     struct list_node node;
     uint64_t first_clock, last_clock;
     int64_t start_position;
@@ -274,12 +274,12 @@ static void
 free_history(struct stepcompress *sc, uint64_t end_clock)
 {
     while (!list_empty(&sc->history_list)) {
-        struct history_move *hm = list_last_entry(
-            &sc->history_list, struct history_move, node);
-        if (hm->last_clock > end_clock)
+        struct history_steps *hs = list_last_entry(
+            &sc->history_list, struct history_steps, node);
+        if (hs->last_clock > end_clock)
             break;
-        list_del(&hm->node);
-        free(hm);
+        list_del(&hs->node);
+        free(hs);
     }
 }
 
@@ -351,14 +351,14 @@ add_move(struct stepcompress *sc, uint64_t first_clock, struct step_move *move)
     sc->last_step_clock = last_clock;
 
     // Create and store move in history tracking
-    struct history_move *hm = malloc(sizeof(*hm));
-    hm->first_clock = first_clock;
-    hm->last_clock = last_clock;
-    hm->start_position = sc->last_position;
-    hm->step_count = sc->sdir ? move->count : -move->count;
-    sc->last_position += hm->step_count;
-    memcpy(&hm->sm, move, sizeof(hm->sm));
-    list_add_head(&hm->node, &sc->history_list);
+    struct history_steps *hs = malloc(sizeof(*hs));
+    hs->first_clock = first_clock;
+    hs->last_clock = last_clock;
+    hs->start_position = sc->last_position;
+    hs->step_count = sc->sdir ? move->count : -move->count;
+    sc->last_position += hs->step_count;
+    memcpy(&hs->sm, move, sizeof(hs->sm));
+    list_add_head(&hs->node, &sc->history_list);
 }
 
 // Convert previously scheduled steps into commands for the mcu
@@ -567,16 +567,16 @@ int64_t __visible
 stepcompress_find_past_position(struct stepcompress *sc, uint64_t clock)
 {
     int64_t last_position = sc->last_position;
-    struct history_move *hm;
-    list_for_each_entry(hm, &sc->history_list, node) {
-        if (clock < hm->first_clock) {
-            last_position = hm->start_position;
+    struct history_steps *hs;
+    list_for_each_entry(hs, &sc->history_list, node) {
+        if (clock < hs->first_clock) {
+            last_position = hs->start_position;
             continue;
         }
-        if (clock >= hm->last_clock)
-            return hm->start_position + hm->step_count;
-        int32_t interval = hm->sm.interval, add = hm->sm.add;
-        int32_t ticks = (int32_t)(clock - hm->first_clock) + interval, offset;
+        if (clock >= hs->last_clock)
+            return hs->start_position + hs->step_count;
+        int32_t interval = hs->sm.interval, add = hs->sm.add;
+        int32_t ticks = (int32_t)(clock - hs->first_clock) + interval, offset;
         if (!add) {
             offset = ticks / interval;
         } else {
@@ -584,9 +584,9 @@ stepcompress_find_past_position(struct stepcompress *sc, uint64_t clock)
             double a = .5 * add, b = interval - .5 * add, c = -ticks;
             offset = (sqrt(b*b - 4*a*c) - b) / (2. * a);
         }
-        if (hm->step_count < 0)
-            return hm->start_position - offset;
-        return hm->start_position + offset;
+        if (hs->step_count < 0)
+            return hs->start_position - offset;
+        return hs->start_position + offset;
     }
     return last_position;
 }

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -5,6 +5,12 @@
 
 #define ERROR_RET -989898989
 
+struct pull_history_steps {
+    uint64_t first_clock, last_clock;
+    int64_t start_position;
+    int step_count, interval, add;
+};
+
 struct stepcompress *stepcompress_alloc(uint32_t oid);
 void stepcompress_fill(struct stepcompress *sc, uint32_t max_error
                        , uint32_t invert_sdir, int32_t queue_step_msgtag
@@ -21,6 +27,9 @@ int stepcompress_set_last_position(struct stepcompress *sc
 int64_t stepcompress_find_past_position(struct stepcompress *sc
                                         , uint64_t clock);
 int stepcompress_queue_msg(struct stepcompress *sc, uint32_t *data, int len);
+int stepcompress_extract_old(struct stepcompress *sc
+                             , struct pull_history_steps *p, int max
+                             , uint64_t start_clock, uint64_t end_clock);
 
 struct serialqueue;
 struct steppersync *steppersync_alloc(

--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -1,6 +1,6 @@
 // Trapezoidal velocity movement queue
 //
-// Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -95,6 +95,7 @@ trapq_alloc(void)
     struct trapq *tq = malloc(sizeof(*tq));
     memset(tq, 0, sizeof(*tq));
     list_init(&tq->moves);
+    list_init(&tq->history);
     struct move *head_sentinel = move_alloc(), *tail_sentinel = move_alloc();
     tail_sentinel->print_time = tail_sentinel->move_t = NEVER_TIME;
     list_add_head(&head_sentinel->node, &tq->moves);
@@ -108,6 +109,11 @@ trapq_free(struct trapq *tq)
 {
     while (!list_empty(&tq->moves)) {
         struct move *m = list_first_entry(&tq->moves, struct move, node);
+        list_del(&m->node);
+        free(m);
+    }
+    while (!list_empty(&tq->history)) {
+        struct move *m = list_first_entry(&tq->history, struct move, node);
         list_del(&m->node);
         free(m);
     }
@@ -157,21 +163,64 @@ trapq_add_move(struct trapq *tq, struct move *m)
     tail_sentinel->print_time = 0.;
 }
 
+#define HISTORY_EXPIRE (30.0)
+
 // Expire any moves older than `print_time` from the trapezoid velocity queue
 void __visible
 trapq_finalize_moves(struct trapq *tq, double print_time)
 {
     struct move *head_sentinel = list_first_entry(&tq->moves, struct move,node);
     struct move *tail_sentinel = list_last_entry(&tq->moves, struct move, node);
+    // Move expired moves from main "moves" list to "history" list
     for (;;) {
         struct move *m = list_next_entry(head_sentinel, node);
         if (m == tail_sentinel) {
             tail_sentinel->print_time = NEVER_TIME;
-            return;
+            break;
         }
         if (m->print_time + m->move_t > print_time)
-            return;
+            break;
+        list_del(&m->node);
+        list_add_head(&m->node, &tq->history);
+    }
+    // Free old moves from history list
+    if (list_empty(&tq->history))
+        return;
+    struct move *latest = list_first_entry(&tq->history, struct move, node);
+    double expire_time = latest->print_time + latest->move_t - HISTORY_EXPIRE;
+    for (;;) {
+        struct move *m = list_last_entry(&tq->history, struct move, node);
+        if (m == latest || m->print_time + m->move_t > expire_time)
+            break;
         list_del(&m->node);
         free(m);
     }
+}
+
+// Return history of movement queue
+int __visible
+trapq_extract_old(struct trapq *tq, struct pull_move *p, int max
+                  , double start_time, double end_time)
+{
+    int res = 0;
+    struct move *m;
+    list_for_each_entry(m, &tq->history, node) {
+        if (start_time >= m->print_time + m->move_t || res >= max)
+            break;
+        if (end_time <= m->print_time)
+            continue;
+        p->print_time = m->print_time;
+        p->move_t = m->move_t;
+        p->start_v = m->start_v;
+        p->accel = 2. * m->half_accel;
+        p->start_x = m->start_pos.x;
+        p->start_y = m->start_pos.y;
+        p->start_z = m->start_pos.z;
+        p->x_r = m->axes_r.x;
+        p->y_r = m->axes_r.y;
+        p->z_r = m->axes_r.z;
+        p++;
+        res++;
+    }
+    return res;
 }

--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -197,6 +197,23 @@ trapq_finalize_moves(struct trapq *tq, double print_time)
     }
 }
 
+// Note a position change in the trapq history
+void __visible
+trapq_set_position(struct trapq *tq, double print_time
+                   , double pos_x, double pos_y, double pos_z)
+{
+    // Flush all moves from trapq
+    trapq_finalize_moves(tq, NEVER_TIME);
+
+    // Add a marker to the trapq history
+    struct move *m = move_alloc();
+    m->print_time = print_time;
+    m->start_pos.x = pos_x;
+    m->start_pos.y = pos_y;
+    m->start_pos.z = pos_z;
+    list_add_head(&m->node, &tq->history);
+}
+
 // Return history of movement queue
 int __visible
 trapq_extract_old(struct trapq *tq, struct pull_move *p, int max

--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -157,9 +157,9 @@ trapq_add_move(struct trapq *tq, struct move *m)
     tail_sentinel->print_time = 0.;
 }
 
-// Free any moves older than `print_time` from the trapezoid velocity queue
+// Expire any moves older than `print_time` from the trapezoid velocity queue
 void __visible
-trapq_free_moves(struct trapq *tq, double print_time)
+trapq_finalize_moves(struct trapq *tq, double print_time)
 {
     struct move *head_sentinel = list_first_entry(&tq->moves, struct move,node);
     struct move *tail_sentinel = list_last_entry(&tq->moves, struct move, node);

--- a/klippy/chelper/trapq.h
+++ b/klippy/chelper/trapq.h
@@ -21,7 +21,14 @@ struct move {
 };
 
 struct trapq {
-    struct list_head moves;
+    struct list_head moves, history;
+};
+
+struct pull_move {
+    double print_time, move_t;
+    double start_v, accel;
+    double start_x, start_y, start_z;
+    double x_r, y_r, z_r;
 };
 
 struct move *move_alloc(void);
@@ -37,5 +44,7 @@ void trapq_free(struct trapq *tq);
 void trapq_check_sentinels(struct trapq *tq);
 void trapq_add_move(struct trapq *tq, struct move *m);
 void trapq_finalize_moves(struct trapq *tq, double print_time);
+int trapq_extract_old(struct trapq *tq, struct pull_move *p, int max
+                      , double start_time, double end_time);
 
 #endif // trapq.h

--- a/klippy/chelper/trapq.h
+++ b/klippy/chelper/trapq.h
@@ -36,6 +36,6 @@ struct trapq *trapq_alloc(void);
 void trapq_free(struct trapq *tq);
 void trapq_check_sentinels(struct trapq *tq);
 void trapq_add_move(struct trapq *tq, struct move *m);
-void trapq_free_moves(struct trapq *tq, double print_time);
+void trapq_finalize_moves(struct trapq *tq, double print_time);
 
 #endif // trapq.h

--- a/klippy/chelper/trapq.h
+++ b/klippy/chelper/trapq.h
@@ -44,6 +44,8 @@ void trapq_free(struct trapq *tq);
 void trapq_check_sentinels(struct trapq *tq);
 void trapq_add_move(struct trapq *tq, struct move *m);
 void trapq_finalize_moves(struct trapq *tq, double print_time);
+void trapq_set_position(struct trapq *tq, double print_time
+                        , double pos_x, double pos_y, double pos_z);
 int trapq_extract_old(struct trapq *tq, struct pull_move *p, int max
                       , double start_time, double end_time);
 

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -56,7 +56,7 @@ class ForceMove:
         if name not in self.steppers:
             raise self.printer.config_error("Unknown stepper %s" % (name,))
         return self.steppers[name]
-    def force_enable(self, stepper):
+    def _force_enable(self, stepper):
         toolhead = self.printer.lookup_object('toolhead')
         print_time = toolhead.get_last_move_time()
         stepper_enable = self.printer.lookup_object('stepper_enable')
@@ -66,7 +66,7 @@ class ForceMove:
             enable.motor_enable(print_time)
             toolhead.dwell(STALL_TIME)
         return was_enable
-    def restore_enable(self, stepper, was_enable):
+    def _restore_enable(self, stepper, was_enable):
         if not was_enable:
             toolhead = self.printer.lookup_object('toolhead')
             toolhead.dwell(STALL_TIME)
@@ -101,7 +101,7 @@ class ForceMove:
     def cmd_STEPPER_BUZZ(self, gcmd):
         stepper = self._lookup_stepper(gcmd)
         logging.info("Stepper buzz %s", stepper.get_name())
-        was_enable = self.force_enable(stepper)
+        was_enable = self._force_enable(stepper)
         toolhead = self.printer.lookup_object('toolhead')
         dist, speed = BUZZ_DISTANCE, BUZZ_VELOCITY
         if stepper.units_in_radians():
@@ -111,7 +111,7 @@ class ForceMove:
             toolhead.dwell(.050)
             self.manual_move(stepper, -dist, speed)
             toolhead.dwell(.450)
-        self.restore_enable(stepper, was_enable)
+        self._restore_enable(stepper, was_enable)
     cmd_FORCE_MOVE_help = "Manually move a stepper; invalidates kinematics"
     def cmd_FORCE_MOVE(self, gcmd):
         stepper = self._lookup_stepper(gcmd)
@@ -120,7 +120,7 @@ class ForceMove:
         accel = gcmd.get_float('ACCEL', 0., minval=0.)
         logging.info("FORCE_MOVE %s distance=%.3f velocity=%.3f accel=%.3f",
                      stepper.get_name(), distance, speed, accel)
-        self.force_enable(stepper)
+        self._force_enable(stepper)
         self.manual_move(stepper, distance, speed, accel)
     cmd_SET_KINEMATIC_POSITION_help = "Force a low-level kinematic position"
     def cmd_SET_KINEMATIC_POSITION(self, gcmd):

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -49,9 +49,8 @@ class ForceMove:
             gcode.register_command('SET_KINEMATIC_POSITION',
                                    self.cmd_SET_KINEMATIC_POSITION,
                                    desc=self.cmd_SET_KINEMATIC_POSITION_help)
-    def register_stepper(self, stepper):
-        name = stepper.get_name()
-        self.steppers[name] = stepper
+    def register_stepper(self, config, mcu_stepper):
+        self.steppers[mcu_stepper.get_name()] = mcu_stepper
     def lookup_stepper(self, name):
         if name not in self.steppers:
             raise self.printer.config_error("Unknown stepper %s" % (name,))

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -36,7 +36,7 @@ class ForceMove:
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
         self.trapq_append = ffi_lib.trapq_append
-        self.trapq_free_moves = ffi_lib.trapq_free_moves
+        self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
         self.stepper_kinematics = ffi_main.gc(
             ffi_lib.cartesian_stepper_alloc('x'), ffi_lib.free)
         # Register commands
@@ -87,7 +87,7 @@ class ForceMove:
                           0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
         print_time = print_time + accel_t + cruise_t + accel_t
         stepper.generate_steps(print_time)
-        self.trapq_free_moves(self.trapq, print_time + 99999.9)
+        self.trapq_finalize_moves(self.trapq, print_time + 99999.9)
         stepper.set_trapq(prev_trapq)
         stepper.set_stepper_kinematics(prev_sk)
         toolhead.note_kinematic_activity(print_time)

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -25,7 +25,7 @@ class ManualStepper:
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
         self.trapq_append = ffi_lib.trapq_append
-        self.trapq_free_moves = ffi_lib.trapq_free_moves
+        self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
         self.rail.setup_itersolve('cartesian_stepper_alloc', 'x')
         self.rail.set_trapq(self.trapq)
         # Register commands
@@ -67,7 +67,7 @@ class ManualStepper:
                           0., cruise_v, accel)
         self.next_cmd_time = self.next_cmd_time + accel_t + cruise_t + accel_t
         self.rail.generate_steps(self.next_cmd_time)
-        self.trapq_free_moves(self.trapq, self.next_cmd_time + 99999.9)
+        self.trapq_finalize_moves(self.trapq, self.next_cmd_time + 99999.9)
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.note_kinematic_activity(self.next_cmd_time)
         if sync:

--- a/klippy/extras/motion_report.py
+++ b/klippy/extras/motion_report.py
@@ -1,0 +1,146 @@
+# Diagnostic tool for reporting stepper and kinematic positions
+#
+# Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+import chelper
+
+# Extract stepper queue_step messages
+class DumpStepper:
+    def __init__(self, printer, mcu_stepper):
+        self.printer = printer
+        self.mcu_stepper = mcu_stepper
+    def get_step_queue(self, start_clock, end_clock):
+        mcu_stepper = self.mcu_stepper
+        res = []
+        while 1:
+            data, count = mcu_stepper.dump_steps(128, start_clock, end_clock)
+            if not count:
+                break
+            res.append((data, count))
+            if count < len(data):
+                break
+            end_clock = data[count-1].first_clock
+        res.reverse()
+        return ([data[i] for i in range(count-1, -1, -1)
+                 for data, count in res], res)
+    def log_steps(self, data):
+        if not data:
+            return
+        out = []
+        out.append("Dumping stepper '%s' (%s) %d queue_step:"
+                   % (self.mcu_stepper.get_name(),
+                      self.mcu_stepper.get_mcu().get_name(), len(data)))
+        for i, s in enumerate(data):
+            out.append("queue_step %d: t=%d p=%d i=%d c=%d a=%d"
+                       % (i, s.first_clock, s.start_position, s.interval,
+                          s.step_count, s.add))
+        logging.info('\n'.join(out))
+
+NEVER_TIME = 9999999999999999.
+
+# Extract trapezoidal motion queue (trapq)
+class DumpTrapQ:
+    def __init__(self, printer, name, trapq):
+        self.printer = printer
+        self.name = name
+        self.trapq = trapq
+    def get_trapq(self, start_time, end_time):
+        ffi_main, ffi_lib = chelper.get_ffi()
+        res = []
+        while 1:
+            data = ffi_main.new('struct pull_move[128]')
+            count = ffi_lib.trapq_extract_old(self.trapq, data, len(data),
+                                              start_time, end_time)
+            if not count:
+                break
+            res.append((data, count))
+            if count < len(data):
+                break
+            end_time = data[count-1].print_time
+        res.reverse()
+        return ([data[i] for i in range(count-1, -1, -1)
+                 for data, count in res], res)
+    def log_trapq(self, data):
+        if not data:
+            return
+        out = ["Dumping trapq '%s' %d moves:" % (self.name, len(data))]
+        for i, m in enumerate(data):
+            out.append("move %d: pt=%.6f mt=%.6f sv=%.6f a=%.6f"
+                       " sp=(%.6f,%.6f,%.6f) ar=(%.6f,%.6f,%.6f)"
+                       % (i, m.print_time, m.move_t, m.start_v, m.accel,
+                          m.start_x, m.start_y, m.start_z, m.x_r, m.y_r, m.z_r))
+        logging.info('\n'.join(out))
+    def get_trapq_position(self, print_time):
+        ffi_main, ffi_lib = chelper.get_ffi()
+        data = ffi_main.new('struct pull_move[1]')
+        count = ffi_lib.trapq_extract_old(self.trapq, data, 1, 0., print_time)
+        if not count:
+            return None
+        move = data[0]
+        move_time = max(0., min(move.move_t, print_time - move.print_time))
+        dist = (move.start_v + .5 * move.accel * move_time) * move_time;
+        return (move.start_x + move.x_r * dist, move.start_y + move.y_r * dist,
+                move.start_z + move.z_r * dist)
+
+class PrinterMotionReport:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.steppers = {}
+        self.trapqs = {}
+        self.printer.register_event_handler("klippy:connect", self._connect)
+        self.printer.register_event_handler("klippy:shutdown", self._shutdown)
+    def register_stepper(self, config, mcu_stepper):
+        ds = DumpStepper(self.printer, mcu_stepper)
+        self.steppers[mcu_stepper.get_name()] = ds
+    def _connect(self):
+        # Lookup toolhead trapq
+        toolhead = self.printer.lookup_object("toolhead")
+        trapq = toolhead.get_trapq()
+        self.trapqs['toolhead'] = DumpTrapQ(self.printer, 'toolhead', trapq)
+        # Lookup extruder trapqs
+        for i in range(99):
+            ename = "extruder%d" % (i,)
+            if ename == "extruder0":
+                ename = "extruder"
+            extruder = self.printer.lookup_object(ename, None)
+            if extruder is None:
+                break
+            etrapq = extruder.get_trapq()
+            self.trapqs[ename] = DumpTrapQ(self.printer, ename, etrapq)
+    # Shutdown handling
+    def _dump_shutdown(self, eventtime):
+        # Log stepper queue_steps on mcu that started shutdown (if any)
+        shutdown_time = NEVER_TIME
+        for dstepper in self.steppers.values():
+            mcu = dstepper.mcu_stepper.get_mcu()
+            sc = mcu.get_shutdown_clock()
+            if not sc:
+                continue
+            shutdown_time = min(shutdown_time, mcu.clock_to_print_time(sc))
+            clock_100ms = mcu.seconds_to_clock(0.100)
+            start_clock = max(0, sc - clock_100ms)
+            end_clock = sc + clock_100ms
+            data, cdata = dstepper.get_step_queue(start_clock, end_clock)
+            dstepper.log_steps(data)
+        if shutdown_time >= NEVER_TIME:
+            return
+        # Log trapqs around time of shutdown
+        for dtrapq in self.trapqs.values():
+            data, cdata = dtrapq.get_trapq(shutdown_time - .100,
+                                           shutdown_time + .100)
+            dtrapq.log_trapq(data)
+        # Log estimated toolhead position at time of shutdown
+        dtrapq = self.trapqs.get('toolhead')
+        if dtrapq is None:
+            return
+        pos = dtrapq.get_trapq_position(shutdown_time)
+        if pos is not None:
+            logging.info("Requested toolhead position at shutdown time %.6f: %s"
+                         , shutdown_time, pos)
+    def _shutdown(self):
+        self.printer.get_reactor().register_callback(self._dump_shutdown)
+
+def load_config(config):
+    return PrinterMotionReport(config)

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -84,10 +84,10 @@ class PrinterStepperEnable:
         gcode.register_command("SET_STEPPER_ENABLE",
                                self.cmd_SET_STEPPER_ENABLE,
                                desc=self.cmd_SET_STEPPER_ENABLE_help)
-    def register_stepper(self, stepper, pin):
-        name = stepper.get_name()
-        enable = setup_enable_pin(self.printer, pin)
-        self.enable_lines[name] = EnableTracking(stepper, enable)
+    def register_stepper(self, config, mcu_stepper):
+        name = mcu_stepper.get_name()
+        enable = setup_enable_pin(self.printer, config.get('enable_pin', None))
+        self.enable_lines[name] = EnableTracking(mcu_stepper, enable)
     def motor_off(self):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.dwell(DISABLE_STALL_TIME)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -98,6 +98,8 @@ class PrinterExtruder:
         return self.name
     def get_heater(self):
         return self.heater
+    def get_trapq(self):
+        return self.trapq
     def sync_stepper(self, stepper):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.flush_step_generation()
@@ -229,6 +231,8 @@ class DummyExtruder:
     def get_name(self):
         return ""
     def get_heater(self):
+        raise self.printer.command_error("Extruder not configured")
+    def get_trapq(self):
         raise self.printer.command_error("Extruder not configured")
 
 def add_printer_objects(config):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -48,7 +48,7 @@ class PrinterExtruder:
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
         self.trapq_append = ffi_lib.trapq_append
-        self.trapq_free_moves = ffi_lib.trapq_free_moves
+        self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
         self.sk_extruder = ffi_main.gc(ffi_lib.extruder_stepper_alloc(),
                                        ffi_lib.free)
         self.stepper.set_stepper_kinematics(self.sk_extruder)
@@ -75,7 +75,7 @@ class PrinterExtruder:
                                    self.name, self.cmd_SET_E_STEP_DISTANCE,
                                    desc=self.cmd_SET_E_STEP_DISTANCE_help)
     def update_move_time(self, flush_time):
-        self.trapq_free_moves(self.trapq, flush_time)
+        self.trapq_finalize_moves(self.trapq, flush_time)
     def _set_pressure_advance(self, pressure_advance, smooth_time):
         old_smooth_time = self.pressure_advance_smooth_time
         if not self.pressure_advance:

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -522,6 +522,7 @@ class MCU:
         self._reset_cmd = self._config_reset_cmd = None
         self._emergency_stop_cmd = None
         self._is_shutdown = self._is_timeout = False
+        self._shutdown_clock = 0
         self._shutdown_msg = ""
         # Config building
         printer.lookup_object('pins').register_chip(self._name, self)
@@ -565,6 +566,9 @@ class MCU:
         if self._is_shutdown:
             return
         self._is_shutdown = True
+        clock = params.get("clock")
+        if clock is not None:
+            self._shutdown_clock = self.clock32_to_clock64(clock)
         self._shutdown_msg = msg = params['static_string_id']
         logging.info("MCU '%s' %s: %s\n%s\n%s", self._name, params['#name'],
                      self._shutdown_msg, self._clocksync.dump_debug(),
@@ -880,6 +884,8 @@ class MCU:
         return self._printer.get_start_args().get('debugoutput') is not None
     def is_shutdown(self):
         return self._is_shutdown
+    def get_shutdown_clock(self):
+        return self._shutdown_clock
     def flush_moves(self, print_time):
         if self._steppersync is None:
             return

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -198,7 +198,7 @@ def PrinterStepper(config, units_in_radians=False):
     mcu_stepper = MCU_stepper(name, step_pin_params, dir_pin_params, step_dist,
                               units_in_radians)
     # Register with helper modules
-    for mname in ['stepper_enable', 'force_move']:
+    for mname in ['stepper_enable', 'force_move', 'motion_report']:
         m = printer.load_object(config, mname)
         m.register_stepper(config, mcu_stepper)
     return mcu_stepper

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -197,12 +197,10 @@ def PrinterStepper(config, units_in_radians=False):
     step_dist = parse_step_distance(config, units_in_radians, True)
     mcu_stepper = MCU_stepper(name, step_pin_params, dir_pin_params, step_dist,
                               units_in_radians)
-    # Support for stepper enable pin handling
-    stepper_enable = printer.load_object(config, 'stepper_enable')
-    stepper_enable.register_stepper(mcu_stepper, config.get('enable_pin', None))
-    # Register STEPPER_BUZZ command
-    force_move = printer.load_object(config, 'force_move')
-    force_move.register_stepper(mcu_stepper)
+    # Register with helper modules
+    for mname in ['stepper_enable', 'force_move']:
+        m = printer.load_object(config, mname)
+        m.register_stepper(config, mcu_stepper)
     return mcu_stepper
 
 # Parse stepper gear_ratio config parameter

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -119,6 +119,12 @@ class MCU_stepper:
     def get_past_commanded_position(self, print_time):
         mcu_pos = self.get_past_mcu_position(print_time)
         return mcu_pos * self._step_dist - self._mcu_position_offset
+    def dump_steps(self, count, start_clock, end_clock):
+        ffi_main, ffi_lib = chelper.get_ffi()
+        data = ffi_main.new('struct pull_history_steps[]', count)
+        count = ffi_lib.stepcompress_extract_old(self._stepqueue, data, count,
+                                                 start_clock, end_clock)
+        return (data, count)
     def set_stepper_kinematics(self, sk):
         old_sk = self._stepper_kinematics
         mcu_pos = 0

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -244,7 +244,7 @@ class ToolHead:
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
         self.trapq_append = ffi_lib.trapq_append
-        self.trapq_free_moves = ffi_lib.trapq_free_moves
+        self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
         self.step_generators = []
         # Create kinematics class
         gcode = self.printer.lookup_object('gcode')
@@ -285,7 +285,7 @@ class ToolHead:
             for sg in self.step_generators:
                 sg(sg_flush_time)
             free_time = max(lkft, sg_flush_time - kin_flush_delay)
-            self.trapq_free_moves(self.trapq, free_time)
+            self.trapq_finalize_moves(self.trapq, free_time)
             self.extruder.update_move_time(free_time)
             mcu_flush_time = max(lkft, sg_flush_time - self.move_flush_time)
             for m in self.all_mcus:
@@ -401,7 +401,7 @@ class ToolHead:
         return list(self.commanded_pos)
     def set_position(self, newpos, homing_axes=()):
         self.flush_step_generation()
-        self.trapq_free_moves(self.trapq, self.reactor.NEVER)
+        self.trapq_finalize_moves(self.trapq, self.reactor.NEVER)
         self.commanded_pos[:] = newpos
         self.kin.set_position(newpos, homing_axes)
         self.printer.send_event("toolhead:set_position")
@@ -477,7 +477,7 @@ class ToolHead:
             self.move_queue.flush()
         except DripModeEndSignal as e:
             self.move_queue.reset()
-            self.trapq_free_moves(self.trapq, self.reactor.NEVER)
+            self.trapq_finalize_moves(self.trapq, self.reactor.NEVER)
         # Exit "Drip" state
         self.flush_step_generation()
     # Misc commands

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -401,7 +401,9 @@ class ToolHead:
         return list(self.commanded_pos)
     def set_position(self, newpos, homing_axes=()):
         self.flush_step_generation()
-        self.trapq_finalize_moves(self.trapq, self.reactor.NEVER)
+        ffi_main, ffi_lib = chelper.get_ffi()
+        ffi_lib.trapq_set_position(self.trapq, self.print_time,
+                                   newpos[0], newpos[1], newpos[2])
         self.commanded_pos[:] = newpos
         self.kin.set_position(newpos, homing_axes)
         self.printer.send_event("toolhead:set_position")


### PR DESCRIPTION
This adds a new module that adds diagnostic reporting on Klipper's motion system.  This initial PR adds support for dumping out the motion queues (the trapq history and the stepper queue_step history) on a shutdown event.

I plan to continue adding additional support to the module.  My goal is to make it possible to export the trapq and step queues in near real-time via the "api server" for analysis purposes.

Separately, I've also locally attempted to extend this new module to report the current "live" toolhead position (ie, the position of the toolhead at the current time - not the last requested gcode position).  Unfortunately, my current code produces misleading results after a `toolhead.set_position()` call.  If I get that working though, I'll push it in a separate PR.

-Kevin