### PR TITLE
Trinamic stepper motor UART updates

### DIFF
--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -59,6 +59,9 @@ class TMC2209:
         self.fields = tmc.FieldHelper(Fields, tmc2208.SignedFields,
                                       FieldFormatters)
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields, 3)
+        # Setup fields for UART
+        self.fields.set_field("pdn_disable", True)
+        self.fields.set_field("SENDDELAY", 2) # Avoid tx errors on shared uart
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -70,7 +70,8 @@ def lookup_tmc_uart_mutex(mcu):
         pmutexes.mcu_to_mutex[mcu] = mutex
     return mutex
 
-TMC_BAUD_RATE = 9000
+TMC_BAUD_RATE = 40000
+TMC_BAUD_RATE_AVR = 9000
 
 # Code for sending messages on a TMC uart
 class MCU_TMC_uart_bitbang:
@@ -90,7 +91,11 @@ class MCU_TMC_uart_bitbang:
         self.tmcuart_send_cmd = None
         self.mcu.register_config_callback(self.build_config)
     def build_config(self):
-        bit_ticks = self.mcu.seconds_to_clock(1. / TMC_BAUD_RATE)
+        baud = TMC_BAUD_RATE
+        mcu_type = self.mcu.get_constants().get("MCU", "")
+        if mcu_type.startswith("atmega") or mcu_type.startswith("at90usb"):
+            baud = TMC_BAUD_RATE_AVR
+        bit_ticks = self.mcu.seconds_to_clock(1. / baud)
         self.mcu.add_config_cmd(
             "config_tmcuart oid=%d rx_pin=%s pull_up=%d tx_pin=%s bit_time=%d"
             % (self.oid, self.rx_pin, self.pullup, self.tx_pin, bit_ticks))


### PR DESCRIPTION
An investigation by @ReXT3d found that the tmc2209 UART behavior is greatly improved by setting SENDDELAY=2.  ( https://klipper.discourse.group/t/intermittent-tmc-uart-weirdness/454 ) As a guess, the additional delay helps the chips identify each others responses on shared UART lines - which may improve their ability to keep synchronized with the UART traffic.

This PR also increases the default UART baud rate to 40000 for 32bit MCUs.  There shouldn't be any harm in using a faster speed on more modern MCUs (the slower AVR chips will continue to use a baud of 9000).

-Kevin