### PR TITLE
filament_motion_sensor: Add time-based runout calculation

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3677,6 +3677,16 @@ detection_length: 7.0
 #   The minimum length of filament pulled through the sensor to trigger
 #   a state change on the switch_pin
 #   Default is 7 mm.
+# time_based: False
+#   When set to true, use a time-based calculation to trigger runout
+#   events instead of distance travelled.  This is less precise than
+#   length measurement, but addresses issues with some movement sensors.
+# timeout_seconds: 30
+#   When time_based is set to True, the number of seconds of no
+#   filament movement before a runout is triggered.
+#   This should be adjusted based on the length of your filament path,
+#   tolerance of jams, etc.
+#   Default is 30 seconds.
 extruder:
 #   The name of the extruder section this sensor is associated with.
 #   This parameter must be provided.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3687,6 +3687,11 @@ detection_length: 7.0
 #   This should be adjusted based on the length of your filament path,
 #   tolerance of jams, etc.
 #   Default is 30 seconds.
+# arm_seconds: 120
+#   The amount of time from the start of printing before the filament
+#   sensor is used.  For sensors which incorrectly trigger during the
+#   homing and heatup sequence.
+#   Default is 0 seconds, immediately armed.
 extruder:
 #   The name of the extruder section this sensor is associated with.
 #   This parameter must be provided.

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -100,10 +100,10 @@ class EncoderSensor:
 
             logging.info(
                     "Filament Sensor %s: last %f diff %f" %
-                    (self.runout_helper.name, self.last_filament_time, 
+                    (self.runout_helper.name, self.last_filament_time,
                         self.last_extruder_time - self.last_filament_time))
             self.runout_helper.note_filament_present(
-                    (self.last_extruder_time - self.last_filament_time) < 
+                    (self.last_extruder_time - self.last_filament_time) <
                     self.timeout_sec)
         else:
             # Check for filament runout

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -45,7 +45,8 @@ class EncoderSensor:
 
         if self.time_based:
             logging.info(
-                    "Filament Sensor %s: using time-based detection, %.2f seconds" %
+                    "Filament Sensor %s: using time-based detection, "
+                    "%.2f seconds" %
                     (self.runout_helper.name, self.timeout_sec))
     def _update_filament_runout_pos(self, eventtime=None):
         logging.info(
@@ -99,9 +100,11 @@ class EncoderSensor:
 
             logging.info(
                     "Filament Sensor %s: last %f diff %f" %
-                    (self.runout_helper.name, self.last_filament_time, self.last_extruder_time - self.last_filament_time))
+                    (self.runout_helper.name, self.last_filament_time, 
+                        self.last_extruder_time - self.last_filament_time))
             self.runout_helper.note_filament_present(
-                    (self.last_extruder_time - self.last_filament_time) < self.timeout_sec)
+                    (self.last_extruder_time - self.last_filament_time) < 
+                    self.timeout_sec)
         else:
             # Check for filament runout
             self.runout_helper.note_filament_present(

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -120,7 +120,7 @@ class EncoderSensor:
             if self.reactor.monotonic() < self.start_time - self.arm_sec:
                 logging.info(
                         "Filament Sensor %s: not armed (%f remaining)" %
-                        (self.runout_helper.name, 
+                        (self.runout_helper.name,
                             self.start_time - self.arm_sec))
                 return eventtime + CHECK_RUNOUT_TIMEOUT
 
@@ -136,7 +136,7 @@ class EncoderSensor:
             if self.reactor.monotonic() < self.start_time - self.arm_sec:
                 logging.info(
                         "Filament Sensor %s: not armed (%f remaining)" %
-                        (self.runout_helper.name, 
+                        (self.runout_helper.name,
                             self.start_time - self.arm_sec))
                 return eventtime + CHECK_RUNOUT_TIMEOUT
 


### PR DESCRIPTION
Add optional time-based runout calculation to filament motion sensors.
This is an alternate calculation method for detecting runout and jams
and addresses problems that can occur with some motion sensors like the
BTT sensor.

Timeout mode is disabled by default.

Signed-off-by: Mike Kershaw <dragorn@kismetwireless.net>