### PR TITLE
idex_modes: fix get_status

### DIFF
--- a/klippy/kinematics/idex_modes.py
+++ b/klippy/kinematics/idex_modes.py
@@ -33,7 +33,7 @@ class DualCarriages:
                 kin.override_rail(self.axis, dc_rail)
                 toolhead.set_position(newpos)
                 kin.update_limits(self.axis, dc_rail.get_range())
-    def get_status(self, eventtime):
+    def get_status(self, eventtime=None):
         dc0, dc1 = self.dc
         if (dc0.is_active() is True):
             return { 'mode': 'FULL_CONTROL', 'active_carriage': 'CARRIAGE_0' }


### PR DESCRIPTION
Fix get_status to be called without eventtime parameter: https://github.com/KevinOConnor/klipper/pull/3956#issuecomment-890457812

Signed-off-by: Fabrice GALLET tircown@gmail.com