### PR TITLE
Add support for BLTouch probe on the Wanhao D9 MK2

### DIFF
--- a/config/printer-wanhao-duplicator-9-2018.cfg
+++ b/config/printer-wanhao-duplicator-9-2018.cfg
@@ -1,6 +1,7 @@
 # This file contains pin mappings for the Wanhao Duplicator 9 MK1,
-# also sold as the Monoprice Maker Pro MK1. To use this config,
-# the firmware should be compiled for the AVR atmega2560.
+# also sold as the Monoprice Maker Pro MK1. Pin assignments for the BLTouch
+# Z probe included on the Wanhao Duplicator 9 MK2 must be uncommented to use.
+# To use this config, the firmware should be compiled for the AVR atmega2560.
 
 # See docs/Config_Reference.md for a description of parameters.
 
@@ -67,6 +68,10 @@ max_temp: 120
 
 [fan]
 pin: PE3
+
+# [bltouch]
+# sensor_pin: PH3
+# control_pin: PH4
 
 [probe]
 pin: !PH3


### PR DESCRIPTION
I'm adding a BLTouch probe to my MK1 printer, so needed to determine which pin is connected for servo control. Based on the pin assignments in `pins_I3PLUS3030.h` in the archive extracted from https://github.com/garychen99/D9MK2 I can determine that the `control_pin` is `PH4`. I'll test this configuration and report success before requesting a merge.