### PR TITLE
docs: Fix reference to neopixel color_data

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -379,4 +379,4 @@ The following information is available for each `[neopixel led_name]` and
   values for a led in the chain.  Note that not all configurations will contain
   a white value.  Each value is represented as a float from 0 to 1.  For
   example, the blue value of the second neopixel in a chain could be accessed
-  at `printer["neopixel <config_name>"].colordata[1].B`.
+  at `printer["neopixel <config_name>"].color_data[1].B`.


### PR DESCRIPTION
The example given for accessing the existing color values of a neopixel chain in the [status reference documentation](https://www.klipper3d.org/Status_Reference.html#neopixel-dotstar) is missing an underscore, so it doesn't work as expected (which confused me while trying to read the values from some neopixels). This change adds it in so the example works!

Hopefully I've submitted this change correctly — please let me know if there's anything I need to update 😊 