### PR TITLE
Track Trinamic driver motor phase

### DIFF
--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -424,11 +424,10 @@ Recv: // gcode homing: X:0.000000 Y:0.000000 Z:0.000000
 The "mcu" position (`stepper.get_mcu_position()` in the code) is the
 total number of steps the micro-controller has issued in a positive
 direction minus the number of steps issued in a negative direction
-since the micro-controller was last reset. The value reported is only
-valid after the stepper has been homed. If the robot is in motion when
-the query is issued then the reported value includes moves buffered on
-the micro-controller, but does not include moves on the look-ahead
-queue.
+since the micro-controller was last reset. If the robot is in motion
+when the query is issued then the reported value includes moves
+buffered on the micro-controller, but does not include moves on the
+look-ahead queue.
 
 The "stepper" position (`stepper.get_commanded_position()`) is the
 position of the given stepper as tracked by the kinematics code. This

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -260,8 +260,7 @@ class TMC2130:
         current_helper = TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
-        self.get_microsteps = cmdhelper.get_microsteps
-        self.get_phase = cmdhelper.get_phase
+        self.get_phase_offset = cmdhelper.get_phase_offset
         # Setup basic register values
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -260,10 +260,9 @@ class TMC2130:
         current_helper = TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
+        self.get_microsteps = cmdhelper.get_microsteps
+        self.get_phase = cmdhelper.get_phase
         # Setup basic register values
-        mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
-        self.get_microsteps = mh.get_microsteps
-        self.get_phase = mh.get_phase
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -24,7 +24,7 @@ ReadRegisters = [
 
 Fields = {}
 Fields["GCONF"] = {
-    "I_scale_analog": 1<<0, "internal_Rsense": 1<<1, "en_pwm_mode": 1<<2,
+    "i_scale_analog": 1<<0, "internal_rsense": 1<<1, "en_pwm_mode": 1<<2,
     "enc_commutation": 1<<3, "shaft": 1<<4, "diag0_error": 1<<5,
     "diag0_otpw": 1<<6, "diag0_stall": 1<<7, "diag1_stall": 1<<8,
     "diag1_index": 1<<9, "diag1_onstate": 1<<10, "diag1_steps_skipped": 1<<11,
@@ -34,58 +34,58 @@ Fields["GCONF"] = {
 }
 Fields["GSTAT"] = { "reset": 1<<0, "drv_err": 1<<1, "uv_cp": 1<<2 }
 Fields["IOIN"] = {
-    "STEP": 1<<0, "DIR": 1<<1, "DCEN_CFG4": 1<<2, "DCIN_CFG5": 1<<3,
-    "DRV_ENN_CFG6": 1<<4, "DCO": 1<<5, "VERSION": 0xff << 24
+    "step": 1<<0, "dir": 1<<1, "dcen_cfg4": 1<<2, "dcin_cfg5": 1<<3,
+    "drv_enn_cfg6": 1<<4, "dco": 1<<5, "version": 0xff << 24
 }
 Fields["IHOLD_IRUN"] = {
-    "IHOLD": 0x1f << 0, "IRUN": 0x1f << 8, "IHOLDDELAY": 0x0f << 16
+    "ihold": 0x1f << 0, "irun": 0x1f << 8, "iholddelay": 0x0f << 16
 }
-Fields["TPOWERDOWN"] = { "TPOWERDOWN": 0xff }
-Fields["TSTEP"] = { "TSTEP": 0xfffff }
-Fields["TPWMTHRS"] = { "TPWMTHRS": 0xfffff }
-Fields["TCOOLTHRS"] = { "TCOOLTHRS": 0xfffff }
-Fields["THIGH"] = { "THIGH": 0xfffff }
-Fields["MSCNT"] = { "MSCNT": 0x3ff }
-Fields["MSCURACT"] = { "CUR_A": 0x1ff, "CUR_B": 0x1ff << 16 }
+Fields["TPOWERDOWN"] = { "tpowerdown": 0xff }
+Fields["TSTEP"] = { "tstep": 0xfffff }
+Fields["TPWMTHRS"] = { "tpwmthrs": 0xfffff }
+Fields["TCOOLTHRS"] = { "tcoolthrs": 0xfffff }
+Fields["THIGH"] = { "thigh": 0xfffff }
+Fields["MSCNT"] = { "mscnt": 0x3ff }
+Fields["MSCURACT"] = { "cur_a": 0x1ff, "cur_b": 0x1ff << 16 }
 Fields["CHOPCONF"] = {
     "toff": 0x0f, "hstrt": 0x07 << 4, "hend": 0x0f << 7, "fd3": 1<<11,
-    "disfdcc": 1<<12, "rndtf": 1<<13, "chm": 1<<14, "TBL": 0x03 << 15,
+    "disfdcc": 1<<12, "rndtf": 1<<13, "chm": 1<<14, "tbl": 0x03 << 15,
     "vsense": 1<<17, "vhighfs": 1<<18, "vhighchm": 1<<19, "sync": 0x0f << 20,
-    "MRES": 0x0f << 24, "intpol": 1<<28, "dedge": 1<<29, "diss2g": 1<<30
+    "mres": 0x0f << 24, "intpol": 1<<28, "dedge": 1<<29, "diss2g": 1<<30
 }
 Fields["COOLCONF"] = {
     "semin": 0x0f, "seup": 0x03 << 5, "semax": 0x0f << 8, "sedn": 0x03 << 13,
     "seimin": 1<<15, "sgt": 0x7f << 16, "sfilt": 1<<24
 }
 Fields["DRV_STATUS"] = {
-    "SG_RESULT": 0x3ff, "fsactive": 1<<15, "CS_ACTUAL": 0x1f << 16,
-    "stallGuard": 1<<24, "ot": 1<<25, "otpw": 1<<26, "s2ga": 1<<27,
+    "sg_result": 0x3ff, "fsactive": 1<<15, "cs_actual": 0x1f << 16,
+    "stallguard": 1<<24, "ot": 1<<25, "otpw": 1<<26, "s2ga": 1<<27,
     "s2gb": 1<<28, "ola": 1<<29, "olb": 1<<30, "stst": 1<<31
 }
 Fields["PWMCONF"] = {
-    "PWM_AMPL": 0xff, "PWM_GRAD": 0xff << 8, "pwm_freq": 0x03 << 16,
+    "pwm_ampl": 0xff, "pwm_grad": 0xff << 8, "pwm_freq": 0x03 << 16,
     "pwm_autoscale": 1<<18, "pwm_symmetric": 1<<19, "freewheel": 0x03 << 20
 }
-Fields["PWM_SCALE"] = { "PWM_SCALE": 0xff }
-Fields["LOST_STEPS"] = { "LOST_STEPS": 0xfffff }
+Fields["PWM_SCALE"] = { "pwm_scale": 0xff }
+Fields["LOST_STEPS"] = { "lost_steps": 0xfffff }
 
-SignedFields = ["CUR_A", "CUR_B", "sgt"]
+SignedFields = ["cur_a", "cur_b", "sgt"]
 
 FieldFormatters = {
-    "I_scale_analog":   (lambda v: "1(ExtVREF)" if v else ""),
+    "i_scale_analog":   (lambda v: "1(ExtVREF)" if v else ""),
     "shaft":            (lambda v: "1(Reverse)" if v else ""),
     "reset":            (lambda v: "1(Reset)" if v else ""),
     "drv_err":          (lambda v: "1(ErrorShutdown!)" if v else ""),
     "uv_cp":            (lambda v: "1(Undervoltage!)" if v else ""),
-    "VERSION":          (lambda v: "%#x" % v),
-    "MRES":             (lambda v: "%d(%dusteps)" % (v, 0x100 >> v)),
+    "version":          (lambda v: "%#x" % v),
+    "mres":             (lambda v: "%d(%dusteps)" % (v, 0x100 >> v)),
     "otpw":             (lambda v: "1(OvertempWarning!)" if v else ""),
     "ot":               (lambda v: "1(OvertempError!)" if v else ""),
     "s2ga":             (lambda v: "1(ShortToGND_A!)" if v else ""),
     "s2gb":             (lambda v: "1(ShortToGND_B!)" if v else ""),
     "ola":              (lambda v: "1(OpenLoad_A!)" if v else ""),
     "olb":              (lambda v: "1(OpenLoad_B!)" if v else ""),
-    "CS_ACTUAL":        (lambda v: ("%d" % v) if v else "0(Reset?)"),
+    "cs_actual":        (lambda v: ("%d" % v) if v else "0(Reset?)"),
 }
 
 
@@ -108,8 +108,8 @@ class TMCCurrentHelper:
         self.sense_resistor = config.getfloat('sense_resistor', 0.110, above=0.)
         vsense, irun, ihold = self._calc_current(run_current, hold_current)
         self.fields.set_field("vsense", vsense)
-        self.fields.set_field("IHOLD", ihold)
-        self.fields.set_field("IRUN", irun)
+        self.fields.set_field("ihold", ihold)
+        self.fields.set_field("irun", irun)
     def _calc_current_bits(self, current, vsense):
         sense_resistor = self.sense_resistor + 0.020
         vref = 0.32
@@ -137,16 +137,16 @@ class TMCCurrentHelper:
             vref = 0.18
         return (bits + 1) * vref / (32 * sense_resistor * math.sqrt(2.))
     def get_current(self):
-        run_current = self._calc_current_from_field("IRUN")
-        hold_current = self._calc_current_from_field("IHOLD")
+        run_current = self._calc_current_from_field("irun")
+        hold_current = self._calc_current_from_field("ihold")
         return run_current, hold_current, MAX_CURRENT
     def set_current(self, run_current, hold_current, print_time):
         vsense, irun, ihold = self._calc_current(run_current, hold_current)
         if vsense != self.fields.get_field("vsense"):
             val = self.fields.set_field("vsense", vsense)
             self.mcu_tmc.set_register("CHOPCONF", val, print_time)
-        self.fields.set_field("IHOLD", ihold)
-        val = self.fields.set_field("IRUN", irun)
+        self.fields.set_field("ihold", ihold)
+        val = self.fields.set_field("irun", irun)
         self.mcu_tmc.set_register("IHOLD_IRUN", val, print_time)
 
 
@@ -270,11 +270,11 @@ class TMC2130:
         set_config_field(config, "toff", 4)
         set_config_field(config, "hstrt", 0)
         set_config_field(config, "hend", 7)
-        set_config_field(config, "TBL", 1)
-        set_config_field(config, "IHOLDDELAY", 8)
-        set_config_field(config, "TPOWERDOWN", 0)
-        set_config_field(config, "PWM_AMPL", 128)
-        set_config_field(config, "PWM_GRAD", 4)
+        set_config_field(config, "tbl", 1)
+        set_config_field(config, "iholddelay", 8)
+        set_config_field(config, "tpowerdown", 0)
+        set_config_field(config, "pwm_ampl", 128)
+        set_config_field(config, "pwm_grad", 4)
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
         set_config_field(config, "sgt", 0)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -192,12 +192,11 @@ class TMC2208:
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
+        self.get_microsteps = cmdhelper.get_microsteps
+        self.get_phase = cmdhelper.get_phase
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
-        mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
-        self.get_microsteps = mh.get_microsteps
-        self.get_phase = mh.get_phase
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -187,12 +187,12 @@ class TMC2208:
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields)
+        self.fields.set_field("pdn_disable", True)
         # Register commands
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
         # Setup basic register values
-        self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
         mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -192,8 +192,7 @@ class TMC2208:
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
-        self.get_microsteps = cmdhelper.get_microsteps
-        self.get_phase = cmdhelper.get_phase
+        self.get_phase_offset = cmdhelper.get_phase_offset
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -25,9 +25,9 @@ ReadRegisters = [
 Fields = {}
 
 Fields["GCONF"] = {
-    "I_scale_analog":      0x01,
-    "internal_Rsense":     0x01 << 1,
-    "en_spreadCycle":      0x01 << 2,
+    "i_scale_analog":      0x01,
+    "internal_rsense":     0x01 << 1,
+    "en_spreadcycle":      0x01 << 2,
     "shaft":               0x01 << 3,
     "index_otpw":          0x01 << 4,
     "index_step":          0x01 << 5,
@@ -42,91 +42,91 @@ Fields["GSTAT"] = {
     "uv_cp":               0x01 << 2
 }
 Fields["IFCNT"] = {
-    "IFCNT":               0xff
+    "ifcnt":               0xff
 }
 Fields["SLAVECONF"] = {
-    "SENDDELAY":           0x0f << 8
+    "senddelay":           0x0f << 8
 }
 Fields["OTP_PROG"] = {
-    "OTPBIT":              0x07,
-    "OTPBYTE":             0x03 << 4,
-    "OTPMAGIC":            0xff << 8
+    "otpbit":              0x07,
+    "otpbyte":             0x03 << 4,
+    "otpmagic":            0xff << 8
 }
 Fields["OTP_READ"] = {
-    "OTP_FCLKTRIM":        0x1f,
-    "otp_OTTRIM":          0x01 << 5,
-    "otp_internalRsense":  0x01 << 6,
-    "otp_TBL":             0x01 << 7,
-    "OTP_PWM_GRAD":        0x0f << 8,
+    "otp_fclktrim":        0x1f,
+    "otp_ottrim":          0x01 << 5,
+    "otp_internalrsense":  0x01 << 6,
+    "otp_tbl":             0x01 << 7,
+    "otp_pwm_grad":        0x0f << 8,
     "otp_pwm_autograd":    0x01 << 12,
-    "OTP_TPWMTHRS":        0x07 << 13,
-    "otp_PWM_OFS":         0x01 << 16,
-    "otp_PWM_REG":         0x01 << 17,
-    "otp_PWM_FREQ":        0x01 << 18,
-    "OTP_IHOLDDELAY":      0x03 << 19,
-    "OTP_IHOLD":           0x03 << 21,
-    "otp_en_spreadCycle":  0x01 << 23
+    "otp_tpwmthrs":        0x07 << 13,
+    "otp_pwm_ofs":         0x01 << 16,
+    "otp_pwm_reg":         0x01 << 17,
+    "otp_pwm_freq":        0x01 << 18,
+    "otp_iholddelay":      0x03 << 19,
+    "otp_ihold":           0x03 << 21,
+    "otp_en_spreadcycle":  0x01 << 23
 }
 # IOIN mapping depends on the driver type (SEL_A field)
 # TMC222x (SEL_A == 0)
 Fields["IOIN@TMC222x"] = {
-    "PDN_UART":            0x01 << 1,
-    "SPREAD":              0x01 << 2,
-    "DIR":                 0x01 << 3,
-    "ENN":                 0x01 << 4,
-    "STEP":                0x01 << 5,
-    "MS1":                 0x01 << 6,
-    "MS2":                 0x01 << 7,
-    "SEL_A":               0x01 << 8,
-    "VERSION":             0xff << 24
+    "pdn_uart":            0x01 << 1,
+    "spread":              0x01 << 2,
+    "dir":                 0x01 << 3,
+    "enn":                 0x01 << 4,
+    "step":                0x01 << 5,
+    "ms1":                 0x01 << 6,
+    "ms2":                 0x01 << 7,
+    "sel_a":               0x01 << 8,
+    "version":             0xff << 24
 }
 # TMC220x (SEL_A == 1)
 Fields["IOIN@TMC220x"] = {
-    "ENN":                 0x01,
-    "MS1":                 0x01 << 2,
-    "MS2":                 0x01 << 3,
-    "DIAG":                0x01 << 4,
-    "PDN_UART":            0x01 << 6,
-    "STEP":                0x01 << 7,
-    "SEL_A":               0x01 << 8,
-    "DIR":                 0x01 << 9,
-    "VERSION":             0xff << 24,
+    "enn":                 0x01,
+    "ms1":                 0x01 << 2,
+    "ms2":                 0x01 << 3,
+    "diag":                0x01 << 4,
+    "pdn_uart":            0x01 << 6,
+    "step":                0x01 << 7,
+    "sel_a":               0x01 << 8,
+    "dir":                 0x01 << 9,
+    "version":             0xff << 24,
 }
 Fields["FACTORY_CONF"] = {
-    "FCLKTRIM":            0x1f,
-    "OTTRIM":              0x03 << 8
+    "fclktrim":            0x1f,
+    "ottrim":              0x03 << 8
 }
 Fields["IHOLD_IRUN"] = {
-    "IHOLD":               0x1f,
-    "IRUN":                0x1f << 8,
-    "IHOLDDELAY":          0x0f << 16
+    "ihold":               0x1f,
+    "irun":                0x1f << 8,
+    "iholddelay":          0x0f << 16
 }
 Fields["TPOWERDOWN"] = {
-    "TPOWERDOWN":          0xff
+    "tpowerdown":          0xff
 }
 Fields["TSTEP"] = {
-    "TSTEP":               0xfffff
+    "tstep":               0xfffff
 }
 Fields["TPWMTHRS"] = {
-    "TPWMTHRS":            0xfffff
+    "tpwmthrs":            0xfffff
 }
 Fields["VACTUAL"] = {
-    "VACTUAL":             0xffffff
+    "vactual":             0xffffff
 }
 Fields["MSCNT"] = {
-    "MSCNT":               0x3ff
+    "mscnt":               0x3ff
 }
 Fields["MSCURACT"] = {
-    "CUR_A":               0x1ff,
-    "CUR_B":               0x1ff << 16
+    "cur_a":               0x1ff,
+    "cur_b":               0x1ff << 16
 }
 Fields["CHOPCONF"] = {
     "toff":                0x0f,
     "hstrt":               0x07 << 4,
     "hend":                0x0f << 7,
-    "TBL":                 0x03 << 15,
+    "tbl":                 0x03 << 15,
     "vsense":              0x01 << 17,
-    "MRES":                0x0f << 24,
+    "mres":                0x0f << 24,
     "intpol":              0x01 << 28,
     "dedge":               0x01 << 29,
     "diss2g":              0x01 << 30,
@@ -145,34 +145,34 @@ Fields["DRV_STATUS"] = {
     "t143":                0x01 << 9,
     "t150":                0x01 << 10,
     "t157":                0x01 << 11,
-    "CS_ACTUAL":           0x1f << 16,
+    "cs_actual":           0x1f << 16,
     "stealth":             0x01 << 30,
     "stst":                0x01 << 31
 }
 Fields["PWMCONF"] = {
-    "PWM_OFS":             0xff,
-    "PWM_GRAD":            0xff << 8,
+    "pwm_ofs":             0xff,
+    "pwm_grad":            0xff << 8,
     "pwm_freq":            0x03 << 16,
     "pwm_autoscale":       0x01 << 18,
     "pwm_autograd":        0x01 << 19,
     "freewheel":           0x03 << 20,
-    "PWM_REG":             0xf << 24,
-    "PWM_LIM":             0xf << 28
+    "pwm_reg":             0xf << 24,
+    "pwm_lim":             0xf << 28
 }
 Fields["PWM_SCALE"] = {
-    "PWM_SCALE_SUM":       0xff,
-    "PWM_SCALE_AUTO":      0x1ff << 16
+    "pwm_scale_sum":       0xff,
+    "pwm_scale_auto":      0x1ff << 16
 }
 Fields["PWM_AUTO"] = {
-    "PWM_OFS_AUTO":        0xff,
-    "PWM_GRAD_AUTO":       0xff << 16
+    "pwm_ofs_auto":        0xff,
+    "pwm_grad_auto":       0xff << 16
 }
 
-SignedFields = ["CUR_A", "CUR_B", "PWM_SCALE_AUTO"]
+SignedFields = ["cur_a", "cur_b", "pwm_scale_auto"]
 
 FieldFormatters = dict(tmc2130.FieldFormatters)
 FieldFormatters.update({
-    "SEL_A":            (lambda v: "%d(%s)" % (v, ["TMC222x", "TMC220x"][v])),
+    "sel_a":            (lambda v: "%d(%s)" % (v, ["TMC222x", "TMC220x"][v])),
     "s2vsa":            (lambda v: "1(LowSideShort_A!)" if v else ""),
     "s2vsb":            (lambda v: "1(LowSideShort_B!)" if v else ""),
 })
@@ -204,19 +204,19 @@ class TMC2208:
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
-        set_config_field(config, "TBL", 2)
-        set_config_field(config, "IHOLDDELAY", 8)
-        set_config_field(config, "TPOWERDOWN", 20)
-        set_config_field(config, "PWM_OFS", 36)
-        set_config_field(config, "PWM_GRAD", 14)
+        set_config_field(config, "tbl", 2)
+        set_config_field(config, "iholddelay", 8)
+        set_config_field(config, "tpowerdown", 20)
+        set_config_field(config, "pwm_ofs", 36)
+        set_config_field(config, "pwm_grad", 14)
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
         set_config_field(config, "pwm_autograd", True)
-        set_config_field(config, "PWM_REG", 8)
-        set_config_field(config, "PWM_LIM", 12)
+        set_config_field(config, "pwm_reg", 8)
+        set_config_field(config, "pwm_lim", 12)
     def read_translate(self, reg_name, val):
         if reg_name == "IOIN":
-            drv_type = self.fields.get_field("SEL_A", val)
+            drv_type = self.fields.get_field("sel_a", val)
             reg_name = "IOIN@TMC220x" if drv_type else "IOIN@TMC222x"
         return reg_name, val
 

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -26,24 +26,24 @@ Fields["COOLCONF"] = {
     "seimin":       0x01 << 15
 }
 Fields["IOIN"] = {
-    "ENN":          0x01 << 0,
-    "MS1":          0x01 << 2,
-    "MS2":          0x01 << 3,
-    "DIAG":         0x01 << 4,
-    "PDN_UART":     0x01 << 6,
-    "STEP":         0x01 << 7,
-    "SPREAD_EN":    0x01 << 8,
-    "DIR":          0x01 << 9,
-    "VERSION":      0xff << 24
+    "enn":          0x01 << 0,
+    "ms1":          0x01 << 2,
+    "ms2":          0x01 << 3,
+    "diag":         0x01 << 4,
+    "pdn_uart":     0x01 << 6,
+    "step":         0x01 << 7,
+    "spread_en":    0x01 << 8,
+    "dir":          0x01 << 9,
+    "version":      0xff << 24
 }
 Fields["SGTHRS"] = {
-    "SGTHRS":       0xFF << 0
+    "sgthrs":       0xFF << 0
 }
 Fields["SG_RESULT"] = {
-    "SG_RESULT":    0x3FF << 0
+    "sg_result":    0x3FF << 0
 }
 Fields["TCOOLTHRS"] = {
-    "TCOOLTHRS": 0xfffff
+    "tcoolthrs": 0xfffff
 }
 
 FieldFormatters = dict(tmc2208.FieldFormatters)
@@ -61,7 +61,7 @@ class TMC2209:
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields, 3)
         # Setup fields for UART
         self.fields.set_field("pdn_disable", True)
-        self.fields.set_field("SENDDELAY", 2) # Avoid tx errors on shared uart
+        self.fields.set_field("senddelay", 2) # Avoid tx errors on shared uart
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
@@ -81,17 +81,17 @@ class TMC2209:
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
-        set_config_field(config, "TBL", 2)
-        set_config_field(config, "IHOLDDELAY", 8)
-        set_config_field(config, "TPOWERDOWN", 20)
-        set_config_field(config, "PWM_OFS", 36)
-        set_config_field(config, "PWM_GRAD", 14)
+        set_config_field(config, "tbl", 2)
+        set_config_field(config, "iholddelay", 8)
+        set_config_field(config, "tpowerdown", 20)
+        set_config_field(config, "pwm_ofs", 36)
+        set_config_field(config, "pwm_grad", 14)
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
         set_config_field(config, "pwm_autograd", True)
-        set_config_field(config, "PWM_REG", 8)
-        set_config_field(config, "PWM_LIM", 12)
-        set_config_field(config, "SGTHRS", 0)
+        set_config_field(config, "pwm_reg", 8)
+        set_config_field(config, "pwm_lim", 12)
+        set_config_field(config, "sgthrs", 0)
 
 def load_config_prefix(config):
     return TMC2209(config)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -68,13 +68,12 @@ class TMC2209:
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
+        self.get_microsteps = cmdhelper.get_microsteps
+        self.get_phase = cmdhelper.get_phase
         # Setup basic register values
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
-        mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
-        self.get_microsteps = mh.get_microsteps
-        self.get_phase = mh.get_phase
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -68,8 +68,7 @@ class TMC2209:
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
-        self.get_microsteps = cmdhelper.get_microsteps
-        self.get_phase = cmdhelper.get_phase
+        self.get_phase_offset = cmdhelper.get_phase_offset
         # Setup basic register values
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -17,19 +17,19 @@ ReadRegisters = [ "READRSP@RDSEL0", "READRSP@RDSEL1", "READRSP@RDSEL2" ]
 Fields = {}
 
 Fields["DRVCTRL"] = {
-    "MRES": 0x0f,
-    "DEDGE": 0x01 << 8,
+    "mres": 0x0f,
+    "dedge": 0x01 << 8,
     "intpol": 0x01 << 9,
 }
 
 Fields["CHOPCONF"] = {
     "toff": 0x0f,
-    "HSTRT": 0x7 << 4,
-    "HEND": 0x0f << 7,
-    "HDEC": 0x03 << 11,
-    "RNDTF": 0x01 << 13,
-    "CHM": 0x01 << 14,
-    "TBL": 0x03 << 15
+    "hstrt": 0x7 << 4,
+    "hend": 0x0f << 7,
+    "hdec": 0x03 << 11,
+    "rndtf": 0x01 << 13,
+    "chm": 0x01 << 14,
+    "tbl": 0x03 << 15
 }
 
 Fields["SMARTEN"] = {
@@ -41,24 +41,24 @@ Fields["SMARTEN"] = {
 }
 
 Fields["SGCSCONF"] = {
-    "CS": 0x1f,
+    "cs": 0x1f,
     "sgt": 0x7F << 8,
     "sfilt": 0x01 << 16
 }
 
 Fields["DRVCONF"] = {
-    "RDSEL": 0x03 << 4,
-    "VSENSE": 0x01 << 6,
-    "SDOFF": 0x01 << 7,
-    "TS2G": 0x03 << 8,
-    "DISS2G": 0x01 << 10,
-    "SLPL": 0x03 << 12,
-    "SLPH": 0x03 << 14,
-    "TST": 0x01 << 16
+    "rdsel": 0x03 << 4,
+    "vsense": 0x01 << 6,
+    "sdoff": 0x01 << 7,
+    "ts2g": 0x03 << 8,
+    "diss2g": 0x01 << 10,
+    "slpl": 0x03 << 12,
+    "slph": 0x03 << 14,
+    "tst": 0x01 << 16
 }
 
 Fields["READRSP@RDSEL0"] = {
-    "stallGuard": 0x01 << 4,
+    "stallguard": 0x01 << 4,
     "ot": 0x01 << 5,
     "otpw": 0x01 << 6,
     "s2ga": 0x01 << 7,
@@ -66,11 +66,11 @@ Fields["READRSP@RDSEL0"] = {
     "ola": 0x01 << 9,
     "olb": 0x01 << 10,
     "stst": 0x01 << 11,
-    "MSTEP": 0x3ff << 14
+    "mstep": 0x3ff << 14
 }
 
 Fields["READRSP@RDSEL1"] = {
-    "stallGuard": 0x01 << 4,
+    "stallguard": 0x01 << 4,
     "ot": 0x01 << 5,
     "otpw": 0x01 << 6,
     "s2ga": 0x01 << 7,
@@ -78,11 +78,11 @@ Fields["READRSP@RDSEL1"] = {
     "ola": 0x01 << 9,
     "olb": 0x01 << 10,
     "stst": 0x01 << 11,
-    "SG_RESULT": 0x3ff << 14
+    "sg_result": 0x3ff << 14
 }
 
 Fields["READRSP@RDSEL2"] = {
-    "stallGuard": 0x01 << 4,
+    "stallguard": 0x01 << 4,
     "ot": 0x01 << 5,
     "otpw": 0x01 << 6,
     "s2ga": 0x01 << 7,
@@ -90,20 +90,20 @@ Fields["READRSP@RDSEL2"] = {
     "ola": 0x01 << 9,
     "olb": 0x01 << 10,
     "stst": 0x01 << 11,
-    "SE": 0x1f << 14,
-    "SG_RESULT@RDSEL2": 0x1f << 19
+    "se": 0x1f << 14,
+    "sg_result@rdsel2": 0x1f << 19
 }
 
 SignedFields = ["sgt"]
 
 FieldFormatters = dict(tmc2130.FieldFormatters)
 FieldFormatters.update({
-    "DEDGE": (lambda v: "1(Both Edges Active!)" if v else ""),
-    "CHM": (lambda v: "1(constant toff)" if v else "0(spreadCycle)"),
-    "VSENSE": (lambda v: "1(165mV)" if v else "0(305mV)"),
-    "SDOFF": (lambda v: "1(Step/Dir disabled!)" if v else ""),
-    "DISS2G": (lambda v: "1(Short to GND disabled!)" if v else ""),
-    "SE": (lambda v: ("%d" % v) if v else "0(Reset?)"),
+    "dedge": (lambda v: "1(Both Edges Active!)" if v else ""),
+    "chm": (lambda v: "1(constant toff)" if v else "0(spreadCycle)"),
+    "vsense": (lambda v: "1(165mV)" if v else "0(305mV)"),
+    "sdoff": (lambda v: "1(Step/Dir disabled!)" if v else ""),
+    "diss2g": (lambda v: "1(Short to GND disabled!)" if v else ""),
+    "se": (lambda v: ("%d" % v) if v else "0(Reset?)"),
 })
 
 
@@ -123,8 +123,8 @@ class TMC2660CurrentHelper:
                                        maxval=MAX_CURRENT)
         self.sense_resistor = config.getfloat('sense_resistor')
         vsense, cs = self._calc_current(self.current)
-        self.fields.set_field("CS", cs)
-        self.fields.set_field("VSENSE", vsense)
+        self.fields.set_field("cs", cs)
+        self.fields.set_field("vsense", vsense)
 
         # Register ready/printing handlers
         self.idle_current_percentage = config.getint(
@@ -161,11 +161,11 @@ class TMC2660CurrentHelper:
 
     def _update_current(self, current, print_time):
         vsense, cs = self._calc_current(current)
-        val = self.fields.set_field("CS", cs)
+        val = self.fields.set_field("cs", cs)
         self.mcu_tmc.set_register("SGCSCONF", val, print_time)
         # Only update VSENSE if we need to
-        if vsense != self.fields.get_field("VSENSE"):
-            val = self.fields.set_field("VSENSE", vsense)
+        if vsense != self.fields.get_field("vsense"):
+            val = self.fields.set_field("vsense", vsense)
             self.mcu_tmc.set_register("DRVCONF", val, print_time)
 
     def get_current(self):
@@ -196,8 +196,8 @@ class MCU_TMC2660_SPI:
         if self.printer.get_start_args().get('debugoutput') is not None:
             return 0
         with self.mutex:
-            old_rdsel = self.fields.get_field("RDSEL")
-            val = self.fields.set_field("RDSEL", new_rdsel)
+            old_rdsel = self.fields.get_field("rdsel")
+            val = self.fields.set_field("rdsel", new_rdsel)
             msg = [((val >> 16) | reg) & 0xff, (val >> 8) & 0xff, val & 0xff]
             if new_rdsel != old_rdsel:
                 # Must set RDSEL value first
@@ -223,7 +223,7 @@ class TMC2660:
     def __init__(self, config):
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
-        self.fields.set_field("SDOFF", 0) # Access DRVCTRL in step/dir mode
+        self.fields.set_field("sdoff", 0) # Access DRVCTRL in step/dir mode
         self.mcu_tmc = MCU_TMC2660_SPI(config, Registers, self.fields)
         # Register commands
         current_helper = TMC2660CurrentHelper(config, self.mcu_tmc)
@@ -236,16 +236,16 @@ class TMC2660:
         self.get_phase = mh.get_phase
         # CHOPCONF
         set_config_field = self.fields.set_config_field
-        set_config_field(config, "TBL", 2)
-        set_config_field(config, "RNDTF", 0)
-        set_config_field(config, "HDEC", 0)
-        set_config_field(config, "CHM", 0)
-        set_config_field(config, "HEND", 3)
-        set_config_field(config, "HSTRT", 3)
+        set_config_field(config, "tbl", 2)
+        set_config_field(config, "rndtf", 0)
+        set_config_field(config, "hdec", 0)
+        set_config_field(config, "chm", 0)
+        set_config_field(config, "hend", 3)
+        set_config_field(config, "hstrt", 3)
         set_config_field(config, "toff", 4)
-        if not self.fields.get_field("CHM"):
-            if (self.fields.get_field("HSTRT") +
-                self.fields.get_field("HEND")) > 15:
+        if not self.fields.get_field("chm"):
+            if (self.fields.get_field("hstrt") +
+                self.fields.get_field("hend")) > 15:
                 raise config.error("driver_HEND + driver_HSTRT must be <= 15")
         # SMARTEN
         set_config_field(config, "seimin", 0)
@@ -259,10 +259,10 @@ class TMC2660:
         set_config_field(config, "sgt", 0)
 
         # DRVCONF
-        set_config_field(config, "SLPH", 0)
-        set_config_field(config, "SLPL", 0)
-        set_config_field(config, "DISS2G", 0)
-        set_config_field(config, "TS2G", 3)
+        set_config_field(config, "slph", 0)
+        set_config_field(config, "slpl", 0)
+        set_config_field(config, "diss2g", 0)
+        set_config_field(config, "ts2g", 3)
 
 def load_config_prefix(config):
     return TMC2660(config)

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -229,11 +229,9 @@ class TMC2660:
         current_helper = TMC2660CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
+        self.get_microsteps = cmdhelper.get_microsteps
+        self.get_phase = cmdhelper.get_phase
 
-        # DRVCTRL
-        mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
-        self.get_microsteps = mh.get_microsteps
-        self.get_phase = mh.get_phase
         # CHOPCONF
         set_config_field = self.fields.set_config_field
         set_config_field(config, "tbl", 2)

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -229,8 +229,7 @@ class TMC2660:
         current_helper = TMC2660CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
-        self.get_microsteps = cmdhelper.get_microsteps
-        self.get_phase = cmdhelper.get_phase
+        self.get_phase_offset = cmdhelper.get_phase_offset
 
         # CHOPCONF
         set_config_field = self.fields.set_config_field

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -294,10 +294,9 @@ class TMC5160:
         current_helper = TMC5160CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
+        self.get_microsteps = cmdhelper.get_microsteps
+        self.get_phase = cmdhelper.get_phase
         # Setup basic register values
-        mh = tmc.TMCMicrostepHelper(config, self.mcu_tmc)
-        self.get_microsteps = mh.get_microsteps
-        self.get_phase = mh.get_phase
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         #   CHOPCONF
         set_config_field = self.fields.set_config_field

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -99,20 +99,20 @@ Fields["CHOPCONF"] = {
     "vhighfs":                  0x01 << 18,
     "vhighchm":                 0x01 << 19,
     "tpfd":                     0x0F << 20, # midrange resonances
-    "MRES":                     0x0F << 24,
+    "mres":                     0x0F << 24,
     "intpol":                   0x01 << 28,
     "dedge":                    0x01 << 29,
     "diss2g":                   0x01 << 30,
     "diss2vs":                  0x01 << 31
 }
 Fields["DRV_STATUS"] = {
-    "SG_RESULT":                0x3FF << 0,
+    "sg_result":                0x3FF << 0,
     "s2vsa":                    0x01 << 12,
     "s2vsb":                    0x01 << 13,
     "stealth":                  0x01 << 14,
     "fsactive":                 0x01 << 15,
-    "CSACTUAL":                 0xFF << 16,
-    "stallGuard":               0x01 << 24,
+    "csactual":                 0xFF << 16,
+    "stallguard":               0x01 << 24,
     "ot":                       0x01 << 25,
     "otpw":                     0x01 << 26,
     "s2ga":                     0x01 << 27,
@@ -122,7 +122,7 @@ Fields["DRV_STATUS"] = {
     "stst":                     0x01 << 31
 }
 Fields["FACTORY_CONF"] = {
-    "FACTORY_CONF":             0x1F << 0
+    "factory_conf":             0x1F << 0
 }
 Fields["GCONF"] = {
     "recalibrate":              0x01 << 0,
@@ -150,72 +150,72 @@ Fields["GSTAT"] = {
     "uv_cp":                    0x01 << 2
 }
 Fields["GLOBALSCALER"] = {
-    "GLOBALSCALER":             0xFF << 0
+    "globalscaler":             0xFF << 0
 }
 Fields["IHOLD_IRUN"] = {
-    "IHOLD":                    0x1F << 0,
-    "IRUN":                     0x1F << 8,
-    "IHOLDDELAY":               0x0F << 16
+    "ihold":                    0x1F << 0,
+    "irun":                     0x1F << 8,
+    "iholddelay":               0x0F << 16
 }
 Fields["IOIN"] = {
-    "REFL_STEP":                0x01 << 0,
-    "REFR_DIR":                 0x01 << 1,
-    "ENCB_DCEN_CFG4":           0x01 << 2,
-    "ENCA_DCIN_CFG5":           0x01 << 3,
-    "DRV_ENN":                  0x01 << 4,
-    "ENC_N_DCO_CFG6":           0x01 << 5,
-    "SD_MODE":                  0x01 << 6,
-    "SWCOMP_IN":                0x01 << 7,
-    "VERSION":                  0xFF << 24
+    "refl_step":                0x01 << 0,
+    "refr_dir":                 0x01 << 1,
+    "encb_dcen_cfg4":           0x01 << 2,
+    "enca_dcin_cfg5":           0x01 << 3,
+    "drv_enn":                  0x01 << 4,
+    "enc_n_dco_cfg6":           0x01 << 5,
+    "sd_mode":                  0x01 << 6,
+    "swcomp_in":                0x01 << 7,
+    "version":                  0xFF << 24
 }
 Fields["LOST_STEPS"] = {
-    "LOST_STEPS":               0xfffff << 0
+    "lost_steps":               0xfffff << 0
 }
 Fields["MSCNT"] = {
-    "MSCNT":                    0x3ff << 0
+    "mscnt":                    0x3ff << 0
 }
 Fields["MSCURACT"] = {
-    "CUR_A":                    0x1ff << 0,
-    "CUR_B":                    0x1ff << 16
+    "cur_a":                    0x1ff << 0,
+    "cur_b":                    0x1ff << 16
 }
 Fields["OTP_READ"] = {
-    "OTP_FCLKTRIM":             0x1f << 0,
-    "otp_S2_LEVEL":             0x01 << 5,
-    "otp_BBM":                  0x01 << 6,
-    "otp_TBL":                  0x01 << 7
+    "otp_fclktrim":             0x1f << 0,
+    "otp_s2_level":             0x01 << 5,
+    "otp_bbm":                  0x01 << 6,
+    "otp_tbl":                  0x01 << 7
 }
 Fields["PWM_AUTO"] = {
-    "PWM_OFS_AUTO":             0xff << 0,
-    "PWM_GRAD_AUTO":            0xff << 16
+    "pwm_ofs_auto":             0xff << 0,
+    "pwm_grad_auto":            0xff << 16
 }
 Fields["PWMCONF"] = {
-    "PWM_OFS":                  0xFF << 0,
-    "PWM_GRAD":                 0xFF << 8,
+    "pwm_ofs":                  0xFF << 0,
+    "pwm_grad":                 0xFF << 8,
     "pwm_freq":                 0x03 << 16,
     "pwm_autoscale":            0x01 << 18,
     "pwm_autograd":             0x01 << 19,
     "freewheel":                0x03 << 20,
-    "PWM_REG":                  0x0F << 24,
-    "PWM_LIM":                  0x0F << 28
+    "pwm_reg":                  0x0F << 24,
+    "pwm_lim":                  0x0F << 28
 }
 Fields["PWM_SCALE"] = {
-    "PWM_SCALE_SUM":            0xff << 0,
-    "PWM_SCALE_AUTO":           0x1ff << 16
+    "pwm_scale_sum":            0xff << 0,
+    "pwm_scale_auto":           0x1ff << 16
 }
 Fields["TPOWERDOWN"] = {
-    "TPOWERDOWN":               0xff << 0
+    "tpowerdown":               0xff << 0
 }
 Fields["TPWMTHRS"] = {
-    "TPWMTHRS":                 0xfffff << 0
+    "tpwmthrs":                 0xfffff << 0
 }
 Fields["TCOOLTHRS"] = {
-    "TCOOLTHRS":                0xfffff << 0
+    "tcoolthrs":                0xfffff << 0
 }
 Fields["TSTEP"] = {
-    "TSTEP":                    0xfffff << 0
+    "tstep":                    0xfffff << 0
 }
 
-SignedFields = ["CUR_A", "CUR_B", "sgt", "XACTUAL", "VACTUAL", "PWM_SCALE_AUTO"]
+SignedFields = ["cur_a", "cur_b", "sgt", "xactual", "vactual", "pwm_scale_auto"]
 
 FieldFormatters = dict(tmc2130.FieldFormatters)
 
@@ -240,17 +240,17 @@ class TMC5160CurrentHelper:
         self.sense_resistor = config.getfloat('sense_resistor', 0.075, above=0.)
         self._set_globalscaler(run_current)
         irun, ihold = self._calc_current(run_current, hold_current)
-        self.fields.set_field("IHOLD", ihold)
-        self.fields.set_field("IRUN", irun)
+        self.fields.set_field("ihold", ihold)
+        self.fields.set_field("irun", irun)
     def _set_globalscaler(self, current):
         globalscaler = int((current * 256. * math.sqrt(2.)
                             * self.sense_resistor / VREF) + .5)
         globalscaler = max(32, globalscaler)
         if globalscaler >= 256:
             globalscaler = 0
-        self.fields.set_field("GLOBALSCALER", globalscaler)
+        self.fields.set_field("globalscaler", globalscaler)
     def _calc_current_bits(self, current):
-        globalscaler = self.fields.get_field("GLOBALSCALER")
+        globalscaler = self.fields.get_field("globalscaler")
         if not globalscaler:
             globalscaler = 256
         cs = int((current * 256. * 32. * math.sqrt(2.) * self.sense_resistor)
@@ -262,20 +262,20 @@ class TMC5160CurrentHelper:
         ihold = self._calc_current_bits(min(hold_current, run_current))
         return irun, ihold
     def _calc_current_from_field(self, field_name):
-        globalscaler = self.fields.get_field("GLOBALSCALER")
+        globalscaler = self.fields.get_field("globalscaler")
         if not globalscaler:
             globalscaler = 256
         bits = self.fields.get_field(field_name)
         return (globalscaler * (bits + 1) * VREF
                 / (256. * 32. * math.sqrt(2.) * self.sense_resistor))
     def get_current(self):
-        run_current = self._calc_current_from_field("IRUN")
-        hold_current = self._calc_current_from_field("IHOLD")
+        run_current = self._calc_current_from_field("irun")
+        hold_current = self._calc_current_from_field("ihold")
         return run_current, hold_current, MAX_CURRENT
     def set_current(self, run_current, hold_current, print_time):
         irun, ihold = self._calc_current(run_current, hold_current)
-        self.fields.set_field("IHOLD", ihold)
-        val = self.fields.set_field("IRUN", irun)
+        self.fields.set_field("ihold", ihold)
+        val = self.fields.set_field("irun", irun)
         self.mcu_tmc.set_register("IHOLD_IRUN", val, print_time)
 
 
@@ -322,18 +322,18 @@ class TMC5160:
         set_config_field(config, "sgt", 0)
         set_config_field(config, "sfilt", 0)
         #   IHOLDIRUN
-        set_config_field(config, "IHOLDDELAY", 6)
+        set_config_field(config, "iholddelay", 6)
         #   PWMCONF
-        set_config_field(config, "PWM_OFS", 30)
-        set_config_field(config, "PWM_GRAD", 0)
+        set_config_field(config, "pwm_ofs", 30)
+        set_config_field(config, "pwm_grad", 0)
         set_config_field(config, "pwm_freq", 0)
         set_config_field(config, "pwm_autoscale", True)
         set_config_field(config, "pwm_autograd", True)
         set_config_field(config, "freewheel", 0)
-        set_config_field(config, "PWM_REG", 4)
-        set_config_field(config, "PWM_LIM", 12)
+        set_config_field(config, "pwm_reg", 4)
+        set_config_field(config, "pwm_lim", 12)
         #   TPOWERDOWN
-        set_config_field(config, "TPOWERDOWN", 10)
+        set_config_field(config, "tpowerdown", 10)
 
 def load_config_prefix(config):
     return TMC5160(config)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -294,8 +294,7 @@ class TMC5160:
         current_helper = TMC5160CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
-        self.get_microsteps = cmdhelper.get_microsteps
-        self.get_phase = cmdhelper.get_phase
+        self.get_phase_offset = cmdhelper.get_phase_offset
         # Setup basic register values
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         #   CHOPCONF

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -122,7 +122,7 @@ class MCU_trsync:
         params = self._trsync_query_cmd.send([self._oid,
                                               self.REASON_HOST_REQUEST])
         for s in self._steppers:
-            s.note_homing_end(did_trigger=True) # XXX
+            s.note_homing_end()
         return params['trigger_reason']
 
 class MCU_endstop:

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -42,6 +42,8 @@ class MCU_stepper:
         self._itersolve_generate_steps = ffi_lib.itersolve_generate_steps
         self._itersolve_check_active = ffi_lib.itersolve_check_active
         self._trapq = ffi_main.NULL
+        self._mcu.get_printer().register_event_handler('klippy:connect',
+                                                       self._query_mcu_position)
     def get_mcu(self):
         return self._mcu
     def get_name(self, short=False):
@@ -136,7 +138,7 @@ class MCU_stepper:
         self.set_trapq(self._trapq)
         self._set_mcu_position(mcu_pos)
         return old_sk
-    def note_homing_end(self, did_trigger=False):
+    def note_homing_end(self):
         ffi_main, ffi_lib = chelper.get_ffi()
         ret = ffi_lib.stepcompress_reset(self._stepqueue, 0)
         if ret:
@@ -145,7 +147,9 @@ class MCU_stepper:
         ret = ffi_lib.stepcompress_queue_msg(self._stepqueue, data, len(data))
         if ret:
             raise error("Internal error in stepcompress")
-        if not did_trigger or self._mcu.is_fileoutput():
+        self._query_mcu_position()
+    def _query_mcu_position(self):
+        if self._mcu.is_fileoutput():
             return
         params = self._get_position_cmd.send([self._oid])
         last_pos = params['pos']
@@ -153,6 +157,7 @@ class MCU_stepper:
             last_pos = -last_pos
         print_time = self._mcu.estimated_print_time(params['#receive_time'])
         clock = self._mcu.print_time_to_clock(print_time)
+        ffi_main, ffi_lib = chelper.get_ffi()
         ret = ffi_lib.stepcompress_set_last_position(self._stepqueue, clock,
                                                      last_pos)
         if ret:

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -163,6 +163,7 @@ class MCU_stepper:
         if ret:
             raise error("Internal error in stepcompress")
         self._set_mcu_position(last_pos)
+        self._mcu.get_printer().send_event("stepper:sync_mcu_position", self)
     def set_trapq(self, tq):
         ffi_main, ffi_lib = chelper.get_ffi()
         if tq is None:


### PR DESCRIPTION
This PR updates Klipper so that it always tracks the motor phase that the Trinamic drivers are using.  The motor phase corresponds with the amount of current going in each of the two motor coils, and thus provides information on the commanded angle of the stepper motor.

This information is useful for high level motion analysis.  It's also useful to help diagnose errors should the micro-controller and stepper driver become out of sync on the step position.

To implement this support, the code will attempt to query the driver's phase every time the Klipper host software starts, after every home/probe attempt, and after any detected stepper driver reset.  The code will log a warning if the driver and micro-controller get out of sync.

-Kevin