### PR TITLE
mcu: Add support for RTS MCU restart method.

### DIFF
--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -382,3 +382,19 @@ def arduino_reset(serialport, reactor):
     ser.dtr = False
     reactor.pause(reactor.monotonic() + 0.100)
     ser.close()
+
+# Attempt reset by pulsing RTS (should be connected to mcu nRST)
+def rts_reset(serialport, reactor):
+    # First try opening the port at a different baud
+    ser = serial.Serial(None, 2400, timeout=0, exclusive=True)
+    ser.port = serialport
+    ser.rts = False
+    ser.open()
+    ser.read(1)
+    reactor.pause(reactor.monotonic() + 0.100)
+    # Then toggle RTS
+    ser.rts = True
+    reactor.pause(reactor.monotonic() + 0.100)
+    ser.rts = False
+    reactor.pause(reactor.monotonic() + 0.100)
+    ser.close()


### PR DESCRIPTION
mcu: Add support for RTS MCU restart method.

Summary
------------
This lets you use RTS line on serial to reboot the mcu.
This has been tested on a pi3 and SKR Mini v2 installed in a Voron 0.

Motivation
-------------
I have connected my Pi to my MCU via the Pi's UART0 because it makes the wiring much more compact than a bulky USB cable, I also feel that the Pi and STM have perfectly good serial interfaces, and adding a USB interface in the middle is just complicating things.

I had a lot of errors until I realized that I had to set `restart_method` to `command` for the board to properly reset. I am uncomfortable using this method though, as in the case with a complete firmware lockup, it will not receive the restart command. 
A better solution would be to pulse the MCU nRST line.

As the raspberry pi UART does not contain a hardware DTR pin, I decided to use RTS, as it doesn't seem to be used for anything else, and it should be compatible with other klipper hosts that implement hardware RTS to pySerial.

Effects
---------
When `restart_method` is set to `rts` in your klipper config, the RTS serial line will remain high during normal operation. During a `FIRMWARE_RESTART`, RTS will be pulled low momentarily, in the same manner as `arduino` restart will pull DTR low.

Wiring/implementation
-----------------------------
Set `restart_method` to `rts` in klipper config.

On the RPi3, run:
`raspi-gpio set 17 a3`
This sets GPIO 17 as RTS0

Connect GPIO 17 (RPi header pin 11) to nRST on SKR Mini v2. I'm using the nRST pin exposed on the SWD port.

After running `FIRMWARE_RESET` g-code command, the board will probably reboot and klipper host will correctly re-establish connection!

---------------------------

Signed-off-by: Robert Cross <quantumcross@gmail.com>