### PR TITLE
Endstop linking

### DIFF
--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -264,6 +264,7 @@ class PrinterRail:
         self.stepper_units_in_radians = units_in_radians
         self.steppers = []
         self.endstops = []
+        self.endstop_map = {}
         self.add_extra_stepper(config)
         mcu_stepper = self.steppers[0]
         self.get_name = mcu_stepper.get_name
@@ -336,18 +337,37 @@ class PrinterRail:
     def add_extra_stepper(self, config):
         stepper = PrinterStepper(config, self.stepper_units_in_radians)
         self.steppers.append(stepper)
-        if self.endstops and config.get('endstop_pin', None) is None:
+        endstop_pin = config.get('endstop_pin', None)
+        if self.endstops and endstop_pin is None:
             # No endstop defined - use primary endstop
             self.endstops[0][0].add_stepper(stepper)
             return
         printer = config.get_printer()
         ppins = printer.lookup_object('pins')
-        mcu_endstop = ppins.setup_pin('endstop', config.get('endstop_pin'))
+        pin_params = ppins.parse_pin(endstop_pin, True, True)
+        # Normalize pin name
+        pin_name = "%s:%s" % (pin_params['chip_name'], pin_params['pin'])
+        # Look for already-registered endstop
+        endstop = self.endstop_map.get(pin_name, None)
+        if endstop is None:
+            # New endstop, register it
+            mcu_endstop = ppins.setup_pin('endstop', endstop_pin)
+            self.endstop_map[pin_name] = {'endstop': mcu_endstop,
+                                          'invert': pin_params['invert'],
+                                          'pullup': pin_params['pullup']}
+            name = stepper.get_name(short=True)
+            self.endstops.append((mcu_endstop, name))
+            query_endstops = printer.load_object(config, 'query_endstops')
+            query_endstops.register_endstop(mcu_endstop, name)
+        else:
+            mcu_endstop = endstop['endstop']
+            changed_invert = pin_params['invert'] != endstop['invert']
+            changed_pullup = pin_params['pullup'] != endstop['pullup']
+            if changed_invert or changed_pullup:
+                raise error("Pinter rail %s shared endstop pin %s "
+                            "must specify the same pullup/invert settings" % (
+                                self.get_name(), pin_name))
         mcu_endstop.add_stepper(stepper)
-        name = stepper.get_name(short=True)
-        self.endstops.append((mcu_endstop, name))
-        query_endstops = printer.load_object(config, 'query_endstops')
-        query_endstops.register_endstop(mcu_endstop, name)
     def setup_itersolve(self, alloc_func, *params):
         for stepper in self.steppers:
             stepper.setup_itersolve(alloc_func, *params)


### PR DESCRIPTION
This adds the ability to, for motors on a rail, specifying another motor to use as endstop, effectively 'linking' the motor to the endstop.

This is useful for printers with multiple motors per rail, e.g. if a machine has two belts for one axis, and two motors for each belt. Using linking, it's possible to, in software, let the motors that share belts, also share their endstop pin.

We've been testing this for some time on the Annex Engineering Tycho printer, which has 8 motors on the XY gantry in just such a configuration(4 belts, 2 motors per belt).

To allow the general case to work, where endstops from both higher and lower indexed rail steppers can be used on any other rail stepper, a two-pass approach is used. All steppers are added, and steppers with endstop pointers are then linked to the correct endstops.