### PR TITLE
Change default smooth_time from 2 seconds to 1 second

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20210903: The default [`smooth_time`](Config_Reference.md#extruder)
+for heaters has changed to 1 second (from 2 seconds).  For most
+printers this will result in more stable temperature control.
+
 20210830: The default adxl345 name is now "adxl345".  The default CHIP
 parameter for the `ACCELEROMETER_MEASURE` and `ACCELEROMETER_QUERY` is
 now also "adxl345".

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -707,10 +707,10 @@ sensor_pin:
 #   The resistance (in ohms) of the pullup attached to the thermistor.
 #   This parameter is only valid when the sensor is a thermistor. The
 #   default is 4700 ohms.
-#smooth_time: 2.0
+#smooth_time: 1.0
 #   A time value (in seconds) over which temperature measurements will
 #   be smoothed to reduce the impact of measurement noise. The default
-#   is 2 seconds.
+#   is 1 seconds.
 control:
 #   Control algorithm (either pid or watermark). This parameter must
 #   be provided.

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -34,7 +34,7 @@ class Heater:
                          is not None)
         self.can_extrude = self.min_extrude_temp <= 0. or is_fileoutput
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
-        self.smooth_time = config.getfloat('smooth_time', 2., above=0.)
+        self.smooth_time = config.getfloat('smooth_time', 1., above=0.)
         self.inv_smooth_time = 1. / self.smooth_time
         self.lock = threading.Lock()
         self.last_temp = self.smoothed_temp = self.target_temp = 0.


### PR DESCRIPTION
A larger smooth_time results in a slower reaction time for the PID.
This increased delay can cause temperature oscillations with high
power heaters.  Many boards produce good results without any
smoothing.  So, it seems a smooth_time of 1 second is a better
default.

Reported by @ReXT3D.

This was discussed at https://klipper.discourse.group/t/default-extruder-smooth-time-is-too-long-causing-temperature-oscillations/699 .

I'm inclined to further reduce the default `smooth_time` after the v0.10.0 release, as I get even better results on my printers with smoothing entirely disabled.

-Kevin