### PR TITLE
Add SKR2 board support for SD flash

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -55,6 +55,12 @@ BOARD_DEFS = {
         'spi_bus': "spi1",
         "cs_pin": "PA4",
         "current_firmware_path": "OLD.BIN"
+    },
+    'btt-skr-2': {
+        'mcu': "stm32f407xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11"
     }
 }
 

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -60,7 +60,8 @@ BOARD_DEFS = {
         'mcu': "stm32f407xx",
         'spi_bus': "swspi",
         'spi_pins': "PC8,PD2,PC12",
-        'cs_pin': "PC11"
+        'cs_pin': "PC11",
+        'interactive': True
     }
 }
 

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -841,13 +841,16 @@ class MCUConnection:
         if self.fatfs is not None:
             self.fatfs.unmount()
             self.fatfs.clear_callbacks()
-        if post_upload is True and self.board_config.get('interactive', False) is True:
+        if (post_upload is True
+          and self.board_config.get('interactive', False) is True):
             try:
                 # fix for Python2
                 input = raw_input
             except NameError:
                 pass
-            input("\n\n[USER INTERACTION REQUIRED: Reinsert SD card or powercycle printer, then press Enter to continue...]\n")
+            input("\n\n[USER INTERACTION REQUIRED: " +
+                  "Reinsert SD card or powercycle printer, " +
+                  "then press Enter to continue...]\n")
         # XXX: do we need to support other reset methods?
         self._serial.send(RESET_CMD)
         self.reactor.pause(self.reactor.monotonic() + 0.015)


### PR DESCRIPTION
I tried it on my SKR2 board, it quite works except "full reset" of the board didn't happen (I have to reset manualy, by reset button or power cycle).
I can see this:
```
pi@fluiddpi:~/klipper $ ./scripts/flash-sdcard.sh /dev/serial/by-id/usb-Klipper_stm32f407xx_2B0023000247393439313338-if00 btt-skr-2
Flashing /home/pi/klipper/out/klipper.bin to /dev/serial/by-id/usb-Klipper_stm32f407xx_2B0023000247393439313338-if00
Checking FatFS CFFI Build...
Connecting to MCU...Connected
Checking Current MCU Configuration...Done
MCU needs restart: is_config=1, is_shutdown=0
Attempting MCU Reset...Done
Waiting for device to reconnect....Done
Connecting to MCU...Connected
Initializing SD Card and Mounting file system...

SD Card Information:
Version: 2.0
SDHC/SDXC: True
Write Protected: False
Sectors: 62333952
manufacturer_id: 3
oem_id: SD
product_name: SL32G
product_revision: 8.128
serial_number: ECAEE005
manufacturing_date: 1/2019
capacity: 29.7 GiB
fs_type: FAT32
volume_label: ENDER
volume_serial: 1081870871
Uploading Klipper Firmware to SD Card...Done
Validating Upload...Done
Firmware Upload Complete: firmware.bin, Size: 22328, Checksum (SHA1): D4516394B634E879F4A39CBA89E25C8CB548F34A
Attempting MCU Reset...Done
Waiting for device to reconnect....Done
Connecting to MCU...Connected
Verifying Flash...
SD Card Flash Error: Version Mismatch: Got 'v0.9.1-629-g0075b290-dirty-20210724_233606-fluiddpi...', expected 'v0.9.1-632-g7e88f922-dirty-20210727_144546-fluiddpi...'
Traceback (most recent call last):
  File "/home/pi/klipper/scripts/spi_flash/spi_flash.py", line 1159, in main
    spiflash.run()
  File "/home/pi/klipper/scripts/spi_flash/spi_flash.py", line 1113, in run
    self.run_reactor_task(self.run_verify)
  File "/home/pi/klipper/scripts/spi_flash/spi_flash.py", line 1095, in run_reactor_task
    k_reactor.run()
  File "/home/pi/klipper/klippy/reactor.py", line 269, in run
    g_next.switch()
  File "/home/pi/klipper/klippy/reactor.py", line 310, in _dispatch_loop
    timeout = self._check_timers(eventtime, busy)
  File "/home/pi/klipper/klippy/reactor.py", line 156, in _check_timers
    t.waketime = waketime = t.callback(eventtime)
  File "/home/pi/klipper/klippy/reactor.py", line 48, in invoke
    res = self.callback(eventtime)
  File "/home/pi/klipper/scripts/spi_flash/spi_flash.py", line 1084, in run_verify
    self.new_dictionary)
  File "/home/pi/klipper/scripts/spi_flash/spi_flash.py", line 966, in verify_flash
    json.loads(req_dictionary)['version']))
SPIFlashError: Version Mismatch: Got 'v0.9.1-629-g0075b290-dirty-20210724_233606-fluiddpi...', expected 'v0.9.1-632-g7e88f922-dirty-20210727_144546-fluiddpi...'
```
and at this moment if I press "reset" button, wait a moment a try again:
```
pi@fluiddpi:~/klipper $ ./scripts/flash-sdcard.sh /dev/serial/by-id/usb-Klipper_stm32f407xx_2B0023000247393439313338-if00 btt-skr-2
Flashing /home/pi/klipper/out/klipper.bin to /dev/serial/by-id/usb-Klipper_stm32f407xx_2B0023000247393439313338-if00
Checking FatFS CFFI Build...
Connecting to MCU...Connected
Checking Current MCU Configuration...Done
Initializing SD Card and Mounting file system...

SD Card Information:
Version: 2.0
SDHC/SDXC: True
Write Protected: False
Sectors: 62333952
manufacturer_id: 3
oem_id: SD
product_name: SL32G
product_revision: 8.128
serial_number: ECAEE005
manufacturing_date: 1/2019
capacity: 29.7 GiB
fs_type: FAT32
volume_label: ENDER
volume_serial: 1081870871
Uploading Klipper Firmware to SD Card...Done
Validating Upload...Done
Firmware Upload Complete: firmware.bin, Size: 22328, Checksum (SHA1): D4516394B634E879F4A39CBA89E25C8CB548F34A
Attempting MCU Reset...Done
Waiting for device to reconnect....Done
Connecting to MCU...Connected
Verifying Flash...Version matched...Done
Found and deleted firmware.bin after reset
Firmware Flash Successful
Current Firmware: v0.9.1-632-g7e88f922-dirty-20210727_144546-fluiddpi
Attempting MCU Reset...Done
SD Card Flash Complete
```



Reset by _spi_flash.py_ does something, as well as "FIRMWARE_RESTART" (there's visible "USB disconnect/New USB device found" in journalctl), but it doesn't seem it really resets the board to the "cold" state (boot through bootloader/firmware flasher).
