### PR TITLE
Document motor_power pin

### DIFF
--- a/config/generic-bigtreetech-skr-2.cfg
+++ b/config/generic-bigtreetech-skr-2.cfg
@@ -88,6 +88,10 @@ pin: PB7
 #[heater_fan fan2]
 #pin: PB5
 
+# Due to BTT implementing a Marlin-specific safety feature,
+# "anti-reversal stepper protection", this pin needs pulling
+# high to pass power to stepper drivers and most FETs
+
 [output_pin motor_power]
 pin: PC13
 value: 1


### PR DESCRIPTION
module: config/generic-bigtreetech-skr-2.cfg

This is just a short inline comment about Bigtreetech's implementation of the "anti-reversal stepper protection" and the way it should be handled in the Klipper printer configuration.

This was discussed in the Klipper discord around 8 to 9 AM UTC September 10, 2021.

Signed-off-by: Jerry Chapman <truckershitch@hambone.e4ward.com>