### PR TITLE
Update Config_Reference.md

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2709,7 +2709,7 @@ Multiple pin outputs (one may define any number of sections with a
 "multi_pin" prefix). A multi_pin output creates an internal pin alias
 that can modify multiple output pins each time the alias pin is
 set. For example, one could define a "[multi_pin my_fan]" object
-containing two pins and then set "pin=multi_pin:my_fan" in the "[fan]"
+containing two pins and then set "pin: multi_pin:my_fan" in the "[fan]"
 section - on each fan change both output pins would be updated. These
 aliases may not be used with stepper motor pins.
 


### PR DESCRIPTION
Change to Config Reference:

Change in the example for `Multi_pin` section as configs use `:` instead of `=` for pin designation

Signed-off-by: Timothy Abraham timothyabe93@gmail.com