### PR TITLE
graphstats: accept parsing `journald`

### DIFF
--- a/scripts/graphstats.py
+++ b/scripts/graphstats.py
@@ -27,9 +27,10 @@ def parse_log(logname, mcu):
     out = []
     for line in f:
         parts = line.split()
-        if not parts or parts[0] not in ('Stats', 'INFO:root:Stats'):
-            #if parts and parts[0] == 'INFO:root:shutdown:':
-            #    break
+        # iterate till a message is found
+        while parts and parts[0] not in ('Stats', 'INFO:root:Stats'):
+            parts.pop(0)
+        if not parts:
             continue
         prefix = ""
         keyparts = {}


### PR DESCRIPTION
I prefer to store all logs in `journald` (it does significantly better job with that) instead of log files.
Sometimes it is useful to parse log as-is. The `graphstats` except very specific output without
a prefix columns (`Jul 26 22:23:48 mk3s python2[3959]:`). This makes the script to skip all trailing columns to find a matching one.

This makes possible to support parsing output as:

```txt
Jul 26 22:23:48 mk3s python2[3959]: INFO:root:Stats 32869.5: gcodein=0 mcu: mcu_awake=0.174 mcu_task_avg=0.000328 mcu_task_stddev=0.000223 bytes_write=4423147 bytes_read=874981 bytes_retransmit=87701 bytes_invalid=188297 send_seq=89012 receive_seq=89012 retransmit_seq=88948 srtt=0.004 rttvar=0.001 rto=0.025 ready_bytes=52 stalled_bytes=1002 freq=15999045 rock64: temp=60.8 sd_pos=962748 heater_bed: target=90 temp=89.8 pwm=0.706 ambient_temp: temp=46.3 sysload=1.17 cputime=1436.931 memavail=3347136 print_time=1640.819 buffer_time=2.204 print_stall=0 extruder: target=240 temp=239.8 pwm=0.362
```

Signed-off-by: Kamil Trzcinski <ayufan@ayufan.eu>