### PR TITLE
cartesian: Initial implementation of independent X/Y accel/velocity

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -202,6 +202,24 @@ available parameters.
 ```
 [printer]
 kinematics: cartesian
+max_x_velocity:
+#   This sets the maximum velocity (in mm/s) of movement along the x
+#   axis. This setting can be used to restrict the maximum speed of
+#   the x stepper motor. The default is to use max_velocity for
+#   max_x_velocity.
+max_x_accel:
+#   This sets the maximum acceleration (in mm/s^2) of movement along
+#   the x axis. It limits the acceleration of the x stepper motor. The
+#   default is to use max_accel for max_x_accel.
+max_y_velocity:
+#   This sets the maximum velocity (in mm/s) of movement along the y
+#   axis. This setting can be used to restrict the maximum speed of
+#   the y stepper motor. The default is to use max_velocity for
+#   max_y_velocity.
+max_y_accel:
+#   This sets the maximum acceleration (in mm/s^2) of movement along
+#   the y axis. It limits the acceleration of the y stepper motor. The
+#   default is to use max_accel for max_y_accel.
 max_z_velocity:
 #   This sets the maximum velocity (in mm/s) of movement along the z
 #   axis. This setting can be used to restrict the maximum speed of


### PR DESCRIPTION
Extend the existing Z acceleration/velocity limits to work on the other axes as well, allowing the user to independently control the maximum acceleration and velocity of each axis. This was driven in large part by a desire to push my bed slinger further - testing on a resonance tower showed that X acceleration could be pushed much further than Y acceleration. While Input Shaper can largely deal with the non-uniform axes, being able to tune acceleration on each axis individually should allow users to achieve greater speeds without sacrificing quality. 

Testing has shown that it functions as expected, allowing independent accelerations on each axis. I think the biggest challenge will be seeing if users are able to make good use of the option.

I targeted this initial implementation at the cartesian kinematic since that covers the common bed slinger design, which is likely to have the most asymmetrical acceleration constraints. From a glance at the code, it looks like it would be relatively trivial to implement in most other non-delta kinematics - CoreXY, CoreXZ, Hybrid CoreXY, andd Hybrid CoreXZ all use the same (or nearly the same?) check_move code.

New parameters have been added to the docs.