### PR TITLE
Export config file warnings for deprecated options

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -28,6 +28,12 @@ The following information is available in the `configfile` object
   setting as read by Klipper during the last software start or
   restart. (Any settings changed at run-time will not be reflected
   here.) All values are returned as strings.
+- `save_config_pending`: Returns true if there are updates that a
+  `SAVE_CONFIG` command may persist to disk.
+- `warnings`: A list of warnings about config options. Each entry in
+  the list will be a dictionary containing a `type` and `message`
+  field (both strings). Additional fields may be available depending
+  on the type of warning.
 
 ## display_status
 

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -260,7 +260,6 @@ class PrinterConfig:
         autosave_data = self._strip_duplicates(autosave_data, regular_config)
         self.autosave = self._build_config_wrapper(autosave_data, filename)
         cfg = self._build_config_wrapper(regular_data + autosave_data, filename)
-        self._build_status(cfg)
         return cfg
     def check_unused_options(self, config):
         fileconfig = config.fileconfig
@@ -282,10 +281,8 @@ class PrinterConfig:
                 if (section, option) not in access_tracking:
                     raise error("Option '%s' is not valid in section '%s'"
                                 % (option, section))
-        # Setup self.status_settings
-        self.status_settings = {}
-        for (section, option), value in config.access_tracking.items():
-            self.status_settings.setdefault(section, {})[option] = value
+        # Setup get_status()
+        self._build_status(config)
     def log_config(self, config):
         lines = ["===== Config file =====",
                  self._build_config_string(config),
@@ -298,6 +295,9 @@ class PrinterConfig:
             self.status_raw_config[section.get_name()] = section_status = {}
             for option in section.get_prefix_options(''):
                 section_status[option] = section.get(option, note_valid=False)
+        self.status_settings = {}
+        for (section, option), value in config.access_tracking.items():
+            self.status_settings.setdefault(section, {})[option] = value
     def get_status(self, eventtime):
         return {'config': self.status_raw_config,
                 'settings': self.status_settings,

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -141,8 +141,10 @@ class GCodeMacro:
                                         desc=self.cmd_SET_GCODE_VARIABLE_help)
         self.in_script = False
         prefix = 'default_parameter_'
-        self.kwparams = { o[len(prefix):].upper(): config.get(o)
-                          for o in config.get_prefix_options(prefix) }
+        self.kwparams = {}
+        for option in config.get_prefix_options(prefix):
+            config.deprecate(option)
+            self.kwparams[option[len(prefix):].upper()] = config.get(option)
         self.variables = {}
         prefix = 'variable_'
         for option in config.get_prefix_options(prefix):

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -180,6 +180,7 @@ class ControlPID:
         self.Ki = config.getfloat('pid_Ki') / PID_PARAM_BASE
         self.Kd = config.getfloat('pid_Kd') / PID_PARAM_BASE
         self.min_deriv_time = heater.get_smooth_time()
+        config.deprecate('pid_integral_max')
         imax = config.getfloat('pid_integral_max', self.heater_max_power,
                                minval=0.)
         self.temp_integ_max = 0.

--- a/klippy/extras/temperature_host.py
+++ b/klippy/extras/temperature_host.py
@@ -20,6 +20,7 @@ class Temperature_HOST:
 
         if config.get("sensor_type", "", note_valid=False).startswith('rpi'):
             # Temporary backwards compatibility
+            config.deprecate("sensor_type", "rpi_temperature")
             self.printer.add_object("rpi_temperature " + self.name, self)
         else:
             self.printer.add_object("temperature_host " + self.name, self)

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -560,6 +560,7 @@ class MCU:
         self._config_cmds = []
         self._restart_cmds = []
         self._init_cmds = []
+        config.deprecate('pin_map')
         self._pin_map = config.get('pin_map', None)
         self._mcu_freq = 0.
         # Move command queuing

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -233,6 +233,7 @@ def parse_step_distance(config, units_in_radians=None, note_valid=False):
         config.get('gear_ratio', note_valid=note_valid)
     else:
         rd = config.get('rotation_distance', None, note_valid=False)
+        config.deprecate('step_distance')
         sd = config.get('step_distance', None, note_valid=False)
         if rd is None and sd is not None:
             # Older config format with step_distance


### PR DESCRIPTION
This PR will add a new `printer.configfile.warnings` entry containing a string message reporting any deprecated config options.  This should be useful for warning users about needed config updates before they become errors.

@Arksine , @meteyou , @cadriel - it would be great if the frontends could prominently display this information.

-Kevin