### PR TITLE
correct pins for ender3max display

### DIFF
--- a/config/printer-creality-ender3max-2021.cfg
+++ b/config/printer-creality-ender3max-2021.cfg
@@ -146,5 +146,5 @@ lcd_type: st7920
 cs_pin: PB12
 sclk_pin: PB13
 sid_pin: PB15
-encoder_pins: ^PD2, ^PD3
-click_pin: ^!PC0
+encoder_pins: ^PB14, ^PB10
+click_pin: ^!PB2

--- a/config/printer-creality-ender3max-2021.cfg
+++ b/config/printer-creality-ender3max-2021.cfg
@@ -146,5 +146,7 @@ lcd_type: st7920
 cs_pin: PB12
 sclk_pin: PB13
 sid_pin: PB15
-encoder_pins: ^PB14, ^PB10
-click_pin: ^!PB2
+# encoder_pins: ^PB14, ^PB10    # enable for 32bit board (v4.2.2)
+# click_pin: ^!PB2              # enable for 32bit board (v4.2.2)
+# encoder_pins: ^PD2, ^PD3      # enable for 8bit board
+# click_pin: ^!PC0              # enable for 8bit board

--- a/config/printer-creality-ender3max-2021.cfg
+++ b/config/printer-creality-ender3max-2021.cfg
@@ -146,7 +146,5 @@ lcd_type: st7920
 cs_pin: PB12
 sclk_pin: PB13
 sid_pin: PB15
-# encoder_pins: ^PB14, ^PB10    # enable for 32bit board (v4.2.2)
-# click_pin: ^!PB2              # enable for 32bit board (v4.2.2)
-# encoder_pins: ^PD2, ^PD3      # enable for 8bit board
-# click_pin: ^!PC0              # enable for 8bit board
+encoder_pins: ^PB14, ^PB10
+click_pin: ^!PB2


### PR DESCRIPTION
knob/clicker doesnt work with current values. Switching to values from printer-creality-ender3pro-2020.cfg work as expected. 

Signed-off-by: Shawn Foley shawnifoley@gmail.com