### PR TITLE
bed_screws: Finish bed_screws_adjust after 4 (corrected: n screws) consecutive accepts

### DIFF
--- a/klippy/extras/bed_screws.py
+++ b/klippy/extras/bed_screws.py
@@ -17,7 +17,8 @@ class BedScrews:
         self.printer = config.get_printer()
         self.state = None
         self.current_screw = 0
-        self.adjust_again = False
+        self.accepted_screws = 0
+        self.number_of_screws = 0
         # Read config
         screws = []
         fine_adjust = []
@@ -34,6 +35,7 @@ class BedScrews:
                 fine_adjust.append((fine_coord, screw_name))
         if len(screws) < 3:
             raise config.error("bed_screws: Must have at least three screws")
+        self.number_of_screws = len(screws)
         self.states = {'adjust': screws, 'fine': fine_adjust}
         self.speed = config.getfloat('speed', 50., above=0.)
         self.lift_speed = config.getfloat('probe_speed', 5., above=0.)
@@ -73,22 +75,25 @@ class BedScrews:
     def cmd_BED_SCREWS_ADJUST(self, gcmd):
         if self.state is not None:
             raise gcmd.error("Already in bed_screws helper; use ABORT to exit")
-        self.adjust_again = False
+        # reset accepted screws
+        self.accepted_screws = 0
         self.move((None, None, self.horizontal_move_z), self.speed)
         self.move_to_screw('adjust', 0)
     cmd_ACCEPT_help = "Accept bed screw position"
     def cmd_ACCEPT(self, gcmd):
         self.unregister_commands()
-        if self.current_screw + 1 < len(self.states[self.state]):
+        self.accepted_screws = self.accepted_screws + 1
+        if self.current_screw + 1 < len(self.states[self.state]) and self.accepted_screws < self.number_of_screws:
             # Continue with next screw
             self.move_to_screw(self.state, self.current_screw + 1)
             return
-        if self.adjust_again:
+        if self.accepted_screws < self.number_of_screws:
             # Retry coarse adjustments
-            self.adjust_again = False
             self.move_to_screw('adjust', 0)
             return
         if self.state == 'adjust' and self.states['fine']:
+            # Reset accepted screws for fine adjustment
+            self.accepted_screws = 0
             # Perform fine screw adjustments
             self.move_to_screw('fine', 0)
             return
@@ -99,7 +104,7 @@ class BedScrews:
     cmd_ADJUSTED_help = "Accept bed screw position after notable adjustment"
     def cmd_ADJUSTED(self, gcmd):
         self.unregister_commands()
-        self.adjust_again = True
+        self.accepted_screws = -1
         self.cmd_ACCEPT(gcmd)
     cmd_ABORT_help = "Abort bed screws tool"
     def cmd_ABORT(self, gcmd):

--- a/klippy/extras/bed_screws.py
+++ b/klippy/extras/bed_screws.py
@@ -83,7 +83,8 @@ class BedScrews:
     def cmd_ACCEPT(self, gcmd):
         self.unregister_commands()
         self.accepted_screws = self.accepted_screws + 1
-        if self.current_screw + 1 < len(self.states[self.state]) and self.accepted_screws < self.number_of_screws:
+        if self.current_screw + 1 < len(self.states[self.state]) \
+                and self.accepted_screws < self.number_of_screws:
             # Continue with next screw
             self.move_to_screw(self.state, self.current_screw + 1)
             return


### PR DESCRIPTION
It always bothered me that on my Ender 3 Pro with 4 bed screws I had to accept 7 times if I adjusted the first screw and after that screw every screw was fine. So I rewrote the code that it would finish the bed_screws_adjust command when you accepted all screws without a adjust in between no matter which screw you accepted first.

In the commit title I wrote 4 consecutive accepts but I meant as many as the printer has screws but just thought of my Ender 3.

I tested the code (except for the fine tuning) on my Ender 3 where it worked fine. 

This is my first contribution to a open-source project ever so please let me know if I did anything wrong.