### PR TITLE
Add referenced config example

### DIFF
--- a/config/sample-pwm-tool.cfg
+++ b/config/sample-pwm-tool.cfg
@@ -1,0 +1,57 @@
+# This file contains an example configuration to use a PWM-controlled tool
+# such as a laser or spindle.
+# See docs/Using_PWM_Tools.md for a more detailed description.
+
+[output_pin TOOL]
+pin: !ar9       # use your fan's pin number
+pwm: True
+hardware_pwm: True
+cycle_time: 0.001
+shutdown_value: 0
+maximum_mcu_duration: 5
+# Default: 0 (disabled)
+# Amount of time in which the host has to acknowledge
+# a non-shutdown output value.
+# Suggested value is around 5 seconds.
+# Use a value that does not burn up your stock.
+# Please note that during homing, your tool
+# needs to be in default speed.
+
+[gcode_macro M3]
+default_parameter_S: 0
+gcode:
+    SET_PIN PIN=TOOL VALUE={S|float / 255}
+
+[gcode_macro M4]
+default_parameter_S: 0
+gcode:
+    SET_PIN PIN=TOOL VALUE={S|float / 255}
+
+[gcode_macro M5]
+gcode:
+    SET_PIN PIN=TOOL VALUE=0
+
+
+# Optional: LCD Menu Control
+
+[menu __main __control __toolonoff]
+type: input
+enable: {'output_pin TOOL' in printer}
+name: Fan: {'ON ' if menu.input else 'OFF'}
+input: {printer['output_pin TOOL'].value}
+input_min: 0
+input_max: 1
+input_step: 1
+gcode:
+    M3 S{255 if menu.input else 0}
+
+[menu __main __control __toolspeed]
+type: input
+enable: {'output_pin TOOL' in printer}
+name: Tool speed: {'%3d' % (menu.input*100)}%
+input: {printer['output_pin TOOL'].value}
+input_min: 0
+input_max: 1
+input_step: 0.01
+gcode:
+    M3 S{'%d' % (menu.input*255)}

--- a/docs/Using_PWM_Tools.md
+++ b/docs/Using_PWM_Tools.md
@@ -24,7 +24,7 @@ and to disconnect the laser when it is not needed.
 Also, you should configure a safety timeout,
 so that when your host or MCU encounters an error, the tool will stop.
 
-For an example configuration, see `config/sample-pwm-tool-cfg`.
+For an example configuration, see [config/sample-pwm-tool.cfg](/config/sample-pwm-tool.cfg).
 
 ## Current Limitations
 


### PR DESCRIPTION
This  PR adds the referenced PWM-Tool config example, which closes #4410.
