### PR TITLE
klipper3d : anchor links not working on Safari

### DIFF
--- a/docs/_klipper3d/mkdocs.yml
+++ b/docs/_klipper3d/mkdocs.yml
@@ -26,7 +26,6 @@ theme:
   icon:
     repo: fontawesome/brands/github
   features:
-      - navigation.instant
       #- navigation.tabs
       #- navigation.expand
       - navigation.top


### PR DESCRIPTION
Solves issue #4538 by disabling the `navigation.instant` feature of the mkdocs-material theme which does not work well with Safari.