### PR TITLE
Add config reading helpers for parsing lists in the config file

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20210821: Several config settings in `printer.configfile.settings`
+will now be reported as lists instead of raw strings.  If the actual
+raw string is desired, use `printer.configfile.config` instead.
+
 20210819: In some cases, a `G28` homing move may end in a position
 that is nominally outside the valid movement range.  In rare
 situations this may result in confusing "Move out of range" errors

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -104,8 +104,8 @@ class ADXL345:
         self.last_tx_time = 0.
         am = {'x': (0, SCALE), 'y': (1, SCALE), 'z': (2, SCALE),
               '-x': (0, -SCALE), '-y': (1, -SCALE), '-z': (2, -SCALE)}
-        axes_map = config.get('axes_map', 'x,y,z').split(',')
-        if len(axes_map) != 3 or any([a.strip() not in am for a in axes_map]):
+        axes_map = config.getlist('axes_map', ('x','y','z'), count=3)
+        if any([a not in am for a in axes_map]):
             raise config.error("Invalid adxl345 axes_map parameter")
         self.axes_map = [am[a.strip()] for a in axes_map]
         self.data_rate = config.getint('rate', 3200)

--- a/klippy/extras/bed_screws.py
+++ b/klippy/extras/bed_screws.py
@@ -1,16 +1,8 @@
 # Helper script to adjust bed screws
 #
-# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-
-def parse_coord(config, param):
-    pair = config.get(param).strip().split(',', 1)
-    try:
-        return (float(pair[0]), float(pair[1]))
-    except:
-        raise config.error("%s:%s needs to be an x,y coordinate" % (
-            config.get_name(), param))
 
 class BedScrews:
     def __init__(self, config):
@@ -26,12 +18,13 @@ class BedScrews:
             prefix = "screw%d" % (i + 1,)
             if config.get(prefix, None) is None:
                 break
-            screw_coord = parse_coord(config, prefix)
+            screw_coord = config.getfloatlist(prefix, count=2)
             screw_name = "screw at %.3f,%.3f" % screw_coord
             screw_name = config.get(prefix + "_name", screw_name)
             screws.append((screw_coord, screw_name))
-            if config.get(prefix + "_fine_adjust", None) is not None:
-                fine_coord = parse_coord(config, prefix + "_fine_adjust")
+            pfa = prefix + "_fine_adjust"
+            if config.get(pfa, None) is not None:
+                fine_coord = config.getfloatlist(pfa, count=2)
                 fine_adjust.append((fine_coord, screw_name))
         if len(screws) < 3:
             raise config.error("bed_screws: Must have at least three screws")

--- a/klippy/extras/board_pins.py
+++ b/klippy/extras/board_pins.py
@@ -1,27 +1,18 @@
 # Support for custom board pin aliases
 #
-# Copyright (C) 2019-2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 class PrinterBoardAliases:
     def __init__(self, config):
         ppins = config.get_printer().lookup_object('pins')
-        mcu_names = [n.strip() for n in config.get('mcu', 'mcu').split(',')]
+        mcu_names = config.getlist('mcu', ('mcu',))
         pin_resolvers = [ppins.get_pin_resolver(n) for n in mcu_names]
         options = ["aliases"] + config.get_prefix_options("aliases_")
         for opt in options:
-            aliases = config.get(opt, "").strip()
-            if not aliases:
-                continue
-            if aliases.endswith(','):
-                aliases = aliases[:-1]
-            parts = [a.split('=', 1) for a in aliases.split(',')]
-            for pair in parts:
-                if len(pair) != 2:
-                    raise ppins.error("Unable to parse aliases in %s"
-                                      % (config.get_name(),))
-                name, value = [s.strip() for s in pair]
+            aliases = config.getlists(opt, seps=('=', ','), count=2)
+            for name, value in aliases:
                 if value.startswith('<') and value.endswith('>'):
                     for pin_resolver in pin_resolvers:
                         pin_resolver.reserve_pin(name, value)

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -14,14 +14,7 @@ from . import probe
 
 # Load a stable position from a config entry
 def load_config_stable(config, option):
-    spos = config.get(option)
-    try:
-        sa, sb, sc = map(float, spos.split(','))
-    except:
-        msg = "Unable to parse stable position '%s'" % (spos,)
-        logging.exception(msg)
-        raise config.error(msg)
-    return sa, sb, sc
+    return config.getfloatlist(option, count=3)
 
 
 ######################################################################

--- a/klippy/extras/display/menu_keys.py
+++ b/klippy/extras/display/menu_keys.py
@@ -44,17 +44,13 @@ class MenuKeys:
         if pin is None:
             return
         buttons = self.printer.lookup_object("buttons")
-        analog_range = config.get('analog_range_' + name, None)
-        if analog_range is None:
+        if config.get('analog_range_' + name, None) is None:
             if push_only:
                 buttons.register_button_push(pin, callback)
             else:
                 buttons.register_buttons([pin], callback)
             return
-        try:
-            amin, amax = map(float, analog_range.split(','))
-        except:
-            raise config.error("Unable to parse analog_range_" + name)
+        amin, amax = config.getfloatlist('analog_range_' + name, count=2)
         pullup = config.getfloat('analog_pullup_resistor', 4700., above=0.)
         if push_only:
             buttons.register_adc_button_push(pin, amin, amax, pullup, callback)

--- a/klippy/extras/duplicate_pin_override.py
+++ b/klippy/extras/duplicate_pin_override.py
@@ -8,7 +8,7 @@ class PrinterDupPinOverride:
     def __init__(self, config):
         printer = config.get_printer()
         ppins = printer.lookup_object('pins')
-        for pin_desc in config.get('pins').split(','):
+        for pin_desc in config.getlist('pins'):
             ppins.allow_multi_use_pin(pin_desc)
 
 def load_config(config):

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -67,11 +67,7 @@ class EndstopPhase:
         self.endstop_phase = None
         trigger_phase = config.get('trigger_phase', None)
         if trigger_phase is not None:
-            try:
-                p, ps = [int(v.strip()) for v in trigger_phase.split('/')]
-            except:
-                raise config.error("Unable to parse trigger_phase '%s'"
-                                   % (trigger_phase,))
+            p, ps = config.getintlist('trigger_phase', sep='/', count=2)
             if p >= ps:
                 raise config.error("Invalid trigger_phase '%s'"
                                    % (trigger_phase,))

--- a/klippy/extras/gcode_button.py
+++ b/klippy/extras/gcode_button.py
@@ -12,14 +12,10 @@ class GCodeButton:
         self.pin = config.get('pin')
         self.last_state = 0
         buttons = self.printer.load_object(config, "buttons")
-        analog_range = config.get('analog_range', None)
-        if analog_range is None:
+        if config.get('analog_range', None) is None:
             buttons.register_buttons([self.pin], self.button_callback)
         else:
-            try:
-                amin, amax = map(float, analog_range.split(','))
-            except:
-                raise config.error("Unable to parse analog_range")
+            amin, amax = config.getfloatlist('analog_range', count=2)
             pullup = config.getfloat('analog_pullup_resistor', 4700., above=0.)
             buttons.register_adc_button(self.pin, amin, amax, pullup,
                                         self.button_callback)

--- a/klippy/extras/heater_fan.py
+++ b/klippy/extras/heater_fan.py
@@ -12,7 +12,7 @@ class PrinterHeaterFan:
         self.printer = config.get_printer()
         self.printer.load_object(config, 'heaters')
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
-        self.heater_name = config.get("heater", "extruder")
+        self.heater_names = config.getlist("heater", ("extruder",))
         self.heater_temp = config.getfloat("heater_temp", 50.0)
         self.heaters = []
         self.fan = fan.Fan(config, default_shutdown_speed=1.)
@@ -20,8 +20,7 @@ class PrinterHeaterFan:
         self.last_speed = 0.
     def handle_ready(self):
         pheaters = self.printer.lookup_object('heaters')
-        self.heaters = [pheaters.lookup_heater(n.strip())
-                        for n in self.heater_name.split(',')]
+        self.heaters = [pheaters.lookup_heater(n) for n in self.heater_names]
         reactor = self.printer.get_reactor()
         reactor.register_timer(self.callback, reactor.monotonic()+PIN_MIN_TIME)
     def get_status(self, eventtime):

--- a/klippy/extras/homing_heaters.py
+++ b/klippy/extras/homing_heaters.py
@@ -15,38 +15,32 @@ class HomingHeaters:
                                             self.handle_homing_move_begin)
         self.printer.register_event_handler("homing:homing_move_end",
                                             self.handle_homing_move_end)
-        self.heaters_to_disable = config.get("heaters", "")
-        self.disable_heaters = []
-        self.steppers_needing_quiet = config.get("steppers", "")
-        self.flaky_steppers = []
+        self.disable_heaters = config.getlist("heaters", None)
+        self.flaky_steppers = config.getlist("steppers", None)
         self.pheaters = self.printer.load_object(config, 'heaters')
         self.target_save = {}
 
     def handle_connect(self):
         # heaters to disable
         all_heaters = self.pheaters.get_all_heaters()
-        self.disable_heaters = [n.strip()
-                          for n in self.heaters_to_disable.split(',')]
-        if self.disable_heaters == [""]:
+        if self.disable_heaters is None:
             self.disable_heaters = all_heaters
         else:
             if not all(x in all_heaters for x in self.disable_heaters):
                 raise self.printer.config_error(
-                    "One or more of these heaters are unknown: %s" % (
-                        self.disable_heaters))
+                    "One or more of these heaters are unknown: %s"
+                    % (self.disable_heaters,))
         # steppers valid?
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         all_steppers = [s.get_name() for s in kin.get_steppers()]
-        self.flaky_steppers = [n.strip()
-                         for n in self.steppers_needing_quiet.split(',')]
-        if self.flaky_steppers == [""]:
+        if self.flaky_steppers is None:
             return
         if not all(x in all_steppers for x in self.flaky_steppers):
             raise self.printer.config_error(
-                "One or more of these steppers are unknown: %s" % (
-                    self.flaky_steppers))
+                "One or more of these steppers are unknown: %s"
+                % (self.flaky_steppers,))
     def check_eligible(self, endstops):
-        if self.flaky_steppers == [""]:
+        if self.flaky_steppers is None:
             return True
         steppers_being_homed = [s.get_name()
                                 for es in endstops

--- a/klippy/extras/multi_pin.py
+++ b/klippy/extras/multi_pin.py
@@ -1,6 +1,6 @@
 # Virtual pin that propagates its changes to multiple output pins
 #
-# Copyright (C) 2017,2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2017-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -13,7 +13,7 @@ class PrinterMultiPin:
         except ppins.error:
             pass
         self.pin_type = None
-        self.pin_list = [pin.strip() for pin in config.get('pins').split(',')]
+        self.pin_list = config.getlist('pins')
         self.mcu_pins = []
     def setup_pin(self, pin_type, pin_params):
         ppins = self.printer.lookup_object('pins')

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -360,14 +360,8 @@ class ProbePointsHelper:
         self.gcode = self.printer.lookup_object('gcode')
         # Read config settings
         if default_points is None or config.get('points', None) is not None:
-            points = config.get('points').split('\n')
-            try:
-                points = [line.split(',', 1) for line in points if line.strip()]
-                self.probe_points = [(float(p[0].strip()), float(p[1].strip()))
-                                     for p in points]
-            except:
-                raise config.error("Unable to parse probe points in %s" % (
-                    self.name))
+            self.probe_points = config.getlists('points', seps=(',', '\n'),
+                                                parser=float, count=2)
         self.horizontal_move_z = config.getfloat('horizontal_move_z', 5.)
         self.speed = config.getfloat('speed', 50., above=0.)
         self.use_offsets = False

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -35,15 +35,8 @@ class QuadGantryLevel:
                 "Need exactly 4 probe points for quad_gantry_level")
         self.z_status = z_tilt.ZAdjustStatus(self.printer)
         self.z_helper = z_tilt.ZAdjustHelper(config, 4)
-        gantry_corners = config.get('gantry_corners').split('\n')
-        try:
-            gantry_corners = [line.split(',', 1)
-                           for line in gantry_corners if line.strip()]
-            self.gantry_corners = [(float(zp[0].strip()), float(zp[1].strip()))
-                                for zp in gantry_corners]
-        except:
-            raise config.error("Unable to parse gantry_corners in %s" % (
-                config.get_name()))
+        self.gantry_corners = config.getlists('gantry_corners', parser=float,
+                                              seps=(',', '\n'), count=2)
         if len(self.gantry_corners) < 2:
             raise config.error(
                 "quad_gantry_level requires at least two gantry_corners")

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -6,15 +6,6 @@
 import logging, math, os, time
 from . import shaper_calibrate
 
-def _parse_probe_points(config):
-    points = config.get('probe_points').split('\n')
-    try:
-        points = [line.split(',', 2) for line in points if line.strip()]
-        return [[float(coord.strip()) for coord in p] for p in points]
-    except:
-        raise config.error("Unable to parse probe_points in %s" % (
-            config.get_name()))
-
 class TestAxis:
     def __init__(self, axis=None, vib_dir=None):
         if axis is None:
@@ -66,7 +57,8 @@ class VibrationPulseTest:
         self.hz_per_sec = config.getfloat('hz_per_sec', 1.,
                                           minval=0.1, maxval=2.)
 
-        self.probe_points = _parse_probe_points(config)
+        self.probe_points = config.getlists('probe_points', seps=(',', '\n'),
+                                            parser=float, count=3)
     def get_start_test_points(self):
         return self.probe_points
     def prepare_test(self, gcmd):

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -7,13 +7,8 @@
 class SafeZHoming:
     def __init__(self, config):
         self.printer = config.get_printer()
-        try:
-            x_pos, y_pos = config.get("home_xy_position").split(',')
-            self.home_x_pos, self.home_y_pos = float(x_pos), float(y_pos)
-        except:
-            raise config.error("Unable to parse home_xy_position in %s"
-                               % (config.get_name(),))
-
+        x_pos, y_pos = config.getfloatlist("home_xy_position", count=2)
+        self.home_x_pos, self.home_y_pos = x_pos, y_pos
         self.z_hop = config.getfloat("z_hop", default=0.0)
         self.z_hop_speed = config.getfloat('z_hop_speed', 15., above=0.)
         zconfig = config.getsection('stepper_z')

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -7,14 +7,6 @@
 import math
 from . import probe
 
-def parse_coord(config, param):
-    pair = config.get(param).strip().split(',', 1)
-    try:
-        return (float(pair[0]), float(pair[1]))
-    except:
-        raise config.error("%s:%s needs to be an x,y coordinate" % (
-            config.get_name(), param))
-
 class ScrewsTiltAdjust:
     def __init__(self, config):
         self.config = config
@@ -26,7 +18,7 @@ class ScrewsTiltAdjust:
             prefix = "screw%d" % (i + 1,)
             if config.get(prefix, None) is None:
                 break
-            screw_coord = parse_coord(config, prefix)
+            screw_coord = config.getfloatlist(prefix, count=2)
             screw_name = "screw at %.3f,%.3f" % screw_coord
             screw_name = config.get(prefix + "_name", screw_name)
             self.screws.append((screw_coord, screw_name))

--- a/klippy/extras/static_digital_output.py
+++ b/klippy/extras/static_digital_output.py
@@ -8,7 +8,7 @@ class PrinterStaticDigitalOut:
     def __init__(self, config):
         printer = config.get_printer()
         ppins = printer.lookup_object('pins')
-        pin_list = [pin.strip() for pin in config.get('pins').split(',')]
+        pin_list = config.getlist('pins')
         for pin_desc in pin_list:
             mcu_pin = ppins.setup_pin('digital_out', pin_desc)
             mcu_pin.setup_start_value(1, 1, True)

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -472,9 +472,11 @@ def TMCMicrostepHelper(config, mcu_tmc):
         and config.get('microsteps', None, note_valid=False) is not None):
         # Older config format with microsteps in tmc config section
         ms_config = config
-    steps = {'256': 0, '128': 1, '64': 2, '32': 3, '16': 4,
-             '8': 5, '4': 6, '2': 7, '1': 8}
-    mres = ms_config.getchoice('microsteps', steps)
+    ms = ms_config.getint('microsteps')
+    mres = {256: 0, 128: 1, 64: 2, 32: 3, 16: 4, 8: 5, 4: 6, 2: 7, 1: 8}.get(ms)
+    if mres is None:
+        raise config.error("Invalid '%s' microstep setting (%d)"
+                           % (config.get_name(), ms))
     fields.set_field("mres", mres)
     fields.set_field("intpol", config.getboolean("interpolate", True))
 

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -1,6 +1,6 @@
 # Helper code for communicating with TMC stepper drivers via UART
 #
-# Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
@@ -16,7 +16,7 @@ class MCU_analog_mux:
         self.cmd_queue = cmd_queue
         ppins = mcu.get_printer().lookup_object("pins")
         select_pin_params = [ppins.lookup_pin(spd, can_invert=True)
-                             for spd in select_pins_desc.split(',')]
+                             for spd in select_pins_desc]
         self.oids = [self.mcu.create_oid() for pp in select_pin_params]
         self.pins = [pp['pin'] for pp in select_pin_params]
         self.pin_values = tuple([-1 for pp in select_pin_params])
@@ -32,7 +32,7 @@ class MCU_analog_mux:
     def get_instance_id(self, select_pins_desc):
         ppins = self.mcu.get_printer().lookup_object("pins")
         select_pin_params = [ppins.parse_pin(spd, can_invert=True)
-                             for spd in select_pins_desc.split(',')]
+                             for spd in select_pins_desc]
         for pin_params in select_pin_params:
             if pin_params['chip'] != self.mcu:
                 raise self.mcu.get_printer().config_error(
@@ -188,8 +188,8 @@ class MCU_TMC_uart_bitbang:
 # Lookup a (possibly shared) tmc uart
 def lookup_tmc_uart_bitbang(config, max_addr):
     ppins = config.get_printer().lookup_object("pins")
-    rx_pin_params = ppins.lookup_pin(
-        config.get('uart_pin'), can_pullup=True, share_type="tmc_uart_rx")
+    rx_pin_params = ppins.lookup_pin(config.get('uart_pin'), can_pullup=True,
+                                     share_type="tmc_uart_rx")
     tx_pin_desc = config.get('tx_pin', None)
     if tx_pin_desc is None:
         tx_pin_params = rx_pin_params
@@ -197,7 +197,7 @@ def lookup_tmc_uart_bitbang(config, max_addr):
         tx_pin_params = ppins.lookup_pin(tx_pin_desc, share_type="tmc_uart_tx")
     if rx_pin_params['chip'] is not tx_pin_params['chip']:
         raise ppins.error("TMC uart rx and tx pins must be on the same mcu")
-    select_pins_desc = config.get('select_pins', None)
+    select_pins_desc = config.getlist('select_pins', None)
     addr = config.getint('uart_address', 0, minval=0, maxval=max_addr)
     mcu_uart = rx_pin_params.get('class')
     if mcu_uart is None:

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -127,15 +127,8 @@ class RetryHelper:
 class ZTilt:
     def __init__(self, config):
         self.printer = config.get_printer()
-        z_positions = config.get('z_positions').split('\n')
-        try:
-            z_positions = [line.split(',', 1)
-                           for line in z_positions if line.strip()]
-            self.z_positions = [(float(zp[0].strip()), float(zp[1].strip()))
-                                for zp in z_positions]
-        except:
-            raise config.error("Unable to parse z_positions in %s" % (
-                config.get_name()))
+        self.z_positions = config.getlists('z_positions', seps=(',', '\n'),
+                                           parser=float, count=2)
         self.retry_helper = RetryHelper(config)
         self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
         self.probe_helper.minimum_points(2)

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -215,17 +215,11 @@ def PrinterStepper(config, units_in_radians=False):
 
 # Parse stepper gear_ratio config parameter
 def parse_gear_ratio(config, note_valid):
-    gear_ratio = config.get('gear_ratio', None, note_valid=note_valid)
-    if gear_ratio is None:
-        return 1.
+    gear_ratio = config.getlists('gear_ratio', (), seps=(':', ','), count=2,
+                                 parser=float, note_valid=note_valid)
     result = 1.
-    try:
-        gears = gear_ratio.split(',')
-        for gear in gears:
-            g1, g2 = [float(v.strip()) for v in gear.split(':')]
-            result *= g1 / g2
-    except:
-        raise config.error("Unable to parse gear_ratio: %s" % (gear_ratio,))
+    for g1, g2 in gear_ratio:
+        result *= g1 / g2
     return result
 
 # Obtain "step distance" information from a config section


### PR DESCRIPTION
This change adds new helper functions to the main `config` object for parsing out lists of numbers, lists of strings, and lists of lists.  I've also gone through and updated many places in the code that manually parse lists to use these new helper functions.

The main goal of this change is so that the `printer.configfile.settings` object will now contain lists for these existing config settings (instead of the encoded strings they currently have).  So, for example, where `printer.configfile.settings.extruder.gear_ratio` might have previously had something like `"50:17"`, it would now have `[[50.0, 17.0]]`.  This should make it easier for API clients to access the core configuration.

@Arksine , @cadriel, @meteyou - FYI, this PR changes the behaviour of `printer.configfile.settings`.  I didn't notice any regressions in Mainsail or Fluidd, but it is possible there is an impact.

@Arksine - the changes to bed_mesh.py were more invasive than the other changes.  You might want to double check them.

-Kevin