### PR TITLE
CONFIGFILE: Added BACKUP and RESTART to SAVE_CONFIG

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -329,11 +329,13 @@ class PrinterConfig:
             f = open(temp_name, 'wb')
             f.write(data)
             f.close()
-            os.rename(cfgname, backup_name)
+            if gcmd.get_int('BACKUP', 1):
+                os.rename(cfgname, backup_name)
             os.rename(temp_name, cfgname)
         except:
             msg = "Unable to write config file during SAVE_CONFIG"
             logging.exception(msg)
             raise gcode.error(msg)
         # Request a restart
-        gcode.request_restart('restart')
+        if gcmd.get_int('RESTART', 1):
+            gcode.request_restart('restart')


### PR DESCRIPTION
Added optional BACKUP and RESTART parameters to prevent creating the
backup file and/or restarting klipper. If unspecified it maintain current
behavior (backing up and restarting)

Signed-off-by: Randell L Hodges <rhodges@taxfodder.com>