### PR TITLE
heater fan: Allow for a minimum target temperature

### DIFF
--- a/klippy/extras/heater_fan.py
+++ b/klippy/extras/heater_fan.py
@@ -14,6 +14,7 @@ class PrinterHeaterFan:
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.heater_names = config.getlist("heater", ("extruder",))
         self.heater_temp = config.getfloat("heater_temp", 50.0)
+        self.min_target_temp = config.getfloat("min_target_temp", 0.0)
         self.heaters = []
         self.fan = fan.Fan(config, default_shutdown_speed=1.)
         self.fan_speed = config.getfloat("fan_speed", 1., minval=0., maxval=1.)
@@ -29,7 +30,8 @@ class PrinterHeaterFan:
         speed = 0.
         for heater in self.heaters:
             current_temp, target_temp = heater.get_temp(eventtime)
-            if target_temp or current_temp > self.heater_temp:
+            if (target_temp >= self.min_target_temp or \
+                    current_temp > self.heater_temp):
                 speed = self.fan_speed
         if speed != self.last_speed:
             self.last_speed = speed


### PR DESCRIPTION
Allows the user to set a minimum target temperature before the heater fan will turn on. This allows for things like exhaust fans to turn on only when higher temp filament is being used such as ABS (Like heater: heater_bed, min_target_temp: 80)
