### PR TITLE
menu: fix crash when opening SDCard menu while printing

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -165,7 +165,7 @@ name: SD Card
 
 [menu __main __sdcard __start]
 type: command
-enable: {('virtual_sdcard' in printer) and printer.virtual_sdcard.file_path}
+enable: {('virtual_sdcard' in printer) and printer.virtual_sdcard.file_path and not printer.virtual_sdcard.is_active}
 name: Start printing
 gcode: M24
 


### PR DESCRIPTION
This fixes the bug introduced by https://github.com/KevinOConnor/klipper/commit/f1091a484bfbf2cc5676e3a6fcd595172f123f67.
The problem is that condition was returning string which
could not be converted to boolean. We solve that by showing
`Start Printing` when `is_active`.

```
ERROR:root:Unhandled exception during run
Traceback (most recent call last):
   ...
   File "/opt/klipper/klippy/extras/display/menu.py", line 117, in eval_enable
     return bool(ast.literal_eval(self._enable_tpl.render(context)))
   File "/usr/lib/python2.7/ast.py", line 49, in literal_eval
     node_or_string = parse(node_or_string, mode='eval')
   File "/usr/lib/python2.7/ast.py", line 37, in parse
     return compile(source, filename, mode, PyCF_ONLY_AST)
   File "<unknown>", line 1
     /opt/octoprint/uploads/wait_print.gcode
```