### PR TITLE
Create printer-creality-crx-2017.cfg

### DIFF
--- a/config/printer-creality-crx-2017.cfg
+++ b/config/printer-creality-crx-2017.cfg
@@ -1,0 +1,243 @@
+# This file contains pin mappings for the 2017 Creality CR-X. To use
+# this config, the firmware should be compiled for the AVR atmega2560.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 323
+homing_speed: 50
+#position_min: -1.0
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 320
+homing_speed: 50
+#position_min: -1.0
+
+[stepper_z]
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+#position_endstop: 0
+position_max: 400
+homing_speed: 50
+
+[input_shaper]
+shaper_freq_x: 66.666
+shaper_freq_y: 100
+
+[bltouch]
+sensor_pin: ^PD3
+control_pin: PB5
+x_offset: -12.5
+y_offset: -38.0
+z_offset: 1.8
+speed: 3.0
+pin_up_touch_mode_reports_triggered: False
+
+[safe_z_home]
+#home_xy_position: 150,150
+home_xy_position: 162.5,188
+#speed: 50.0
+speed: 300.0
+z_hop: 5.0
+z_hop_speed: 100
+
+[bed_mesh]
+speed: 300 # Alt 120
+horizontal_move_z: 5
+mesh_min: 12,12
+mesh_max: 286, 278
+probe_count: 5,5
+move_check_distance: 5
+split_delta_z: .025
+fade_start: 1
+fade_end: 10
+fade_target: 0
+
+[gcode_macro HOME]
+description: Home if needed
+gcode:
+  {% if printer.toolhead.homed_axes != "xyz" %}
+    { action_respond_info("Printer: Homing") }
+    G28
+  {% else %}
+    { action_respond_info("Printer: Homed") }
+  {% endif %}
+
+[gcode_macro G29]
+description: Load Mesh (Probe)
+gcode:
+  HOME
+  BED_MESH_PROFILE LOAD=default
+
+[gcode_macro MESH_PROBE]
+# MESH_PROBE H=80 B=30
+description: Probe mesh short
+gcode:
+  {% set hotend_temp = params.H|default(180)|float %}
+  {% set bed_temp = params.B|default(60)|float %}
+  { action_respond_info("Heating Hotend: %3.1f Bead: %3.1f" % ((hotend_temp), (bed_temp))) }
+  M104 S{hotend_temp}; Set Hotend Temperature
+  {% if printer.toolhead.homed_axes != "xyz" %}
+    G28
+  {% endif %}
+  M109 S{hotend_temp}; Set Extruder Temperature and Wait
+  M190 S{bed_temp}; Wait for bed temperature to reach target temp
+  BED_MESH_CALIBRATE
+  TURN_OFF_HEATERS
+
+[gcode_macro CLEAN_NOZZLE]
+description: Clean Nozzle with Purge Bucket
+gcode:
+  {% set wipe_count = 3 %}
+  {% set purge_x = 320 %}
+  {% set purge_y = 0 %}
+  SAVE_GCODE_STATE NAME=clean_nozzle_state
+  G28 O
+  G90
+  G0 X{purge_x} Y{purge_y} Z15 F12000 E20
+  {% for wipe in range(wipe_count) %}
+    {% for coordinate in [(purge_x,purge_y),(purge_x - 20 ,purge_y)] %}
+      G0 X{coordinate[0]} Y{coordinate[1]} F12000
+    {% endfor %}
+  {% endfor %}
+  RESTORE_GCODE_STATE NAME=clean_nozzle_state
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.0 # Calibrate - see https://github.com/KevinOConnor/klipper/blob/master/docs/Rotation_Distance.md
+nozzle_diameter: 0.400
+max_extrude_only_distance: 150
+filament_diameter: 1.750
+#pressure_advance: 0.51   # Calibrate - see https://github.com/KevinOConnor/klipper/blob/master/docs/Pressure_Advance.md
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+control: pid
+sensor_pin: PK5
+pid_Kp=26.537
+pid_Ki=1.701
+pid_Kd=103.494
+min_temp: 0
+max_temp: 250
+
+[extruder1]
+step_pin: PC1 #ar36
+dir_pin: !PC3 #ar34
+enable_pin: !PC7 #!ar30
+microsteps: 16
+rotation_distance: 33.0 # Calibrate - see https://github.com/KevinOConnor/klipper/blob/master/docs/Rotation_Distance.md
+nozzle_diameter: 0.400
+max_extrude_only_distance: 150
+filament_diameter: 1.750
+#pressure_advance: 0.51   # Calibrate - see https://github.com/KevinOConnor/klipper/blob/master/docs/Pressure_Advance.md
+shared_heater: extruder
+
+[gcode_macro T0]
+description: Select Tool 0
+gcode:
+  ACTIVATE_EXTRUDER EXTRUDER=extruder
+
+[gcode_macro T1]
+description: Select Tool 1
+gcode:
+  ACTIVATE_EXTRUDER EXTRUDER=extruder1
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PK6
+control: pid
+pid_kp: 75.190
+pid_ki: 1.347
+pid_kd: 1048.899
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PH6
+
+[mcu]
+baud: 250000
+serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AC00FBEK-if00-port0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_accel_to_decel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[display]
+lcd_type: st7920
+cs_pin: PH1
+sclk_pin: PA1
+sid_pin: PH0
+encoder_pins: ^PC4, ^PC6
+click_pin: ^!PC2
+
+[output_pin BEEPER_pin]
+pin: PC0
+
+[gcode_macro M300]
+description: Output Sound
+gcode:
+  # Use a default 1kHz tone if S is omitted.
+  {% set S = params.S|default(1000)|int %}
+  # Use a 10ms duration is P is omitted.
+  {% set P = params.P|default(100)|int %}
+  SET_PIN PIN=BEEPER_pin VALUE=0.5 CYCLE_TIME={ 1.0/S if S > 0 else 1 }
+  G4 P{P}
+  SET_PIN PIN=BEEPER_pin VALUE=0
+
+[firmware_retraction]
+retract_length: 0
+#   The length of filament (in mm) to retract when G10 is activated,
+#   and to unretract when G11 is activated (but see
+#   unretract_extra_length below). The default is 0 mm.
+retract_speed: 20
+#   The speed of retraction, in mm/s. The default is 20 mm/s.
+unretract_extra_length: 0
+#   The length (in mm) of *additional* filament to add when
+#   unretracting.
+unretract_speed: 10
+#   The speed of unretraction, in mm/s. The default is 10 mm/s.
+
+[respond]
+default_type: echo
+#   Sets the default prefix of the "M118" and "RESPOND" output to one
+#   of the following:
+#       echo: "echo: " (This is the default)
+#       command: "// "
+#       error: "!! "
+default_prefix: echo:
+#   Directly sets the default prefix. If present, this value will
+#   override the "default_type".
+
+[gcode_arcs]
+resolution: 1.0
+#   An arc will be split into segments. Each segment's length will
+#   equal the resolution in mm set above. Lower values will produce a
+#   finer arc, but also more work for your machine. Arcs smaller than
+#   the configured value will become straight lines. The default is
+#   1mm.


### PR DESCRIPTION
This file contains pin mappings for the 2017 Creality CR-X. To use
this config, the firmware should be compiled for the AVR atmega2560.

TESTED AND WORKING