### PR TITLE
Workaround for issue Release-info-change on a Rpi OS

### DIFF
--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -21,7 +21,7 @@ install_packages()
 
     # Update system package info
     report_status "Running apt-get update..."
-    sudo apt-get update
+    sudo apt-get update --allow-releaseinfo-change
 
     # Install desired packages
     report_status "Installing packages..."


### PR DESCRIPTION
Hey, installing klipper for the first time and got this issue where the error is:
```
E: Repository 'http://raspbian.raspberrypi.org/raspbian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
```

I had this also on CustomPiOS, and this is the current workaround

|Related:
https://github.com/guysoft/CustomPiOS/issues/143
https://github.com/RPi-Distro/pi-gen/issues/546