### PR TITLE
bed_mesh_calibrate: Added PROFILE name option

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -345,13 +345,17 @@ are identified in green.
 
 ### Calibration
 
-`BED_MESH_CALIBRATE METHOD=[manual | automatic] [<probe_parameter>=<value>]
+`BED_MESH_CALIBRATE PROFILE=name METHOD=[manual | automatic] [<probe_parameter>=<value>]
  [<mesh_parameter>=<value>]`\
+_Default Profile:  default_\
 _Default Method:  automatic if a probe is detected, otherwise manual_
 
-Initiates the probing procedure for Bed Mesh Calibration.  If `METHOD=manual`
-is selected then manual probing will occur.  When switching between automatic
-and manual probing the generated mesh points will automatically be adjusted.
+Initiates the probing procedure for Bed Mesh Calibration.
+
+The mesh will be saved into a profile specified by the `PROFILE` parameter,
+or `default` if unspecified. If `METHOD=manual` is selected then manual probing
+will occur.  When switching between automatic and manual probing the generated
+mesh points will automatically be adjusted.
 
 It is possible to specify mesh parameters to modify the probed area.  The
 following parameters are available:

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -265,6 +265,7 @@ class BedMeshCalibrate:
         self.mesh_config = collections.OrderedDict()
         self._init_mesh_config(config)
         self._generate_points(config.error)
+        self._profile_name = None
         self.orig_points = self.points
         self.probe_helper = probe.ProbePointsHelper(
             config, self.probe_finalize, self._get_adjusted_points())
@@ -571,6 +572,7 @@ class BedMeshCalibrate:
         return adj_pts
     cmd_BED_MESH_CALIBRATE_help = "Perform Mesh Bed Leveling"
     def cmd_BED_MESH_CALIBRATE(self, gcmd):
+        self._profile_name = gcmd.get('PROFILE', "default")
         self.bedmesh.set_mesh(None)
         self.update_config(gcmd)
         self.probe_helper.start_probe(gcmd)
@@ -691,7 +693,7 @@ class BedMeshCalibrate:
             raise self.gcode.error(str(e))
         self.bedmesh.set_mesh(z_mesh)
         self.gcode.respond_info("Mesh Bed Leveling Complete")
-        self.bedmesh.save_profile("default")
+        self.bedmesh.save_profile(self._profile_name)
     def _dump_points(self, probed_pts, corrected_pts, offsets):
         # logs generated points with offset applied, points received
         # from the finalize callback, and the list of corrected points


### PR DESCRIPTION
Added an optional parameter to allow bed_mesh_calibrate directly into the named profile instead of `default`. If not provided, it will default to the current behavior of `default`.

A use case would be when a person creates a mesh for a different temperature or maybe a different build surface, they can specify the name then. Otherwise they have to remember to run bed_mesh_profile save=name when they are done and potentially overwrite their `default` mesh if they already have one.