### PR TITLE
stm32h7 port - set adc to 12bit mode

### DIFF
--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -1,4 +1,4 @@
-// ADC functions on STM32
+// ADC functions on STM32H7
 //
 // Copyright (C) 2020 Konstantin Vogel <konstantin.vogel@gmx.net>
 //
@@ -94,7 +94,7 @@ static const uint8_t adc_pins[] = {
 
 
 // ADC timing:
-// ADC clock=30Mhz, Tconv=8.5, Tsamp=64.5, total=2.4333us*OVERSAMPLES
+// ADC clock=30Mhz, Tconv=6.5, Tsamp=64.5, total=2.3666us*OVERSAMPLES
 
 struct gpio_adc
 gpio_adc_setup(uint32_t pin)
@@ -174,6 +174,8 @@ gpio_adc_setup(uint32_t pin)
                    | (aticks << 27));
         // Disable Continuous Mode
         MODIFY_REG(adc->CFGR, ADC_CFGR_CONT_Msk, 0);
+        // Set to 12 bit
+        MODIFY_REG(adc->CFGR, ADC_CFGR_RES_Msk, 0b110 << ADC_CFGR_RES_Pos);
         // Set hardware oversampling
         MODIFY_REG(adc->CFGR2, ADC_CFGR2_ROVSE_Msk, ADC_CFGR2_ROVSE);
         MODIFY_REG(adc->CFGR2, ADC_CFGR2_OVSR_Msk,
@@ -206,8 +208,8 @@ gpio_adc_sample(struct gpio_adc g)
     // Start sample
     adc->SQR1 = (g.chan << 6);
     adc->CR |= ADC_CR_ADSTART;
-    // Should take 2.4333us, add 1us for clock synchronisation etc.
-    return timer_from_us(1 + 2.4333*OVERSAMPLES);
+    // Should take 2.3666us, add 1us for clock synchronisation etc.
+    return timer_from_us(1 + 2.3666*OVERSAMPLES);
 }
 
 // Read a value; use only after gpio_adc_sample() returns zero
@@ -215,7 +217,7 @@ uint16_t
 gpio_adc_read(struct gpio_adc g)
 {
     ADC_TypeDef *adc = g.adc;
-    return (adc->DR >> 4) & 0x0fff;
+    return adc->DR;
 }
 
 // Cancel a sample that may have been started with gpio_adc_sample()

--- a/src/stm32/stm32h7_serial.c
+++ b/src/stm32/stm32h7_serial.c
@@ -1,4 +1,4 @@
-// STM32 serial
+// STM32H7 serial
 //
 // Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
 //
@@ -11,7 +11,6 @@
 #include "internal.h" // enable_pclock
 #include "sched.h" // DECL_INIT
 
-// USART6 (STM32H7) is not implemented yet
 // Select the configured serial port
 #if CONFIG_STM32_SERIAL_USART1
   DECL_CONSTANT_STR("RESERVE_PINS_serial", "PA10,PA9");


### PR DESCRIPTION
This is a continuation of work on #3912
 
Set the adc to 12 bit mode, as promised.
I also merged the work-stm32h7-20210902 branch into my fork, and everything still works. So the changes should be fine (I cant easily test the work-stm32h7-20210902 branch without reinstalling on python2).
